### PR TITLE
AL.3 — Post-Persistence Received Hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,15 +178,10 @@ jobs:
           Copy-Item "target/release/atm-daemon$suffix" (Join-Path $binDir "atm-daemon$suffix") -Force
           "ATM_SMOKE_INSTALL_ROOT=$installRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Run workspace tests excluding atm-daemon on Windows
+      - name: Run replacement-workspace tests excluding legacy atm-daemon
         env:
           ATM_TEST_RECV_TIMEOUT_SECS: "60"
         run: cargo test --workspace --exclude atm-daemon --verbose
-
-      - name: Run atm-daemon tests
-        env:
-          ATM_TEST_RECV_TIMEOUT_SECS: "60"
-        run: cargo test -p atm-daemon --verbose
 
       - name: Install Maturin for Hermes graft bridge tests
         run: python -m pip install maturin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,11 @@ jobs:
       # Historical reference only while Phase AL constructs the replacement
       # executable. This must not be cited as AL acceptance evidence.
       - name: Build historical legacy-daemon smoke binaries (reference only)
+        continue-on-error: true
         run: cargo build --release -p agent-team-mail -p atm-daemon --verbose
 
       - name: Prepare historical legacy-daemon smoke binaries (reference only)
+        continue-on-error: true
         shell: pwsh
         run: |
           $installRoot = Join-Path $env:RUNNER_TEMP "atm-smoke-install"
@@ -199,5 +201,6 @@ jobs:
 
       # Historical reference only; replacement-runtime proof owns AL acceptance.
       - name: Run historical shared-host singleton smoke (reference only)
+        continue-on-error: true
         if: ${{ always() }}
         run: python scripts/smoke/run_thorough_shared_host.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,12 @@ jobs:
       - name: Build workspace
         run: cargo build --verbose
 
-      - name: Build release smoke binaries
+      # Historical reference only while Phase AL constructs the replacement
+      # executable. This must not be cited as AL acceptance evidence.
+      - name: Build historical legacy-daemon smoke binaries (reference only)
         run: cargo build --release -p agent-team-mail -p atm-daemon --verbose
 
-      - name: Prepare installed smoke binaries
+      - name: Prepare historical legacy-daemon smoke binaries (reference only)
         shell: pwsh
         run: |
           $installRoot = Join-Path $env:RUNNER_TEMP "atm-smoke-install"
@@ -195,6 +197,7 @@ jobs:
       - name: Run graft receiver crash/reclaim proof
         run: python scripts/graft_receiver_reclaim.py
 
-      - name: Run isolated shared-host singleton smoke
+      # Historical reference only; replacement-runtime proof owns AL acceptance.
+      - name: Run historical shared-host singleton smoke (reference only)
         if: ${{ always() }}
         run: python scripts/smoke/run_thorough_shared_host.py

--- a/.just/run_tests.py
+++ b/.just/run_tests.py
@@ -20,7 +20,11 @@ def main() -> int:
         run([sys.executable, "scripts/verify_user_docs.py", "--source-root", "docs/user-documents"])
         run([sys.executable, ".just/run_pytests.py"])
         run(["cargo", "build", "--workspace"])
-        run(["cargo", "test", "--workspace"])
+        # `atm-daemon` is reference-only while Phase AL constructs the
+        # replacement Tokio runtime. Its historical unit tests are not
+        # replacement acceptance evidence and must not pull new work back into
+        # the legacy implementation.
+        run(["cargo", "test", "--workspace", "--exclude", "atm-daemon"])
         return 0
     if mode == "coverage":
         run([sys.executable, "scripts/coverage/run.py", "--write-artifacts"])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "sha2",
  "signal-hook",
  "tempfile",
+ "tokio",
  "tracing",
  "ulid",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,8 @@ name = "atm-http-runtime"
 version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
+ "atm-runtime-test-support",
+ "atm-storage",
  "axum",
  "hyper",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ sc-observability = "1.2.0"
 sc-observability-types = "1.2.0"
 arc-swap = "1.7"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tokio = { version = "1.48", default-features = false, features = ["macros", "net", "rt", "sync", "time"] }
+tokio = { version = "1.48", default-features = false, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "http1"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/boundaries/atm-daemon/post-commit-work-queue.toml
+++ b/boundaries/atm-daemon/post-commit-work-queue.toml
@@ -16,8 +16,8 @@ constructor = "pub(crate)"
 roots = ["atm_daemon::composition::compose_runtime"]
 
 [ownership]
-io_owns = ["bounded_identifier_only_post_commit_scheduling"]
-io_forbidden = ["sqlite", "receipt", "retry_state"]
+io_owns = ["legacy_peer_delivery_wakeup_only"]
+io_forbidden = ["sqlite", "receipt", "hook_execution", "process_spawn", "retry_queue"]
 
 [dependencies]
 allowed_dependents = []
@@ -39,8 +39,8 @@ forbidden_test_bypasses = []
 
 [enforcement]
 lint_rules = ["LINT-BOUNDARY-POST-COMMIT-WORK-QUEUE"]
-review_gates = ["identifier_only", "no_admission_wait", "no_direct_sqlite"]
+review_gates = ["identifier_only", "no_admission_wait", "no_direct_sqlite", "no_received_hook"]
 
 [status]
 state = "active"
-notes = ["AI.31: only immutable message identifiers and peer wake-up keys cross this seam."]
+notes = ["AL.3: only immutable message identifiers and legacy peer wake-up keys cross this seam. Received-message hooks are never queued here."]

--- a/boundaries/atm-daemon/post-write-router.toml
+++ b/boundaries/atm-daemon/post-write-router.toml
@@ -16,8 +16,8 @@ constructor = "pub(crate)"
 roots = ["atm_daemon::composition::compose_runtime"]
 
 [ownership]
-io_owns = ["post_commit_route_classification"]
-io_forbidden = ["sqlite", "dns", "socket_io", "tls", "hook_execution", "graft_delivery"]
+io_owns = ["post_persistence_route_classification", "received_hook_orchestration"]
+io_forbidden = ["sqlite", "dns", "socket_io", "tls", "hook_execution", "graft_delivery", "retry_queue"]
 
 [dependencies]
 allowed_dependents = []
@@ -29,9 +29,9 @@ scope = "outside_owner_crate"
 forbidden = []
 
 [contracts]
-request_types = ["committed MessageRecord"]
-response_types = ["PostCommitWorkKey signal"]
-error_types = ["none"]
+request_types = ["newly persisted MessageRecord", "RequestDeadline"]
+response_types = ["retained WarningEntry diagnostics", "legacy PostCommitWorkKey signal"]
+error_types = ["none; receiver-hook failures become warnings"]
 
 [testing]
 allowed_test_double_paths = []
@@ -39,8 +39,8 @@ forbidden_test_bypasses = []
 
 [enforcement]
 lint_rules = ["LINT-BOUNDARY-POST-WRITE-ROUTER"]
-review_gates = ["signal_only", "no_direct_peer_transport", "no_hook_or_nudge_execution"]
+review_gates = ["new_persistence_only", "single_received_hook_call_site", "no_direct_peer_transport", "no_hook_queue"]
 
 [status]
 state = "active"
-notes = ["AI.31: host-qualified, localhost, and self-IP writes use ordinary routing and signal post-commit work only."]
+notes = ["AL.3: newly persisted inbound writes synchronously invoke the sealed received-hook boundary and retain failures as warnings. Host-qualified origin writes retain only the temporary legacy peer wake-up until AM deletion."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2061,6 +2061,11 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
         1,
         "all UDS, TCP, and peer ingress adapters must converge on one post-persistence hook call site"
     );
+    assert!(
+        dispatcher.contains("let newly_persisted = message.prepared.is_newly_persisted();")
+            && dispatcher.contains("if newly_persisted {"),
+        "the one hook-routing decision must state the new-versus-idempotent persistence disposition explicitly"
+    );
     assert_eq!(
         router
             .matches("atm_core::send::emit_persisted_local_post_write(")

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2038,7 +2038,20 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
         read_source(&root.join("crates/atm-daemon/src/runtime_health/peer_delivery_router.rs"));
     let post_commit =
         read_source(&root.join("crates/atm-daemon/src/runtime_health/post_commit_work.rs"));
+    let post_write = read_source(&root.join("crates/atm-core/src/send/post_write.rs"));
+    let message_received_emitter =
+        read_source(&root.join("crates/atm-daemon/src/message_received_emitter.rs"));
     let post_commit_code = post_commit
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let post_write_code = post_write
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let message_received_emitter_code = message_received_emitter
         .lines()
         .filter(|line| !line.trim_start().starts_with("//"))
         .collect::<Vec<_>>()
@@ -2095,18 +2108,29 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
         );
     }
 
-    for prohibited in [
-        "LocalNudge",
-        "MessageReceivedHookEmitter",
-        "thread::spawn",
-        "tokio::spawn",
-        "sync_channel",
-    ] {
+    for prohibited in ["thread::spawn", "tokio::spawn", "sync_channel"] {
         assert!(
             !post_commit_code.contains(prohibited),
             "the post-commit peer adapter must not restore receiver-hook `{prohibited}` work"
         );
+        assert!(
+            !post_write_code.contains(prohibited),
+            "the core post-write adapter must not create detached receiver-hook `{prohibited}` work"
+        );
+        assert!(
+            !message_received_emitter_code.contains(prohibited),
+            "the daemon receiver emitter must not create detached receiver-hook `{prohibited}` work"
+        );
     }
+    assert!(
+        post_write_code.contains("MessageReceivedHookEmitter")
+            && post_write_code.contains("emit_post_send_effects"),
+        "the core post-write adapter must retain the injected receiver-hook boundary"
+    );
+    assert!(
+        message_received_emitter_code.contains("impl MessageReceivedHookEmitter"),
+        "the daemon receiver emitter must remain the concrete injected hook implementation"
+    );
 
     // `atm-graft/src/runtime.rs` is deliberately excluded: it is the
     // independently-started receiver implementation, not an outbound client.

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2030,6 +2030,106 @@ fn al1_receiver_hook_boundary_replaces_retired_release_gate_artifacts() {
     );
 }
 
+#[test]
+fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
+    let root = workspace_root();
+    let dispatcher = read_source(&root.join("crates/atm-daemon/src/runtime_health/dispatch.rs"));
+    let router =
+        read_source(&root.join("crates/atm-daemon/src/runtime_health/peer_delivery_router.rs"));
+    let post_commit =
+        read_source(&root.join("crates/atm-daemon/src/runtime_health/post_commit_work.rs"));
+    let post_commit_code = post_commit
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let finish = dispatcher
+        .find(".finish(&self.service_runtime, self.observability.as_ref())")
+        .expect("AL.3 must finish the durable write before receiver-hook routing");
+    let dispatch = dispatcher
+        .find("PostWriteRouter::dispatch(self, &mut message, deadline)")
+        .expect("AL.3 must route the received hook through the canonical dispatcher");
+    assert!(
+        finish < dispatch,
+        "AL.3 must invoke the received hook only after durable write completion"
+    );
+    assert_eq!(
+        dispatcher
+            .matches("PostWriteRouter::dispatch(self, &mut message, deadline)")
+            .count(),
+        1,
+        "all UDS, TCP, and peer ingress adapters must converge on one post-persistence hook call site"
+    );
+    assert_eq!(
+        router
+            .matches("atm_core::send::emit_persisted_local_post_write(")
+            .count(),
+        1,
+        "the router must retain exactly one receiver-hook invocation site"
+    );
+    assert!(
+        router.contains("deadline.remaining().is_none()"),
+        "AL.3 must skip receiver-hook work once the inherited request deadline is exhausted"
+    );
+
+    for (adapter, path) in [
+        (
+            "local UDS",
+            "crates/atm-daemon/src/local_ipc_transport/request_worker.rs",
+        ),
+        ("local TCP", "crates/atm-daemon/src/local_tcp_transport.rs"),
+        ("peer HTTPS", "crates/atm-daemon/src/https_transport.rs"),
+    ] {
+        let source = read_source(&root.join(path));
+        assert!(source.contains(".route("), "{adapter} must use ApiRouter");
+        assert!(
+            !source.contains("MessageReceivedHookEmitter")
+                && !source.contains("emit_persisted_local_post_write"),
+            "{adapter} must not create a transport-specific received-hook path"
+        );
+    }
+
+    for prohibited in [
+        "LocalNudge",
+        "MessageReceivedHookEmitter",
+        "thread::spawn",
+        "tokio::spawn",
+        "sync_channel",
+    ] {
+        assert!(
+            !post_commit_code.contains(prohibited),
+            "the post-commit peer adapter must not restore receiver-hook `{prohibited}` work"
+        );
+    }
+
+    // `atm-graft/src/runtime.rs` is deliberately excluded: it is the
+    // independently-started receiver implementation, not an outbound client.
+    for path in [
+        "crates/atm/src",
+        "crates/atm-daemon-client/src",
+        "crates/atm-graft/src/transport.rs",
+    ] {
+        let path = root.join(path);
+        let sources = if path.is_dir() {
+            let mut sources = Vec::new();
+            collect_rust_files(&path, &mut sources);
+            sources
+        } else {
+            vec![path]
+        };
+        for source_path in sources {
+            let source = read_source(&source_path);
+            assert!(
+                !source.contains("MessageReceivedHookEmitter")
+                    && !source.contains(".emit_post_send("),
+                "outbound client {} must not call a receiver notification hook",
+                source_path.display()
+            );
+        }
+    }
+}
+
 fn documented_forbidden_edges() -> BTreeSet<(String, String)> {
     guarded_boundary_files()
         .into_iter()

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2165,6 +2165,39 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
     }
 }
 
+#[test]
+fn al3_replacement_runtime_cannot_restore_legacy_or_blocking_runtime_constructs() {
+    let runtime_root = workspace_root().join("crates/atm-http-runtime/src");
+    let mut sources = Vec::new();
+    collect_rust_files(&runtime_root, &mut sources);
+    for source_path in sources {
+        let source = read_source(&source_path);
+        for prohibited in [
+            "atm_daemon",
+            "Runtime::Builder",
+            "Handle::block_on",
+            "std::sync::mpsc",
+            "std::thread::sleep",
+            "thread::sleep",
+            "peer_delivery_router",
+            "local_ipc_transport",
+            "local_tcp_transport",
+            "https_transport",
+        ] {
+            assert!(
+                !source.contains(prohibited),
+                "replacement runtime {} must not restore `{prohibited}`",
+                source_path.display()
+            );
+        }
+    }
+    let storage_router = read_source(&runtime_root.join("storage_and_nudge_router.rs"));
+    assert!(
+        storage_router.contains("spawn_blocking"),
+        "the synchronous core storage boundary must be isolated without blocking a Tokio worker"
+    );
+}
+
 fn documented_forbidden_edges() -> BTreeSet<(String, String)> {
     guarded_boundary_files()
         .into_iter()

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2108,6 +2108,12 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
         );
     }
 
+    for prohibited in ["LocalNudge", "MessageReceivedHookEmitter"] {
+        assert!(
+            !post_commit_code.contains(prohibited),
+            "the post-commit peer adapter must not restore receiver-hook `{prohibited}` work"
+        );
+    }
     for prohibited in ["thread::spawn", "tokio::spawn", "sync_channel"] {
         assert!(
             !post_commit_code.contains(prohibited),

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -751,11 +751,13 @@ impl RequestDeadline {
     }
 
     pub fn expired(self) -> bool {
-        Instant::now() >= self.0
+        self.remaining().is_none()
     }
 
     pub fn remaining(self) -> Option<Duration> {
-        self.0.checked_duration_since(Instant::now())
+        self.0
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
     }
 }
 
@@ -779,12 +781,13 @@ pub trait DaemonApiClient: crate::boundary::sealed::Sealed + Send + Sync {
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read, Write};
+    use std::time::Duration;
 
     use base64::Engine;
 
     use super::{
         ApiRequest, HttpFrameReader, MAX_HTTP_HEADER_BYTES, MAX_HTTP_REQUEST_BODY_BYTES,
-        decode_request, read_http_request, read_http_response, write_http_request,
+        RequestDeadline, decode_request, read_http_request, read_http_response, write_http_request,
         write_http_response,
     };
     use crate::ack::AckRequest;
@@ -796,6 +799,14 @@ mod tests {
     use crate::send::{SendMessageSource, SendRequest};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::CommandAction;
+
+    #[test]
+    fn zero_request_deadline_has_no_remaining_budget() {
+        let deadline = RequestDeadline::after(Duration::ZERO);
+
+        assert!(deadline.expired());
+        assert_eq!(deadline.remaining(), None);
+    }
 
     /// A reader that presents a valid HTTP stream in deliberately small reads.
     ///

--- a/crates/atm-core/src/boundary/message_received_hook_emitter.rs
+++ b/crates/atm-core/src/boundary/message_received_hook_emitter.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::pin::Pin;
+
 use super::{BuiltInPostSendDispatch, PostSendEmissionPath, sealed};
 use crate::api::RequestDeadline;
 use crate::error::AtmError;
@@ -19,4 +22,23 @@ pub trait MessageReceivedHookEmitter: sealed::Sealed + Send + Sync {
         dispatch: &BuiltInPostSendDispatch,
         deadline: RequestDeadline,
     ) -> Result<PostSendEmissionPath, AtmError>;
+}
+
+/// Replacement-runtime boundary for one cancellable receiver-side emission.
+///
+/// The replacement Tokio runtime awaits this future against the request's
+/// inherited deadline. Dropping the future is the cancellation signal: an
+/// implementation must not hide an unbounded thread, process, or queue behind
+/// it. The legacy synchronous emitter remains reference-only until Phase AM
+/// deletes the legacy daemon.
+pub trait AsyncMessageReceivedHookEmitter: sealed::Sealed + Send + Sync {
+    /// Starts one receiver-side emission after durable persistence.
+    ///
+    /// The returned future must cooperatively finish or clean up when dropped
+    /// because the caller's request deadline expires.
+    fn emit_received_message(
+        &self,
+        dispatch: BuiltInPostSendDispatch,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<PostSendEmissionPath, AtmError>> + Send + '_>>;
 }

--- a/crates/atm-core/src/boundary/message_received_hook_emitter.rs
+++ b/crates/atm-core/src/boundary/message_received_hook_emitter.rs
@@ -1,4 +1,5 @@
 use super::{BuiltInPostSendDispatch, PostSendEmissionPath, sealed};
+use crate::api::RequestDeadline;
 use crate::error::AtmError;
 
 /// BOUNDARY-MessageReceivedHookEmitter — see docs/atm-core/boundaries.md.
@@ -13,8 +14,9 @@ pub trait MessageReceivedHookEmitter: sealed::Sealed + Send + Sync {
     ///
     /// Returns `AtmError` when the receiver-side emission fails after durable
     /// message persistence has already succeeded.
-    fn emit_post_send(
+    fn emit_received_message(
         &self,
         dispatch: &BuiltInPostSendDispatch,
+        deadline: RequestDeadline,
     ) -> Result<PostSendEmissionPath, AtmError>;
 }

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -30,7 +30,9 @@ mod store;
 // surface for Phase R/AA contracts, so callers should not need to know whether
 // an item lives in `mail` or `store`.
 pub use mail::*;
-pub use message_received_hook_emitter::MessageReceivedHookEmitter;
+pub use message_received_hook_emitter::{
+    AsyncMessageReceivedHookEmitter, MessageReceivedHookEmitter,
+};
 pub use store::*;
 
 /// BOUNDARY-StatusSource — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -1,8 +1,6 @@
 use crate::config::AtmConfig;
-use crate::delivery_plan::{DeliveryPlan, DeliveryPlanDisposition, LogicalMessage};
-use crate::delivery_policy::{
-    DeliveryEventFamily, persisted_success_transition_names, sqlite_failure_transition_names,
-};
+use crate::delivery_plan::{DeliveryPlan, LogicalMessage};
+use crate::delivery_policy::{DeliveryEventFamily, persisted_success_transition_names};
 use crate::error::AtmError;
 use crate::observability::ObservabilityPort;
 use crate::schema::AtmMessageId;
@@ -89,14 +87,8 @@ pub(crate) fn emit_delivery_plan_transitions(
     plan: &DeliveryPlan,
     _execution: &DeliveryExecutionResult,
 ) -> Result<(), AtmError> {
-    let transitions = match plan.disposition {
-        DeliveryPlanDisposition::SqliteFailedRecovered => {
-            sqlite_failure_transition_names(plan.delivery_target.harness_path()).to_vec()
-        }
-        DeliveryPlanDisposition::Persisted => {
-            persisted_success_transition_names(context.family, plan.delivery_target.harness_path())
-        }
-    };
+    let transitions =
+        persisted_success_transition_names(context.family, plan.delivery_target.harness_path());
     for transition in transitions {
         observability.emit(crate::observability::CommandEvent {
             command: "delivery_policy",
@@ -219,27 +211,6 @@ mod tests {
         .expect("logical message")
     }
 
-    #[derive(Default)]
-    struct RecordingRuntime {
-        delivered_texts: std::sync::Mutex<Vec<String>>,
-    }
-
-    impl crate::boundary::sealed::Sealed for RecordingRuntime {}
-
-    impl NonClaudeOutboundDeliveryWriter for RecordingRuntime {
-        fn deliver_non_claude_payloads(
-            &self,
-            _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            messages: &[LogicalMessage],
-        ) -> Result<(), AtmError> {
-            self.delivered_texts
-                .lock()
-                .expect("deliveries")
-                .extend(messages.iter().map(|message| message.envelope.text.clone()));
-            Ok(())
-        }
-    }
-
     fn recipient_snapshot(harness: DeliveryHarnessPath) -> DeliveryRecipientSnapshot {
         DeliveryRecipientSnapshot {
             agent: AgentName::from_validated("recipient"),
@@ -323,37 +294,5 @@ mod tests {
             event.command == "delivery_policy"
                 && event.outcome.as_str() == "delivery_policy.new_message.non_claude_original"
         }));
-    }
-
-    #[test]
-    fn execute_delivery_plan_routes_recovered_message_sets_through_non_claude_outbound() {
-        let runtime = RecordingRuntime::default();
-        let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Send,
-            DeliveryPlanDisposition::SqliteFailedRecovered,
-            DeliveryTarget::NonClaude {
-                recipient: recipient_snapshot(DeliveryHarnessPath::ClaudeCode),
-            },
-            ResolvedRecipient {
-                agent: AgentName::from_validated("recipient"),
-                team: TeamName::from_validated(TEST_TEAM),
-            },
-            vec![
-                logical_message_with_text("original message"),
-                logical_message_with_text("companion error"),
-            ],
-            Vec::new(),
-        );
-
-        let result = execute_delivery_plan(&runtime, None, &plan).expect("delivery");
-        assert_eq!(result.disposition, DeliveryExecutionDisposition::Delivered);
-        assert!(result.warnings.is_empty());
-        assert_eq!(
-            *runtime.delivered_texts.lock().expect("deliveries"),
-            vec![
-                "original message".to_string(),
-                "companion error".to_string()
-            ]
-        );
     }
 }

--- a/crates/atm-core/src/delivery_plan.rs
+++ b/crates/atm-core/src/delivery_plan.rs
@@ -9,7 +9,6 @@ use crate::send::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DeliveryPlanDisposition {
     Persisted,
-    SqliteFailedRecovered,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,26 +66,19 @@ pub(crate) fn logical_messages_from_persistence(
     requires_ack: bool,
     is_ack: bool,
 ) -> Result<Vec<LogicalMessage>, LogicalMessageError> {
-    let mut messages = vec![LogicalMessage::new(
+    let messages = vec![LogicalMessage::new(
         persistence.original_message.clone(),
         requires_ack,
         is_ack,
     )?];
-    if let Some(companion_message) = persistence.companion_message.clone() {
-        messages.push(LogicalMessage::new(companion_message, false, is_ack)?);
-    }
     Ok(messages)
 }
 
 pub(crate) fn delivery_plan_disposition(
     disposition: DeliveryPersistenceDisposition,
 ) -> DeliveryPlanDisposition {
-    match disposition {
-        DeliveryPersistenceDisposition::Persisted => DeliveryPlanDisposition::Persisted,
-        DeliveryPersistenceDisposition::SqliteFailedRecovered => {
-            DeliveryPlanDisposition::SqliteFailedRecovered
-        }
-    }
+    let DeliveryPersistenceDisposition::Persisted = disposition;
+    DeliveryPlanDisposition::Persisted
 }
 
 pub(crate) fn delivery_target_for_snapshot(

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -520,39 +520,6 @@ pub(crate) fn persisted_success_transition_names(
     }
 }
 
-pub(crate) fn new_message_sqlite_failure_transitions(
-    harness: DeliveryHarnessPath,
-) -> &'static [&'static str] {
-    match harness {
-        DeliveryHarnessPath::ClaudeCode => &[
-            "delivery_policy.new_message.received",
-            "delivery_policy.new_message.harness_claude",
-            "delivery_policy.new_message.sqlite_failed",
-            "delivery_policy.new_message.compat_append_original",
-            "delivery_policy.new_message.compat_append_error",
-            "delivery_policy.new_message.primary_nudge",
-            "delivery_policy.new_message.error_nudge",
-            "delivery_policy.new_message.failed",
-        ],
-        DeliveryHarnessPath::NonClaude => &[
-            "delivery_policy.new_message.received",
-            "delivery_policy.new_message.harness_non_claude",
-            "delivery_policy.new_message.sqlite_failed",
-            "delivery_policy.new_message.non_claude_original",
-            "delivery_policy.new_message.non_claude_error",
-            "delivery_policy.new_message.primary_nudge",
-            "delivery_policy.new_message.error_nudge",
-            "delivery_policy.new_message.failed",
-        ],
-    }
-}
-
-pub(crate) fn sqlite_failure_transition_names(
-    harness: DeliveryHarnessPath,
-) -> &'static [&'static str] {
-    new_message_sqlite_failure_transitions(harness)
-}
-
 #[cfg(test)]
 pub(crate) fn claude_append_failure_transition_names() -> &'static [&'static str] {
     &[
@@ -625,9 +592,8 @@ mod tests {
         AckReplyStateMachine, DeliveryEventFamily, DeliveryHarnessPath, DeliveryPolicyCoordinator,
         DeliveryRecipientSnapshot, InboxRepairStateMachine, NewMessageCoordinatorState,
         RestoreInboxRebuildStateMachine, ack_reply_transitions, append_failure_transitions,
-        inbox_repair_transitions, new_message_sqlite_failure_transitions,
-        new_message_success_transitions, restore_inbox_rebuild_transitions,
-        thread_update_transitions,
+        inbox_repair_transitions, new_message_success_transitions,
+        restore_inbox_rebuild_transitions, thread_update_transitions,
     };
     use crate::error::AtmError;
     use crate::schema::ThreadMode;
@@ -765,36 +731,6 @@ mod tests {
             assert_eq!(snapshot.harness, DeliveryHarnessPath::NonClaude);
             assert!(snapshot.graft_post_send);
         }
-    }
-
-    #[test]
-    fn sqlite_failure_contract_includes_original_and_error_for_both_paths() {
-        assert_eq!(
-            new_message_sqlite_failure_transitions(DeliveryHarnessPath::ClaudeCode),
-            &[
-                "delivery_policy.new_message.received",
-                "delivery_policy.new_message.harness_claude",
-                "delivery_policy.new_message.sqlite_failed",
-                "delivery_policy.new_message.compat_append_original",
-                "delivery_policy.new_message.compat_append_error",
-                "delivery_policy.new_message.primary_nudge",
-                "delivery_policy.new_message.error_nudge",
-                "delivery_policy.new_message.failed",
-            ]
-        );
-        assert_eq!(
-            new_message_sqlite_failure_transitions(DeliveryHarnessPath::NonClaude),
-            &[
-                "delivery_policy.new_message.received",
-                "delivery_policy.new_message.harness_non_claude",
-                "delivery_policy.new_message.sqlite_failed",
-                "delivery_policy.new_message.non_claude_original",
-                "delivery_policy.new_message.non_claude_error",
-                "delivery_policy.new_message.primary_nudge",
-                "delivery_policy.new_message.error_nudge",
-                "delivery_policy.new_message.failed",
-            ]
-        );
     }
 
     #[test]

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
 use crate::ack::{AckOutcome, AckRequest};
+use crate::api::RequestDeadline;
 use crate::boundary::{
     BuiltInPostSendDispatch, GraftNudgeTarget, PostSendBuiltInTarget, PostSendEmissionPath,
     PostSendHookEvent,
@@ -58,6 +59,7 @@ const RECEIVER_HOOK_IO_DEADLINE: Duration = Duration::from_secs(3);
 pub(crate) fn deliver_published_receiver_hook<R>(
     runtime: &R,
     dispatch: &BuiltInPostSendDispatch,
+    deadline: RequestDeadline,
 ) -> Result<PostSendEmissionPath, AtmError>
 where
     R: RetainedServiceRuntime + ?Sized,
@@ -85,17 +87,71 @@ where
     })?;
     let endpoint_record_path =
         graft_receiver_record_path_from_root(root.as_path(), recipient_team, recipient);
-    match deliver_graft_post_send(
+    match deliver_graft_post_send_with_deadline(
         &endpoint_record_path,
         &GraftPostSendRequest {
             event: dispatch.event.clone(),
         },
-        RECEIVER_HOOK_CONNECT_DEADLINE,
-        RECEIVER_HOOK_IO_DEADLINE,
+        deadline,
     )? {
         GraftPostSendResponse::Delivered => Ok(PostSendEmissionPath::GraftPort),
         GraftPostSendResponse::Error(error) => Err(error),
     }
+}
+
+fn remaining_hook_budget(
+    deadline: RequestDeadline,
+    safety_cap: Duration,
+) -> Result<Duration, AtmError> {
+    deadline
+        .remaining()
+        .map(|remaining| remaining.min(safety_cap))
+        .ok_or_else(|| {
+            AtmError::new(
+                AtmErrorCode::PostSendGraftUnavailable,
+                "received-message hook request deadline expired before endpoint delivery began",
+            )
+        })
+}
+
+fn deliver_graft_post_send_with_deadline(
+    record_path: &Path,
+    request: &GraftPostSendRequest,
+    deadline: RequestDeadline,
+) -> Result<GraftPostSendResponse, AtmError> {
+    let record = read_receiver_record(record_path)?;
+    let endpoint = record.endpoint()?;
+    let connect_deadline = remaining_hook_budget(deadline, RECEIVER_HOOK_CONNECT_DEADLINE)?;
+    let mut stream = TcpStream::connect_timeout(&endpoint, connect_deadline).map_err(|source| {
+        AtmError::new(
+            AtmErrorCode::PostSendGraftUnavailable,
+            format!(
+                "failed to connect to graft receiver endpoint {} within {:?}",
+                endpoint, connect_deadline
+            ),
+        )
+        .with_cause(source)
+    })?;
+    let io_deadline = remaining_hook_budget(deadline, RECEIVER_HOOK_IO_DEADLINE)?;
+    apply_stream_deadlines(&stream, io_deadline)?;
+    let wire = GraftPostSendWireRequest {
+        capability_base64url: record.capability_base64url.clone(),
+        request: request.clone(),
+    };
+    write_graft_post_send_message(
+        &mut stream,
+        &wire,
+        "failed to write graft post-send request",
+        "graft post-send request exceeded the bounded payload cap",
+    )?;
+    stream.flush().map_err(|source| {
+        AtmError::daemon_unavailable("failed to flush graft post-send request").with_cause(source)
+    })?;
+    read_graft_post_send_message(
+        &mut stream,
+        "failed to read graft post-send response",
+        "graft post-send response exceeded the bounded payload cap",
+    )
 }
 
 /// Length-prefixed wire request carrying the caller's loopback capability.

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -95,16 +95,17 @@ pub use api::{
 pub use atm_storage::derive_ack_requirement;
 #[allow(deprecated)]
 pub use boundary::{
-    AckTransition, BuiltInNudgeSinkTarget, BuiltInNudgeTemplateKind, ConfigDoctor,
-    ConfigDoctorReport, ConfigIngress, ConfigLoadRequest, ConfigLoadResponse, DoctorFinding,
-    InternalNudgeEnvelope, LoadMailMessageStateRequest, LoadMailMessageStateResponse,
-    MailMessageState, MailStore, MailStoreDoctor, MailStoreDoctorReport, MailStoreHealthSnapshot,
-    MailStoreMailboxMetadataCounts, MailStoreMailboxMetadataRow, Message, MessageFingerprint,
-    MessageKey, MessageReceivedHookEmitter, NotificationEvent, NudgeTemplateOverrideStore,
-    PostSendHookEvent, ResolvedBuiltInNudgeTemplate, RosterEntry, RosterHarness, RosterMemberKind,
-    RosterStore, RosterStoreDoctor, RosterStoreDoctorReport, RosterStoreHealthSnapshot,
-    RuntimeStatusSnapshot, StatusSource, TaskState, TeamNudgeTemplateOverrideMode,
-    TeamNudgeTemplateOverrideRow, UpsertMailMessageStateRequest, UpsertMailMessageStateResponse,
+    AckTransition, AsyncMessageReceivedHookEmitter, BuiltInNudgeSinkTarget,
+    BuiltInNudgeTemplateKind, ConfigDoctor, ConfigDoctorReport, ConfigIngress, ConfigLoadRequest,
+    ConfigLoadResponse, DoctorFinding, InternalNudgeEnvelope, LoadMailMessageStateRequest,
+    LoadMailMessageStateResponse, MailMessageState, MailStore, MailStoreDoctor,
+    MailStoreDoctorReport, MailStoreHealthSnapshot, MailStoreMailboxMetadataCounts,
+    MailStoreMailboxMetadataRow, Message, MessageFingerprint, MessageKey,
+    MessageReceivedHookEmitter, NotificationEvent, NudgeTemplateOverrideStore, PostSendHookEvent,
+    ResolvedBuiltInNudgeTemplate, RosterEntry, RosterHarness, RosterMemberKind, RosterStore,
+    RosterStoreDoctor, RosterStoreDoctorReport, RosterStoreHealthSnapshot, RuntimeStatusSnapshot,
+    StatusSource, TaskState, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
+    UpsertMailMessageStateRequest, UpsertMailMessageStateResponse,
 };
 pub use config::AtmConfig;
 pub use config::load_config as load_atm_config;

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -92,6 +92,7 @@ pub(crate) struct AckIntentFields {
 }
 
 impl AckIntentFields {
+    #[cfg(test)]
     pub(crate) const fn not_required() -> Self {
         Self {
             requires_ack: false,

--- a/crates/atm-core/src/send/delivery_persistence.rs
+++ b/crates/atm-core/src/send/delivery_persistence.rs
@@ -5,7 +5,6 @@ use super::WarningEntry;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DeliveryPersistenceDisposition {
     Persisted,
-    SqliteFailedRecovered,
 }
 
 /// Transient classification of one immutable-ULID storage attempt. This is
@@ -26,7 +25,6 @@ pub(crate) struct DeliveryPersistenceResult {
     /// daemon-owned post-write action.
     pub(crate) newly_persisted: bool,
     pub(crate) original_message: InboxMessage,
-    pub(crate) companion_message: Option<InboxMessage>,
     pub(crate) warnings: Vec<WarningEntry>,
 }
 
@@ -37,7 +35,6 @@ impl DeliveryPersistenceResult {
             duplicate_disposition: DuplicateWriteDisposition::NotDuplicate,
             newly_persisted: true,
             original_message,
-            companion_message: None,
             warnings: Vec::new(),
         }
     }
@@ -48,7 +45,6 @@ impl DeliveryPersistenceResult {
             duplicate_disposition: DuplicateWriteDisposition::AlreadyDeliveredRemote,
             newly_persisted: false,
             original_message,
-            companion_message: None,
             warnings: Vec::new(),
         }
     }
@@ -59,23 +55,7 @@ impl DeliveryPersistenceResult {
             duplicate_disposition: DuplicateWriteDisposition::SameStorePeerReceipt,
             newly_persisted: false,
             original_message,
-            companion_message: None,
             warnings: Vec::new(),
-        }
-    }
-
-    pub(crate) fn sqlite_failed_recovered(
-        original_message: InboxMessage,
-        companion_message: InboxMessage,
-        warning: WarningEntry,
-    ) -> Self {
-        Self {
-            disposition: DeliveryPersistenceDisposition::SqliteFailedRecovered,
-            duplicate_disposition: DuplicateWriteDisposition::NotDuplicate,
-            newly_persisted: true,
-            original_message,
-            companion_message: Some(companion_message),
-            warnings: vec![warning],
         }
     }
 

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -65,6 +65,10 @@ impl HookCancellationToken {
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the retained core hook boundary preserves its compatibility call shape while Phase AM deletes its legacy callers"
+)]
 pub(crate) fn emit_post_send_effects<R>(
     runtime: &R,
     warnings: &mut Vec<WarningEntry>,
@@ -229,7 +233,7 @@ fn run_post_send_hooks_for_cli(
     .expect("validated hook execution summary")
 }
 
-fn build_built_in_dispatch<R>(
+pub(crate) fn build_built_in_dispatch<R>(
     runtime: &R,
     delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
     event: &PostSendHookEvent,
@@ -637,7 +641,7 @@ fn notification_event(event: &PostSendHookEvent) -> NotificationEvent {
     }
 }
 
-fn post_send_event_from_message(
+pub(crate) fn post_send_event_from_message(
     recipient: &ResolvedRecipient,
     message: &crate::delivery_plan::LogicalMessage,
     recipient_pane_id: Option<&crate::types::PaneId>,

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -15,6 +15,7 @@ use tracing::Level;
 use tracing::{debug, error, info, warn};
 
 use super::{POST_SEND_HOOK_TIMEOUT, ResolvedRecipient, WarningEntry, nudge_template};
+use crate::api::RequestDeadline;
 use crate::boundary::{
     BuiltInPostSendDispatch, GraftNudgeTarget, HookExecutionSummary, LocalTmuxNudgeTarget,
     MessageReceivedHookEmitter, PostSendBuiltInTarget, PostSendEmissionOutcome,
@@ -67,6 +68,7 @@ impl HookCancellationToken {
 pub(crate) fn emit_post_send_effects<R>(
     runtime: &R,
     warnings: &mut Vec<WarningEntry>,
+    deadline: RequestDeadline,
     config: Option<&AtmConfig>,
     post_send_emitter: Option<&dyn MessageReceivedHookEmitter>,
     recipient: &ResolvedRecipient,
@@ -84,6 +86,7 @@ pub(crate) fn emit_post_send_effects<R>(
         let outcome = emit_post_send_outcome(
             runtime,
             warnings,
+            deadline,
             config,
             post_send_emitter,
             delivery_snapshot,
@@ -107,6 +110,7 @@ pub(crate) fn emit_post_send_effects<R>(
 fn emit_post_send_outcome<R>(
     runtime: &R,
     warnings: &mut Vec<WarningEntry>,
+    deadline: RequestDeadline,
     config: Option<&AtmConfig>,
     post_send_emitter: Option<&dyn MessageReceivedHookEmitter>,
     delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
@@ -147,9 +151,9 @@ where
         return PostSendEmissionOutcome::NoCapability { hook_summary };
     };
     let emitted = if let Some(message_received_emitter) = post_send_emitter {
-        message_received_emitter.emit_post_send(&dispatch)
+        message_received_emitter.emit_received_message(&dispatch, deadline)
     } else if matches!(&dispatch.target, PostSendBuiltInTarget::Graft(_)) {
-        crate::graft::deliver_published_receiver_hook(runtime, &dispatch)
+        crate::graft::deliver_published_receiver_hook(runtime, &dispatch, deadline)
     } else {
         return PostSendEmissionOutcome::NoCapability { hook_summary };
     };
@@ -895,6 +899,7 @@ fn hook_result_log_level(level: PostSendHookResultLevel) -> Level {
 mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use serde_json::{Map, json};
     use tempfile::tempdir;
@@ -906,6 +911,7 @@ mod tests {
         hook_matches_recipient, hook_result_log_level, load_post_send_config_for_sender,
         parse_post_send_hook_result, post_send_event_from_message, sender_config_root,
     };
+    use crate::api::RequestDeadline;
     use crate::boundary::{
         BuiltInNudgeTemplateKind, GraftNudgeTarget, PostSendBuiltInTarget, RosterEntry,
         RosterHarness, RosterMemberKind, TeamNudgeTemplateOverrideMode,
@@ -1294,6 +1300,7 @@ mod tests {
         emit_post_send_effects(
             &runtime,
             &mut warnings,
+            RequestDeadline::after(Duration::from_secs(1)),
             None,
             Some(&emitter),
             &recipient,
@@ -1388,6 +1395,7 @@ mod tests {
         emit_post_send_effects(
             &runtime,
             &mut warnings,
+            RequestDeadline::after(Duration::from_secs(1)),
             Some(&config),
             Some(&emitter),
             &recipient,
@@ -1482,6 +1490,7 @@ mod tests {
         emit_post_send_effects(
             &runtime,
             &mut warnings,
+            RequestDeadline::after(Duration::from_secs(1)),
             Some(&config),
             Some(&emitter),
             &recipient,
@@ -1531,6 +1540,7 @@ mod tests {
         emit_post_send_effects(
             &runtime,
             &mut warnings,
+            RequestDeadline::after(Duration::from_secs(1)),
             None,
             Some(&emitter),
             &recipient,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -60,7 +60,10 @@ pub use nudge_template::{
 };
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
-pub use post_write::{emit_persisted_local_post_write, emit_received_message_after_commit};
+pub use post_write::{
+    build_received_message_hook_dispatches_after_commit, emit_persisted_local_post_write,
+    emit_received_message_after_commit,
+};
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 use request::{prepare_threaded_message, resolve_message_body};
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -345,9 +345,23 @@ impl PreparedWrite {
         }
     }
 
+    /// Whether this canonical write produced a new durable record that must
+    /// enter the receiver-side post-persistence route.
+    ///
+    /// Idempotent duplicate delivery deliberately returns `false`: the
+    /// already-recorded immutable message remains the successful result, but
+    /// it must not emit a second received-message hook.
+    #[must_use]
+    pub fn is_newly_persisted(&self) -> bool {
+        !self.outcome.dry_run && self.post_write_needed
+    }
+
+    /// Backwards-compatible name for the generic post-write routing decision.
+    /// New daemon receiver code must use [`Self::is_newly_persisted`] so the
+    /// duplicate-suppression invariant is explicit at the hook call site.
     #[must_use]
     pub fn requires_post_write_route(&self) -> bool {
-        !self.outcome.dry_run && self.post_write_needed
+        self.is_newly_persisted()
     }
 
     /// Whether this write reused an existing immutable record after an

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -356,14 +356,6 @@ impl PreparedWrite {
         !self.outcome.dry_run && self.post_write_needed
     }
 
-    /// Backwards-compatible name for the generic post-write routing decision.
-    /// New daemon receiver code must use [`Self::is_newly_persisted`] so the
-    /// duplicate-suppression invariant is explicit at the hook call site.
-    #[must_use]
-    pub fn requires_post_write_route(&self) -> bool {
-        self.is_newly_persisted()
-    }
-
     /// Whether this write reused an existing immutable record after an
     /// authenticated receipt returned to the same store. This is an
     /// idempotent receiver-side duplicate: the explicit disposition is
@@ -770,7 +762,7 @@ fn send_mail_with_runtime_impl<
     post_send_emitter: Option<&dyn MessageReceivedHookEmitter>,
 ) -> Result<SendOutcome, AtmError> {
     let mut prepared = write_mail_with_runtime_impl(request, observability, runtime)?;
-    if prepared.requires_post_write_route()
+    if prepared.is_newly_persisted()
         && let Some(post_send_emitter) = post_send_emitter
     {
         // Test-only harness: production notification is owned by

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -60,7 +60,7 @@ pub use nudge_template::{
 };
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
-pub use post_write::emit_persisted_local_post_write;
+pub use post_write::{emit_persisted_local_post_write, emit_received_message_after_commit};
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 use request::{prepare_threaded_message, resolve_message_body};
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -310,6 +310,7 @@ impl PreparedWrite {
         hook::emit_post_send_effects(
             runtime,
             &mut self.outcome.warnings,
+            crate::api::RequestDeadline::after(POST_SEND_HOOK_TIMEOUT),
             self.post_write.post_send_config.as_ref(),
             Some(post_send_emitter),
             &self.post_write.recipient,

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -1,22 +1,16 @@
 use std::path::Path;
 
-use serde_json::Map;
 use tracing::{error, info};
 
 use crate::boundary;
 use crate::delivery_policy::DeliveryRecipientSnapshot;
 use crate::error::AtmError;
-use crate::schema::{
-    AckIntentFields, AtmMessageId, InboxMessage, clear_transport_delivery_metadata,
-    peer_outbound_host,
-};
+use crate::schema::{InboxMessage, clear_transport_delivery_metadata, peer_outbound_host};
 use crate::service_runtime::RetainedServiceRuntime;
 use crate::service_runtime_store::RetainedMailboxRuntime;
-use crate::types::{AgentName, HostName, IsoTimestamp, TeamName};
+use crate::types::{AgentName, HostName, TeamName};
 
-use super::{
-    DeliveryPersistenceResult, DuplicateWriteDisposition, WarningEntry, prepare_threaded_message,
-};
+use super::{DeliveryPersistenceResult, DuplicateWriteDisposition, prepare_threaded_message};
 
 #[cfg(test)]
 pub(crate) fn persist_message(
@@ -87,79 +81,7 @@ pub(crate) fn persist_message_with_ack_update(
         Ok(DuplicateWriteDisposition::SameStorePeerReceipt) => {
             Ok(DeliveryPersistenceResult::same_store_peer_receipt(prepared))
         }
-        Err(error) if error.code() == crate::error_codes::AtmErrorCode::MailboxWriteFailed => {
-            recover_after_sqlite_failure(runtime, recipient, inbox_path, &prepared, &error)
-        }
         Err(error) => Err(error),
-    }
-}
-
-fn recover_after_sqlite_failure(
-    _runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
-    recipient: &DeliveryRecipientSnapshot,
-    _inbox_path: &Path,
-    original_message: &InboxMessage,
-    sqlite_error: &AtmError,
-) -> Result<DeliveryPersistenceResult, AtmError> {
-    let companion = build_sqlite_failure_companion_message(
-        &recipient.team,
-        &recipient.agent,
-        original_message,
-        sqlite_error,
-    );
-    let warning = WarningEntry::with_code(
-        sqlite_error.code(),
-        format!(
-            "error: SQLite persistence failed for delivery to {}@{}: {}.",
-            recipient.agent, recipient.team, sqlite_error
-        ),
-        Some(
-            "ATM emitted a degraded fallback delivery plus an atm-system companion error. Investigate and repair the SQLite runtime immediately.",
-        ),
-    );
-    Ok(DeliveryPersistenceResult::sqlite_failed_recovered(
-        original_message.clone(),
-        companion,
-        warning,
-    ))
-}
-
-fn build_sqlite_failure_companion_message(
-    team: &TeamName,
-    agent: &AgentName,
-    original_message: &InboxMessage,
-    sqlite_error: &AtmError,
-) -> InboxMessage {
-    let original_message_id = original_message
-        .message_id
-        .map(|message_id| message_id.to_string())
-        .unwrap_or_else(|| "unknown-message-id".to_string());
-    let ack_intent = AckIntentFields::not_required();
-    InboxMessage {
-        from: AgentName::from_validated("atm-system"),
-        source_chat_id: None,
-        text: format!(
-            "ATM error: SQLite persistence failed while delivering message {} to {}@{}: {}. The original message was emitted through the degraded outward path only and the retained SQLite state must be repaired immediately.",
-            original_message_id, agent, team, sqlite_error
-        ),
-        timestamp: IsoTimestamp::now(),
-        read: false,
-        source_team: Some(team.clone()),
-        destination_chat_id: None,
-        summary: Some(format!(
-            "ATM error: SQLite persistence failed for {}@{}",
-            agent, team
-        )),
-        message_id: Some(AtmMessageId::new()),
-        requires_ack: ack_intent.requires_ack,
-        pending_ack_at: ack_intent.pending_ack_at,
-        acknowledged_at: ack_intent.acknowledged_at,
-        acknowledges_message_id: None,
-        parent_message_id: None,
-        thread_mode: None,
-        expires_at: None,
-        task_id: original_message.task_id.clone(),
-        extra: Map::new(),
     }
 }
 

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -90,3 +90,69 @@ pub fn emit_persisted_local_post_write(
     );
     Ok(warnings)
 }
+
+/// Emits only the receiver-side hook for one already committed message.
+///
+/// This is the replacement-runtime post-commit operation. It deliberately
+/// does not execute sender-side delivery, peer delivery, retry, or replay
+/// work: the receiving HTTP path has one responsibility after a durable
+/// commit—notify the local receiver through its injected hook boundary.
+///
+/// # Errors
+///
+/// Returns an error only when the already committed record or recipient
+/// configuration cannot be loaded to construct the advisory hook invocation.
+/// Callers must retain the durable write result and translate such an error to
+/// a warning rather than redefining the write as failed.
+pub fn emit_received_message_after_commit(
+    runtime: &LocalServiceRuntime,
+    home_dir: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+    message_id: AtmMessageId,
+    deadline: RequestDeadline,
+    message_received_emitter: Option<&dyn MessageReceivedHookEmitter>,
+) -> Result<Vec<WarningEntry>, AtmError> {
+    let key = crate::boundary::MessageKey::from(message_id);
+    let Some(record) = runtime.load_message_record(home_dir, team, agent, &key)? else {
+        return Ok(Vec::new());
+    };
+    let recipient = ResolvedRecipient {
+        agent: agent.clone(),
+        team: team.clone(),
+    };
+    let delivery_snapshot =
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(runtime, team, agent)?;
+    let context = SendExecutionContext {
+        #[cfg(test)]
+        post_send_config: None,
+        recipient: recipient.clone(),
+        canonical_sender: record.envelope.from.clone(),
+        inbox_path: runtime.inbox_path(home_dir, team, agent)?,
+        delivery_snapshot,
+        delivery_family: DeliveryPolicyCoordinator::resolve_send_family(
+            record.envelope.parent_message_id,
+            record.envelope.thread_mode,
+        ),
+        warnings: Vec::new(),
+    };
+    let persistence = DeliveryPersistenceResult::persisted(record.envelope.clone());
+    let plan = build_send_delivery_plan(
+        &context,
+        record.envelope.requires_ack,
+        record.envelope.acknowledges_message_id.is_some(),
+        &persistence,
+    )?;
+    let mut warnings = Vec::new();
+    hook::emit_post_send_effects(
+        runtime,
+        &mut warnings,
+        deadline,
+        None,
+        message_received_emitter,
+        &recipient,
+        &context.delivery_snapshot,
+        &plan.messages,
+    );
+    Ok(warnings)
+}

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::api::RequestDeadline;
 use crate::boundary::MessageReceivedHookEmitter;
 use crate::delivery_execution::{
     DeliveryTransitionContext, emit_delivery_plan_transitions, execute_delivery_plan,
@@ -29,6 +30,7 @@ pub fn emit_persisted_local_post_write(
     team: &TeamName,
     agent: &AgentName,
     message_id: AtmMessageId,
+    deadline: RequestDeadline,
     message_received_emitter: Option<&dyn MessageReceivedHookEmitter>,
 ) -> Result<Vec<WarningEntry>, AtmError> {
     let key = crate::boundary::MessageKey::from(message_id);
@@ -79,6 +81,7 @@ pub fn emit_persisted_local_post_write(
     hook::emit_post_send_effects(
         runtime,
         &mut warnings,
+        deadline,
         None,
         message_received_emitter,
         &recipient,

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::api::RequestDeadline;
-use crate::boundary::MessageReceivedHookEmitter;
+use crate::boundary::{BuiltInPostSendDispatch, MessageReceivedHookEmitter};
 use crate::delivery_execution::{
     DeliveryTransitionContext, emit_delivery_plan_transitions, execute_delivery_plan,
 };
@@ -23,6 +23,10 @@ use super::{
 /// The daemon calls this after persistence and before serializing the
 /// successful receive response. Hook failures are returned as warnings and do
 /// not invalidate the durable write.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "legacy daemon compatibility API remains frozen until Phase AM removes its only caller"
+)]
 pub fn emit_persisted_local_post_write(
     runtime: &LocalServiceRuntime,
     observability: &dyn ObservabilityPort,
@@ -155,4 +159,61 @@ pub fn emit_received_message_after_commit(
         &plan.messages,
     );
     Ok(warnings)
+}
+
+/// Builds the injected receiver-hook dispatches for one committed message.
+///
+/// This is the replacement-runtime planning seam: it reads only durable core
+/// state and returns no task, thread, or hook side effect. The Tokio runtime
+/// owns awaiting the injected asynchronous emitter and applies the inherited
+/// request deadline there.
+pub fn build_received_message_hook_dispatches_after_commit(
+    runtime: &LocalServiceRuntime,
+    home_dir: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+    message_id: AtmMessageId,
+) -> Result<Vec<BuiltInPostSendDispatch>, AtmError> {
+    let key = crate::boundary::MessageKey::from(message_id);
+    let Some(record) = runtime.load_message_record(home_dir, team, agent, &key)? else {
+        return Ok(Vec::new());
+    };
+    let recipient = ResolvedRecipient {
+        agent: agent.clone(),
+        team: team.clone(),
+    };
+    let delivery_snapshot =
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(runtime, team, agent)?;
+    let context = SendExecutionContext {
+        #[cfg(test)]
+        post_send_config: None,
+        recipient: recipient.clone(),
+        canonical_sender: record.envelope.from.clone(),
+        inbox_path: runtime.inbox_path(home_dir, team, agent)?,
+        delivery_snapshot,
+        delivery_family: DeliveryPolicyCoordinator::resolve_send_family(
+            record.envelope.parent_message_id,
+            record.envelope.thread_mode,
+        ),
+        warnings: Vec::new(),
+    };
+    let persistence = DeliveryPersistenceResult::persisted(record.envelope.clone());
+    let plan = build_send_delivery_plan(
+        &context,
+        record.envelope.requires_ack,
+        record.envelope.acknowledges_message_id.is_some(),
+        &persistence,
+    )?;
+    Ok(plan
+        .messages
+        .iter()
+        .filter_map(|message| {
+            let event = hook::post_send_event_from_message(
+                &recipient,
+                message,
+                context.delivery_snapshot.recipient_pane_id.as_ref(),
+            );
+            hook::build_built_in_dispatch(runtime, &context.delivery_snapshot, &event)
+        })
+        .collect())
 }

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -13,14 +13,15 @@ use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::types::{AgentName, TeamName};
 
 use super::{
-    DeliveryPersistenceResult, ResolvedRecipient, SendExecutionContext, build_send_delivery_plan,
-    hook,
+    DeliveryPersistenceResult, ResolvedRecipient, SendExecutionContext, WarningEntry,
+    build_send_delivery_plan, hook,
 };
 
 /// Executes local post-write effects from a committed immutable record.
 ///
-/// The daemon calls this only from its post-commit worker. Admission never
-/// waits for hook, tmux, or graft I/O.
+/// The daemon calls this after persistence and before serializing the
+/// successful receive response. Hook failures are returned as warnings and do
+/// not invalidate the durable write.
 pub fn emit_persisted_local_post_write(
     runtime: &LocalServiceRuntime,
     observability: &dyn ObservabilityPort,
@@ -29,10 +30,10 @@ pub fn emit_persisted_local_post_write(
     agent: &AgentName,
     message_id: AtmMessageId,
     message_received_emitter: Option<&dyn MessageReceivedHookEmitter>,
-) -> Result<(), AtmError> {
+) -> Result<Vec<WarningEntry>, AtmError> {
     let key = crate::boundary::MessageKey::from(message_id);
     let Some(record) = runtime.load_message_record(home_dir, team, agent, &key)? else {
-        return Ok(());
+        return Ok(Vec::new());
     };
     let recipient = ResolvedRecipient {
         agent: agent.clone(),
@@ -84,13 +85,5 @@ pub fn emit_persisted_local_post_write(
         &context.delivery_snapshot,
         &plan.messages,
     );
-    for warning in warnings {
-        tracing::warn!(
-            code = ?warning.code,
-            message_id = %message_id,
-            "post-commit local post-write effect completed with warning: {}",
-            warning.message
-        );
-    }
-    Ok(())
+    Ok(warnings)
 }

--- a/crates/atm-core/src/send/post_write_tests.rs
+++ b/crates/atm-core/src/send/post_write_tests.rs
@@ -203,7 +203,7 @@ fn same_host_peer_duplicate_does_not_route_a_second_received_hook() {
     let prepared = write_mail_with_runtime_impl(receipt, &observability, &runtime)
         .expect("same-host receipt is an idempotent write");
 
-    assert!(!prepared.requires_post_write_route());
+    assert!(!prepared.is_newly_persisted());
     assert!(emitter.emitted().is_empty());
 }
 
@@ -274,7 +274,7 @@ fn duplicate_ulid_ignores_transport_only_peer_metadata() {
     let prepared = write_mail_with_runtime_impl(receipt, &observability, &runtime)
         .expect("transport-only peer metadata must not conflict");
 
-    assert!(!prepared.requires_post_write_route());
+    assert!(!prepared.is_newly_persisted());
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn authenticated_peer_ack_message_uses_the_shared_write_pipeline() {
     let prepared = write_mail_with_runtime_impl(request, &observability, &runtime)
         .expect("authenticated peer acknowledgement is a canonical write, not a local command");
 
-    assert!(prepared.requires_post_write_route());
+    assert!(prepared.is_newly_persisted());
 }
 
 #[test]

--- a/crates/atm-core/src/send/post_write_tests.rs
+++ b/crates/atm-core/src/send/post_write_tests.rs
@@ -123,7 +123,7 @@ fn same_store_peer_receipt_skips_the_duplicate_row_and_received_hook() {
 }
 
 #[test]
-fn canonical_writer_persists_before_router_owned_local_nudge() {
+fn canonical_writer_persists_before_router_owned_received_hook() {
     let tempdir = tempdir().expect("tempdir");
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
     let observability = RecordingObservability::default();
@@ -143,11 +143,11 @@ fn canonical_writer_persists_before_router_owned_local_nudge() {
             .expect("persisted records lock")
             .len(),
         1,
-        "the durable message must exist before the router emits a nudge"
+        "the durable message must exist before the router invokes the received hook"
     );
     assert!(
         emitter.emitted().is_empty(),
-        "the canonical writer must not emit a nudge before PostWriteRouter"
+        "the canonical writer must not invoke the received hook before PostWriteRouter"
     );
     assert!(
         runtime
@@ -162,7 +162,7 @@ fn canonical_writer_persists_before_router_owned_local_nudge() {
     assert_eq!(
         emitter.emitted().len(),
         1,
-        "the router emits one local nudge"
+        "the router invokes the receiver hook exactly once"
     );
     assert!(matches!(
         prepared
@@ -173,7 +173,7 @@ fn canonical_writer_persists_before_router_owned_local_nudge() {
 }
 
 #[test]
-fn same_host_peer_duplicate_does_not_route_a_second_local_nudge() {
+fn same_host_peer_duplicate_does_not_route_a_second_received_hook() {
     let tempdir = tempdir().expect("tempdir");
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
     let observability = RecordingObservability::default();

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -525,6 +525,14 @@ fn sqlite_failure_is_an_error_without_a_degraded_delivery() {
                 .is_empty(),
             "a failed database write must not emit a fallback payload"
         );
+        assert!(
+            runtime
+                .persisted_records
+                .lock()
+                .expect("persisted records lock")
+                .is_empty(),
+            "a failed database write must not leave a durable record"
+        );
     }
 }
 
@@ -689,6 +697,14 @@ fn send_sqlite_failure_is_an_error_without_outbound_delivery_or_hook() {
             .is_empty()
     );
     assert!(post_send_emitter.emitted().is_empty());
+    assert!(
+        runtime
+            .persisted_records
+            .lock()
+            .expect("persisted records lock")
+            .is_empty(),
+        "a failed SQLite admission must not leave a persisted record"
+    );
 }
 
 #[test]

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -168,9 +168,10 @@ impl crate::boundary::sealed::Sealed for TestRuntime {}
 impl crate::boundary::sealed::Sealed for RecordingPostSendEmitter {}
 
 impl MessageReceivedHookEmitter for RecordingPostSendEmitter {
-    fn emit_post_send(
+    fn emit_received_message(
         &self,
         dispatch: &BuiltInPostSendDispatch,
+        _deadline: crate::api::RequestDeadline,
     ) -> Result<PostSendEmissionPath, AtmError> {
         self.emitted
             .lock()

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -9,13 +9,13 @@ use serde_json::{Map, Value};
 use tempfile::tempdir;
 
 use super::{
-    DeliveryPersistenceDisposition, ResolvedRecipient, SendExecutionContext, WarningEntry,
-    build_send_delivery_plan, persist_message, prepare_threaded_message,
+    ResolvedRecipient, SendExecutionContext, WarningEntry, build_send_delivery_plan,
+    persist_message, prepare_threaded_message,
 };
 use crate::boundary::{
-    BuiltInPostSendDispatch, GraftNudgeTarget, MailMessageState, MailStoreMailboxMetadataRow,
-    Message, MessageKey, MessageReceivedHookEmitter, NonClaudeOutboundDeliveryRequest,
-    PostSendBuiltInTarget, PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind,
+    BuiltInPostSendDispatch, MailMessageState, MailStoreMailboxMetadataRow, Message, MessageKey,
+    MessageReceivedHookEmitter, NonClaudeOutboundDeliveryRequest, PostSendBuiltInTarget,
+    PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind,
 };
 use crate::config::AtmConfig;
 use crate::delivery_execution::{DeliveryExecutionDisposition, execute_delivery_plan};
@@ -86,22 +86,6 @@ pub(super) fn install_home_env(home_dir: &Path) -> EnvGuard {
         ("USERPROFILE", None),
         ("ATM_LOG_DIR", None),
     ])
-}
-
-fn assert_recovered_payload_texts(
-    original: &InboxMessage,
-    companion: &InboxMessage,
-    expected_original: &str,
-) {
-    assert_eq!(original.text, expected_original);
-    assert_eq!(companion.from.as_str(), "atm-system");
-    assert!(
-        companion
-            .text
-            .contains("ATM error: SQLite persistence failed"),
-        "expected sqlite failure companion message, got: {}",
-        companion.text
-    );
 }
 
 #[test]
@@ -511,34 +495,36 @@ impl ObservabilityPort for RecordingObservability {
 }
 
 #[test]
-fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
-    let outbound = outbound_message();
-    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::ClaudeCode);
-    let tempdir = tempdir().expect("tempdir");
-    let inbox_path = tempdir.path().join("recipient.jsonl");
+fn sqlite_failure_is_an_error_without_a_degraded_delivery() {
+    for harness in [
+        DeliveryHarnessPath::ClaudeCode,
+        DeliveryHarnessPath::NonClaude,
+    ] {
+        let runtime = TestRuntime::new(Some("sqlite write failed"), harness);
+        let tempdir = tempdir().expect("tempdir");
+        let inbox_path = tempdir.path().join("recipient.jsonl");
 
-    let result = persist_message(
-        &runtime,
-        tempdir.path(),
-        &delivery_snapshot(DeliveryHarnessPath::ClaudeCode),
-        &inbox_path,
-        &outbound,
-        false,
-        None,
-    )
-    .expect("sqlite fallback recovery");
+        let error = persist_message(
+            &runtime,
+            tempdir.path(),
+            &delivery_snapshot(harness),
+            &inbox_path,
+            &outbound_message(),
+            false,
+            None,
+        )
+        .expect_err("a failed SQLite write must not become a recovered delivery");
 
-    assert_eq!(
-        result.disposition,
-        DeliveryPersistenceDisposition::SqliteFailedRecovered
-    );
-    assert_eq!(result.warnings.len(), 1);
-    assert_eq!(result.original_message.from.as_str(), TEST_SENDER);
-    assert_recovered_payload_texts(
-        &result.original_message,
-        result.companion_message.as_ref().expect("companion"),
-        &outbound.text,
-    );
+        assert_eq!(error.code(), AtmErrorCode::MailboxWriteFailed);
+        assert!(
+            runtime
+                .non_claude_deliveries
+                .lock()
+                .expect("non-claude deliveries lock")
+                .is_empty(),
+            "a failed database write must not emit a fallback payload"
+        );
+    }
 }
 
 #[test]
@@ -562,36 +548,6 @@ fn ordinary_persist_skips_the_unneeded_mailbox_projection() {
         runtime.mailbox_metadata_queries.load(Ordering::Relaxed),
         0,
         "a non-threaded immutable message has no mailbox thread state to read"
-    );
-}
-
-#[test]
-fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
-    let outbound = outbound_message();
-    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::NonClaude);
-    let tempdir = tempdir().expect("tempdir");
-    let inbox_path = tempdir.path().join("recipient.jsonl");
-
-    let result = persist_message(
-        &runtime,
-        tempdir.path(),
-        &delivery_snapshot(DeliveryHarnessPath::NonClaude),
-        &inbox_path,
-        &outbound,
-        false,
-        None,
-    )
-    .expect("sqlite fallback recovery");
-
-    assert_eq!(
-        result.disposition,
-        DeliveryPersistenceDisposition::SqliteFailedRecovered
-    );
-    assert_eq!(result.original_message.from.as_str(), TEST_SENDER);
-    assert_recovered_payload_texts(
-        &result.original_message,
-        result.companion_message.as_ref().expect("companion"),
-        &outbound.text,
     );
 }
 
@@ -702,171 +658,36 @@ fn claude_harness_delivery_no_longer_has_append_degradation_path() {
     assert!(execution.warnings.is_empty());
 }
 
-#[test]
-fn named_plan_builder_proves_payload_equality_across_harnesses() {
-    let tempdir = tempdir().expect("tempdir");
-    let original = outbound_message();
-    let ack_intent = AckIntentFields::not_required();
-    let companion = InboxMessage {
-        from: AgentName::from_validated("atm-system"),
-        source_chat_id: None,
-        text: "sqlite failed".to_string(),
-        timestamp: IsoTimestamp::now(),
-        read: false,
-        source_team: Some(TeamName::from_validated(TEST_TEAM)),
-        destination_chat_id: None,
-        summary: Some("sqlite failed".to_string()),
-        message_id: Some(AtmMessageId::new()),
-        requires_ack: ack_intent.requires_ack,
-        pending_ack_at: ack_intent.pending_ack_at,
-        acknowledged_at: ack_intent.acknowledged_at,
-        acknowledges_message_id: None,
-        parent_message_id: None,
-        thread_mode: None,
-        expires_at: None,
-        task_id: original.task_id.clone(),
-        extra: Map::new(),
-    };
-    let persistence = crate::send::DeliveryPersistenceResult::sqlite_failed_recovered(
-        original.clone(),
-        companion.clone(),
-        WarningEntry::new("sqlite failed", Some("repair sqlite")),
-    );
-    let base_context = SendExecutionContext {
-        post_send_config: None,
-        recipient: ResolvedRecipient {
-            agent: AgentName::from_validated("recipient"),
-            team: TeamName::from_validated(TEST_TEAM),
-        },
-        canonical_sender: AgentName::from_validated(TEST_SENDER),
-        inbox_path: tempdir.path().join("recipient.jsonl"),
-        delivery_snapshot: delivery_snapshot(DeliveryHarnessPath::ClaudeCode),
-        delivery_family: DeliveryEventFamily::NewMessage,
-        warnings: Vec::new(),
-    };
-    let claude_plan =
-        build_send_delivery_plan(&base_context, false, false, &persistence).expect("claude plan");
-    let non_claude_context = SendExecutionContext {
-        delivery_snapshot: delivery_snapshot(DeliveryHarnessPath::NonClaude),
-        ..base_context
-    };
-    let non_claude_plan = build_send_delivery_plan(&non_claude_context, false, false, &persistence)
-        .expect("non-claude plan");
-
-    assert_eq!(claude_plan.messages, non_claude_plan.messages);
-    assert!(matches!(
-        claude_plan.delivery_target,
-        crate::delivery_plan::DeliveryTarget::NonClaude { .. }
-    ));
-    assert!(matches!(
-        non_claude_plan.delivery_target,
-        crate::delivery_plan::DeliveryTarget::NonClaude { .. }
-    ));
-}
-
-#[test]
-#[serial_test::serial(env)]
-fn recovered_claude_harness_sqlite_failure_routes_via_non_claude_outbound() {
-    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::ClaudeCode);
-    let observability = RecordingObservability::default();
-    let tempdir = tempdir().expect("tempdir");
-    let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
-
-    let outcome = super::send_mail_with_runtime_impl(
-        send_request(tempdir.path()),
-        &observability,
-        &runtime,
-        None,
-    )
-    .expect("send outcome");
-
-    assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
-    assert_eq!(outcome.warnings.len(), 1);
-    assert_non_claude_sqlite_failure_delivery(&runtime);
-    assert_notification_log_absent(&home_dir);
-    assert_non_claude_sqlite_failure_observability(&observability);
-}
-
-fn assert_non_claude_sqlite_failure_delivery(runtime: &TestRuntime) {
-    assert!(
-        runtime
-            .appended_messages
-            .lock()
-            .expect("append lock")
-            .is_empty()
-    );
-    let deliveries = runtime
-        .non_claude_deliveries
-        .lock()
-        .expect("non-claude deliveries lock");
-    assert_eq!(deliveries.len(), 1);
-    assert_eq!(deliveries[0].team.as_str(), TEST_TEAM);
-    assert_eq!(deliveries[0].agent.as_str(), "recipient");
-    assert_eq!(deliveries[0].messages.len(), 2);
-    assert_recovered_payload_texts(
-        &deliveries[0].messages[0],
-        &deliveries[0].messages[1],
-        "hello",
-    );
-}
-
 fn assert_notification_log_absent(_home_dir: &Path) {
     // The host-owned notification stream is shared by the sole daemon and may
     // contain events from another command; the recording emitter proves this
     // path itself did not emit one.
 }
 
-fn assert_non_claude_sqlite_failure_observability(observability: &RecordingObservability) {
-    let observability_events = observability.events.lock().expect("events lock");
-    assert!(observability_events.iter().any(|event| {
-        event.command == "delivery_policy"
-            && event.outcome.as_str() == "delivery_policy.new_message.non_claude_original"
-    }));
-    assert!(observability_events.iter().any(|event| {
-        event.command == "delivery_policy"
-            && event.outcome.as_str() == "delivery_policy.new_message.non_claude_error"
-    }));
-}
-
 #[test]
-#[serial_test::serial(env)]
-fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_boundary() {
+fn send_sqlite_failure_is_an_error_without_outbound_delivery_or_hook() {
     let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::NonClaude);
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
-    let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
     let post_send_emitter = RecordingPostSendEmitter::succeed();
 
-    let outcome = super::send_mail_with_runtime_impl(
+    let error = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
         &observability,
         &runtime,
         Some(&post_send_emitter),
     )
-    .expect("send outcome");
+    .expect_err("failed SQLite admission must fail the send");
 
-    assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
-    assert_eq!(outcome.warnings.len(), 1);
-    assert_non_claude_sqlite_failure_delivery(&runtime);
-    let events = read_notification_events(&home_dir);
-    assert!(events.last().is_some());
-    assert_non_claude_sqlite_failure_observability(&observability);
-    let emitted = post_send_emitter.emitted();
-    assert_eq!(emitted.len(), 1);
-    assert_eq!(emitted[0].event.sender.as_str(), TEST_SENDER);
-    assert!(!emitted[0].event.is_ack);
-    match &emitted[0].target {
-        PostSendBuiltInTarget::Graft(GraftNudgeTarget {
-            recipient,
-            recipient_team,
-        }) => {
-            assert_eq!(recipient.as_str(), "recipient");
-            assert_eq!(recipient_team.as_str(), TEST_TEAM);
-        }
-        other => panic!("expected graft post-send target, got {other:?}"),
-    }
+    assert_eq!(error.code(), AtmErrorCode::MailboxWriteFailed);
+    assert!(
+        runtime
+            .non_claude_deliveries
+            .lock()
+            .expect("non-claude deliveries lock")
+            .is_empty()
+    );
+    assert!(post_send_emitter.emitted().is_empty());
 }
 
 #[test]

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+tokio.workspace = true
 ulid.workspace = true
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
 atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.1-beta-aj" }

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -37,7 +37,7 @@ use std::thread;
 use crate::local_ipc_transport::shutdown::remove_stale_endpoint;
 #[cfg(test)]
 pub(crate) use crate::request_worker::DISPATCH_PANIC_RECOVERED_MESSAGE;
-use crate::request_worker::DispatchWorkerPool;
+use crate::request_worker::TokioDispatchExecutor;
 #[cfg(test)]
 pub(crate) use crate::request_worker::install_injected_accept_error_for_test;
 use accept_loop::{handle_shutdown_probe, take_accept_error};
@@ -506,7 +506,7 @@ fn start_tcp<'scope>(
     start_tcp_loopback_server(
         scope,
         tcp_loopback,
-        Arc::clone(&worker_pools.dispatch_workers),
+        Arc::clone(&worker_pools.dispatch_executor),
         observability.clone(),
         lifecycle_control.clone(),
     )
@@ -514,7 +514,7 @@ fn start_tcp<'scope>(
 
 struct RuntimeWorkerPools {
     connection_workers: ConnectionWorkerPool,
-    dispatch_workers: Arc<DispatchWorkerPool>,
+    dispatch_executor: Arc<TokioDispatchExecutor>,
 }
 
 fn start_worker_pools(
@@ -523,7 +523,7 @@ fn start_worker_pools(
     force_shutdown: &Arc<AtomicBool>,
     observability: &SubsystemObservability,
 ) -> Result<RuntimeWorkerPools, AtmError> {
-    let dispatch_workers = DispatchWorkerPool::start(
+    let dispatch_executor = TokioDispatchExecutor::start(
         Arc::clone(dispatcher),
         Arc::clone(registry),
         observability.clone(),
@@ -533,17 +533,17 @@ fn start_worker_pools(
         Arc::clone(force_shutdown),
         Arc::clone(registry),
         observability.clone(),
-        Arc::clone(&dispatch_workers),
+        Arc::clone(&dispatch_executor),
     )?;
     Ok(RuntimeWorkerPools {
         connection_workers,
-        dispatch_workers,
+        dispatch_executor,
     })
 }
 
 fn shutdown_runtime_worker_pools(worker_pools: RuntimeWorkerPools) -> Option<AtmError> {
     let connection_error = worker_pools.connection_workers.shutdown().err();
-    let dispatch_error = worker_pools.dispatch_workers.shutdown().err();
+    let dispatch_error = worker_pools.dispatch_executor.shutdown().err();
     connection_error.or(dispatch_error)
 }
 
@@ -620,7 +620,7 @@ fn build_accept_context<'a>(
 fn start_tcp_loopback_server<'scope>(
     scope: &'scope thread::Scope<'scope, '_>,
     server: LocalTcpLoopbackServer,
-    dispatch_workers: Arc<DispatchWorkerPool>,
+    dispatch_executor: Arc<TokioDispatchExecutor>,
     observability: SubsystemObservability,
     lifecycle: LifecycleControlSourceAdapter,
 ) -> Result<TcpLoopbackWorker<'scope>, AtmError> {
@@ -629,7 +629,7 @@ fn start_tcp_loopback_server<'scope>(
     let worker = thread::Builder::new()
         .name("local-loopback-tcp-http".to_string())
         .spawn_scoped(scope, move || {
-            server.serve_until_terminated(dispatch_workers, observability, &lifecycle, worker_stop)
+            server.serve_until_terminated(dispatch_executor, observability, &lifecycle, worker_stop)
         })
         .map_err(|source| {
             AtmError::daemon_unavailable(format!(
@@ -1000,7 +1000,7 @@ mod tests {
         let registry = Arc::new(ActiveConnectionRegistry::default());
         let (started_tx, started_rx) = mpsc::channel();
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let dispatch_workers = DispatchWorkerPool::start(
+        let dispatch_executor = TokioDispatchExecutor::start(
             Arc::new(BlockingDoctorDispatcher {
                 started: started_tx,
                 release: Arc::clone(&release),
@@ -1014,7 +1014,7 @@ mod tests {
             Arc::clone(&force_shutdown),
             registry,
             SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
-            Arc::clone(&dispatch_workers),
+            Arc::clone(&dispatch_executor),
         )
         .expect("start connection workers");
         let request = atm_core::protocol::RequestEnvelope::Doctor(DoctorQuery::default());
@@ -1081,26 +1081,21 @@ mod tests {
         drop(extra_client);
         drop(queued_clients);
         drop(clients);
-        let (connection_join_tx, connection_join_rx) = mpsc::sync_channel(1);
-        let (dispatch_join_tx, dispatch_join_rx) = mpsc::sync_channel(1);
-        connection_workers.install_shutdown_join_signal_for_test(connection_join_tx);
-        dispatch_workers.install_shutdown_join_signal_for_test(dispatch_join_tx);
         let (connection_shutdown_tx, connection_shutdown_rx) = mpsc::sync_channel(1);
         let (dispatch_shutdown_tx, dispatch_shutdown_rx) = mpsc::sync_channel(1);
-        let dispatch_workers_for_shutdown = Arc::clone(&dispatch_workers);
+        let dispatch_executor_for_shutdown = Arc::clone(&dispatch_executor);
         std::thread::scope(|scope| {
             scope.spawn(move || {
                 let _ = connection_shutdown_tx.send(connection_workers.shutdown());
             });
             scope.spawn(move || {
-                let _ = dispatch_shutdown_tx.send(dispatch_workers_for_shutdown.shutdown());
+                let _ = dispatch_shutdown_tx.send(dispatch_executor_for_shutdown.shutdown());
             });
-            connection_join_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("connection shutdown reaches its worker join before dispatch release");
-            dispatch_join_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("dispatch shutdown reaches its worker join before dispatch release");
+            // Both shutdown paths have closed their admission channels.  They
+            // must still await the already-admitted work rather than detach
+            // it: the connection pool waits on its synchronous readers and
+            // the Tokio executor awaits its in-flight `spawn_blocking` jobs.
+            std::thread::sleep(Duration::from_millis(20));
             assert!(matches!(
                 connection_shutdown_rx.try_recv(),
                 Err(mpsc::TryRecvError::Empty)
@@ -1110,11 +1105,8 @@ mod tests {
                 Err(mpsc::TryRecvError::Empty)
             ));
 
-            // At this point both shutdown paths have dropped their admission
-            // senders and reached `worker.join()` while every worker is still
-            // blocked inside the dispatcher. Releasing only now makes the
-            // ordering regression detectable: the previous test released
-            // before shutdown and would complete both receivers above.
+            // Releasing only after both shutdown calls are observed pending
+            // detects a regression that would detach admitted dispatch work.
             let (released, wake) = release.as_ref();
             *released.lock().expect("release lock") = true;
             wake.notify_all();

--- a/crates/atm-daemon/src/local_ipc_transport/connection_workers.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/connection_workers.rs
@@ -11,7 +11,7 @@ use crate::daemon_worker_join::{
 };
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::local_admission::{BOUNDED_ADMISSION_RETRY_INTERVAL, send_with_bounded_admission};
-use crate::request_worker::{DispatchWorkerPool, handle_connection};
+use crate::request_worker::{TokioDispatchExecutor, handle_connection};
 use crate::shutdown_beacon::ShutdownBeacon;
 
 use super::MAX_CONCURRENT_CONNECTIONS;
@@ -37,8 +37,6 @@ pub(super) struct ConnectionWorkerPool {
     workers: Mutex<Vec<CompletionTrackedJoinHandle<()>>>,
     #[cfg(test)]
     saturated_admission_signal: Mutex<Option<std::sync::mpsc::SyncSender<()>>>,
-    #[cfg(test)]
-    shutdown_join_signal: Mutex<Option<std::sync::mpsc::SyncSender<()>>>,
 }
 
 impl ConnectionWorkerPool {
@@ -46,7 +44,7 @@ impl ConnectionWorkerPool {
         force_shutdown: Arc<AtomicBool>,
         registry: Arc<ActiveConnectionRegistry>,
         observability: SubsystemObservability,
-        dispatch_workers: Arc<DispatchWorkerPool>,
+        dispatch_executor: Arc<TokioDispatchExecutor>,
     ) -> Result<Self, AtmError> {
         let (sender, receiver) = std::sync::mpsc::sync_channel(CONNECTION_ADMISSION_QUEUE);
         let receiver = Arc::new(Mutex::new(receiver));
@@ -56,7 +54,7 @@ impl ConnectionWorkerPool {
             let force_shutdown = Arc::clone(&force_shutdown);
             let registry = Arc::clone(&registry);
             let observability = observability.clone();
-            let dispatch_workers = Arc::clone(&dispatch_workers);
+            let dispatch_executor = Arc::clone(&dispatch_executor);
             let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
             let worker = std::thread::Builder::new()
                 .name(format!("local-ipc-connection-{worker_index}"))
@@ -75,7 +73,7 @@ impl ConnectionWorkerPool {
                             handle_connection(
                                 stream,
                                 force_shutdown.as_ref(),
-                                dispatch_workers.as_ref(),
+                                dispatch_executor.as_ref(),
                                 &observability,
                             )
                         }));
@@ -112,8 +110,6 @@ impl ConnectionWorkerPool {
             workers: Mutex::new(workers),
             #[cfg(test)]
             saturated_admission_signal: Mutex::new(None),
-            #[cfg(test)]
-            shutdown_join_signal: Mutex::new(None),
         })
     }
 
@@ -172,41 +168,13 @@ impl ConnectionWorkerPool {
         }
     }
 
-    #[cfg(test)]
-    pub(super) fn install_shutdown_join_signal_for_test(
-        &self,
-        signal: std::sync::mpsc::SyncSender<()>,
-    ) {
-        *self
-            .shutdown_join_signal
-            .lock()
-            .expect("lock connection-worker shutdown-join test signal") = Some(signal);
-    }
-
-    #[cfg(test)]
-    fn signal_shutdown_join_for_test(signal_slot: &Mutex<Option<std::sync::mpsc::SyncSender<()>>>) {
-        if let Some(signal) = signal_slot
-            .lock()
-            .expect("lock connection-worker shutdown-join test signal")
-            .take()
-        {
-            let _ = signal.send(());
-        }
-    }
-
     pub(super) fn shutdown(self) -> Result<(), AtmError> {
         let Self {
-            sender,
-            workers,
-            #[cfg(test)]
-            shutdown_join_signal,
-            ..
+            sender, workers, ..
         } = self;
         drop(sender);
         // The sender must be gone before joining: otherwise idle workers can
         // remain in `recv` and turn ordinary shutdown into a deadlock.
-        #[cfg(test)]
-        Self::signal_shutdown_join_for_test(&shutdown_join_signal);
         for worker in workers.into_inner().map_err(|_| {
             AtmError::daemon_unavailable("local IPC connection worker lock poisoned")
         })? {

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
 use std::time::Duration;
 
 use atm_core::api::{ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline, decode_request};
@@ -17,10 +18,6 @@ use interprocess::local_socket::traits::Stream as _;
 
 use crate::SubsystemObservability;
 use crate::active_connection_registry::ActiveConnectionRegistry;
-use crate::daemon_worker_join::{
-    CompletionTrackedJoinHandle, JoinTimeoutPolicy, LOCAL_WORKER_JOIN_DEADLINE, join_with_timeout,
-};
-use crate::local_admission::{BOUNDED_ADMISSION_RETRY_INTERVAL, send_with_bounded_admission};
 
 use crate::MAX_KEEP_ALIVE_REQUESTS;
 #[cfg(all(test, unix))]
@@ -29,76 +26,155 @@ use crate::local_ipc_transport::PreparedRuntimeServer;
 use crate::local_ipc_transport::shutdown::reject_shutdown_request;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
-const LOCAL_IPC_DISPATCH_JOIN_POLICY: JoinTimeoutPolicy = JoinTimeoutPolicy {
-    subsystem: "local_ipc_transport",
-    worker_kind: "local IPC dispatch worker",
-    panic_message: "local IPC dispatch worker panicked during shutdown",
-    timeout_message: "local IPC dispatch worker exceeded the shutdown join deadline",
-};
 pub(crate) const DISPATCH_PANIC_RECOVERED_MESSAGE: &str =
     "daemon local IPC dispatch worker panicked before completing; transport thread recovered";
 
-type DispatchResultRx = std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>;
 pub(crate) const MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS: usize = 8;
 
 struct DispatchWork {
     request: ApiRequest,
     deadline: RequestDeadline,
     result_tx: std::sync::mpsc::SyncSender<Result<ResponseEnvelope, AtmError>>,
+    state: DispatchJobState,
 }
 
-/// Fixed dispatcher workers with one bounded worker-batch queue preserve the
-/// post-timeout execution contract without creating a thread per admission.
+/// The only legal write-admission transitions are queued -> started and
+/// queued -> cancelled-before-start.  A caller may cancel only a queued job;
+/// once the executor has started it, the caller waits for the durable route's
+/// actual result rather than receiving a synthetic timeout.
+#[derive(Clone, Debug)]
+struct DispatchJobState(Arc<AtomicU8>);
+
+impl DispatchJobState {
+    const QUEUED: u8 = 0;
+    const STARTED: u8 = 1;
+    const CANCELLED_BEFORE_START: u8 = 2;
+
+    fn queued() -> Self {
+        Self(Arc::new(AtomicU8::new(Self::QUEUED)))
+    }
+
+    fn start(&self) -> bool {
+        self.0
+            .compare_exchange(
+                Self::QUEUED,
+                Self::STARTED,
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn cancel_before_start(&self) -> bool {
+        self.0
+            .compare_exchange(
+                Self::QUEUED,
+                Self::CANCELLED_BEFORE_START,
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn has_started(&self) -> bool {
+        self.0.load(AtomicOrdering::Acquire) == Self::STARTED
+    }
+}
+
+#[derive(Debug)]
+struct DispatchCompletion {
+    result_rx: std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>,
+    state: DispatchJobState,
+}
+
+impl Drop for DispatchCompletion {
+    fn drop(&mut self) {
+        // A disconnected transport cannot cancel a transaction that has
+        // begun, but it can prevent an unstarted queued request from becoming
+        // an invisible durable write.
+        self.state.cancel_before_start();
+    }
+}
+
+#[cfg(test)]
+impl DispatchCompletion {
+    fn recv_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<Result<ResponseEnvelope, AtmError>, std::sync::mpsc::RecvTimeoutError> {
+        self.result_rx.recv_timeout(timeout)
+    }
+}
+
+/// Tokio owns bounded request admission and scheduling for every legacy local
+/// connector while the canonical application router remains synchronous.
 ///
-/// A queued frame has crossed only the in-memory dispatch boundary.  When the
-/// queue is full, admission remains deadline-bounded rather than adding an
-/// unbounded daemon-side backlog.
-pub(crate) struct DispatchWorkerPool {
-    sender: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<DispatchWork>>>,
-    workers: std::sync::Mutex<Vec<CompletionTrackedJoinHandle<()>>>,
-    #[cfg(test)]
-    shutdown_join_signal: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<()>>>,
+/// This replaces the former synchronous pool outright: there is no
+/// daemon-managed worker thread or synchronous work queue. The one Tokio task
+/// receives bounded work, and `spawn_blocking` is the only isolation boundary
+/// for the existing synchronous router/storage contract.
+pub(crate) struct TokioDispatchExecutor {
+    sender: std::sync::Mutex<Option<tokio::sync::mpsc::Sender<DispatchWork>>>,
+    runtime: std::sync::Mutex<Option<tokio::runtime::Runtime>>,
+    workers: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
-impl DispatchWorkerPool {
+impl TokioDispatchExecutor {
     pub(crate) fn start(
         dispatcher: Arc<dyn ApiRouter + Send + Sync>,
         registry: Arc<ActiveConnectionRegistry>,
         observability: SubsystemObservability,
         worker_count: usize,
     ) -> Result<Arc<Self>, AtmError> {
-        let (sender, receiver) = std::sync::mpsc::sync_channel::<DispatchWork>(worker_count);
-        let receiver = Arc::new(std::sync::Mutex::new(receiver));
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(worker_count)
+            .enable_all()
+            .build()
+            .map_err(|source| {
+                AtmError::daemon_unavailable_with_cause(
+                    "failed to start Tokio local dispatch runtime",
+                    source,
+                )
+            })?;
+        let (sender, receiver) = tokio::sync::mpsc::channel::<DispatchWork>(worker_count);
+        let receiver = Arc::new(tokio::sync::Mutex::new(receiver));
         let mut workers = Vec::with_capacity(worker_count);
-        for worker_index in 0..worker_count {
+        for _worker_index in 0..worker_count {
             let receiver = Arc::clone(&receiver);
             let dispatcher = Arc::clone(&dispatcher);
             let registry = Arc::clone(&registry);
             let observability = observability.clone();
-            let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
-            let worker = std::thread::Builder::new()
-                .name(format!("local-ipc-dispatch-{worker_index}"))
-                .spawn(move || {
-                    let _completion_tx = completion_tx;
-                    loop {
-                    let work = match receiver.lock() {
-                        Ok(receiver) => receiver.recv(),
-                        Err(_) => return,
-                    };
-                    let Ok(work) = work else {
+            workers.push(runtime.spawn(async move {
+                loop {
+                    let Some(work) = receiver.lock().await.recv().await else {
                         return;
                     };
+                    if !work.state.start() {
+                        continue;
+                    }
+                    if work.deadline.expired() {
+                        let _ = work.result_tx.send(Err(AtmError::daemon_unavailable(
+                            "request deadline expired before the local dispatch job started",
+                        )));
+                        continue;
+                    }
                     let _dispatch_work = registry.register_dispatch_work();
-                    let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        dispatcher
-                            .route(work.request, AuthenticatedIngress::Local, work.deadline)
-                            .map(|response| response.into_inner())
-                    }));
+                    let response = tokio::task::spawn_blocking({
+                        let dispatcher = Arc::clone(&dispatcher);
+                        move || {
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                dispatcher
+                                    .route(work.request, AuthenticatedIngress::Local, work.deadline)
+                                    .map(|response| response.into_inner())
+                            }))
+                        }
+                    })
+                    .await;
                     let response = match response {
-                        Ok(response) => response,
-                        Err(_) => {
+                        Ok(Ok(response)) => response,
+                        Ok(Err(_)) | Err(_) => {
                             observability.emit_or_warn(
-                                "dispatch_worker",
+                                "tokio_dispatch_executor",
                                 "panic_recovered",
                                 DISPATCH_PANIC_RECOVERED_MESSAGE,
                             );
@@ -108,24 +184,13 @@ impl DispatchWorkerPool {
                         }
                     };
                     let _ = work.result_tx.send(response);
-                    }
-                })
-                .map_err(|source| {
-                    AtmError::daemon_unavailable_with_cause(
-                        "failed to start local IPC dispatch worker",
-                        source,
-                    )
-                })?;
-            workers.push(CompletionTrackedJoinHandle {
-                completion_rx,
-                join_handle: worker,
-            });
+                }
+            }));
         }
         Ok(Arc::new(Self {
             sender: std::sync::Mutex::new(Some(sender)),
+            runtime: std::sync::Mutex::new(Some(runtime)),
             workers: std::sync::Mutex::new(workers),
-            #[cfg(test)]
-            shutdown_join_signal: std::sync::Mutex::new(None),
         }))
     }
 
@@ -133,7 +198,7 @@ impl DispatchWorkerPool {
         &self,
         request: ApiRequest,
         deadline: RequestDeadline,
-    ) -> Result<DispatchResultRx, AtmError> {
+    ) -> Result<DispatchCompletion, AtmError> {
         let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
         let sender = self
             .sender
@@ -147,44 +212,35 @@ impl DispatchWorkerPool {
             request,
             deadline,
             result_tx,
+            state: DispatchJobState::queued(),
         };
-        send_with_bounded_admission(
-            &sender,
-            work,
-            || {
-                let Some(remaining) = deadline.remaining() else {
-                    return Err(AtmError::daemon_unavailable(
+        let state = work.state.clone();
+        let remaining = deadline.remaining().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "local IPC dispatch capacity remained saturated until the request deadline; retry the command after the daemon catches up",
+            )
+        })?;
+        let runtime = self.runtime.lock().map_err(|_| {
+            AtmError::daemon_unavailable("Tokio local dispatch runtime lock poisoned")
+        })?;
+        let runtime = runtime.as_ref().ok_or_else(|| {
+            AtmError::daemon_unavailable("Tokio local dispatch executor is stopping")
+        })?;
+        runtime.handle().block_on(async {
+            tokio::time::timeout(remaining, sender.send(work))
+                .await
+                .map_err(|_| {
+                    AtmError::daemon_unavailable(
                         "local IPC dispatch capacity remained saturated until the request deadline; retry the command after the daemon catches up",
-                    ));
-                };
-                Ok(remaining.min(BOUNDED_ADMISSION_RETRY_INTERVAL))
-            },
-            "local IPC dispatch workers stopped accepting work",
-        )?;
-        Ok(result_rx)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn install_shutdown_join_signal_for_test(
-        &self,
-        signal: std::sync::mpsc::SyncSender<()>,
-    ) {
-        *self
-            .shutdown_join_signal
-            .lock()
-            .expect("lock dispatch-worker shutdown-join test signal") = Some(signal);
-    }
-
-    #[cfg(test)]
-    fn signal_shutdown_join_for_test(&self) {
-        if let Some(signal) = self
-            .shutdown_join_signal
-            .lock()
-            .expect("lock dispatch-worker shutdown-join test signal")
-            .take()
-        {
-            let _ = signal.send(());
-        }
+                    )
+                })?
+                .map_err(|_| {
+                    AtmError::daemon_unavailable(
+                        "Tokio local dispatch executor stopped accepting work",
+                    )
+                })
+        })?;
+        Ok(DispatchCompletion { result_rx, state })
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
@@ -193,17 +249,29 @@ impl DispatchWorkerPool {
             .map_err(|_| AtmError::daemon_unavailable("local IPC dispatch sender lock poisoned"))?
             .take();
         let workers = std::mem::take(&mut *self.workers.lock().map_err(|_| {
-            AtmError::daemon_unavailable("local IPC dispatch worker lock poisoned")
+            AtmError::daemon_unavailable("Tokio local dispatch worker lock poisoned")
         })?);
-        #[cfg(test)]
-        self.signal_shutdown_join_for_test();
-        for worker in workers {
-            join_with_timeout(
-                worker,
-                LOCAL_WORKER_JOIN_DEADLINE,
-                LOCAL_IPC_DISPATCH_JOIN_POLICY,
-            )?;
-        }
+        let runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| {
+                AtmError::daemon_unavailable("Tokio local dispatch runtime lock poisoned")
+            })?
+            .take()
+            .ok_or_else(|| {
+                AtmError::daemon_unavailable("Tokio local dispatch executor already stopped")
+            })?;
+        runtime.block_on(async {
+            for worker in workers {
+                worker.await.map_err(|_| {
+                    AtmError::daemon_unavailable(
+                        "Tokio local dispatch worker panicked during shutdown",
+                    )
+                })?;
+            }
+            Ok::<(), AtmError>(())
+        })?;
+        runtime.shutdown_timeout(Duration::from_secs(3));
         Ok(())
     }
 }
@@ -218,7 +286,7 @@ enum RequestExecutionRisk {
 pub(crate) fn handle_connection(
     mut stream: LocalSocketStream,
     force_shutdown: &AtomicBool,
-    dispatch_workers: &DispatchWorkerPool,
+    dispatch_executor: &TokioDispatchExecutor,
     observability: &SubsystemObservability,
 ) -> Result<(), AtmError> {
     apply_primary_request_deadline(&mut stream);
@@ -236,7 +304,7 @@ pub(crate) fn handle_connection(
             raw_request,
             &mut request_count,
             &mut frames,
-            dispatch_workers,
+            dispatch_executor,
             observability,
         )?;
         if !write_pending_responses(&mut stream, pending, observability)? {
@@ -250,13 +318,13 @@ fn enqueue_buffered_requests(
     raw_request: atm_core::api::HttpRequest,
     request_count: &mut usize,
     frames: &mut HttpFrameReader,
-    dispatch_workers: &DispatchWorkerPool,
+    dispatch_executor: &TokioDispatchExecutor,
     observability: &SubsystemObservability,
 ) -> Result<Vec<PendingRequest>, AtmError> {
     let mut pending = vec![enqueue_request(
         raw_request,
         *request_count,
-        dispatch_workers,
+        dispatch_executor,
         observability,
     )?];
     while pending.len() < MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS
@@ -270,7 +338,7 @@ fn enqueue_buffered_requests(
         pending.push(enqueue_request(
             raw_request,
             *request_count,
-            dispatch_workers,
+            dispatch_executor,
             observability,
         )?);
     }
@@ -284,13 +352,10 @@ fn write_pending_responses(
     observability: &SubsystemObservability,
 ) -> Result<bool, AtmError> {
     for pending in pending {
-        let response = await_dispatch_response(
-            pending.request_id,
-            pending.execution_risk,
-            pending.deadline,
-            pending.result_rx,
-        );
-        if let Err(error) = write_local_http_response(stream, &response, pending.keep_alive) {
+        let request_id = pending.request_id;
+        let keep_alive = pending.keep_alive;
+        let response = pending.await_response();
+        if let Err(error) = write_local_http_response(stream, &response, keep_alive) {
             let classification = classify_connection_failure(&error);
             if classification == ConnectionFailureClassification::ExpectedPeerDisconnect {
                 observability.emit_event_or_warn(
@@ -302,7 +367,7 @@ fn write_pending_responses(
                         )
                         .with_connection_failure(DaemonConnectionFailureFields {
                             code: error.code(),
-                            request_id: Some(pending.request_id),
+                            request_id: Some(request_id),
                             classification,
                         })
                         .with_transport_context("response_write"),
@@ -312,12 +377,12 @@ fn write_pending_responses(
             emit_connection_failure_event(
                 observability,
                 &error,
-                Some(pending.request_id),
+                Some(request_id),
                 "response_write",
             );
             return Err(error);
         }
-        if !pending.keep_alive {
+        if !keep_alive {
             return Ok(false);
         }
     }
@@ -375,7 +440,7 @@ pub(crate) struct PendingRequest {
     request_id: RequestId,
     execution_risk: RequestExecutionRisk,
     deadline: RequestDeadline,
-    result_rx: DispatchResultRx,
+    completion: DispatchCompletion,
 }
 
 impl PendingRequest {
@@ -388,7 +453,7 @@ impl PendingRequest {
             self.request_id,
             self.execution_risk,
             self.deadline,
-            self.result_rx,
+            self.completion,
         )
     }
 }
@@ -396,7 +461,7 @@ impl PendingRequest {
 pub(crate) fn enqueue_request(
     raw_request: atm_core::api::HttpRequest,
     request_count: usize,
-    dispatch_workers: &DispatchWorkerPool,
+    dispatch_executor: &TokioDispatchExecutor,
     observability: &SubsystemObservability,
 ) -> Result<PendingRequest, AtmError> {
     let keep_alive = raw_request
@@ -411,7 +476,7 @@ pub(crate) fn enqueue_request(
     let request_id = atm_core::protocol::next_request_id();
     let deadline = RequestDeadline::after(REQUEST_DEADLINE);
     let execution_risk = request_execution_risk(&request);
-    let result_rx = dispatch_workers
+    let result_rx = dispatch_executor
         .dispatch(request, deadline)
         .inspect_err(|error| {
             emit_connection_failure_event(
@@ -426,7 +491,7 @@ pub(crate) fn enqueue_request(
         request_id,
         execution_risk,
         deadline,
-        result_rx,
+        completion: result_rx,
     })
 }
 
@@ -451,22 +516,35 @@ fn await_dispatch_response(
     request_id: RequestId,
     execution_risk: RequestExecutionRisk,
     deadline: RequestDeadline,
-    result_rx: std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>,
+    completion: DispatchCompletion,
 ) -> ResponseEnvelope {
     let remaining = deadline.remaining().unwrap_or(Duration::ZERO);
-    match result_rx.recv_timeout(remaining) {
+    match completion.result_rx.recv_timeout(remaining) {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => ResponseEnvelope::Error(error),
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!(
-                subsystem = "local_ipc",
-                action = "dispatch",
-                outcome = "deadline_exceeded",
-                request_id = %request_id,
-                deadline_ms = remaining.as_millis(),
-                "daemon request dispatcher exceeded the runtime deadline"
+            if completion.state.cancel_before_start() {
+                tracing::warn!(
+                    subsystem = "local_ipc",
+                    action = "dispatch",
+                    outcome = "deadline_exceeded_before_start",
+                    request_id = %request_id,
+                    deadline_ms = remaining.as_millis(),
+                    "daemon request did not begin before the runtime deadline"
+                );
+                return dispatch_timeout_response(execution_risk);
+            }
+            debug_assert!(
+                completion.state.has_started(),
+                "a non-cancelled dispatch completion must have started before its caller waits without a deadline"
             );
-            dispatch_timeout_response(execution_risk)
+            match completion.result_rx.recv() {
+                Ok(Ok(response)) => response,
+                Ok(Err(error)) => ResponseEnvelope::Error(error),
+                Err(_) => ResponseEnvelope::Error(AtmError::daemon_unavailable(
+                    "daemon request dispatcher stopped before returning a started request result",
+                )),
+            }
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
             ResponseEnvelope::Error(AtmError::daemon_unavailable(
@@ -512,9 +590,9 @@ pub(crate) fn install_injected_accept_error_for_test(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        DispatchWorkerPool, MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, RequestExecutionRisk,
-        classify_connection_failure, dispatch_timeout_response, handle_connection,
-        request_execution_risk,
+        MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, RequestExecutionRisk, TokioDispatchExecutor,
+        await_dispatch_response, classify_connection_failure, dispatch_timeout_response,
+        handle_connection, request_execution_risk,
     };
     use atm_core::api::{
         ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline,
@@ -588,7 +666,7 @@ mod tests {
         let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
         let registry = Arc::new(ActiveConnectionRegistry::default());
-        let dispatch_workers = DispatchWorkerPool::start(
+        let dispatch_executor = TokioDispatchExecutor::start(
             Arc::new(BlockingDoctorDispatcher {
                 started: started_tx,
                 release: Mutex::new(release_rx),
@@ -598,7 +676,7 @@ mod tests {
             1,
         )
         .expect("start occupied-dispatch fixture");
-        let first = dispatch_workers
+        let first = dispatch_executor
             .dispatch(
                 ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
                 RequestDeadline::after(Duration::from_secs(1)),
@@ -608,13 +686,13 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("dispatcher started first request");
 
-        let queued = dispatch_workers
+        let queued = dispatch_executor
             .dispatch(
                 ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
                 RequestDeadline::after(Duration::from_secs(1)),
             )
             .expect("queue one request behind the occupied worker");
-        let error = dispatch_workers
+        let error = dispatch_executor
             .dispatch(
                 ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
                 RequestDeadline::after(Duration::ZERO),
@@ -634,9 +712,125 @@ mod tests {
         let _ = queued
             .recv_timeout(Duration::from_secs(1))
             .expect("queued dispatcher responds after release");
-        dispatch_workers
+        dispatch_executor
             .shutdown()
             .expect("saturated fixture shutdown completes after forced release");
+    }
+
+    #[test]
+    fn dropping_a_queued_dispatch_completion_prevents_the_unstarted_route() {
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(2);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(2);
+        let executor = TokioDispatchExecutor::start(
+            Arc::new(BlockingDoctorDispatcher {
+                started: started_tx,
+                release: Mutex::new(release_rx),
+            }),
+            Arc::new(ActiveConnectionRegistry::default()),
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            1,
+        )
+        .expect("start bounded dispatch fixture");
+        let started = executor
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .expect("start first route");
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first route entered dispatcher");
+
+        let queued = executor
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .expect("queue second route");
+        drop(queued);
+
+        release_tx.send(()).expect("release first route");
+        let _ = started
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first route returns after release");
+        assert!(matches!(
+            started_rx.recv_timeout(Duration::from_millis(100)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        executor.shutdown().expect("bounded executor shuts down");
+    }
+
+    #[test]
+    fn started_dispatch_reports_its_actual_result_after_advisory_deadline() {
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let executor = TokioDispatchExecutor::start(
+            Arc::new(BlockingDoctorDispatcher {
+                started: started_tx,
+                release: Mutex::new(release_rx),
+            }),
+            Arc::new(ActiveConnectionRegistry::default()),
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            1,
+        )
+        .expect("start bounded dispatch fixture");
+        let deadline = RequestDeadline::after(Duration::from_millis(10));
+        let completion = executor
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
+                deadline,
+            )
+            .expect("start route");
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("route entered dispatcher before deadline");
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(25));
+            release_tx.send(()).expect("release started route");
+        });
+
+        let response = await_dispatch_response(
+            atm_core::protocol::next_request_id(),
+            RequestExecutionRisk::SideEffecting,
+            deadline,
+            completion,
+        );
+        release.join().expect("release thread joins");
+        let ResponseEnvelope::Error(error) = response else {
+            panic!("blocking test dispatcher returns an error envelope");
+        };
+        assert_eq!(error.code(), AtmErrorCode::DaemonUnavailable);
+        executor.shutdown().expect("bounded executor shuts down");
+    }
+
+    #[test]
+    fn zero_deadline_does_not_enqueue_or_start_a_route() {
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (_release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let executor = TokioDispatchExecutor::start(
+            Arc::new(BlockingDoctorDispatcher {
+                started: started_tx,
+                release: Mutex::new(release_rx),
+            }),
+            Arc::new(ActiveConnectionRegistry::default()),
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            1,
+        )
+        .expect("start bounded dispatch fixture");
+
+        let error = executor
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Doctor(DoctorQuery::default())),
+                RequestDeadline::after(Duration::ZERO),
+            )
+            .expect_err("zero budget cannot enter the bounded executor");
+
+        assert_eq!(error.code(), AtmErrorCode::DaemonUnavailable);
+        assert!(matches!(
+            started_rx.recv_timeout(Duration::from_millis(100)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        executor.shutdown().expect("bounded executor shuts down");
     }
 
     #[test]
@@ -754,7 +948,7 @@ mod tests {
             .expect("client connected");
         let started = Instant::now();
         let registry = Arc::new(ActiveConnectionRegistry::default());
-        let dispatch_workers = DispatchWorkerPool::start(
+        let dispatch_executor = TokioDispatchExecutor::start(
             Arc::new(DoctorOnlyDispatcher),
             Arc::clone(&registry),
             SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
@@ -764,7 +958,7 @@ mod tests {
         let result = handle_connection(
             server_stream,
             &AtomicBool::new(false),
-            dispatch_workers.as_ref(),
+            dispatch_executor.as_ref(),
             &SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
         );
 
@@ -778,7 +972,7 @@ mod tests {
         );
         let _ = release_client_tx.send(());
         client.join().expect("join wedged peer");
-        dispatch_workers
+        dispatch_executor
             .shutdown()
             .expect("shutdown dispatch workers");
     }
@@ -799,7 +993,7 @@ mod tests {
             let server = std::thread::spawn(move || {
                 let stream = listener.accept().expect("accept client");
                 let registry = Arc::new(ActiveConnectionRegistry::default());
-                let dispatch_workers = DispatchWorkerPool::start(
+                let dispatch_executor = TokioDispatchExecutor::start(
                     Arc::new(DoctorOnlyDispatcher),
                     Arc::clone(&registry),
                     SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
@@ -809,11 +1003,11 @@ mod tests {
                 handle_connection(
                     stream,
                     &AtomicBool::new(false),
-                    dispatch_workers.as_ref(),
+                    dispatch_executor.as_ref(),
                     &SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
                 )
                 .expect("serve keep-alive requests");
-                dispatch_workers
+                dispatch_executor
                     .shutdown()
                     .expect("shutdown dispatch workers");
             });
@@ -870,7 +1064,7 @@ mod tests {
         let server = std::thread::spawn(move || {
             let stream = listener.accept().expect("accept client");
             let registry = Arc::new(ActiveConnectionRegistry::default());
-            let dispatch_workers = DispatchWorkerPool::start(
+            let dispatch_executor = TokioDispatchExecutor::start(
                 Arc::new(DoctorOnlyDispatcher),
                 Arc::clone(&registry),
                 SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
@@ -880,11 +1074,11 @@ mod tests {
             handle_connection(
                 stream,
                 &AtomicBool::new(false),
-                dispatch_workers.as_ref(),
+                dispatch_executor.as_ref(),
                 &SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
             )
             .expect("serve pipelined requests");
-            dispatch_workers
+            dispatch_executor
                 .shutdown()
                 .expect("shutdown dispatch workers");
         });

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -56,7 +56,7 @@ use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::ready_signal::emit_ready_signal_if_requested;
 #[cfg(any(unix, windows))]
 use crate::request_worker::{
-    DispatchWorkerPool, MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, enqueue_request,
+    MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, TokioDispatchExecutor, enqueue_request,
 };
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
@@ -127,7 +127,7 @@ impl LocalTcpLoopbackServer {
 
     pub(crate) fn serve_until_terminated(
         self,
-        dispatch_workers: Arc<DispatchWorkerPool>,
+        dispatch_executor: Arc<TokioDispatchExecutor>,
         observability: SubsystemObservability,
         lifecycle: &LifecycleControlSourceAdapter,
         stop: Arc<AtomicBool>,
@@ -137,7 +137,7 @@ impl LocalTcpLoopbackServer {
         let mut workers = Vec::with_capacity(TCP_CONNECTION_WORKERS);
         for worker_index in 0..TCP_CONNECTION_WORKERS {
             let receiver = Arc::clone(&receiver);
-            let dispatch_workers = Arc::clone(&dispatch_workers);
+            let dispatch_executor = Arc::clone(&dispatch_executor);
             let capability = self.capability.clone();
             let stop = Arc::clone(&stop);
             let observability = observability.clone();
@@ -148,7 +148,7 @@ impl LocalTcpLoopbackServer {
                     let _completion_tx = completion_tx;
                     run_tcp_connection_worker(
                         receiver,
-                        dispatch_workers,
+                        dispatch_executor,
                         capability,
                         stop,
                         observability,
@@ -211,7 +211,7 @@ fn accept_tcp_connections(
 #[cfg(unix)]
 fn run_tcp_connection_worker(
     receiver: Arc<Mutex<mpsc::Receiver<TcpStream>>>,
-    dispatch_workers: Arc<DispatchWorkerPool>,
+    dispatch_executor: Arc<TokioDispatchExecutor>,
     capability: LocalCapability,
     stop: Arc<AtomicBool>,
     observability: SubsystemObservability,
@@ -224,11 +224,11 @@ fn run_tcp_connection_worker(
         let Ok(stream) = stream else {
             return;
         };
-        if let Err(error) = handle_connection_with_dispatch_workers(
+        if let Err(error) = handle_connection_with_dispatch_executor(
             stream,
             &capability,
             &stop,
-            dispatch_workers.as_ref(),
+            dispatch_executor.as_ref(),
             &observability,
         ) {
             tracing::warn!(
@@ -373,7 +373,7 @@ impl PreparedRuntimeServer {
         (hooks.publish_ready)()?;
         let registry = Arc::new(ActiveConnectionRegistry::default());
         let force_shutdown = Arc::new(AtomicBool::new(false));
-        let dispatch_workers = DispatchWorkerPool::start(
+        let dispatch_executor = TokioDispatchExecutor::start(
             Arc::clone(&router),
             Arc::clone(&registry),
             observability.clone(),
@@ -408,7 +408,7 @@ impl PreparedRuntimeServer {
                             &registry,
                             &capability,
                             &force_shutdown,
-                            &dispatch_workers,
+                            &dispatch_executor,
                             &observability,
                         )?;
                     }
@@ -424,7 +424,7 @@ impl PreparedRuntimeServer {
                 }
             }
         })();
-        let worker_shutdown_result = dispatch_workers.shutdown();
+        let worker_shutdown_result = dispatch_executor.shutdown();
         drop(hooks.endpoint_guard);
         serve_result.and(worker_shutdown_result)
     }
@@ -436,7 +436,7 @@ fn spawn_windows_connection(
     registry: &Arc<ActiveConnectionRegistry>,
     capability: &LocalCapability,
     force_shutdown: &Arc<AtomicBool>,
-    dispatch_workers: &Arc<DispatchWorkerPool>,
+    dispatch_executor: &Arc<TokioDispatchExecutor>,
     observability: &SubsystemObservability,
 ) -> Result<(), AtmError> {
     registry.reap_finished_dispatches()?;
@@ -446,16 +446,16 @@ fn spawn_windows_connection(
     };
     let capability = capability.clone();
     let force_shutdown = Arc::clone(force_shutdown);
-    let dispatch_workers = Arc::clone(dispatch_workers);
+    let dispatch_executor = Arc::clone(dispatch_executor);
     let observability = observability.clone();
     let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
     let join_handle = thread::spawn(move || {
         let _active = active_connection;
-        let _ = handle_connection_with_dispatch_workers(
+        let _ = handle_connection_with_dispatch_executor(
             stream,
             &capability,
             force_shutdown.as_ref(),
-            dispatch_workers.as_ref(),
+            dispatch_executor.as_ref(),
             &observability,
         );
         let _ = completion_tx.send(());
@@ -504,11 +504,11 @@ fn windows_capacity_rejection_response() -> ResponseEnvelope {
 }
 
 #[cfg(any(unix, windows))]
-fn handle_connection_with_dispatch_workers(
+fn handle_connection_with_dispatch_executor(
     mut stream: TcpStream,
     capability: &LocalCapability,
     force_shutdown: &AtomicBool,
-    dispatch_workers: &DispatchWorkerPool,
+    dispatch_executor: &TokioDispatchExecutor,
     observability: &SubsystemObservability,
 ) -> Result<(), AtmError> {
     configure_connection(&stream)?;
@@ -527,7 +527,7 @@ fn handle_connection_with_dispatch_workers(
             raw_request,
             request_count,
             capability,
-            dispatch_workers,
+            dispatch_executor,
             observability,
             &mut pending,
         )?;
@@ -543,7 +543,7 @@ fn handle_connection_with_dispatch_workers(
                 raw_request,
                 request_count,
                 capability,
-                dispatch_workers,
+                dispatch_executor,
                 observability,
                 &mut pending,
             )?;
@@ -616,7 +616,7 @@ fn enqueue_tcp_request(
     raw_request: atm_core::api::HttpRequest,
     request_count: usize,
     capability: &LocalCapability,
-    dispatch_workers: &DispatchWorkerPool,
+    dispatch_executor: &TokioDispatchExecutor,
     observability: &SubsystemObservability,
     pending: &mut Vec<TcpPendingResponse>,
 ) -> Result<(), AtmError> {
@@ -636,7 +636,7 @@ fn enqueue_tcp_request(
         });
         return Ok(());
     }
-    match enqueue_request(raw_request, request_count, dispatch_workers, observability) {
+    match enqueue_request(raw_request, request_count, dispatch_executor, observability) {
         Ok(request) => pending.push(TcpPendingResponse::Dispatched(request)),
         Err(error) => pending.push(TcpPendingResponse::Immediate {
             keep_alive,
@@ -925,13 +925,13 @@ mod tests {
     use atm_core::test_support::{ROLE_TEAM_LEAD, TEST_TEAM};
     use ulid::Ulid;
 
-    #[cfg(any(unix, windows))]
-    use super::{
-        DispatchWorkerPool, MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS,
-        handle_connection_with_dispatch_workers,
-    };
     use super::{
         LOCAL_CAPABILITY_HEADER, LocalCapability, MAX_KEEP_ALIVE_REQUESTS, handle_connection,
+    };
+    #[cfg(any(unix, windows))]
+    use super::{
+        MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, TokioDispatchExecutor,
+        handle_connection_with_dispatch_executor,
     };
     #[cfg(any(unix, windows))]
     use crate::active_connection_registry::ActiveConnectionRegistry;
@@ -1013,7 +1013,7 @@ mod tests {
     }
 
     #[cfg(any(unix, windows))]
-    fn serve_one_with_dispatch_workers(
+    fn serve_one_with_dispatch_executor(
         capability: LocalCapability,
     ) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind loopback");
@@ -1024,22 +1024,22 @@ mod tests {
             let registry = Arc::new(ActiveConnectionRegistry::default());
             let observability =
                 SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport);
-            let dispatch_workers = DispatchWorkerPool::start(
+            let dispatch_executor = TokioDispatchExecutor::start(
                 Arc::new(DoctorOnlyDispatcher),
                 registry,
                 observability.clone(),
                 MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS,
             )
             .expect("start dispatch workers");
-            handle_connection_with_dispatch_workers(
+            handle_connection_with_dispatch_executor(
                 stream,
                 &capability,
                 &AtomicBool::new(false),
-                dispatch_workers.as_ref(),
+                dispatch_executor.as_ref(),
                 &observability,
             )
             .expect("serve pipelined local TCP requests");
-            dispatch_workers
+            dispatch_executor
                 .shutdown()
                 .expect("shutdown dispatch workers");
         });
@@ -1051,11 +1051,15 @@ mod tests {
     fn windows_tcp_dispatch_pool_is_available_without_unix_ipc_module() {
         let registry = Arc::new(ActiveConnectionRegistry::default());
         let observability = SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport);
-        let dispatch_workers =
-            DispatchWorkerPool::start(Arc::new(DoctorOnlyDispatcher), registry, observability, 1)
-                .expect("start Windows TCP dispatch worker");
+        let dispatch_executor = TokioDispatchExecutor::start(
+            Arc::new(DoctorOnlyDispatcher),
+            registry,
+            observability,
+            1,
+        )
+        .expect("start Windows TCP dispatch worker");
 
-        dispatch_workers
+        dispatch_executor
             .shutdown()
             .expect("shutdown Windows TCP dispatch worker");
     }
@@ -1111,10 +1115,10 @@ mod tests {
 
     #[cfg(any(unix, windows))]
     #[test]
-    fn loopback_tcp_dispatch_workers_serve_a_pipelined_run_in_response_order() {
+    fn loopback_tcp_dispatch_executor_serve_a_pipelined_run_in_response_order() {
         let capability = LocalCapability::generate().expect("capability");
         let header = capability.to_base64url();
-        let (address, server) = serve_one_with_dispatch_workers(capability);
+        let (address, server) = serve_one_with_dispatch_executor(capability);
         let request = RequestEnvelope::Doctor(DoctorQuery::default());
         let mut wire = Vec::new();
         for request_count in 1..=MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS {

--- a/crates/atm-daemon/src/message_received_emitter.rs
+++ b/crates/atm-daemon/src/message_received_emitter.rs
@@ -2,6 +2,7 @@ use std::process::{Child, Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use atm_core::RequestDeadline;
 use atm_core::boundary::{
     self, BuiltInPostSendDispatch, LocalTmuxNudgeTarget, MessageReceivedHookEmitter,
     PostSendBuiltInTarget, PostSendEmissionPath, PostSendHookEvent, RosterEntry,
@@ -19,16 +20,17 @@ pub(crate) struct TmuxMessageReceivedHookEmitter;
 impl boundary::sealed::Sealed for TmuxMessageReceivedHookEmitter {}
 
 impl MessageReceivedHookEmitter for TmuxMessageReceivedHookEmitter {
-    fn emit_post_send(
+    fn emit_received_message(
         &self,
         dispatch: &BuiltInPostSendDispatch,
+        deadline: RequestDeadline,
     ) -> Result<PostSendEmissionPath, AtmError> {
         let PostSendBuiltInTarget::LocalTmux(target) = &dispatch.target else {
             return Err(AtmError::validation(
                 "tmux message-received emitter received a non-tmux target",
             ));
         };
-        deliver_tmux_nudge(&dispatch.event, target)?;
+        deliver_tmux_nudge(&dispatch.event, target, deadline)?;
         Ok(PostSendEmissionPath::LocalTmux)
     }
 }
@@ -52,6 +54,7 @@ pub(crate) fn message_received_emitter_for_harness(
 fn deliver_tmux_nudge(
     event: &PostSendHookEvent,
     target: &LocalTmuxNudgeTarget,
+    deadline: RequestDeadline,
 ) -> Result<(), AtmError> {
     run_tmux_command(
         {
@@ -66,6 +69,7 @@ fn deliver_tmux_nudge(
             command
         },
         event,
+        deadline,
         "send literal nudge",
     )?;
     run_tmux_command(
@@ -75,9 +79,14 @@ fn deliver_tmux_nudge(
             command
         },
         event,
+        deadline,
         "send first Enter to nudge pane",
     )?;
-    thread::sleep(TMUX_DOUBLE_ENTER_DELAY);
+    let delay = tmux_remaining_budget(deadline)?.min(TMUX_DOUBLE_ENTER_DELAY);
+    thread::sleep(delay);
+    // A shortened sleep can consume the final positive duration exactly. Do
+    // not start a third command after the inherited request budget is spent.
+    tmux_remaining_budget(deadline)?;
     run_tmux_command(
         {
             let mut command = tmux_command();
@@ -85,6 +94,7 @@ fn deliver_tmux_nudge(
             command
         },
         event,
+        deadline,
         "send second Enter to nudge pane",
     )
 }
@@ -100,18 +110,23 @@ fn tmux_command() -> Command {
 fn run_tmux_command(
     mut command: Command,
     event: &PostSendHookEvent,
+    deadline: RequestDeadline,
     action: &'static str,
 ) -> Result<(), AtmError> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let child = command
         .spawn()
         .map_err(|_source| AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed))?;
-    let output = wait_for_tmux_output(child, action)?;
+    let output = wait_for_tmux_output(child, deadline, action)?;
     ensure_tmux_success(output, event, action)
 }
 
-fn wait_for_tmux_output(mut child: Child, _action: &'static str) -> Result<Output, AtmError> {
-    let started_at = Instant::now();
+fn wait_for_tmux_output(
+    mut child: Child,
+    deadline: RequestDeadline,
+    _action: &'static str,
+) -> Result<Output, AtmError> {
+    let safety_deadline = Instant::now() + TMUX_SEND_TIMEOUT;
     loop {
         match child.try_wait() {
             Ok(Some(_)) => {
@@ -119,13 +134,23 @@ fn wait_for_tmux_output(mut child: Child, _action: &'static str) -> Result<Outpu
                     .wait_with_output()
                     .map_err(|_source| AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed));
             }
-            Ok(None) if started_at.elapsed() < TMUX_SEND_TIMEOUT => {
-                thread::sleep(Duration::from_millis(50));
-            }
             Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed));
+                let Some(request_remaining) = deadline.remaining() else {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed));
+                };
+                let Some(safety_remaining) = safety_deadline.checked_duration_since(Instant::now())
+                else {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed));
+                };
+                thread::sleep(
+                    Duration::from_millis(50)
+                        .min(request_remaining)
+                        .min(safety_remaining),
+                );
             }
             Err(_source) => {
                 let _ = child.kill();
@@ -134,6 +159,13 @@ fn wait_for_tmux_output(mut child: Child, _action: &'static str) -> Result<Outpu
             }
         }
     }
+}
+
+fn tmux_remaining_budget(deadline: RequestDeadline) -> Result<Duration, AtmError> {
+    deadline
+        .remaining()
+        .map(|remaining| remaining.min(TMUX_SEND_TIMEOUT))
+        .ok_or_else(|| AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed))
 }
 
 fn ensure_tmux_success(
@@ -151,4 +183,48 @@ fn ensure_tmux_success(
         format!("tmux exited unsuccessfully while trying to {action}: {stderr}")
     };
     Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    use atm_core::RequestDeadline;
+    use atm_core::error_codes::AtmErrorCode;
+
+    use super::{TMUX_SEND_TIMEOUT, tmux_remaining_budget, wait_for_tmux_output};
+
+    #[test]
+    fn hook_safety_cap_never_enlarges_the_request_budget() {
+        let capped = tmux_remaining_budget(RequestDeadline::after(Duration::from_secs(30)))
+            .expect("positive request budget");
+
+        assert!(capped <= TMUX_SEND_TIMEOUT);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stalled_tmux_child_is_killed_when_the_inherited_request_budget_expires() {
+        let child = Command::new("sh")
+            .args(["-c", "sleep 1"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn stalled child");
+        let started = Instant::now();
+
+        let error = wait_for_tmux_output(
+            child,
+            RequestDeadline::after(Duration::from_millis(25)),
+            "test stalled child",
+        )
+        .expect_err("the inherited request deadline must stop a stalled hook");
+
+        assert_eq!(error.code(), AtmErrorCode::PostSendTmuxSendFailed);
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "the hook must not wait for the child safety cap after request expiry"
+        );
+    }
 }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -78,7 +78,6 @@ pub(crate) struct DaemonRequestDispatcher {
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
     https_transport: SharedHttpsTransport,
     peer_delivery_coordinator: Arc<dyn PeerDeliveryCoordinator>,
-    post_commit_signals: Arc<PeerPostCommitWorkQueue>,
     post_commit_work_queue: Arc<dyn PostCommitWorkQueue>,
     runtime_reload_hook: std::sync::Mutex<Option<RuntimeReloadHook>>,
     peer_delivery_projection: Arc<PeerDeliveryProjection>,
@@ -374,13 +373,9 @@ impl DaemonRequestDispatcher {
             &runtime_health_observability,
         );
         let service_runtime = runtime_assembly.service_runtime;
-        let post_commit_signals = Arc::new(PeerPostCommitWorkQueue::new(
-            Arc::clone(&peer_delivery_coordinator),
-            service_runtime.clone(),
-            home_dir.clone(),
-            Arc::clone(&observability),
-        ));
-        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = post_commit_signals.clone();
+        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = Arc::new(
+            PeerPostCommitWorkQueue::new(Arc::clone(&peer_delivery_coordinator)),
+        );
         let admission_runtime_view = AdmissionRuntimeView::new(service_runtime.clone());
         Self {
             home_dir,
@@ -394,7 +389,6 @@ impl DaemonRequestDispatcher {
             peer_config_store,
             https_transport,
             peer_delivery_coordinator,
-            post_commit_signals,
             post_commit_work_queue,
             runtime_reload_hook: std::sync::Mutex::new(None),
             peer_delivery_projection,
@@ -417,13 +411,12 @@ impl DaemonRequestDispatcher {
     }
 
     pub(crate) fn start_peer_drain_coordinator(&self) -> Result<(), AtmError> {
-        self.post_commit_signals.start()?;
         self.peer_delivery_coordinator.start()
     }
 
     pub(crate) fn stop_peer_drain_coordinator(&self) -> Result<(), AtmError> {
         self.peer_delivery_coordinator.stop()?;
-        self.post_commit_signals.stop()
+        Ok(())
     }
 
     #[cfg(test)]
@@ -535,16 +528,9 @@ impl DaemonRequestDispatcher {
         );
         let service_runtime = runtime_assembly.service_runtime.clone();
         let daemon_home = crate::AtmHomeDir::from_path_for_test(home_dir.clone());
-        let post_commit_signals = Arc::new(PeerPostCommitWorkQueue::new(
-            Arc::clone(&peer_delivery_coordinator),
-            service_runtime.clone(),
-            daemon_home.clone(),
-            Arc::clone(&runtime_observability),
-        ));
-        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = post_commit_signals.clone();
-        post_commit_signals
-            .start()
-            .expect("start post-commit worker for dispatcher test");
+        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = Arc::new(
+            PeerPostCommitWorkQueue::new(Arc::clone(&peer_delivery_coordinator)),
+        );
         Self {
             home_dir: daemon_home,
             observability: runtime_observability,
@@ -557,7 +543,6 @@ impl DaemonRequestDispatcher {
             peer_config_store,
             https_transport,
             peer_delivery_coordinator,
-            post_commit_signals,
             post_commit_work_queue,
             runtime_reload_hook: std::sync::Mutex::new(None),
             peer_delivery_projection,

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -32,10 +32,14 @@ trait MessageWriter: Send + Sync {
 }
 
 pub(crate) trait PostWriteRouter: Send + Sync {
-    /// Non-blocking, infallible post-commit scheduling. A committed admission
-    /// response is constructed before this signal and cannot be relabelled by
-    /// worker availability or notification delivery.
-    fn dispatch(&self, message: &mut MessageRecord);
+    /// Runs receiver-only post-persistence work. Hook failures are represented
+    /// as warnings on the already-successful durable write, never as a receive
+    /// failure.
+    fn dispatch(
+        &self,
+        message: &mut MessageRecord,
+        deadline: RequestDeadline,
+    ) -> Vec<atm_core::send::WarningEntry>;
 }
 
 impl DaemonRequestDispatcher {
@@ -57,7 +61,7 @@ impl DaemonRequestDispatcher {
         let side_effecting = request_may_have_side_effects(&request);
         require_dispatch_budget(deadline, false)?;
         let response = match request {
-            RequestEnvelope::Write(request) => self.route_write(*request, ingress),
+            RequestEnvelope::Write(request) => self.route_write(*request, ingress, deadline),
             request => self.dispatch_non_write(request, ingress),
         }?;
         require_dispatch_budget(deadline, side_effecting)?;
@@ -68,31 +72,28 @@ impl DaemonRequestDispatcher {
         &self,
         request: WriteRequest,
         ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
     ) -> Result<ResponseEnvelope, AtmError> {
         let observation =
             TrustedActivityObservation::from_local(ingress, request.activity_observation.clone());
         let mut message = MessageWriter::write(self, request)?;
-        let requires_post_commit_signal = message.prepared.requires_post_write_route();
-        // Admission is complete before any post-commit work is even signalled.
-        // In particular, an acknowledgement's source transition completes here,
-        // before the peer worker can observe or deliver the reply.
-        let outcome = message
+        let requires_post_persistence_effect = message.prepared.requires_post_write_route();
+        // Admission is complete before the received hook is attempted. In
+        // particular, an acknowledgement's source transition completes here,
+        // before its recipient can be nudged.
+        let mut outcome = message
             .prepared
             .finish(&self.service_runtime, self.observability.as_ref())?;
-        let response = match outcome {
-            WriteOutcome::Sent(outcome) => {
-                ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome))
-            }
-            WriteOutcome::Acknowledged(outcome) => {
-                ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
-            }
-        };
+        if requires_post_persistence_effect {
+            append_write_warnings(
+                &mut outcome,
+                PostWriteRouter::dispatch(self, &mut message, deadline),
+            );
+        }
+        let response = write_response(outcome);
         if let Some(observation) = observation.as_ref() {
             self.status_cache
                 .touch_member(observation, IsoTimestamp::now());
-        }
-        if requires_post_commit_signal {
-            PostWriteRouter::dispatch(self, &mut message);
         }
         Ok(response)
     }
@@ -153,6 +154,22 @@ impl DaemonRequestDispatcher {
                 Ok(ResponseEnvelope::RuntimeViewReloaded)
             }
             RequestEnvelope::Write(_) => unreachable!("writes are handled by route_write"),
+        }
+    }
+}
+
+fn append_write_warnings(outcome: &mut WriteOutcome, warnings: Vec<atm_core::send::WarningEntry>) {
+    match outcome {
+        WriteOutcome::Sent(send) => send.warnings.extend(warnings),
+        WriteOutcome::Acknowledged(acknowledged) => acknowledged.warnings.extend(warnings),
+    }
+}
+
+fn write_response(outcome: WriteOutcome) -> ResponseEnvelope {
+    match outcome {
+        WriteOutcome::Sent(outcome) => ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)),
+        WriteOutcome::Acknowledged(outcome) => {
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
         }
     }
 }

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -62,14 +62,15 @@ impl DaemonRequestDispatcher {
         ingress: AuthenticatedIngress,
         deadline: RequestDeadline,
     ) -> Result<ResponseEnvelope, AtmError> {
-        let side_effecting = request_may_have_side_effects(&request);
         require_dispatch_budget(deadline, false)?;
-        let response = match request {
+        match request {
+            // A write response describes the durable result. Once `route_write`
+            // has committed it, an exhausted advisory-hook budget is represented
+            // by a warning on that successful response—not by a late generic
+            // timeout that falsely reports the write as uncertain.
             RequestEnvelope::Write(request) => self.route_write(*request, ingress, deadline),
             request => self.dispatch_non_write(request, ingress),
-        }?;
-        require_dispatch_budget(deadline, side_effecting)?;
-        Ok(response)
+        }
     }
 
     fn route_write(
@@ -197,16 +198,6 @@ fn require_dispatch_budget(
     Err(AtmError::daemon_unavailable(
         "daemon request exceeded its shared deadline before dispatch work started",
     ))
-}
-
-fn request_may_have_side_effects(request: &RequestEnvelope) -> bool {
-    !matches!(
-        request,
-        RequestEnvelope::CompatibilityPreflight(_)
-            | RequestEnvelope::List(_)
-            | RequestEnvelope::Peek(_)
-            | RequestEnvelope::Doctor(_)
-    )
 }
 
 impl MessageWriter for DaemonRequestDispatcher {

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -32,9 +32,13 @@ trait MessageWriter: Send + Sync {
 }
 
 pub(crate) trait PostWriteRouter: Send + Sync {
-    /// Runs receiver-only post-persistence work. Hook failures are represented
-    /// as warnings on the already-successful durable write, never as a receive
-    /// failure.
+    /// Classifies canonical post-persistence work.
+    ///
+    /// A newly persisted inbound write runs the receiver hook and retains hook
+    /// failures as warnings on the already-successful durable response. A
+    /// host-qualified origin write may only signal the temporary legacy peer
+    /// delivery coordinator; that origin-only path never invokes a receiver
+    /// hook.
     fn dispatch(
         &self,
         message: &mut MessageRecord,
@@ -77,14 +81,14 @@ impl DaemonRequestDispatcher {
         let observation =
             TrustedActivityObservation::from_local(ingress, request.activity_observation.clone());
         let mut message = MessageWriter::write(self, request)?;
-        let requires_post_persistence_effect = message.prepared.requires_post_write_route();
+        let newly_persisted = message.prepared.is_newly_persisted();
         // Admission is complete before the received hook is attempted. In
         // particular, an acknowledgement's source transition completes here,
         // before its recipient can be nudged.
         let mut outcome = message
             .prepared
             .finish(&self.service_runtime, self.observability.as_ref())?;
-        if requires_post_persistence_effect {
+        if newly_persisted {
             append_write_warnings(
                 &mut outcome,
                 PostWriteRouter::dispatch(self, &mut message, deadline),

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -85,6 +85,7 @@ impl DaemonRequestDispatcher {
             &team,
             &agent,
             message_id,
+            deadline,
             emitter.as_deref(),
         ) {
             Ok(warnings) => {

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -1,30 +1,26 @@
-use atm_core::protocol::next_request_id;
+use atm_core::{RequestDeadline, protocol::next_request_id};
 
 use super::{DaemonRequestDispatcher, MessageRecord, PostCommitWorkKey, PostWriteRouter};
 use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryEventKind};
+use atm_core::send::WarningEntry;
 
 impl PostWriteRouter for DaemonRequestDispatcher {
-    fn dispatch(&self, message: &mut MessageRecord) {
-        if message.prepared.is_peer_receipt() {
-            tracing::info!(
-                subsystem = "runtime_health",
-                action = "post_write",
-                outcome = "peer_ingress_local_post_write",
-                message_id = ?message.outbound_request.origin_message_id,
-                "authenticated peer receipt uses the canonical local post-write route"
-            );
-            self.signal_local_post_write(message);
-            return;
-        }
+    fn dispatch(
+        &self,
+        message: &mut MessageRecord,
+        deadline: RequestDeadline,
+    ) -> Vec<WarningEntry> {
         let Some(host) = message
             .outbound_request
             .to
             .as_ref()
             .and_then(|address| address.host())
         else {
-            self.signal_local_post_write(message);
-            return;
+            return self.run_received_hook(message, deadline);
         };
+        if message.prepared.is_peer_receipt() {
+            return self.run_received_hook(message, deadline);
+        }
         let request_id = next_request_id();
         let message_id = message.prepared.persisted_message_id();
         self.record_peer_delivery_event(PeerDeliveryEvent {
@@ -44,34 +40,78 @@ impl PostWriteRouter for DaemonRequestDispatcher {
                 peer: host.clone(),
                 message_id,
             });
+        Vec::new()
     }
 }
 
 impl DaemonRequestDispatcher {
-    fn signal_local_post_write(&self, message: &mut MessageRecord) {
-        if message.prepared.is_peer_receipt() && message.prepared.is_same_store_peer_receipt() {
-            let mut event = self.runtime_health_observability.event(
-                "peer_duplicate_write_skipped",
-                "ok",
-                "peer duplicate write skipped; continuing the ordinary local post-write action",
-            );
-            event.message_id = Some(message.prepared.persisted_message_id());
-            self.runtime_health_observability.emit_event_or_warn(event);
+    fn run_received_hook(
+        &self,
+        message: &MessageRecord,
+        deadline: RequestDeadline,
+    ) -> Vec<WarningEntry> {
+        tracing::info!(
+            subsystem = "runtime_health",
+            action = "post_write",
+            outcome = "received_hook",
+            message_id = ?message.outbound_request.origin_message_id,
+            "newly persisted inbound write uses the canonical received-hook route"
+        );
+        if deadline.remaining().is_none() {
+            return vec![hook_warning(atm_core::error::AtmError::daemon_unavailable(
+                "received-message hook was skipped because the request deadline was exhausted after persistence",
+            ))];
         }
         let message_id = message.prepared.persisted_message_id();
         let Some(target) = message.outbound_request.to.as_ref() else {
-            tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", %message_id, "local post-commit work had no canonical destination");
-            return;
+            return vec![hook_warning(atm_core::error::AtmError::validation(
+                "durably received message had no canonical destination for receiver hook",
+            ))];
         };
-        self.post_commit_signals.register_local_nudge(
+        let team = target
+            .team()
+            .cloned()
+            .unwrap_or_else(|| message.outbound_request.caller_team.clone());
+        let agent = target.agent().clone();
+        let emitter = match self.service_runtime.load_roster_member(&team, &agent) {
+            Ok(Some(member)) => {
+                crate::message_received_emitter::message_received_emitter_for_harness(&member)
+            }
+            Ok(None) => None,
+            Err(error) => return vec![hook_warning(error)],
+        };
+        match atm_core::send::emit_persisted_local_post_write(
+            &self.service_runtime,
+            self.observability.as_ref(),
+            self.home_dir.as_path(),
+            &team,
+            &agent,
             message_id,
-            target
-                .team()
-                .cloned()
-                .unwrap_or_else(|| message.outbound_request.caller_team.clone()),
-            target.agent().clone(),
-        );
-        self.post_commit_work_queue
-            .signal(PostCommitWorkKey::LocalNudge(message_id));
+            emitter.as_deref(),
+        ) {
+            Ok(warnings) => {
+                for warning in &warnings {
+                    tracing::warn!(
+                        subsystem = "runtime_health",
+                        action = "message_received_hook",
+                        outcome = "warning",
+                        %message_id,
+                        code = ?warning.code,
+                        "received-message hook completed with warning: {}",
+                        warning.message
+                    );
+                }
+                warnings
+            }
+            Err(error) => vec![hook_warning(error)],
+        }
     }
+}
+
+fn hook_warning(error: atm_core::error::AtmError) -> WarningEntry {
+    WarningEntry::with_code(
+        error.code(),
+        format!("message received successfully, but its receiver hook did not run: {error}"),
+        Some("inspect the receiver hook endpoint or harness, then continue normally"),
+    )
 }

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -57,10 +57,8 @@ impl DaemonRequestDispatcher {
             message_id = ?message.outbound_request.origin_message_id,
             "newly persisted inbound write uses the canonical received-hook route"
         );
-        if deadline.remaining().is_none() {
-            return vec![hook_warning(atm_core::error::AtmError::daemon_unavailable(
-                "received-message hook was skipped because the request deadline was exhausted after persistence",
-            ))];
+        if let Some(warning) = received_hook_deadline_warning(deadline) {
+            return vec![warning];
         }
         let message_id = message.prepared.persisted_message_id();
         let Some(target) = message.outbound_request.to.as_ref() else {
@@ -114,4 +112,29 @@ fn hook_warning(error: atm_core::error::AtmError) -> WarningEntry {
         format!("message received successfully, but its receiver hook did not run: {error}"),
         Some("inspect the receiver hook endpoint or harness, then continue normally"),
     )
+}
+
+fn received_hook_deadline_warning(deadline: RequestDeadline) -> Option<WarningEntry> {
+    deadline.remaining().is_none().then(|| {
+        hook_warning(atm_core::error::AtmError::daemon_unavailable(
+            "received-message hook was skipped because the request deadline was exhausted after persistence",
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use atm_core::error_codes::AtmErrorCode;
+
+    use super::{RequestDeadline, received_hook_deadline_warning};
+
+    #[test]
+    fn exhausted_inherited_budget_returns_a_retained_hook_warning() {
+        let warning = received_hook_deadline_warning(RequestDeadline::after(Duration::ZERO))
+            .expect("an exhausted post-persistence hook budget must be retained as a warning");
+        assert_eq!(warning.code, Some(AtmErrorCode::DaemonUnavailable));
+        assert!(warning.message.contains("hook was skipped"));
+    }
 }

--- a/crates/atm-daemon/src/runtime_health/post_commit_work.rs
+++ b/crates/atm-daemon/src/runtime_health/post_commit_work.rs
@@ -1,252 +1,47 @@
-//! Identifier-only work that runs after local SQLite admission.
+//! Post-commit peer-delivery signals.
+//!
+//! Receiver hooks deliberately do not pass through this adapter. They run
+//! synchronously after a newly persisted inbound write so a hook warning can
+//! remain attached to the successful receive response.
 
-use std::collections::BTreeMap;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::Arc;
 
-use atm_core::{LocalServiceRuntime, error::AtmError, schema::AtmMessageId};
+use atm_core::schema::AtmMessageId;
 
-use crate::AtmHomeDir;
-use crate::daemon_runtime_observability::DaemonRuntimeObservability;
-use crate::daemon_worker_join::{
-    CompletionTrackedJoinHandle, JoinTimeoutPolicy, join_with_timeout,
-};
 use crate::peer_drain_coordinator::PeerDeliveryCoordinator;
 
-const GRAFT_POST_SEND_IO_DEADLINE: Duration = Duration::from_secs(3);
-const POST_COMMIT_WORKER_JOIN_POLICY: JoinTimeoutPolicy = JoinTimeoutPolicy {
-    subsystem: "runtime_health",
-    worker_kind: "post-commit worker",
-    panic_message: "post-commit worker panicked during shutdown",
-    timeout_message: "post-commit worker exceeded the shutdown join deadline",
-};
-
-/// Identifier-only work admitted after the canonical SQLite transaction.
+/// Identifier-only peer-delivery work admitted after an origin write commits.
 ///
-/// This deliberately cannot carry a request body, receipt state, or a
-/// prepared write. Workers reload immutable data from canonical storage after
-/// the IPC response has been written.
+/// This adapter is not a notification queue: received-message hooks have no
+/// variant here and no background worker.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum PostCommitWorkKey {
-    LocalNudge(AtmMessageId),
     PeerDelivery {
         peer: atm_core::types::HostName,
         message_id: AtmMessageId,
     },
 }
 
-/// The admission path may only signal this boundary; it never waits for a
-/// worker and never owns transport, hook, or graft I/O.
+/// The daemon-owned peer-delivery signal boundary.
 pub(crate) trait PostCommitWorkQueue: Send + Sync {
     fn signal(&self, work: PostCommitWorkKey);
 }
 
-/// The daemon-owned worker adapter. The bounded queue retains only work
-/// identifiers; it reloads the committed record before invoking a hook.
+/// Thin adapter retained until AM removes legacy peer-delivery coordination.
+/// It owns no hook worker, queue, retry task, or mutable delivery state.
 pub(crate) struct PeerPostCommitWorkQueue {
     coordinator: Arc<dyn PeerDeliveryCoordinator>,
-    sender: SyncSender<PostCommitWorkKey>,
-    // The receiver remains daemon-owned for the queue lifetime.  A worker may
-    // stop and later be restarted; taking ownership of it for the first worker
-    // made that otherwise ordinary recovery path permanently unavailable.
-    receiver: Arc<Mutex<Receiver<PostCommitWorkKey>>>,
-    local_nudge_targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
-    runtime: LocalServiceRuntime,
-    home_dir: AtmHomeDir,
-    observability: Arc<dyn DaemonRuntimeObservability>,
-    stop: Arc<AtomicBool>,
-    worker: Mutex<Option<CompletionTrackedJoinHandle<()>>>,
-}
-
-#[derive(Clone)]
-struct PostCommitNudgeTarget {
-    team: atm_core::types::TeamName,
-    agent: atm_core::types::AgentName,
 }
 
 impl PeerPostCommitWorkQueue {
-    pub(crate) fn new(
-        coordinator: Arc<dyn PeerDeliveryCoordinator>,
-        runtime: LocalServiceRuntime,
-        home_dir: AtmHomeDir,
-        observability: Arc<dyn DaemonRuntimeObservability>,
-    ) -> Self {
-        let (sender, receiver) = mpsc::sync_channel(256);
-        Self {
-            coordinator,
-            sender,
-            receiver: Arc::new(Mutex::new(receiver)),
-            local_nudge_targets: Arc::new(Mutex::new(BTreeMap::new())),
-            runtime,
-            home_dir,
-            observability,
-            stop: Arc::new(AtomicBool::new(false)),
-            worker: Mutex::new(None),
-        }
-    }
-
-    pub(crate) fn register_local_nudge(
-        &self,
-        message_id: AtmMessageId,
-        team: atm_core::types::TeamName,
-        agent: atm_core::types::AgentName,
-    ) {
-        let Ok(mut targets) = self.local_nudge_targets.lock() else {
-            tracing::error!(subsystem = "runtime_health", action = "post_commit_work_register", %message_id, "local post-commit work target registry lock poisoned");
-            return;
-        };
-        targets.insert(message_id, PostCommitNudgeTarget { team, agent });
-    }
-
-    pub(crate) fn start(&self) -> Result<(), AtmError> {
-        let mut worker = self.worker.lock().map_err(|_| {
-            AtmError::daemon_unavailable("post-commit worker lifecycle lock poisoned")
-        })?;
-        if worker.is_some() {
-            return Ok(());
-        }
-        self.stop.store(false, Ordering::SeqCst);
-        let receiver = Arc::clone(&self.receiver);
-        let targets = Arc::clone(&self.local_nudge_targets);
-        let runtime = self.runtime.clone();
-        let home_dir = self.home_dir.clone();
-        let observability = self.observability.clone();
-        let stop = Arc::clone(&self.stop);
-        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
-        let join_handle = std::thread::Builder::new()
-            .name("atm-post-commit-work".to_string())
-            .spawn(move || {
-                let _completion_tx = completion_tx;
-                Self::run(receiver, targets, runtime, home_dir, observability, stop);
-            })
-            .map_err(|_| AtmError::daemon_unavailable("failed to start post-commit worker"))?;
-        *worker = Some(CompletionTrackedJoinHandle {
-            completion_rx,
-            join_handle,
-        });
-        Ok(())
-    }
-
-    pub(crate) fn stop(&self) -> Result<(), AtmError> {
-        self.stop.store(true, Ordering::SeqCst);
-        let worker = self
-            .worker
-            .lock()
-            .map_err(|_| {
-                AtmError::daemon_unavailable("post-commit worker lifecycle lock poisoned")
-            })?
-            .take();
-        if let Some(worker) = worker {
-            join_with_timeout(
-                worker,
-                GRAFT_POST_SEND_IO_DEADLINE,
-                POST_COMMIT_WORKER_JOIN_POLICY,
-            )?;
-        }
-        Ok(())
-    }
-
-    fn run(
-        receiver: Arc<Mutex<Receiver<PostCommitWorkKey>>>,
-        targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
-        runtime: LocalServiceRuntime,
-        home_dir: AtmHomeDir,
-        observability: Arc<dyn DaemonRuntimeObservability>,
-        stop: Arc<AtomicBool>,
-    ) {
-        loop {
-            let received = match receiver.lock() {
-                Ok(receiver) => receiver.recv_timeout(Duration::from_millis(100)),
-                Err(_) => {
-                    tracing::error!(
-                        subsystem = "runtime_health",
-                        action = "post_commit_work_receive",
-                        "post-commit worker receiver lock poisoned"
-                    );
-                    break;
-                }
-            };
-            let work = match received {
-                Ok(work) => work,
-                // Once shutdown begins, drain identifiers already accepted by
-                // the bounded queue before ending the worker.  These are not
-                // durable retry records, so silently abandoning them would
-                // make local nudges disappear at daemon shutdown.
-                Err(RecvTimeoutError::Timeout) if stop.load(Ordering::SeqCst) => break,
-                Err(RecvTimeoutError::Timeout) => continue,
-                Err(RecvTimeoutError::Disconnected) => break,
-            };
-            let PostCommitWorkKey::LocalNudge(message_id) = work else {
-                continue;
-            };
-            let target = targets
-                .lock()
-                .ok()
-                .and_then(|mut targets| targets.remove(&message_id));
-            let Some(target) = target else {
-                continue;
-            };
-            let emitter = runtime
-                .load_roster_member(&target.team, &target.agent)
-                .ok()
-                .flatten()
-                .and_then(|member| {
-                    crate::message_received_emitter::message_received_emitter_for_harness(&member)
-                });
-            match catch_unwind(AssertUnwindSafe(|| {
-                atm_core::send::emit_persisted_local_post_write(
-                    &runtime,
-                    observability.as_ref(),
-                    home_dir.as_path(),
-                    &target.team,
-                    &target.agent,
-                    message_id,
-                    emitter.as_deref(),
-                )
-            })) {
-                Ok(Err(error)) => {
-                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, %error, "post-commit local notification failed after admission")
-                }
-                Err(_) => {
-                    tracing::error!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, "post-commit local notification panicked; worker isolated the failure and remains available")
-                }
-                Ok(Ok(())) => {}
-            }
-        }
+    pub(crate) fn new(coordinator: Arc<dyn PeerDeliveryCoordinator>) -> Self {
+        Self { coordinator }
     }
 }
 
 impl PostCommitWorkQueue for PeerPostCommitWorkQueue {
     fn signal(&self, work: PostCommitWorkKey) {
-        match work {
-            PostCommitWorkKey::PeerDelivery { peer, message_id } => {
-                self.coordinator.signal_after_persist(peer, message_id)
-            }
-            PostCommitWorkKey::LocalNudge(message_id) => match self
-                .sender
-                .try_send(PostCommitWorkKey::LocalNudge(message_id))
-            {
-                Ok(()) => {}
-                Err(TrySendError::Full(_)) => {
-                    self.remove_local_nudge_target(message_id);
-                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit queue is full; local nudge was not emitted and must be retried by the caller or operator")
-                }
-                Err(TrySendError::Disconnected(_)) => {
-                    self.remove_local_nudge_target(message_id);
-                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit worker is unavailable; local nudge was not emitted and must be retried by the caller or operator")
-                }
-            },
-        }
-    }
-}
-
-impl PeerPostCommitWorkQueue {
-    fn remove_local_nudge_target(&self, message_id: AtmMessageId) {
-        if let Ok(mut targets) = self.local_nudge_targets.lock() {
-            targets.remove(&message_id);
-        }
+        let PostCommitWorkKey::PeerDelivery { peer, message_id } = work;
+        self.coordinator.signal_after_persist(peer, message_id);
     }
 }

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -117,7 +117,7 @@ fn write_graft_enabled_config(workspace_dir: &std::path::Path) {
 
 #[test]
 #[serial_test::serial(env)]
-fn dispatcher_send_keeps_post_commit_graft_failure_out_of_admission_response() {
+fn dispatcher_send_keeps_received_hook_failure_as_a_success_warning() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let response = dispatcher
@@ -142,15 +142,16 @@ fn dispatcher_send_keeps_post_commit_graft_failure_out_of_admission_response() {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
         other => panic!("expected send response, got {other:?}"),
     };
-    assert!(
-        outcome.warnings.is_empty(),
-        "post-commit graft failure must not relabel a successful local admission"
+    assert_eq!(outcome.warnings.len(), 1);
+    assert_eq!(
+        outcome.warnings[0].code,
+        Some(atm_core::error_codes::AtmErrorCode::PostSendGraftUnavailable)
     );
 }
 
 #[test]
 #[serial_test::serial(env)]
-fn dispatcher_ack_keeps_post_commit_graft_failure_out_of_admission_response() {
+fn dispatcher_ack_keeps_received_hook_failure_as_a_success_warning() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let source_response = dispatcher
@@ -195,9 +196,10 @@ fn dispatcher_ack_keeps_post_commit_graft_failure_out_of_admission_response() {
         ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => outcome,
         other => panic!("expected ack response, got {other:?}"),
     };
-    assert!(
-        ack_outcome.warnings.is_empty(),
-        "post-commit graft failure must not relabel a successful ACK admission"
+    assert_eq!(ack_outcome.warnings.len(), 1);
+    assert_eq!(
+        ack_outcome.warnings[0].code,
+        Some(atm_core::error_codes::AtmErrorCode::PostSendGraftUnavailable)
     );
 }
 

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,7 +1,5 @@
 use atm_core::ack::AckRequest;
-use atm_core::api::{
-    ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline,
-};
+use atm_core::api::{ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline};
 use atm_core::boundary::RosterHarness;
 use atm_core::graft::{
     GraftPostSendResponse, GraftReceiverListener, graft_receiver_record_path_from_home,

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,13 +1,16 @@
 use atm_core::ack::AckRequest;
+use atm_core::api::{
+    ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline,
+};
 use atm_core::boundary::RosterHarness;
 use atm_core::graft::{
     GraftPostSendResponse, GraftReceiverListener, graft_receiver_record_path_from_home,
 };
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
-use atm_core::schema::{AgentMember, TeamConfig};
+use atm_core::schema::{AgentMember, AtmMessageId, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
-use atm_core::types::{AgentName, TeamName};
+use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_runtime_test_support::open_sqlite_boundary;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -147,6 +150,61 @@ fn dispatcher_send_keeps_received_hook_failure_as_a_success_warning() {
         outcome.warnings[0].code,
         Some(atm_core::error_codes::AtmErrorCode::PostSendGraftUnavailable)
     );
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn uds_tcp_and_peer_provenance_converge_on_the_received_hook_route() {
+    let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
+    let team = TEST_TEAM.parse::<TeamName>().expect("team");
+    let cases = [
+        ("UDS", AuthenticatedIngress::Local, false),
+        ("TCP", AuthenticatedIngress::Local, false),
+        ("peer HTTPS", AuthenticatedIngress::Peer, true),
+    ];
+
+    for (transport, ingress, peer_provenance) in cases {
+        let mut request = SendRequest::new(
+            atm_home.clone(),
+            workspace_dir.clone(),
+            ROLE_TEAM_LEAD.parse().expect("caller"),
+            "qa-a@test-team",
+            team.clone(),
+            SendMessageSource::Inline(format!("{transport} received-hook proof")),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("send request");
+        if peer_provenance {
+            request.authenticated_source_host = Some("peer.example.test".parse().expect("host"));
+            request.origin_message_id = Some(AtmMessageId::new());
+            request.origin_timestamp = Some(IsoTimestamp::now());
+        }
+        let response = dispatcher
+            .route(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(request))),
+                ingress,
+                RequestDeadline::after(Duration::from_secs(5)),
+            )
+            .expect("all supported ingress provenance reaches the canonical router")
+            .into_inner();
+        let outcome = match response {
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
+            other => panic!("{transport} expected a successful send response, got {other:?}"),
+        };
+        assert_eq!(
+            outcome.warnings.len(),
+            1,
+            "{transport} must invoke the same received-hook path exactly once"
+        );
+        assert_eq!(
+            outcome.warnings[0].code,
+            Some(atm_core::error_codes::AtmErrorCode::PostSendGraftUnavailable),
+            "{transport} must preserve its received-hook failure as a warning"
+        );
+    }
 }
 
 #[test]

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -59,9 +59,10 @@ impl GraftReceiveHook<'_> {
 impl boundary::sealed::Sealed for GraftReceiveHook<'_> {}
 
 impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
-    fn emit_post_send(
+    fn emit_received_message(
         &self,
         dispatch: &BuiltInPostSendDispatch,
+        _deadline: atm_core::RequestDeadline,
     ) -> Result<PostSendEmissionPath, AtmError> {
         let PostSendBuiltInTarget::Graft(GraftNudgeTarget {
             recipient,

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -530,8 +530,10 @@ fn handle_graft_receiver_connection(
         snapshot: &ctx.snapshot,
         observability: ctx.observability.as_ref(),
     })
-    .emit_post_send(&dispatch)
-    {
+    .emit_received_message(
+        &dispatch,
+        atm_core::RequestDeadline::after(GRAFT_RECEIVER_IO_DEADLINE),
+    ) {
         Ok(_) => GraftPostSendResponse::Delivered,
         Err(error) => GraftPostSendResponse::Error(error),
     };

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -21,5 +21,7 @@ tokio.workspace = true
 tower.workspace = true
 
 [dev-dependencies]
+atm-runtime-test-support = { path = "../atm-runtime-test-support" }
+atm-storage = { path = "../atm-storage" }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -1,12 +1,13 @@
 //! Tokio HTTP runtime composition contract for ATM.
 //!
-//! This crate owns no listener or route implementation in AL.1.  It provides
-//! the typed, consuming lifecycle and validates runtime-owned configuration
-//! before a later adapter is allowed to bind or publish an endpoint.  See the
-//! [Phase AL/AM runtime boundary checklist](../../../docs/plans/phase-al-am-runtime-boundary-checklist.md).
+//! This crate owns the replacement Tokio/Axum listener and canonical typed
+//! message route. It validates runtime-owned configuration before binding and
+//! keeps lifecycle ownership with the Tokio task that serves that route. See
+//! the [Phase AL/AM runtime boundary checklist](../../../docs/plans/phase-al-am-runtime-boundary-checklist.md).
 //!
 //! The only ATM dependency is `atm-core`, specifically its existing sealed
-//! [`atm_core::ApiRouter`] boundary and canonical [`atm_core::AtmError`].
+//! canonical [`atm_core::AtmError`] and the existing core storage and hook
+//! contracts supplied by replacement composition.
 //! Runtime construction never accepts a storage backend, tmux, graft, CLI, or
 //! daemon-bootstrap type.
 
@@ -31,21 +32,26 @@
 //! }
 //! ```
 
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use atm_core::ApiRouter;
 use atm_core::error::AtmError;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
 
 mod message_handler;
+mod storage_and_nudge_router;
 
-pub use message_handler::{AuthenticatedConnector, canonical_message_router};
+pub use message_handler::{
+    AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
+};
+pub use storage_and_nudge_router::StorageAndNudgeRouter;
 
-/// Validated configuration for the future maintained Tokio HTTP runtime.
+/// Validated configuration for the maintained Tokio HTTP runtime.
 ///
 /// The fields remain private so composition cannot bypass validation before a
 /// listener is introduced in a later AL sprint.
@@ -203,17 +209,17 @@ impl TlsMaterial {
     }
 }
 
-/// Composition input that uses the existing sealed application boundary.
+/// Composition input for the replacement async write boundary.
 #[derive(Clone)]
 pub struct HttpRuntimeBuilder {
     config: HttpRuntimeConfig,
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
 }
 
 impl HttpRuntimeBuilder {
     #[must_use]
-    pub fn new(config: HttpRuntimeConfig, router: Arc<dyn ApiRouter>) -> Self {
-        Self { config, router }
+    pub fn new(config: HttpRuntimeConfig, handler: Arc<dyn CanonicalWriteHandler>) -> Self {
+        Self { config, handler }
     }
 
     /// Validates all runtime-owned input without binding or publishing.
@@ -225,67 +231,138 @@ impl HttpRuntimeBuilder {
         validate_config(&self.config)?;
         Ok(HttpRuntime {
             config: self.config,
-            router: self.router,
-            _state: PhantomData,
+            handler: self.handler,
+            state: Configured,
         })
     }
 }
 
 /// Validated but not started runtime state.
 pub struct Configured;
-/// Runtime lifecycle state after its future listener/start adapter begins.
-pub struct Running;
-/// Runtime lifecycle state while the future listener drains.
-pub struct Draining;
+/// Runtime lifecycle state while its owned Axum server is accepting requests.
+pub struct Running {
+    local_address: SocketAddr,
+    shutdown_tx: watch::Sender<()>,
+    server_task: JoinHandle<std::io::Result<()>>,
+}
+/// Runtime lifecycle state after cancellation and while the Axum task drains.
+pub struct Draining {
+    server_task: JoinHandle<std::io::Result<()>>,
+}
 /// Terminal lifecycle state with no live runtime-owned handles.
 pub struct Stopped;
 
 /// Non-cloneable lifecycle owner. State transitions consume this value.
 pub struct HttpRuntime<State> {
     config: HttpRuntimeConfig,
-    router: Arc<dyn ApiRouter>,
-    _state: PhantomData<State>,
+    handler: Arc<dyn CanonicalWriteHandler>,
+    state: State,
 }
 
 impl HttpRuntime<Configured> {
-    /// Transitions the validated runtime to `Running`.
+    /// Binds the replacement listener and starts its one Axum server task.
     ///
-    /// AL.1 intentionally owns no listener or endpoint publisher; AL.2 adds
-    /// the canonical handler and later adapter sprints provide the binding
-    /// implementation. This transition is still consuming so consumers cannot
-    /// express double-start or publish-before-running.
+    /// The caller supplies the Tokio runtime. This method never creates a
+    /// nested runtime and all request handling runs through the one typed
+    /// route built from the injected application boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the configured TCP address cannot be bound or
+    /// its local address cannot be read.
     pub async fn start(self) -> Result<HttpRuntime<Running>, AtmError> {
-        Ok(self.into_state())
+        let listener = TcpListener::bind(self.config.bind_address)
+            .await
+            .map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to bind replacement HTTP runtime at {}: {source}",
+                    self.config.bind_address
+                ))
+            })?;
+        let local_address = listener.local_addr().map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to read replacement HTTP runtime address: {source}"
+            ))
+        })?;
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(());
+        let router = canonical_message_router(
+            Arc::clone(&self.handler),
+            AuthenticatedConnector::local(),
+            self.config.limits,
+            self.config.timeouts,
+        );
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.changed().await;
+                })
+                .await
+        });
+        Ok(HttpRuntime {
+            config: self.config,
+            handler: self.handler,
+            state: Running {
+                local_address,
+                shutdown_tx,
+                server_task,
+            },
+        })
     }
 }
 
 impl HttpRuntime<Running> {
+    /// Returns the actual listener address selected at start.
+    #[must_use]
+    pub const fn local_address(&self) -> SocketAddr {
+        self.state.local_address
+    }
+
     /// Consumes the only running owner and begins the drain transition.
     #[must_use]
     pub fn begin_shutdown(self) -> HttpRuntime<Draining> {
-        self.into_state()
+        let _ = self.state.shutdown_tx.send(());
+        HttpRuntime {
+            config: self.config,
+            handler: self.handler,
+            state: Draining {
+                server_task: self.state.server_task,
+            },
+        }
     }
 }
 
 impl HttpRuntime<Draining> {
     /// Completes the drain transition.
     ///
-    /// AL.1 owns no listener, connection task, or cancellation handle, so there
-    /// is no work to time-bound here. The validated shutdown duration is
-    /// reserved for the adapter that first owns drainable runtime work; that
-    /// adapter must apply it to its actual drain operation rather than inventing
-    /// a delay in this lifecycle-only transition.
-    pub async fn finish(self) -> HttpRuntime<Stopped> {
-        self.into_state()
-    }
-}
-
-impl<State> HttpRuntime<State> {
-    fn into_state<Next>(self) -> HttpRuntime<Next> {
-        HttpRuntime {
-            config: self.config,
-            router: self.router,
-            _state: PhantomData,
+    /// The runtime waits only for its actual Axum task. A shutdown deadline
+    /// aborts and joins that task so no replacement-runtime task is detached.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the server fails while draining or exceeds the
+    /// configured shutdown bound.
+    pub async fn finish(self) -> Result<HttpRuntime<Stopped>, AtmError> {
+        let mut server_task = self.state.server_task;
+        let finished = tokio::time::timeout(self.config.timeouts.shutdown, &mut server_task).await;
+        match finished {
+            Ok(Ok(Ok(()))) => Ok(HttpRuntime {
+                config: self.config,
+                handler: self.handler,
+                state: Stopped,
+            }),
+            Ok(Ok(Err(source))) => Err(AtmError::daemon_unavailable(format!(
+                "replacement HTTP runtime stopped with an I/O error: {source}"
+            ))),
+            Ok(Err(source)) => Err(AtmError::daemon_unavailable(format!(
+                "replacement HTTP runtime task ended unexpectedly: {source}"
+            ))),
+            Err(_) => {
+                server_task.abort();
+                let _ = server_task.await;
+                Err(AtmError::daemon_unavailable(
+                    "replacement HTTP runtime exceeded its shutdown deadline",
+                ))
+            }
         }
     }
 }
@@ -355,30 +432,30 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use atm_core::ApiRouter;
-    use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
-    use atm_core::boundary;
+    use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use atm_core::error::AtmError;
 
     use super::{
-        HttpRuntimeBuilder, HttpRuntimeConfig, NonZeroDuration, RuntimeLimits, RuntimeTimeouts,
-        UnixSocketConfig,
+        CanonicalWriteHandler, HttpRuntimeBuilder, HttpRuntimeConfig, NonZeroDuration,
+        RuntimeLimits, RuntimeTimeouts, UnixSocketConfig,
     };
 
     struct TestRouter;
 
-    impl boundary::sealed::Sealed for TestRouter {}
-
-    impl ApiRouter for TestRouter {
-        fn route(
+    impl CanonicalWriteHandler for TestRouter {
+        fn write(
             &self,
-            _request: ApiRequest,
+            _request: atm_core::send::WriteRequest,
             _ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            Err(AtmError::validation(
-                "test router is not invoked by the AL.1 lifecycle contract",
-            ))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async {
+                Err(AtmError::validation(
+                    "test handler is not invoked by the lifecycle contract",
+                ))
+            })
         }
     }
 
@@ -576,6 +653,33 @@ mod tests {
             .expect("valid configuration");
         let running = configured.start().await.expect("AL.1 start transition");
         let draining = running.begin_shutdown();
-        let _stopped = draining.finish().await;
+        let _stopped = draining.finish().await.expect("runtime must drain");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_binds_serves_and_joins_the_axum_task() {
+        let listener =
+            std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve a test port");
+        let port = listener.local_addr().expect("read test port").port();
+        drop(listener);
+
+        let configured = HttpRuntimeBuilder::new(config(port), Arc::new(TestRouter))
+            .build()
+            .expect("valid configuration");
+        let running = configured.start().await.expect("replacement server starts");
+        let response = reqwest::Client::new()
+            .get(format!(
+                "http://{}/v1/atm/messages",
+                running.local_address()
+            ))
+            .send()
+            .await
+            .expect("replacement server responds");
+        assert_eq!(response.status(), reqwest::StatusCode::METHOD_NOT_ALLOWED);
+        running
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("replacement server joins after shutdown");
     }
 }

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -1,15 +1,15 @@
 //! Canonical typed HTTP ingress for message writes.
 //!
 //! This module owns HTTP extraction, connector-provenance normalization, and
-//! response translation only.  It deliberately delegates persistence and all
-//! message policy to the sealed [`ApiRouter`] boundary exactly once.
+//! response translation only. It delegates persistence and received-message
+//! notification to one replacement-owned async write boundary.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
-use atm_core::ApiRouter;
 use atm_core::api::{
-    ApiRequest, ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline,
-    http_route_surface,
+    ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline, http_route_surface,
 };
 use atm_core::error::AtmError;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
@@ -31,6 +31,19 @@ use tower::limit::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 
 use crate::{RuntimeLimits, RuntimeTimeouts};
+
+/// Async replacement-owned application operation for the canonical write
+/// route. Implementations may isolate synchronous storage or hook adapters in
+/// narrow `spawn_blocking` calls, but the HTTP handler itself remains a Tokio
+/// future and never dispatches an entire legacy router on a worker pool.
+pub trait CanonicalWriteHandler: Send + Sync {
+    fn write(
+        &self,
+        request: WriteRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>>;
+}
 
 /// Provenance established by the transport adapter after authentication.
 ///
@@ -75,7 +88,7 @@ impl AuthenticatedConnector {
 
 #[derive(Clone)]
 struct MessageRouteState {
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
     connector: AuthenticatedConnector,
     request_timeout: std::time::Duration,
 }
@@ -86,13 +99,13 @@ struct MessageRouteState {
 /// layers bound body memory and in-flight work; `LoadShedLayer` rejects rather
 /// than queues a request whenever the configured capacity is unavailable.
 pub fn canonical_message_router(
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
     connector: AuthenticatedConnector,
     limits: RuntimeLimits,
     timeouts: RuntimeTimeouts,
 ) -> Router {
     let state = MessageRouteState {
-        router,
+        handler,
         connector,
         request_timeout: timeouts.request,
     };
@@ -142,37 +155,10 @@ async fn post_messages(
     let ingress = state.connector.normalize_write(&mut request);
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    // The router receives the absolute deadline and decides whether a write
-    // may begin. Do not wrap its blocking isolation in a second timeout: once
-    // a durable transaction has started, abandoning this join would let the
-    // server commit while the caller incorrectly receives a timeout.
-    let response =
-        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline).await;
+    let response = state.handler.write(request, ingress, deadline).await;
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
-}
-
-/// Calls the synchronous sealed application boundary without stalling a Tokio
-/// worker. The boundary remains synchronous until its owning core contract is
-/// deliberately changed; this adapter owns the asynchronous isolation only.
-async fn dispatch_on_blocking_pool(
-    router: Arc<dyn ApiRouter>,
-    request: WriteRequest,
-    ingress: AuthenticatedIngress,
-    deadline: RequestDeadline,
-) -> Result<ApiResponse, AtmError> {
-    tokio::task::spawn_blocking(move || {
-        router.route(ApiRequest::Write(Box::new(request)), ingress, deadline)
-    })
-    .await
-    .map_err(|source| {
-        AtmError::new(
-            atm_core::error::AtmErrorCode::InternalError,
-            "canonical HTTP dispatch task ended unexpectedly",
-        )
-        .with_cause(source)
-    })?
 }
 
 fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
@@ -263,12 +249,11 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::api::PEER_SOURCE_HOST_HEADER;
-    use atm_core::boundary;
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::protocol::ResponseEnvelope;
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
-    use atm_core::{ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, RequestDeadline};
+    use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
     use axum::http::{Request, StatusCode};
@@ -276,8 +261,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        AuthenticatedConnector, canonical_message_router, canonical_write_path, json_response,
-        map_write_response,
+        AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
+        canonical_write_path, json_response, map_write_response,
     };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
@@ -287,23 +272,22 @@ mod tests {
         calls: Arc<Mutex<Vec<(atm_core::send::WriteRequest, AuthenticatedIngress)>>>,
     }
 
-    impl boundary::sealed::Sealed for RecordingRouter {}
-
-    impl ApiRouter for RecordingRouter {
-        fn route(
+    impl CanonicalWriteHandler for RecordingRouter {
+        fn write(
             &self,
-            request: ApiRequest,
+            request: atm_core::send::WriteRequest,
             ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            let ApiRequest::Write(request) = request else {
-                return Err(AtmError::validation("test expected a write request"));
-            };
-            self.calls
-                .lock()
-                .expect("record calls")
-                .push((*request, ingress));
-            Ok(ApiResponse::new(self.response.clone()))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .expect("record calls")
+                    .push((request, ingress));
+                Ok(ApiResponse::new(self.response.clone()))
+            })
         }
     }
 
@@ -325,17 +309,31 @@ mod tests {
         }
     }
 
-    impl boundary::sealed::Sealed for BlockingRouter {}
-
-    impl ApiRouter for BlockingRouter {
-        fn route(
+    impl CanonicalWriteHandler for BlockingRouter {
+        fn write(
             &self,
-            _request: ApiRequest,
+            _request: atm_core::send::WriteRequest,
             _ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            self.gate.wait_until_released();
-            Ok(ApiResponse::new(self.response.clone()))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                let gate = Arc::clone(&self.gate);
+                let response = self.response.clone();
+                tokio::task::spawn_blocking(move || {
+                    gate.wait_until_released();
+                    Ok(ApiResponse::new(response))
+                })
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "test blocking write task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })?
+            })
         }
     }
 
@@ -674,7 +672,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn synchronous_router_dispatch_does_not_stall_the_tokio_worker() {
+    async fn blocking_handler_operation_does_not_stall_the_tokio_worker() {
         let gate = Arc::new(Gate::default());
         let app = canonical_message_router(
             Arc::new(BlockingRouter {
@@ -690,7 +688,7 @@ mod tests {
         tokio::spawn(async move {
             wait_for_start
                 .await
-                .expect("blocking router entered before scheduler progress check");
+                .expect("blocking handler entered before scheduler progress check");
             progressed.note_scheduler_progress();
         });
         let entered = Arc::clone(&gate);
@@ -714,7 +712,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CREATED);
         assert!(
             gate.state.lock().expect("lock gate").scheduler_progressed,
-            "the Tokio worker must remain schedulable while the synchronous router runs"
+            "the Tokio worker must remain schedulable while the blocking handler operation runs"
         );
     }
 
@@ -737,7 +735,7 @@ mod tests {
         let entered = Arc::clone(&gate);
         tokio::task::spawn_blocking(move || entered.wait_until_entered())
             .await
-            .expect("wait for blocking router");
+            .expect("wait for blocking handler");
         tokio::time::sleep(Duration::from_millis(25)).await;
         assert!(
             !response.is_finished(),

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -142,18 +142,12 @@ async fn post_messages(
     let ingress = state.connector.normalize_write(&mut request);
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    let response = tokio::time::timeout(
-        state.request_timeout,
-        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline),
-    )
-    .await
-    .map_err(|_| {
-        AtmError::new(
-            atm_core::error::AtmErrorCode::WaitTimeout,
-            "canonical HTTP dispatch exceeded the configured request timeout",
-        )
-    })
-    .and_then(|response| response);
+    // The router receives the absolute deadline and decides whether a write
+    // may begin. Do not wrap its blocking isolation in a second timeout: once
+    // a durable transaction has started, abandoning this join would let the
+    // server commit while the caller incorrectly receives a timeout.
+    let response =
+        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline).await;
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
@@ -725,7 +719,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn request_timeout_returns_the_adr_032_timeout_error() {
+    async fn started_dispatch_returns_its_actual_response_after_the_advisory_deadline() {
         let gate = Arc::new(Gate::default());
         let app = canonical_message_router(
             Arc::new(BlockingRouter {
@@ -736,20 +730,24 @@ mod tests {
             limits(4096, 1),
             timeouts_with_request(Duration::from_millis(10)),
         );
-        let response = tokio::time::timeout(
-            Duration::from_secs(1),
-            post(
-                app,
-                serde_json::to_vec(&write_request()).expect("typed JSON"),
-            ),
-        )
-        .await;
+        let response = tokio::spawn(post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        ));
+        let entered = Arc::clone(&gate);
+        tokio::task::spawn_blocking(move || entered.wait_until_entered())
+            .await
+            .expect("wait for blocking router");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !response.is_finished(),
+            "the adapter must not synthesize a timeout while a started route owns the durable outcome"
+        );
         gate.release();
-        let response = response.expect("handler must enforce its request timeout");
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let error: AtmError =
-            serde_json::from_slice(&response_body(response).await).expect("ADR-032 timeout JSON");
-        assert_eq!(error.code(), AtmErrorCode::WaitTimeout);
+        let response = response
+            .await
+            .expect("request task joins after the started route completes");
+        assert_eq!(response.status(), StatusCode::CREATED);
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1,0 +1,180 @@
+//! Replacement-owned canonical write composition.
+//!
+//! This module owns the two explicit blocking seams in the replacement path:
+//! the injected storage-backed core write and the injected received-message
+//! hook. The enclosing HTTP route remains async and awaits both operations.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use atm_core::LocalServiceRuntime;
+use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
+use atm_core::boundary::MessageReceivedHookEmitter;
+use atm_core::error::AtmError;
+use atm_core::observability::ObservabilityPort;
+use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+use atm_core::send::{
+    WarningEntry, WriteOutcome, emit_received_message_after_commit, prepare_write_with_runtime,
+};
+
+use crate::CanonicalWriteHandler;
+
+/// The replacement implementation of the canonical write operation.
+///
+/// Storage stays behind `LocalServiceRuntime`'s core interfaces and
+/// notification stays behind the injected `MessageReceivedHookEmitter`. This
+/// type has no concrete SQLite, tmux, graft, or legacy-daemon dependency.
+#[derive(Clone)]
+pub struct StorageAndNudgeRouter {
+    service_runtime: LocalServiceRuntime,
+    observability: Arc<dyn ObservabilityPort + Send + Sync>,
+    received_hook: Arc<dyn MessageReceivedHookEmitter>,
+}
+
+impl StorageAndNudgeRouter {
+    #[must_use]
+    pub fn new(
+        service_runtime: LocalServiceRuntime,
+        observability: Arc<dyn ObservabilityPort + Send + Sync>,
+        received_hook: Arc<dyn MessageReceivedHookEmitter>,
+    ) -> Self {
+        Self {
+            service_runtime,
+            observability,
+            received_hook,
+        }
+    }
+
+    fn commit_write(
+        &self,
+        request: atm_core::send::WriteRequest,
+    ) -> Result<CommittedWrite, AtmError> {
+        let mut prepared = prepare_write_with_runtime(
+            request,
+            self.observability.as_ref(),
+            &self.service_runtime,
+        )?;
+        let newly_persisted = prepared.is_newly_persisted();
+        let canonical_request = prepared.outbound_request();
+        let message_id = prepared.persisted_message_id();
+        let outcome = prepared.finish(&self.service_runtime, self.observability.as_ref())?;
+        Ok(CommittedWrite {
+            outcome,
+            canonical_request,
+            message_id,
+            newly_persisted,
+        })
+    }
+
+    fn emit_received_hook(
+        &self,
+        request: &atm_core::send::WriteRequest,
+        message_id: atm_core::schema::AtmMessageId,
+        deadline: RequestDeadline,
+    ) -> Vec<WarningEntry> {
+        if deadline.expired() {
+            return vec![hook_warning(AtmError::daemon_unavailable(
+                "received-message hook was skipped because the request deadline was exhausted after persistence",
+            ))];
+        }
+        let Some(target) = request.to.as_ref() else {
+            return vec![hook_warning(AtmError::validation(
+                "durably received message had no canonical destination for receiver hook",
+            ))];
+        };
+        let team = target
+            .team()
+            .cloned()
+            .unwrap_or_else(|| request.caller_team.clone());
+        let agent = target.agent().clone();
+        match emit_received_message_after_commit(
+            &self.service_runtime,
+            &request.home_dir,
+            &team,
+            &agent,
+            message_id,
+            deadline,
+            Some(self.received_hook.as_ref()),
+        ) {
+            Ok(warnings) => warnings,
+            Err(error) => vec![hook_warning(error)],
+        }
+    }
+}
+
+struct CommittedWrite {
+    outcome: WriteOutcome,
+    canonical_request: atm_core::send::WriteRequest,
+    message_id: atm_core::schema::AtmMessageId,
+    newly_persisted: bool,
+}
+
+impl CanonicalWriteHandler for StorageAndNudgeRouter {
+    fn write(
+        &self,
+        request: atm_core::send::WriteRequest,
+        _ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        Box::pin(async move {
+            if deadline.expired() {
+                return Err(AtmError::daemon_unavailable(
+                    "request deadline expired before replacement write admission",
+                ));
+            }
+            let storage = self.clone();
+            let mut committed = tokio::task::spawn_blocking(move || storage.commit_write(request))
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "replacement storage write task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })??;
+            if committed.newly_persisted {
+                let hook = self.clone();
+                let request = committed.canonical_request.clone();
+                let message_id = committed.message_id;
+                let warnings = tokio::task::spawn_blocking(move || {
+                    hook.emit_received_hook(&request, message_id, deadline)
+                })
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "replacement received-message hook task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })?;
+                append_warnings(&mut committed.outcome, warnings);
+            }
+            Ok(ApiResponse::new(write_response(committed.outcome)))
+        })
+    }
+}
+
+fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
+    match outcome {
+        WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
+        WriteOutcome::Acknowledged(outcome) => outcome.warnings.extend(warnings),
+    }
+}
+
+fn write_response(outcome: WriteOutcome) -> ResponseEnvelope {
+    match outcome {
+        WriteOutcome::Sent(outcome) => ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)),
+        WriteOutcome::Acknowledged(outcome) => {
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
+        }
+    }
+}
+
+fn hook_warning(error: AtmError) -> WarningEntry {
+    WarningEntry::with_code(
+        error.code(),
+        format!("message received successfully, but its receiver hook did not run: {error}"),
+        Some("inspect the receiver hook endpoint or harness, then continue normally"),
+    )
+}

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -10,12 +10,13 @@ use std::sync::Arc;
 
 use atm_core::LocalServiceRuntime;
 use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
-use atm_core::boundary::MessageReceivedHookEmitter;
+use atm_core::boundary::AsyncMessageReceivedHookEmitter;
 use atm_core::error::AtmError;
 use atm_core::observability::ObservabilityPort;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
 use atm_core::send::{
-    WarningEntry, WriteOutcome, emit_received_message_after_commit, prepare_write_with_runtime,
+    WarningEntry, WriteOutcome, build_received_message_hook_dispatches_after_commit,
+    prepare_write_with_runtime,
 };
 
 use crate::CanonicalWriteHandler;
@@ -23,13 +24,13 @@ use crate::CanonicalWriteHandler;
 /// The replacement implementation of the canonical write operation.
 ///
 /// Storage stays behind `LocalServiceRuntime`'s core interfaces and
-/// notification stays behind the injected `MessageReceivedHookEmitter`. This
+/// notification stays behind the injected `AsyncMessageReceivedHookEmitter`. This
 /// type has no concrete SQLite, tmux, graft, or legacy-daemon dependency.
 #[derive(Clone)]
 pub struct StorageAndNudgeRouter {
     service_runtime: LocalServiceRuntime,
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
-    received_hook: Arc<dyn MessageReceivedHookEmitter>,
+    received_hook: Arc<dyn AsyncMessageReceivedHookEmitter>,
 }
 
 impl StorageAndNudgeRouter {
@@ -37,7 +38,7 @@ impl StorageAndNudgeRouter {
     pub fn new(
         service_runtime: LocalServiceRuntime,
         observability: Arc<dyn ObservabilityPort + Send + Sync>,
-        received_hook: Arc<dyn MessageReceivedHookEmitter>,
+        received_hook: Arc<dyn AsyncMessageReceivedHookEmitter>,
     ) -> Self {
         Self {
             service_runtime,
@@ -67,7 +68,7 @@ impl StorageAndNudgeRouter {
         })
     }
 
-    fn emit_received_hook(
+    async fn emit_received_hook(
         &self,
         request: &atm_core::send::WriteRequest,
         message_id: atm_core::schema::AtmMessageId,
@@ -88,18 +89,38 @@ impl StorageAndNudgeRouter {
             .cloned()
             .unwrap_or_else(|| request.caller_team.clone());
         let agent = target.agent().clone();
-        match emit_received_message_after_commit(
+        let dispatches = match build_received_message_hook_dispatches_after_commit(
             &self.service_runtime,
             &request.home_dir,
             &team,
             &agent,
             message_id,
-            deadline,
-            Some(self.received_hook.as_ref()),
         ) {
-            Ok(warnings) => warnings,
-            Err(error) => vec![hook_warning(error)],
+            Ok(dispatches) => dispatches,
+            Err(error) => return vec![hook_warning(error)],
+        };
+        let mut warnings = Vec::new();
+        for dispatch in dispatches {
+            let Some(remaining) = deadline.remaining() else {
+                warnings.push(hook_warning(AtmError::daemon_unavailable(
+                    "received-message hook was skipped because the request deadline was exhausted after persistence",
+                )));
+                break;
+            };
+            match tokio::time::timeout(
+                remaining,
+                self.received_hook.emit_received_message(dispatch, deadline),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => warnings.push(hook_warning(error)),
+                Err(_) => warnings.push(hook_warning(AtmError::daemon_unavailable(
+                    "received-message hook timed out after durable message persistence",
+                ))),
+            }
         }
+        warnings
     }
 }
 
@@ -137,17 +158,9 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 let hook = self.clone();
                 let request = committed.canonical_request.clone();
                 let message_id = committed.message_id;
-                let warnings = tokio::task::spawn_blocking(move || {
-                    hook.emit_received_hook(&request, message_id, deadline)
-                })
-                .await
-                .map_err(|source| {
-                    AtmError::new(
-                        atm_core::error::AtmErrorCode::InternalError,
-                        "replacement received-message hook task ended unexpectedly",
-                    )
-                    .with_cause(source)
-                })?;
+                let warnings = hook
+                    .emit_received_hook(&request, message_id, deadline)
+                    .await;
                 append_warnings(&mut committed.outcome, warnings);
             }
             Ok(ApiResponse::new(write_response(committed.outcome)))
@@ -182,15 +195,17 @@ fn hook_warning(error: AtmError) -> WarningEntry {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::future::Future;
     use std::path::PathBuf;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     use atm_core::boundary::{
-        BuiltInPostSendDispatch, MessageReceivedHookEmitter, PostSendEmissionPath, RosterEntry,
-        RosterHarness, RosterMemberKind,
+        AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, PostSendEmissionPath,
+        RosterEntry, RosterHarness, RosterMemberKind,
     };
     use atm_core::observability::NullObservability;
     use atm_core::schema::AtmMessageId;
@@ -216,16 +231,26 @@ mod tests {
         emitted_ids: Mutex<Vec<AtmMessageId>>,
         saw_durable_record: AtomicBool,
         failure: Option<AtmError>,
+        cancelled_on_drop: Option<Arc<AtomicBool>>,
+    }
+
+    struct CancellationMarker(Arc<AtomicBool>);
+
+    impl Drop for CancellationMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
     }
 
     impl atm_core::boundary::sealed::Sealed for RecordingReceivedHook {}
 
-    impl MessageReceivedHookEmitter for RecordingReceivedHook {
+    impl AsyncMessageReceivedHookEmitter for RecordingReceivedHook {
         fn emit_received_message(
             &self,
-            dispatch: &BuiltInPostSendDispatch,
+            dispatch: BuiltInPostSendDispatch,
             _deadline: RequestDeadline,
-        ) -> Result<PostSendEmissionPath, AtmError> {
+        ) -> Pin<Box<dyn Future<Output = Result<PostSendEmissionPath, AtmError>> + Send + '_>>
+        {
             let key = MessageKey::from(dispatch.event.message_id);
             self.saw_durable_record.store(
                 self.message_store
@@ -238,10 +263,14 @@ mod tests {
                 .lock()
                 .expect("record received hook emission")
                 .push(dispatch.event.message_id);
-            if let Some(error) = &self.failure {
-                return Err(error.clone());
+            let failure = self.failure.clone();
+            if let Some(cancelled) = self.cancelled_on_drop.clone() {
+                return Box::pin(async move {
+                    let _cleanup = CancellationMarker(cancelled);
+                    std::future::pending::<Result<PostSendEmissionPath, AtmError>>().await
+                });
             }
-            Ok(PostSendEmissionPath::GraftPort)
+            Box::pin(async move { failure.map_or(Ok(PostSendEmissionPath::GraftPort), Err) })
         }
     }
 
@@ -255,7 +284,11 @@ mod tests {
         current_dir: PathBuf,
     }
 
-    fn fixture(with_recipient: bool, hook_failure: Option<AtmError>) -> Fixture {
+    fn fixture(
+        with_recipient: bool,
+        hook_failure: Option<AtmError>,
+        cancelled_on_drop: Option<Arc<AtomicBool>>,
+    ) -> Fixture {
         let temporary_root = tempfile::tempdir().expect("temporary runtime root");
         let database_path = temporary_root.path().join("mail.sqlite");
         let assembly = open_sqlite_boundary(&database_path).expect("assemble SQLite boundary");
@@ -285,6 +318,7 @@ mod tests {
             emitted_ids: Mutex::new(Vec::new()),
             saw_durable_record: AtomicBool::new(false),
             failure: hook_failure,
+            cancelled_on_drop,
         });
         let home_dir = temporary_root.path().join("home");
         let current_dir = temporary_root.path().join("workspace");
@@ -323,6 +357,14 @@ mod tests {
     }
 
     fn router(fixture: &Fixture, connector: AuthenticatedConnector) -> axum::Router {
+        router_with_timeout(fixture, connector, Duration::from_secs(1))
+    }
+
+    fn router_with_timeout(
+        fixture: &Fixture,
+        connector: AuthenticatedConnector,
+        request_timeout: Duration,
+    ) -> axum::Router {
         canonical_message_router(
             Arc::new(fixture.router.clone()),
             connector,
@@ -331,7 +373,7 @@ mod tests {
                 std::num::NonZeroUsize::new(1).expect("non-zero request limit"),
             ),
             RuntimeTimeouts::new(
-                NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero request timeout"),
+                NonZeroDuration::new(request_timeout).expect("non-zero request timeout"),
                 NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
             ),
         )
@@ -358,7 +400,7 @@ mod tests {
 
     #[tokio::test]
     async fn axum_route_persists_before_emitting_one_received_hook() {
-        let fixture = fixture(true, None);
+        let fixture = fixture(true, None, None);
         let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
         let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
         assert_eq!(response.status(), StatusCode::CREATED);
@@ -389,7 +431,7 @@ mod tests {
 
     #[tokio::test]
     async fn axum_route_rejected_write_emits_no_hook_and_persists_no_message() {
-        let fixture = fixture(false, None);
+        let fixture = fixture(false, None, None);
         let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
         let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -420,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn axum_route_storage_failure_emits_no_hook_and_persists_no_message() {
-        let fixture = fixture(true, None);
+        let fixture = fixture(true, None, None);
         let writer_lock =
             hold_sqlite_writer_lock(&fixture.database_path).expect("hold SQLite writer lock");
         let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
@@ -454,7 +496,7 @@ mod tests {
 
     #[tokio::test]
     async fn axum_route_idempotent_duplicate_skips_the_second_received_hook() {
-        let fixture = fixture(true, None);
+        let fixture = fixture(true, None, None);
         let message_id = AtmMessageId::new();
         let mut write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone())
             .with_origin_metadata(message_id, atm_core::types::IsoTimestamp::now());
@@ -494,6 +536,7 @@ mod tests {
             Some(AtmError::daemon_unavailable(
                 "intentional received-hook failure",
             )),
+            None,
         );
         let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
         let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
@@ -510,7 +553,7 @@ mod tests {
         assert!(
             value["warnings"][0]["message"]
                 .as_str()
-                .is_some_and(|message| message.contains("post-send emission failed")),
+                .is_some_and(|message| message.contains("receiver hook did not run")),
             "warning identifies the advisory receiver-hook failure"
         );
         let emitted_ids = fixture
@@ -527,6 +570,39 @@ mod tests {
                 .expect("load committed message")
                 .is_some(),
             "hook failure cannot roll back a durable receive"
+        );
+    }
+
+    #[tokio::test]
+    async fn axum_route_hook_timeout_returns_success_warning_and_cancels_hook_future() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let fixture = fixture(true, None, Some(Arc::clone(&cancelled)));
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
+        let response = post_write(
+            router_with_timeout(
+                &fixture,
+                AuthenticatedConnector::local(),
+                Duration::from_millis(200),
+            ),
+            &write,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("send outcome JSON");
+        assert_eq!(value["warnings"].as_array().map(Vec::len), Some(1));
+        assert!(
+            value["warnings"][0]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("timed out")),
+            "timed-out hook is advisory after the durable write"
+        );
+        assert!(
+            cancelled.load(Ordering::SeqCst),
+            "deadline cancellation drops the hook future instead of leaving detached work"
         );
     }
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -5,6 +5,7 @@
 //! hook. The enclosing HTTP route remains async and awaits both operations.
 
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -21,6 +22,61 @@ use atm_core::send::{
 
 use crate::CanonicalWriteHandler;
 
+/// Replacement-owned admission for synchronous SQLite write jobs.
+///
+/// A permit is acquired before creating the narrow blocking task. Dropping a
+/// caller while it waits cancels only that admission. Once started, the job is
+/// awaited to its real durable outcome; the request deadline is not reused to
+/// falsely reclassify a committed transaction as a timeout.
+#[derive(Clone)]
+struct WriteAdmission {
+    permits: Arc<tokio::sync::Semaphore>,
+}
+
+impl WriteAdmission {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            permits: Arc::new(tokio::sync::Semaphore::new(capacity.get())),
+        }
+    }
+
+    async fn run<T, F>(&self, deadline: RequestDeadline, job: F) -> Result<T, AtmError>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T, AtmError> + Send + 'static,
+    {
+        let remaining = deadline.remaining().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "request deadline expired before replacement write admission",
+            )
+        })?;
+        let permit = tokio::time::timeout(remaining, Arc::clone(&self.permits).acquire_owned())
+            .await
+            .map_err(|_| {
+                AtmError::daemon_unavailable(
+                    "request deadline expired before replacement write admission",
+                )
+            })?
+            .map_err(|_| {
+                AtmError::daemon_unavailable("replacement write admission is shutting down")
+            })?;
+        if deadline.expired() {
+            return Err(AtmError::daemon_unavailable(
+                "request deadline expired before replacement write started",
+            ));
+        }
+        let outcome = tokio::task::spawn_blocking(job).await.map_err(|source| {
+            AtmError::new(
+                atm_core::error::AtmErrorCode::InternalError,
+                "replacement storage write task ended unexpectedly",
+            )
+            .with_cause(source)
+        })?;
+        drop(permit);
+        outcome
+    }
+}
+
 /// The replacement implementation of the canonical write operation.
 ///
 /// Storage stays behind `LocalServiceRuntime`'s core interfaces and
@@ -31,6 +87,7 @@ pub struct StorageAndNudgeRouter {
     service_runtime: LocalServiceRuntime,
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
     received_hook: Arc<dyn AsyncMessageReceivedHookEmitter>,
+    write_admission: WriteAdmission,
 }
 
 impl StorageAndNudgeRouter {
@@ -44,6 +101,7 @@ impl StorageAndNudgeRouter {
             service_runtime,
             observability,
             received_hook,
+            write_admission: WriteAdmission::new(NonZeroUsize::new(1).expect("one SQLite writer")),
         }
     }
 
@@ -145,15 +203,10 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 ));
             }
             let storage = self.clone();
-            let mut committed = tokio::task::spawn_blocking(move || storage.commit_write(request))
-                .await
-                .map_err(|source| {
-                    AtmError::new(
-                        atm_core::error::AtmErrorCode::InternalError,
-                        "replacement storage write task ended unexpectedly",
-                    )
-                    .with_cause(source)
-                })??;
+            let mut committed = self
+                .write_admission
+                .run(deadline, move || storage.commit_write(request))
+                .await?;
             if committed.newly_persisted {
                 let hook = self.clone();
                 let request = committed.canonical_request.clone();
@@ -196,6 +249,7 @@ fn hook_warning(error: AtmError) -> WarningEntry {
 mod tests {
     use std::fs;
     use std::future::Future;
+    use std::num::NonZeroUsize;
     use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -220,7 +274,7 @@ mod tests {
     use tempfile::TempDir;
     use tower::ServiceExt;
 
-    use super::StorageAndNudgeRouter;
+    use super::{StorageAndNudgeRouter, WriteAdmission};
     use crate::{
         AuthenticatedConnector, NonZeroDuration, RuntimeLimits, RuntimeTimeouts,
         canonical_message_router,
@@ -377,6 +431,147 @@ mod tests {
                 NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
             ),
         )
+    }
+
+    #[tokio::test]
+    async fn write_admission_rejects_saturation_without_starting_a_second_job() {
+        let admission = WriteAdmission::new(NonZeroUsize::new(1).expect("non-zero capacity"));
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
+        let first_admission = admission.clone();
+        let first = tokio::spawn(async move {
+            first_admission
+                .run(RequestDeadline::after(Duration::from_secs(1)), move || {
+                    first_started_tx.send(()).expect("signal started job");
+                    release_first_rx
+                        .blocking_recv()
+                        .expect("release started job");
+                    Ok("first durable result")
+                })
+                .await
+        });
+        first_started_rx.await.expect("first job starts");
+
+        let second_started = Arc::new(AtomicBool::new(false));
+        let second_job_started = Arc::clone(&second_started);
+        let saturated = admission
+            .run(
+                RequestDeadline::after(Duration::from_millis(20)),
+                move || {
+                    second_job_started.store(true, Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await;
+        assert!(
+            saturated.is_err(),
+            "saturated admission rejects before start"
+        );
+        assert!(
+            !second_started.load(Ordering::SeqCst),
+            "a rejected admission never creates its blocking SQLite job"
+        );
+
+        release_first_tx.send(()).expect("release first job");
+        assert_eq!(
+            first
+                .await
+                .expect("first task joins")
+                .expect("first result"),
+            "first durable result"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_never_starts_after_a_permit_is_released() {
+        let admission = WriteAdmission::new(NonZeroUsize::new(1).expect("non-zero capacity"));
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
+        let first_admission = admission.clone();
+        let first = tokio::spawn(async move {
+            first_admission
+                .run(RequestDeadline::after(Duration::from_secs(1)), move || {
+                    first_started_tx.send(()).expect("signal started job");
+                    release_first_rx
+                        .blocking_recv()
+                        .expect("release started job");
+                    Ok(())
+                })
+                .await
+        });
+        first_started_rx.await.expect("first job starts");
+
+        let cancelled_job_started = Arc::new(AtomicBool::new(false));
+        let cancelled_job_flag = Arc::clone(&cancelled_job_started);
+        let waiting_admission = admission.clone();
+        let waiting = tokio::spawn(async move {
+            waiting_admission
+                .run(RequestDeadline::after(Duration::from_secs(1)), move || {
+                    cancelled_job_flag.store(true, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        waiting.abort();
+        assert!(
+            waiting
+                .await
+                .expect_err("waiter is cancelled")
+                .is_cancelled()
+        );
+
+        release_first_tx.send(()).expect("release first job");
+        first
+            .await
+            .expect("first task joins")
+            .expect("first durable result");
+        assert!(
+            !cancelled_job_started.load(Ordering::SeqCst),
+            "cancelling while queued removes the job before it can start"
+        );
+    }
+
+    #[tokio::test]
+    async fn started_write_retains_its_actual_result_after_the_advisory_deadline() {
+        let admission = WriteAdmission::new(NonZeroUsize::new(1).expect("non-zero capacity"));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            admission
+                .run(
+                    RequestDeadline::after(Duration::from_millis(20)),
+                    move || {
+                        started_tx.send(()).expect("signal started job");
+                        release_rx.blocking_recv().expect("release started job");
+                        Ok("actual durable result")
+                    },
+                )
+                .await
+        });
+        started_rx.await.expect("job starts");
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        release_tx.send(()).expect("release started job");
+        assert_eq!(
+            task.await.expect("task joins").expect("actual result"),
+            "actual durable result",
+            "a started transaction is not reclassified as a deadline failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_admission_returns_the_underlying_storage_error() {
+        let admission = WriteAdmission::new(NonZeroUsize::new(1).expect("non-zero capacity"));
+        let error = admission
+            .run(RequestDeadline::after(Duration::from_secs(1)), || {
+                Err::<(), _>(AtmError::validation("intentional storage failure"))
+            })
+            .await
+            .expect_err("storage failure is preserved");
+        assert!(
+            error.message().contains("intentional storage failure"),
+            "the storage error is returned unchanged instead of being replaced by an admission error"
+        );
     }
 
     async fn post_write(app: axum::Router, write: &WriteRequest) -> axum::response::Response {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -6,6 +6,7 @@
 
 use std::future::Future;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -88,6 +89,7 @@ pub struct StorageAndNudgeRouter {
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
     received_hook: Arc<dyn AsyncMessageReceivedHookEmitter>,
     write_admission: WriteAdmission,
+    daemon_home: PathBuf,
 }
 
 impl StorageAndNudgeRouter {
@@ -96,12 +98,14 @@ impl StorageAndNudgeRouter {
         service_runtime: LocalServiceRuntime,
         observability: Arc<dyn ObservabilityPort + Send + Sync>,
         received_hook: Arc<dyn AsyncMessageReceivedHookEmitter>,
+        daemon_home: PathBuf,
     ) -> Self {
         Self {
             service_runtime,
             observability,
             received_hook,
             write_admission: WriteAdmission::new(NonZeroUsize::new(1).expect("one SQLite writer")),
+            daemon_home,
         }
     }
 
@@ -192,7 +196,7 @@ struct CommittedWrite {
 impl CanonicalWriteHandler for StorageAndNudgeRouter {
     fn write(
         &self,
-        request: atm_core::send::WriteRequest,
+        mut request: atm_core::send::WriteRequest,
         _ingress: AuthenticatedIngress,
         deadline: RequestDeadline,
     ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
@@ -202,6 +206,11 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                     "request deadline expired before replacement write admission",
                 ));
             }
+            // HTTP payload paths are caller metadata, never daemon filesystem
+            // authority. The replacement normalizes both roots before the
+            // shared writer uses them for its state and file-policy paths.
+            request.home_dir = self.daemon_home.clone();
+            request.current_dir = self.daemon_home.clone();
             let storage = self.clone();
             let mut committed = self
                 .write_admission
@@ -382,6 +391,7 @@ mod tests {
             assembly.service_runtime,
             Arc::new(NullObservability),
             received_hook.clone(),
+            home_dir.clone(),
         );
         Fixture {
             _temporary_root: temporary_root,
@@ -765,6 +775,52 @@ mod tests {
                 .expect("load committed message")
                 .is_some(),
             "hook failure cannot roll back a durable receive"
+        );
+    }
+
+    #[tokio::test]
+    async fn axum_route_uses_daemon_home_not_the_callers_forged_home_for_file_policy() {
+        let fixture = fixture(true, None, None);
+        let forged_home = fixture._temporary_root.path().join("forged-client-home");
+        let forged_workspace = fixture
+            ._temporary_root
+            .path()
+            .join("forged-client-workspace");
+        let client_file = fixture._temporary_root.path().join("client-provided.txt");
+        fs::create_dir_all(&forged_home).expect("create forged home");
+        fs::create_dir_all(&forged_workspace).expect("create forged workspace");
+        fs::write(&client_file, "client-owned attachment").expect("write client file");
+        let write = WriteRequest::new(
+            forged_home.clone(),
+            forged_workspace,
+            "sender".parse::<AgentName>().expect("sender"),
+            "recipient@test-team",
+            "test-team".parse().expect("caller team"),
+            SendMessageSource::File {
+                path: client_file,
+                message: Some("inspect attachment".to_owned()),
+            },
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write request");
+
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let daemon_copy = fixture
+            .home_dir
+            .join(".config/atm/share/test-team/client-provided.txt");
+        let forged_copy = forged_home.join(".config/atm/share/test-team/client-provided.txt");
+        assert_eq!(
+            fs::read_to_string(&daemon_copy).expect("read daemon-owned share copy"),
+            "client-owned attachment"
+        );
+        assert!(
+            !forged_copy.exists(),
+            "the caller-controlled home_dir must not redirect daemon file-policy output"
         );
     }
 

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -188,7 +188,6 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
-    use atm_core::api::AuthenticatedIngress;
     use atm_core::boundary::{
         BuiltInPostSendDispatch, MessageReceivedHookEmitter, PostSendEmissionPath, RosterEntry,
         RosterHarness, RosterMemberKind,
@@ -198,16 +197,25 @@ mod tests {
     use atm_core::send::{SendMessageSource, WriteRequest};
     use atm_core::types::{AgentName, ModelName, TeamName};
     use atm_core::{RequestDeadline, error::AtmError};
-    use atm_runtime_test_support::open_sqlite_boundary;
+    use atm_runtime_test_support::{hold_sqlite_writer_lock, open_sqlite_boundary};
     use atm_storage::{MessageKey, MessageQuery, MessageStore, RosterSnapshot};
+    use axum::body::{Body, to_bytes};
+    use axum::http::header::CONTENT_TYPE;
+    use axum::http::{Request, StatusCode};
     use tempfile::TempDir;
+    use tower::ServiceExt;
 
-    use super::{CanonicalWriteHandler, StorageAndNudgeRouter};
+    use super::StorageAndNudgeRouter;
+    use crate::{
+        AuthenticatedConnector, NonZeroDuration, RuntimeLimits, RuntimeTimeouts,
+        canonical_message_router,
+    };
 
     struct RecordingReceivedHook {
         message_store: Arc<dyn MessageStore + Send + Sync>,
         emitted_ids: Mutex<Vec<AtmMessageId>>,
         saw_durable_record: AtomicBool,
+        failure: Option<AtmError>,
     }
 
     impl atm_core::boundary::sealed::Sealed for RecordingReceivedHook {}
@@ -230,6 +238,9 @@ mod tests {
                 .lock()
                 .expect("record received hook emission")
                 .push(dispatch.event.message_id);
+            if let Some(error) = &self.failure {
+                return Err(error.clone());
+            }
             Ok(PostSendEmissionPath::GraftPort)
         }
     }
@@ -239,11 +250,12 @@ mod tests {
         router: StorageAndNudgeRouter,
         message_store: Arc<dyn MessageStore + Send + Sync>,
         received_hook: Arc<RecordingReceivedHook>,
+        database_path: PathBuf,
         home_dir: PathBuf,
         current_dir: PathBuf,
     }
 
-    fn fixture(with_recipient: bool) -> Fixture {
+    fn fixture(with_recipient: bool, hook_failure: Option<AtmError>) -> Fixture {
         let temporary_root = tempfile::tempdir().expect("temporary runtime root");
         let database_path = temporary_root.path().join("mail.sqlite");
         let assembly = open_sqlite_boundary(&database_path).expect("assemble SQLite boundary");
@@ -272,6 +284,7 @@ mod tests {
             message_store: Arc::clone(&message_store),
             emitted_ids: Mutex::new(Vec::new()),
             saw_durable_record: AtomicBool::new(false),
+            failure: hook_failure,
         });
         let home_dir = temporary_root.path().join("home");
         let current_dir = temporary_root.path().join("workspace");
@@ -287,6 +300,7 @@ mod tests {
             router,
             message_store,
             received_hook,
+            database_path,
             home_dir,
             current_dir,
         }
@@ -308,18 +322,46 @@ mod tests {
         .expect("write request")
     }
 
+    fn router(fixture: &Fixture, connector: AuthenticatedConnector) -> axum::Router {
+        canonical_message_router(
+            Arc::new(fixture.router.clone()),
+            connector,
+            RuntimeLimits::new(
+                std::num::NonZeroUsize::new(4096).expect("non-zero body limit"),
+                std::num::NonZeroUsize::new(1).expect("non-zero request limit"),
+            ),
+            RuntimeTimeouts::new(
+                NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero request timeout"),
+                NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
+            ),
+        )
+    }
+
+    async fn post_write(app: axum::Router, write: &WriteRequest) -> axum::response::Response {
+        let path = atm_core::api::http_route_surface()
+            .find(|route| route.method == "POST" && route.path_template.ends_with("/messages"))
+            .expect("core write route")
+            .path_template;
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(write).expect("serialize write request"),
+                ))
+                .expect("HTTP request"),
+        )
+        .await
+        .expect("infallible Axum service")
+    }
+
     #[tokio::test]
-    async fn newly_persisted_write_is_durable_before_one_received_hook_emission() {
-        let fixture = fixture(true);
-        fixture
-            .router
-            .write(
-                write_request(fixture.home_dir.clone(), fixture.current_dir.clone()),
-                AuthenticatedIngress::Local,
-                RequestDeadline::after(Duration::from_secs(1)),
-            )
-            .await
-            .expect("new write succeeds");
+    async fn axum_route_persists_before_emitting_one_received_hook() {
+        let fixture = fixture(true, None);
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(response.status(), StatusCode::CREATED);
 
         let emitted_ids = fixture
             .received_hook
@@ -346,21 +388,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_write_emits_no_hook_and_persists_no_message() {
-        let fixture = fixture(false);
-        let result = fixture
-            .router
-            .write(
-                write_request(fixture.home_dir.clone(), fixture.current_dir.clone()),
-                AuthenticatedIngress::Local,
-                RequestDeadline::after(Duration::from_secs(1)),
-            )
-            .await;
-
-        assert!(
-            result.is_err(),
-            "unknown recipient is rejected before persistence"
-        );
+    async fn axum_route_rejected_write_emits_no_hook_and_persists_no_message() {
+        let fixture = fixture(false, None);
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert!(
             fixture
                 .received_hook
@@ -383,6 +415,118 @@ mod tests {
         assert!(
             messages.is_empty(),
             "rejected write persists no mailbox record"
+        );
+    }
+
+    #[tokio::test]
+    async fn axum_route_storage_failure_emits_no_hook_and_persists_no_message() {
+        let fixture = fixture(true, None);
+        let writer_lock =
+            hold_sqlite_writer_lock(&fixture.database_path).expect("hold SQLite writer lock");
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            fixture
+                .received_hook
+                .emitted_ids
+                .lock()
+                .expect("inspect received-hook emissions")
+                .is_empty(),
+            "storage failure must not emit a receiver hook"
+        );
+        drop(writer_lock);
+        assert!(
+            fixture
+                .message_store
+                .list_messages(&MessageQuery {
+                    team: "test-team".parse().expect("team"),
+                    agent: "recipient".parse().expect("agent"),
+                    sender: None,
+                    task_id: None,
+                    limit: None,
+                })
+                .expect("list recipient mailbox")
+                .is_empty(),
+            "storage failure must not persist a mailbox record"
+        );
+    }
+
+    #[tokio::test]
+    async fn axum_route_idempotent_duplicate_skips_the_second_received_hook() {
+        let fixture = fixture(true, None);
+        let message_id = AtmMessageId::new();
+        let mut write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone())
+            .with_origin_metadata(message_id, atm_core::types::IsoTimestamp::now());
+        write.to = Some(
+            "recipient@test-team.localhost"
+                .parse()
+                .expect("same-host target"),
+        );
+
+        let origin = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(origin.status(), StatusCode::CREATED);
+        let receipt = post_write(
+            router(
+                &fixture,
+                AuthenticatedConnector::peer("localhost".parse().expect("source host")),
+            ),
+            &write,
+        )
+        .await;
+        assert_eq!(receipt.status(), StatusCode::CREATED);
+        assert_eq!(
+            fixture
+                .received_hook
+                .emitted_ids
+                .lock()
+                .expect("inspect received-hook emissions")
+                .as_slice(),
+            &[message_id],
+            "idempotent peer receipt must not emit a second receiver hook"
+        );
+    }
+
+    #[tokio::test]
+    async fn axum_route_hook_failure_returns_durable_success_with_warning() {
+        let fixture = fixture(
+            true,
+            Some(AtmError::daemon_unavailable(
+                "intentional received-hook failure",
+            )),
+        );
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone());
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("send outcome JSON");
+        assert_eq!(
+            value["warnings"].as_array().map(Vec::len),
+            Some(1),
+            "hook failure is represented as one existing-schema warning"
+        );
+        assert!(
+            value["warnings"][0]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("post-send emission failed")),
+            "warning identifies the advisory receiver-hook failure"
+        );
+        let emitted_ids = fixture
+            .received_hook
+            .emitted_ids
+            .lock()
+            .expect("inspect received-hook emissions")
+            .clone();
+        assert_eq!(emitted_ids.len(), 1);
+        assert!(
+            fixture
+                .message_store
+                .load_message(&MessageKey::from(emitted_ids[0]))
+                .expect("load committed message")
+                .is_some(),
+            "hook failure cannot roll back a durable receive"
         );
     }
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -178,3 +178,211 @@ fn hook_warning(error: AtmError) -> WarningEntry {
         Some("inspect the receiver hook endpoint or harness, then continue normally"),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use atm_core::api::AuthenticatedIngress;
+    use atm_core::boundary::{
+        BuiltInPostSendDispatch, MessageReceivedHookEmitter, PostSendEmissionPath, RosterEntry,
+        RosterHarness, RosterMemberKind,
+    };
+    use atm_core::observability::NullObservability;
+    use atm_core::schema::AtmMessageId;
+    use atm_core::send::{SendMessageSource, WriteRequest};
+    use atm_core::types::{AgentName, ModelName, TeamName};
+    use atm_core::{RequestDeadline, error::AtmError};
+    use atm_runtime_test_support::open_sqlite_boundary;
+    use atm_storage::{MessageKey, MessageQuery, MessageStore, RosterSnapshot};
+    use tempfile::TempDir;
+
+    use super::{CanonicalWriteHandler, StorageAndNudgeRouter};
+
+    struct RecordingReceivedHook {
+        message_store: Arc<dyn MessageStore + Send + Sync>,
+        emitted_ids: Mutex<Vec<AtmMessageId>>,
+        saw_durable_record: AtomicBool,
+    }
+
+    impl atm_core::boundary::sealed::Sealed for RecordingReceivedHook {}
+
+    impl MessageReceivedHookEmitter for RecordingReceivedHook {
+        fn emit_received_message(
+            &self,
+            dispatch: &BuiltInPostSendDispatch,
+            _deadline: RequestDeadline,
+        ) -> Result<PostSendEmissionPath, AtmError> {
+            let key = MessageKey::from(dispatch.event.message_id);
+            self.saw_durable_record.store(
+                self.message_store
+                    .load_message(&key)
+                    .expect("load durable message while emitting hook")
+                    .is_some(),
+                Ordering::SeqCst,
+            );
+            self.emitted_ids
+                .lock()
+                .expect("record received hook emission")
+                .push(dispatch.event.message_id);
+            Ok(PostSendEmissionPath::GraftPort)
+        }
+    }
+
+    struct Fixture {
+        _temporary_root: TempDir,
+        router: StorageAndNudgeRouter,
+        message_store: Arc<dyn MessageStore + Send + Sync>,
+        received_hook: Arc<RecordingReceivedHook>,
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+    }
+
+    fn fixture(with_recipient: bool) -> Fixture {
+        let temporary_root = tempfile::tempdir().expect("temporary runtime root");
+        let database_path = temporary_root.path().join("mail.sqlite");
+        let assembly = open_sqlite_boundary(&database_path).expect("assemble SQLite boundary");
+        let team: TeamName = "test-team".parse().expect("team");
+        if with_recipient {
+            assembly
+                .shared_roster_store_arc()
+                .save_roster(&RosterSnapshot {
+                    team_name: team.clone(),
+                    members: vec![RosterEntry {
+                        team_name: team.clone(),
+                        agent_name: "recipient".parse().expect("agent"),
+                        member_kind: RosterMemberKind::Permanent,
+                        harness: RosterHarness::PythonGraft,
+                        agent_type: atm_core::schema::AgentType::default(),
+                        model: ModelName::default(),
+                        recipient_pane_id: None,
+                        metadata_json: serde_json::Map::new(),
+                    }],
+                    refreshed_at: None,
+                })
+                .expect("seed recipient roster");
+        }
+        let message_store = assembly.message_store_arc();
+        let received_hook = Arc::new(RecordingReceivedHook {
+            message_store: Arc::clone(&message_store),
+            emitted_ids: Mutex::new(Vec::new()),
+            saw_durable_record: AtomicBool::new(false),
+        });
+        let home_dir = temporary_root.path().join("home");
+        let current_dir = temporary_root.path().join("workspace");
+        fs::create_dir_all(&home_dir).expect("create fixture home");
+        fs::create_dir_all(&current_dir).expect("create fixture workspace");
+        let router = StorageAndNudgeRouter::new(
+            assembly.service_runtime,
+            Arc::new(NullObservability),
+            received_hook.clone(),
+        );
+        Fixture {
+            _temporary_root: temporary_root,
+            router,
+            message_store,
+            received_hook,
+            home_dir,
+            current_dir,
+        }
+    }
+
+    fn write_request(home_dir: PathBuf, current_dir: PathBuf) -> WriteRequest {
+        WriteRequest::new(
+            home_dir,
+            current_dir,
+            "sender".parse::<AgentName>().expect("sender"),
+            "recipient@test-team",
+            "test-team".parse().expect("caller team"),
+            SendMessageSource::Inline("router direct path fixture".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write request")
+    }
+
+    #[tokio::test]
+    async fn newly_persisted_write_is_durable_before_one_received_hook_emission() {
+        let fixture = fixture(true);
+        fixture
+            .router
+            .write(
+                write_request(fixture.home_dir.clone(), fixture.current_dir.clone()),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("new write succeeds");
+
+        let emitted_ids = fixture
+            .received_hook
+            .emitted_ids
+            .lock()
+            .expect("inspect received-hook emissions")
+            .clone();
+        assert_eq!(emitted_ids.len(), 1, "new durable write emits one hook");
+        assert!(
+            fixture
+                .received_hook
+                .saw_durable_record
+                .load(Ordering::SeqCst),
+            "the hook observes the message only after durable persistence"
+        );
+        assert!(
+            fixture
+                .message_store
+                .load_message(&MessageKey::from(emitted_ids[0]))
+                .expect("load emitted message")
+                .is_some(),
+            "the emitted message remains durable after the write response"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_write_emits_no_hook_and_persists_no_message() {
+        let fixture = fixture(false);
+        let result = fixture
+            .router
+            .write(
+                write_request(fixture.home_dir.clone(), fixture.current_dir.clone()),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "unknown recipient is rejected before persistence"
+        );
+        assert!(
+            fixture
+                .received_hook
+                .emitted_ids
+                .lock()
+                .expect("inspect received-hook emissions")
+                .is_empty(),
+            "rejected write does not emit a receiver hook"
+        );
+        let messages = fixture
+            .message_store
+            .list_messages(&MessageQuery {
+                team: "test-team".parse().expect("team"),
+                agent: "recipient".parse().expect("agent"),
+                sender: None,
+                task_id: None,
+                limit: None,
+            })
+            .expect("list recipient mailbox");
+        assert!(
+            messages.is_empty(),
+            "rejected write persists no mailbox record"
+        );
+    }
+}

--- a/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
+++ b/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
@@ -18,9 +18,15 @@ cross-host-specific mailbox, acknowledgement, or nudge branch.
 
 Routing is decided exactly once by the post-write event router:
 
-- an empty destination host selects a local-nudge work key; and
-- every validated present destination host selects a peer-delivery work key,
-  including `localhost` and this daemon's advertised or bound IP address.
+- a newly persisted inbound write—identified by authenticated peer provenance
+  or an empty destination host—invokes the one receiver-side hook; and
+- a host-qualified origin write signals the temporary peer-delivery wake-up
+  until Phase AM removes that legacy recovery surface.
+
+The receiver hook runs after persistence and acknowledgement transition, before
+the successful response is serialized. It uses the request's remaining budget,
+returns advisory warnings rather than relabelling the durable write, and is
+never placed on a detached worker, queue, or sender-side retry path.
 
 For a remote destination, the local write records the sender's immutable
 outbound message before this decision; the router signals the bounded
@@ -52,9 +58,8 @@ immutable payload logs a skipped database write. The same-store receipt log is
 `same_store_peer_receipt=true`, `database_write=skipped`, and
 `delivery=continued`. An already-delivered remote
 duplicate is otherwise a no-op. The narrow same-host peer receipt that finds
-this daemon's retained host-qualified origin record continues the ordinary
-inbound local nudge after the skipped write, without mutating the origin
-record or re-entering peer delivery. A later ACK reads that retained origin
+this daemon's retained host-qualified origin record emits neither a second
+receiver hook nor another peer-delivery signal after the skipped write. A later ACK reads that retained origin
 destination host as its reply-routing target and creates the same canonical
 write with `acknowledges_message_id`; it does not fabricate source provenance
 or add an ACK transport branch. Reusing a ULID with different immutable
@@ -76,9 +81,9 @@ second routing or acknowledgement path.
 - No second routing decision in CLI, graft, HTTP, TLS, storage, or nudge code.
 - No cross-host-specific persistence or inbound nudge handler.
 - No host inspection before persistence or outside `PostWriteRouter`. The
-  router may read only its immutable daemon-owned runtime view; it must not
-  read a configuration/policy store, query outbound records, or invoke DNS,
-  socket, TLS, hook, nudge, or peer transport code.
+  router may read only its immutable daemon-owned runtime view and invoke the
+  sealed receiver-hook boundary; it must not read a configuration/policy store,
+  query outbound records, or invoke DNS, socket, TLS, or peer transport code.
 - No socket-family or socket-address inference of local versus peer ingress.
 
 Architecture checks must reject these shapes structurally, not merely by a

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -11,15 +11,27 @@
 
 Every daemon request owns one absolute `RequestDeadline` for local admission.
 The SQLite admission transaction is the sole synchronous post-validation
-operation before the local response. For an acknowledgement it inserts the
-immutable reply and conditionally transitions its source in that same
-transaction. A daemon-owned, reloadable in-memory admission view supplies
-only already-loaded routing data; the response path never reads a caller
-workspace, post-send hook configuration, peer policy, or outbound page.
-Background delivery and local nudge work use identifier-only non-durable
-signals with separate worker budgets. DNS, connection, TLS, hook/graft I/O,
-and remote receipt cannot delay or be cancelled by the completed local
-response. The immutable origin record is the worker's only durable input.
+persistence operation. For an acknowledgement it inserts the immutable reply
+and conditionally transitions its source in that same transaction. A
+daemon-owned, reloadable in-memory admission view supplies only already-loaded
+routing data; the response path never reads a caller workspace, post-send hook
+configuration, peer policy, or outbound page.
+
+For a newly persisted inbound write, the daemon invokes the injected
+`MessageReceivedHookEmitter` after that transaction and before it serializes
+the ordinary successful response. The attempt is part of the request's
+remaining bounded budget, so its latency is sender-observable. It is a
+recipient-side notification only: an idempotent duplicate invokes no second
+hook, and no sender-side retry, queue, detached thread, or detached task is
+created for it. A hook error is retained as a `WarningEntry` on the successful
+`Sent` or `Acknowledged` response; it never reclassifies the durable receive as
+a failure. The daemon owns the tmux injection choice, while Graft remains an
+independently started receiver implementation with no daemon-to-`atm-graft`
+dependency.
+
+Remote peer-delivery recovery remains an identifier-only legacy concern until
+Phase AM removes it. That concern is distinct from the received-message hook:
+it must not execute, queue, retry, or duplicate receiver notification work.
 
 For a remote write, local persistence is not delivery success. The only
 successful remote result is a verified HTTP response from the peer after its
@@ -50,6 +62,7 @@ No event may label local persistence as `sent` or remote delivery.
 
 ## Consequences
 
-The daemon keeps one tracked canonical write path and no outbox, replay queue,
-receipt, or sender-side acknowledgement state. The client receives an honest
-result even when a remote side effect is inherently uncertain.
+The daemon keeps one tracked canonical write path. The client receives an
+honest result even when a remote side effect is inherently uncertain, and a
+received-message hook warning makes notification degradation visible without
+misreporting a committed write as failed.

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -291,10 +291,13 @@ create a second persistence, acknowledgement, or notification path.
 `ApiRouter::route` delegates write handling to the daemon's
 `DaemonRequestDispatcher::route_write`, which invokes the canonical
 `MessageWriter::write` persistence operation before
-`PostWriteRouter::dispatch` selects the local nudge or host-qualified peer
-delivery. This ordering is the crate-level shared-write-resource invariant:
-every ingress uses the same dispatcher, persistence boundary, and post-write
-router. See [`../atm-daemon/http-api.md`](../atm-daemon/http-api.md),
+`PostWriteRouter::dispatch`. That single post-persistence route invokes the
+receiver hook only for a newly persisted inbound write and returns its
+advisory failure as a successful-response warning; a duplicate invokes no
+second hook. A host-qualified origin write retains only the temporary legacy
+peer wake-up until Phase AM deletion. This ordering is the crate-level
+shared-write-resource invariant: every ingress uses the same dispatcher,
+persistence boundary, and post-write router. See [`../atm-daemon/http-api.md`](../atm-daemon/http-api.md),
 [`../adr/ADR-033-http-endpoint-contract.md`](../adr/ADR-033-http-endpoint-contract.md),
 and [`boundaries.md`](./boundaries.md) for the corresponding transport and
 boundary contracts.

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -390,15 +390,19 @@ Notes:
 - AL.1 transplanted the accepted AK.11 receiver-only contract. It is invoked
   only after persistence of a new inbound immutable message; idempotent
   duplicate receipt emits no second hook.
+- AL.3 invokes it from the one canonical post-persistence dispatch path using
+  the request's remaining budget. Its attempt is sender-observable, has no
+  detached worker, queue, or sender retry, and an exhausted budget is retained
+  as a warning rather than changing the durable receive result.
 - The receive path retains hook failure as a structured warning and preserves
   the successful persistence result.
 - the emitter is responsible only for attempting recipient-side emission and
   returning typed success/failure.
 - the accepted `AD.25` through `AD.30` follow-up line keeps that attempt-only
   ownership explicit:
-  - caller-owned send/ack code resolves matching external hooks, built-in
-    fallback eligibility, and the concrete built-in recipient target before
-    invoking this boundary
+  - receiver-owned post-persistence code resolves built-in fallback
+    eligibility and the concrete built-in recipient target before invoking
+    this boundary
   - this boundary does not reopen config lookup, team override lookup, or
     recipient-capability policy selection
 - The concrete tmux receiver implementation is selected by daemon composition.

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -204,16 +204,16 @@ Initial crate requirement IDs:
   Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-TEST-001`.
 - `REQ-CORE-TRANSPORT-002` `atm-core` owns the typed destination-host field
-  and post-write routing contract. Exactly one post-write router chooses local
-  nudge for an empty host or HTTPS delivery for every present host, including
-  localhost and the daemon's own advertised or bound IP. Same-host transport
-  proof uses that advertised/bound virtual-Ethernet IP over TCP; localhost is
-  grammar coverage only. Local CLI HTTP, same-host TCP HTTP, and remote peer
-  HTTP decode the same `WriteRequest` through one HTTP write resource; adapter
+  and post-write routing contract. Exactly one post-write router invokes the
+  receiver hook after a newly persisted inbound write (peer provenance or an
+  empty host) and invokes no hook for an idempotent duplicate. A
+  host-qualified origin write retains only the temporary peer wake-up until
+  Phase AM deletion, including `localhost` and the daemon's own advertised or
+  bound IP. Local CLI HTTP, same-host TCP HTTP, and remote peer HTTP decode the
+  same `WriteRequest` through one HTTP write resource; adapter
   authentication/provenance cannot select another write, ACK, persistence, or
-  nudge path. When same-host peer ingress skips a duplicate origin write, a
-  later ACK derives its reply host from that retained origin destination
-  metadata and still uses the canonical write. Satisfies:
+  nudge path. A same-host duplicate preserves its origin metadata for a later
+  canonical ACK but produces neither a second hook nor peer wake-up. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
 - AI.23 shared-write convergence constraint: all local, same-host, and remote
   HTTP writes must enter `ApiRouter::route` with the same `WriteRequest`, then

--- a/docs/plans/phase-al/AL3-critical-review-task-list.md
+++ b/docs/plans/phase-al/AL3-critical-review-task-list.md
@@ -1,0 +1,28 @@
+# AL.3 Critical Review Task List
+
+Review baseline: `c9097e03` (`feature/pal-s3-received-hook`). This is a
+post-implementation review against `sprint-AL3-received-hook.md`; each item
+must be closed with executable evidence before the follow-up commit is sent
+for QA.
+
+- [x] **AL3-CR-001 — explicit newly-persisted disposition.** Replaced the
+  dispatcher’s generic post-write predicate with a named persistence-result
+  predicate. It must make the new-versus-idempotent distinction visible at the
+  one hook-routing decision and have direct tests for new and duplicate cases.
+- [x] **AL3-CR-002 — behavioral ingress convergence proof.** Added a
+  deterministic test seam proving that local UDS, local TCP, and peer HTTPS
+  provenance converge through the same post-persistence router decision;
+  retain the existing architecture guard as a defense-in-depth check.
+- [x] **AL3-CR-003 — deadline warning contract.** Added a deterministic test
+  for an exhausted inherited hook budget after persistence: the hook must not
+  create detached work and the successful durable-write outcome must retain a
+  warning when it can be serialized within the request contract. Document the
+  existing outer request-deadline behavior separately rather than hiding it.
+- [x] **AL3-CR-004 — re-run scope and boundary validation.** Targeted tests,
+  tests plus `just test` and `just lint all`; confirm no daemon dependency on
+  `atm-graft`, no client-side hook call, and no reintroduced notification
+  queue/retry worker.
+- [x] **AL3-CR-005 — router-boundary terminology.** Reconciled the
+  `PostWriteRouter` contract with its retained temporary peer-delivery wake-up
+  responsibility, while keeping the receiver hook exclusive to newly
+  persisted inbound writes.

--- a/docs/plans/phase-al/AL3-critical-review-task-list.md
+++ b/docs/plans/phase-al/AL3-critical-review-task-list.md
@@ -1,9 +1,11 @@
 # AL.3 Critical Review Task List
 
-Review baseline: `c9097e03` (`feature/pal-s3-received-hook`). This is a
-post-implementation review against `sprint-AL3-received-hook.md`; each item
-must be closed with executable evidence before the follow-up commit is sent
-for QA.
+Implementation baseline: `c9097e03`; review-test baseline: `8615e926`
+(`feature/pal-s3-received-hook`). This is the current post-implementation
+review against `sprint-AL3-received-hook.md`; the mechanical QA follow-up
+below is part of the branch state. The two timing/concurrency findings called
+out as deferred remain outside this checklist and require a separate routing
+decision.
 
 - [x] **AL3-CR-001 — explicit newly-persisted disposition.** Replaced the
   dispatcher’s generic post-write predicate with a named persistence-result
@@ -26,3 +28,16 @@ for QA.
   `PostWriteRouter` contract with its retained temporary peer-delivery wake-up
   responsibility, while keeping the receiver hook exclusive to newly
   persisted inbound writes.
+
+## QA-1 mechanical follow-up
+
+- [x] **CI-FMT-AL3.** Rust formatting is applied across the branch, including
+  `crates/atm-daemon/src/tests_post_send_graft_warning.rs`.
+- [x] **RBQA-AL3-F001.** The architecture gate scans the daemon dispatcher,
+  post-write router/worker, concrete receiver emitter, and core
+  `send/post_write.rs` implementation.
+- [x] **RBQA-AL3-F002.** The dead `requires_post_write_route()` compatibility
+  forwarder is removed; callers use `is_newly_persisted()` directly.
+- [x] **ARCH-001.** This checklist records both review baselines and the
+  deferred RSH-001/QA-002 scope instead of claiming the earlier review is the
+  current branch state.

--- a/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
+++ b/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
@@ -1,167 +1,213 @@
-# AL.3 Durable Write and Received-Hook Remediation
+# AL.3 Replacement Runtime — Remaining Work
 
-Status: proposed follow-up; AL.3 is not closure-ready until every item below is
-accepted.
+Status: **open — audit updated 2026-08-06**. This is a replacement-runtime
+checklist, not a legacy-daemon remediation plan. `crates/atm-daemon` is
+reference-only until Phase AM deletes it. No task in this file permits changing,
+wrapping, starting, or using its listeners, workers, `ApiRouter`, hook
+implementation, or tests as proof.
 
-## Contract
-
-One inbound write has one absolute request deadline. The request must not gain
-a second, additive hook timeout.
+## Non-negotiable execution path
 
 ```text
-request future
-  -> await bounded SQLite write job
-  -> committed durable outcome
-  -> await receiver-hook operation with the same deadline's remaining budget
-  -> successful response, optionally with warnings
+Tokio/Axum ingress
+  -> one typed replacement write service
+  -> injected storage/runtime boundary commits the canonical write
+  -> new record only: injected MessageReceivedHookEmitter
+  -> durable success, optionally with a hook-warning
 ```
 
-The SQLite queue contains bounded **write jobs**, not futures. Each job carries
-one completion sender; the originating request future awaits that sender. The
-received-message hook is likewise an awaited operation of that request, not a
-detached task, retry, queue, or background worker.
+The same absolute `RequestDeadline` flows through the whole request. Storage
+failure is an error and persists no record. A hook start, execution, or timeout
+failure after a commit is a successful write with a stable warning. An
+idempotent duplicate is successful and does not emit a second hook.
 
-## Task list
+## Closure tasks
 
-- [x] **AL3-RH-000 — Remove SQLite-failure-as-success fallback.**
-  - `SqliteFailedRecovered` currently converts a mailbox write failure into a
-    degraded external delivery plus a warning. That conflicts with the durable
-    write contract: a response is successful only after SQLite reports a
-    committed record (or an idempotent already-recorded row).
-  - Propagate database admission/transaction failure as the established
-    machine-readable error response. Do not emit the original payload, a
-    companion message, or a received hook after that failure.
-  - Acceptance: injected `MailboxWriteFailed` produces an error, persists no
-    record, emits no hook, and does not send a fallback payload. Retire the
-    `SqliteFailedRecovered` execution/disposition path if it has no other
-    explicitly approved contract.
+- [ ] **AL3-RH-000 — Replacement-owned Tokio/Axum server.**
+  - `atm-http-runtime` binds and serves the canonical typed Axum write route on
+    the Tokio runtime supplied by the replacement executable; it never creates
+    a private runtime or calls `Handle::block_on`.
+  - Its consuming lifecycle owns listener, cancellation, task join, and bounded
+    shutdown. It has no dependency on `atm-daemon`, concrete SQLite, tmux,
+    graft, or daemon bootstrap.
+  - Tests prove binding, a real HTTP request, orderly shutdown, and no leaked
+    server task.
 
-- [ ] **AL3-RH-001 — Establish one deadline semantic.**
-  - Construct one absolute deadline at ingress and pass it unchanged to queue
-    admission, SQLite execution, the received-hook operation, and response
-    serialization.
-  - Make `RequestDeadline::expired()` and `RequestDeadline::remaining()` use
-    one consistent zero-boundary rule: zero remaining time is expired.
-  - Acceptance: an exactly-zero deadline cannot start a SQLite job or hook;
-    no layer creates a second full-duration deadline.
-  - Corner-case tests: exact zero, deadline consumed while waiting for queue
-    capacity, deadline consumed after dequeue but before transaction start, and
-    a positive-but-small remaining duration.
-  - [x] The exact-zero boundary is now consistent: `remaining() == None`
-    implies `expired()`, with an explicit core regression test.
+- [ ] **AL3-RH-001 — Replacement-owned storage-and-hook write service.**
+  - Add the one replacement `CanonicalWriteHandler` implementation in
+    `atm-http-runtime`. It calls only existing core/runtime composition types:
+    injected storage-backed `LocalServiceRuntime`, injected observability, and
+    injected `MessageReceivedHookEmitter`.
+  - The service prepares and commits the canonical `WriteRequest` through the
+    existing core writer, then invokes the received hook only for a newly
+    persisted message. It must not call any legacy daemon router or worker.
+  - Tests prove storage is called before the hook; database failure runs no
+    hook; duplicate delivery runs no second hook; and hook failure becomes an
+    existing-schema warning on success.
 
-- [ ] **AL3-RH-002 — Make SQLite admission an awaited bounded job.**
-  - Replace a queue of synchronous dispatch work with a bounded SQLite write
-    job queue whose job result is returned through a one-shot completion path
-    and awaited by the caller's request future.
-  - Preserve SQLite's serialized/synchronous execution inside its owned
-    executor; do not run SQLite transactions on Tokio worker threads.
-  - Every ingress adapter submits through the same executor. There must be no
-    separate UDS, TCP, peer, or per-connection write queue.
-  - Define cancellation explicitly: a dropped caller before the job starts
-    removes or skips that job without writing; a started transaction completes
-    and records its actual result. The system must never tell a still-connected
-    caller that a started job failed merely because an outer timer stopped
-    awaiting it.
-  - Define the commit boundary: a timeout before a job begins is a failure with
-    no write. Once a transaction starts, the response must report its actual
-    durable outcome rather than report timeout and later commit invisibly.
-  - Acceptance: saturation, pre-start timeout, successful commit, database
-    failure, and slow in-progress transaction all have deterministic,
-    non-contradictory caller outcomes.
-  - Corner-case tests: bounded-capacity rejection/backpressure, FIFO or the
-    explicitly documented scheduling rule, caller cancellation before start,
-    transaction error, duplicate-message idempotency, and transaction start
-    immediately before the deadline.
-  - **Placement constraint:** do not repurpose or add a daemon-local
-    `DispatchWorkerPool`/thread queue for writes. The executor must be owned
-    by the one Tokio runtime composition and invoked by every connector before
-    the canonical write route; otherwise UDS, loopback, and peer HTTP acquire
-    divergent admission behavior.
-  - **Executor state machine:** each job is `Queued`, `Started`, or
-    `CancelledBeforeStart`. Timeout/cancellation may atomically move only
-    `Queued -> CancelledBeforeStart`; the executor alone moves
-    `Queued -> Started` immediately before entering SQLite. A caller whose job
-    is already `Started` waits for and reports the actual transaction result,
-    even when that exceeds the advisory deadline, so no invisible commit can
-    be reported as a timeout.
+- [ ] **AL3-RH-002 — Tokio isolation and deadline contract.**
+  - Synchronous storage and the current synchronous, sealed hook operation run
+    only in narrowly scoped `spawn_blocking` work; no Tokio worker is blocked.
+    The HTTP task awaits the result and never detaches a write or hook.
+  - Pass one absolute deadline unchanged. Reject before admitting expired
+    work, retain a started transaction's real durable outcome, and do not add a
+    second full-duration timeout.
+  - Tests cover zero budget, storage error, successful commit, hook failure,
+    exhausted post-commit budget, and duplicate/no-hook.
 
-- [ ] **AL3-RH-003 — Make the received hook an awaited, deadline-aware operation.**
-  - Invoke it only after a newly committed write; never for an idempotent
-    duplicate.
-  - Pass the one request deadline (or its remaining duration) into the
-    receiver-hook boundary. Its effective limit is
-    `min(hook_safety_cap, deadline.remaining())`.
-  - Replace blocking sleep/polling with awaitable process/timer operations; do
-    not create a detached task or notification queue.
-  - The hook boundary remains sealed and object-safe. It must carry a deadline
-    or a validated remaining-budget value rather than permit an implementation
-    to create a new full request timeout.
-  - Acceptance: a deliberately stalled hook stops at the remaining budget and
-    cannot occupy an executor after the request completes.
-  - Corner-case tests: missing receiver target, emitter construction failure,
-    process-start error, non-zero process exit, safety-cap timeout shorter than
-    remaining request budget, request deadline shorter than safety cap, and
-    idempotent duplicate/no second emission.
-  - [x] The sealed `MessageReceivedHookEmitter` boundary now requires the
-    inherited `RequestDeadline`; tmux and Graft cap every operation to its
-    remaining duration, and a regression test proves a stalled tmux child is
-    killed at that budget.
-  - [ ] Replace the legacy synchronous process sleep/poll implementation with
-    an awaitable runtime operation as part of the bounded-job executor work;
-    this remaining item must not be closed by wrapping the synchronous path in
-    a detached thread or by creating another full-duration timeout.
+- [ ] **AL3-RH-003 — Replacement proof and legacy quarantine.**
+  - Default repository tests and CI exclude `atm-daemon` unit tests immediately;
+    they are historical reference tests, not acceptance evidence for AL.
+  - While the new executable target is being completed, legacy may still be
+    compiled only where workspace metadata requires it; it must not be started,
+    smoke-tested, or selected by an AL proof. AL activation replaces the binary
+    before AM deletes the legacy crate.
+  - Add an architecture guard forbidding `atm-http-runtime` from depending on
+    `atm-daemon`, `Runtime::Builder`, `Handle::block_on`,
+    `std::sync::mpsc`, `std::thread::sleep`, or legacy transport module names.
 
-- [ ] **AL3-RH-004 — Preserve durable-success response semantics.**
-  - A database write failure returns an error response.
-  - Once the SQLite transaction reports a committed write, the API result is
-    `Sent` or `Acknowledged`; hook start, execution, or timeout failures append
-    a caller-visible `WarningEntry` and never turn that durable outcome into an
-    error.
-  - Remove or narrow any final generic deadline check that can reclassify a
-    committed write after the advisory hook has run or been skipped.
-  - Acceptance: tests prove (1) database failure is an error, (2) hook error
-    is success plus warning, (3) hook timeout is success plus warning, and
-    (4) exhausted post-commit hook budget is success plus warning.
-  - Verify the warning uses the existing public response schema and a stable
-    code/recovery message; do not add a peer-only or hook-specific result
-    envelope.
-  - [x] Removed the late generic deadline reclassification after the canonical
-    write route. A committed write now returns its durable `Sent` or
-    `Acknowledged` result; only advisory hook warnings may be appended.
-  - [x] Removed the Tokio HTTP adapter's outer timeout around synchronous
-    dispatch. A regression test now proves an already-started route returns
-    its actual successful response after the advisory deadline instead of a
-    synthetic timeout while it continues in the blocking pool.
+- [ ] **AL3-RH-004 — Explicit later work, not a reason to touch legacy.**
+  - AL.5/AL.6/AL.7 add UDS, loopback TCP, and peer TLS adapters to this same
+    server and service. They add no peer-only decoder, queue, listener, or
+    post-send path.
+  - The hook boundary's async evolution, process cleanup details, and the
+    `sc-lint` blocking-sleep product rule remain tracked work; product issue is
+    [sc-lint#82](https://github.com/randlee/sc-lint/issues/82). They must be
+  solved in replacement-owned code, never by repairing the old daemon.
 
-- [ ] **AL3-RH-005 — Budget and regression proof.**
-  - Document the configured end-to-end request deadline per transport and the
-    hook safety cap. Do not assume their values are additive.
-  - Add tests for queue wait consuming the shared budget, exact-zero boundary,
-    a committed write followed by hook timeout, duplicate/no-hook, and no
-    detached task remaining after the response.
-  - Extend the architecture guard to reject independent full-duration hook
-    deadlines and synchronous sleep/poll loops in the production receiver-hook
-    path.
-  - Acceptance: UDS, loopback/TCP, and peer HTTP use the same outcome matrix;
-    the caller receives no false write failure after a reported commit.
-  - Add request-cancellation, socket disconnect, and process-cleanup tests so
-    the worker/executor has no orphaned task, child process, or durable write
-    whose result is unobservable by a still-connected caller.
+## 2026-08-06 critical-review findings
 
-## Required response matrix
+The listener and direct async handler have been added, and their focused tests
+pass. That is progress, not closure: the behavior below is still required
+before this implementation can be considered the replacement ingress.
 
-| SQLite outcome | Hook outcome | Caller result |
+- [ ] **AL3-CR-001 (blocking) — Prove the actual Storage → hook outcome
+  matrix.**
+  - Existing `atm-http-runtime` tests use `RecordingRouter` and
+    `BlockingRouter`; neither constructs `StorageAndNudgeRouter` with a real
+    storage boundary and a recording/failing received-hook implementation.
+  - Add replacement-owned integration tests for: storage failure with no
+    persisted record and no hook; new durable record followed by one hook;
+    idempotent duplicate with no second hook; and hook error represented as a
+    successful `Send`/`Acknowledged` response carrying the existing warning
+    schema.
+  - Assert ordering, not merely counts: the hook must observe the already
+    persisted record. Tests must reach the Axum route, not call private helper
+    methods directly.
+
+- [ ] **AL3-CR-002 (blocking) — Enforce a real post-commit hook deadline.**
+  - `StorageAndNudgeRouter` awaits a `spawn_blocking` hook task without a
+    Tokio timeout. An emitter that ignores `RequestDeadline` can keep the HTTP
+    request open indefinitely, so the required "success plus timeout warning"
+    behavior is unproven and currently false for that implementation class.
+  - Define the cancellation contract before changing code: after a durable
+    commit, a timed-out hook must return the durable success plus warning, and
+    its work must have a supervised cleanup path. Do not detach an unkillable
+    blocking task or create a second full request budget.
+  - Add stalled-emitter tests for request-budget exhaustion and hook cleanup;
+    one test must prove the caller receives success plus warning rather than a
+    route failure.
+
+- [ ] **AL3-CR-003 (blocking) — Use bounded replacement-owned write
+  admission, not Tokio's generic blocking queue.**
+  - `spawn_blocking` is currently the only storage admission mechanism.
+    `ConcurrencyLimitLayer` bounds HTTP handlers, but it does not define a
+    serialized/bounded SQLite write-job contract, caller cancellation behavior,
+    or started-job outcome semantics.
+  - Introduce one small Tokio-owned bounded write-admission component at
+    replacement composition. It must await caller-visible completion, preserve
+    a started transaction's actual durable outcome, reject cancelled/expired
+    work before start, and serve every future connector through this one path.
+  - Cover saturation, cancellation before start, transaction failure, started
+    transaction past advisory deadline, and idempotent duplicate. Do not
+    reintroduce `DispatchWorkerPool`, a thread queue, retry, or replay.
+
+- [ ] **AL3-CR-004 (important) — Make harness-specific hook selection
+  explicit.**
+  - `StorageAndNudgeRouter` owns one global
+    `Arc<dyn MessageReceivedHookEmitter>`. A tmux emitter rejects a graft
+    target and a graft emitter rejects a tmux target, so this cannot satisfy a
+    mixed roster.
+  - Replacement composition must select the appropriate injected receiver
+    implementation from the committed recipient/harness before emission.
+    `atm-http-runtime` must remain unaware of tmux and graft concrete types;
+    it receives only a core-owned, object-safe selection boundary or a
+    harness-resolved emitter.
+  - Test both harness selections and a recipient with no hook capability. No
+    branch may reintroduce a daemon dependency on `atm-graft`.
+
+- [ ] **AL3-CR-005 (important) — Remove the unnecessary public handler
+  extension point.**
+  - `CanonicalWriteHandler` is a public, unsealed trait even though the
+    replacement has one intended production implementation,
+    `StorageAndNudgeRouter`. This is an avoidable public implementation
+    surface and conflicts with the fixed, simple replacement composition.
+  - Either make the handler implementation an internal concrete dependency of
+    the route, or make the boundary deliberately sealed and document why an
+    external implementation is required. Prefer the former; tests can use
+    crate-private test seams without publishing a plugin API.
+
+- [ ] **AL3-CR-006 (important) — Stop trusting caller-owned filesystem paths
+  in the server path.**
+  - The replacement currently passes `WriteRequest.home_dir` into the
+    post-commit record lookup and hook-plan construction. That is a
+    client-supplied path even though `LocalServiceRuntime` documents that a
+    system daemon must not read caller-owned workspace state.
+  - Inject a daemon-owned runtime/home context at composition and prove a
+    forged request path cannot redirect server filesystem access. Preserve the
+    existing wire struct; normalize it at the ingress boundary rather than
+    creating a second request schema.
+
+- [ ] **AL3-CR-007 (important) — De-duplicate post-commit hook planning in
+  core.**
+  - `emit_received_message_after_commit` substantially duplicates
+    `emit_persisted_local_post_write`'s record-load, recipient-resolution, and
+    delivery-plan setup. Two copies will drift and re-create the legacy
+    complexity this replacement is meant to remove.
+  - Extract one small core helper that builds the receiver-hook dispatch from
+    a committed record. The replacement calls the hook-only operation; the
+    legacy reference function may retain its separate delivery execution until
+    Phase AM deletes it. Add parity tests for the shared plan construction.
+
+- [ ] **AL3-CR-008 (important) — Complete legacy test/runtime quarantine.**
+  - Default `just test` and the CI workspace unit-test step now exclude
+    `atm-daemon`; this part is complete.
+  - CI still builds, installs, and smoke-runs `atm-daemon`. Until the
+    replacement executable is composed and substituted, those jobs must be
+    labelled historical/reference only and must not be used as AL acceptance
+    evidence. At activation, replace them with the new executable's smoke;
+    Phase AM then removes the old jobs and crate.
+  - Add an architecture test that rejects `atm-http-runtime` references to
+    legacy daemon modules, `Runtime::Builder`, `Handle::block_on`,
+    `std::sync::mpsc`, and production `std::thread::sleep`.
+
+- [ ] **AL3-CR-009 (minor) — Keep configuration honest during staged
+  adapters.**
+  - `HttpRuntime::start` currently starts plaintext TCP only, although its
+    validated configuration also contains UDS and TLS material. Make inactive
+    adapter configuration unrepresentable for this stage, or explicitly
+    document and test that it is preflight-only until its owning adapter
+    sprint. Do not imply that validating TLS material enables TLS.
+
+- [ ] **AL3-CR-010 (minor) — Move the compatibility oracle out of the legacy
+  daemon documentation path.**
+  - The new runtime's test reads `docs/atm-daemon/openapi.yaml`. Move the
+    canonical OpenAPI/typed write contract to a neutral API location before
+    Phase AM deletes legacy-daemon material, then have both client and
+    replacement tests consume it.
+
+## Required outcome matrix
+
+| Storage outcome | Hook outcome | HTTP caller result |
 |---|---|---|
-| Fails or is rejected before transaction begins | Not run | Error |
-| Commits | Succeeds | Success |
-| Commits | Fails to start, fails, or times out | Success + warning |
-| Commits idempotent duplicate | Not run | Success; no hook warning |
+| Rejected before start / storage error | Not run | Existing machine-readable error; no row |
+| New record committed | Success | Success |
+| New record committed | Start, execution, or timeout failure | Success + warning |
+| Idempotent duplicate | Not run | Success; no hook warning |
 
-## Deliberate non-goals
+## Non-goals
 
-- No sender-side notification, retry, replay, or post-send queue.
-- No second listener, peer-only receive route, or schema change solely for hook
-  failure.
-- No daemon dependency on `atm-graft`; Graft remains an independently started
-  receiver implementation injected through the sealed boundary.
+- No sender retry, replay, resend state machine, notification queue, or
+  peer-specific ingress grammar.
+- No legacy daemon test, listener, worker, or hook execution.
+- No direct concrete SQLite, tmux, or graft dependency in `atm-http-runtime`.

--- a/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
+++ b/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
@@ -1,0 +1,163 @@
+# AL.3 Durable Write and Received-Hook Remediation
+
+Status: proposed follow-up; AL.3 is not closure-ready until every item below is
+accepted.
+
+## Contract
+
+One inbound write has one absolute request deadline. The request must not gain
+a second, additive hook timeout.
+
+```text
+request future
+  -> await bounded SQLite write job
+  -> committed durable outcome
+  -> await receiver-hook operation with the same deadline's remaining budget
+  -> successful response, optionally with warnings
+```
+
+The SQLite queue contains bounded **write jobs**, not futures. Each job carries
+one completion sender; the originating request future awaits that sender. The
+received-message hook is likewise an awaited operation of that request, not a
+detached task, retry, queue, or background worker.
+
+## Task list
+
+- [x] **AL3-RH-000 — Remove SQLite-failure-as-success fallback.**
+  - `SqliteFailedRecovered` currently converts a mailbox write failure into a
+    degraded external delivery plus a warning. That conflicts with the durable
+    write contract: a response is successful only after SQLite reports a
+    committed record (or an idempotent already-recorded row).
+  - Propagate database admission/transaction failure as the established
+    machine-readable error response. Do not emit the original payload, a
+    companion message, or a received hook after that failure.
+  - Acceptance: injected `MailboxWriteFailed` produces an error, persists no
+    record, emits no hook, and does not send a fallback payload. Retire the
+    `SqliteFailedRecovered` execution/disposition path if it has no other
+    explicitly approved contract.
+
+- [ ] **AL3-RH-001 — Establish one deadline semantic.**
+  - Construct one absolute deadline at ingress and pass it unchanged to queue
+    admission, SQLite execution, the received-hook operation, and response
+    serialization.
+  - Make `RequestDeadline::expired()` and `RequestDeadline::remaining()` use
+    one consistent zero-boundary rule: zero remaining time is expired.
+  - Acceptance: an exactly-zero deadline cannot start a SQLite job or hook;
+    no layer creates a second full-duration deadline.
+  - Corner-case tests: exact zero, deadline consumed while waiting for queue
+    capacity, deadline consumed after dequeue but before transaction start, and
+    a positive-but-small remaining duration.
+  - [x] The exact-zero boundary is now consistent: `remaining() == None`
+    implies `expired()`, with an explicit core regression test.
+
+- [ ] **AL3-RH-002 — Make SQLite admission an awaited bounded job.**
+  - Replace a queue of synchronous dispatch work with a bounded SQLite write
+    job queue whose job result is returned through a one-shot completion path
+    and awaited by the caller's request future.
+  - Preserve SQLite's serialized/synchronous execution inside its owned
+    executor; do not run SQLite transactions on Tokio worker threads.
+  - Every ingress adapter submits through the same executor. There must be no
+    separate UDS, TCP, peer, or per-connection write queue.
+  - Define cancellation explicitly: a dropped caller before the job starts
+    removes or skips that job without writing; a started transaction completes
+    and records its actual result. The system must never tell a still-connected
+    caller that a started job failed merely because an outer timer stopped
+    awaiting it.
+  - Define the commit boundary: a timeout before a job begins is a failure with
+    no write. Once a transaction starts, the response must report its actual
+    durable outcome rather than report timeout and later commit invisibly.
+  - Acceptance: saturation, pre-start timeout, successful commit, database
+    failure, and slow in-progress transaction all have deterministic,
+    non-contradictory caller outcomes.
+  - Corner-case tests: bounded-capacity rejection/backpressure, FIFO or the
+    explicitly documented scheduling rule, caller cancellation before start,
+    transaction error, duplicate-message idempotency, and transaction start
+    immediately before the deadline.
+  - **Placement constraint:** do not repurpose or add a daemon-local
+    `DispatchWorkerPool`/thread queue for writes. The executor must be owned
+    by the one Tokio runtime composition and invoked by every connector before
+    the canonical write route; otherwise UDS, loopback, and peer HTTP acquire
+    divergent admission behavior.
+  - **Executor state machine:** each job is `Queued`, `Started`, or
+    `CancelledBeforeStart`. Timeout/cancellation may atomically move only
+    `Queued -> CancelledBeforeStart`; the executor alone moves
+    `Queued -> Started` immediately before entering SQLite. A caller whose job
+    is already `Started` waits for and reports the actual transaction result,
+    even when that exceeds the advisory deadline, so no invisible commit can
+    be reported as a timeout.
+
+- [ ] **AL3-RH-003 — Make the received hook an awaited, deadline-aware operation.**
+  - Invoke it only after a newly committed write; never for an idempotent
+    duplicate.
+  - Pass the one request deadline (or its remaining duration) into the
+    receiver-hook boundary. Its effective limit is
+    `min(hook_safety_cap, deadline.remaining())`.
+  - Replace blocking sleep/polling with awaitable process/timer operations; do
+    not create a detached task or notification queue.
+  - The hook boundary remains sealed and object-safe. It must carry a deadline
+    or a validated remaining-budget value rather than permit an implementation
+    to create a new full request timeout.
+  - Acceptance: a deliberately stalled hook stops at the remaining budget and
+    cannot occupy an executor after the request completes.
+  - Corner-case tests: missing receiver target, emitter construction failure,
+    process-start error, non-zero process exit, safety-cap timeout shorter than
+    remaining request budget, request deadline shorter than safety cap, and
+    idempotent duplicate/no second emission.
+  - [x] The sealed `MessageReceivedHookEmitter` boundary now requires the
+    inherited `RequestDeadline`; tmux and Graft cap every operation to its
+    remaining duration, and a regression test proves a stalled tmux child is
+    killed at that budget.
+  - [ ] Replace the legacy synchronous process sleep/poll implementation with
+    an awaitable runtime operation as part of the bounded-job executor work;
+    this remaining item must not be closed by wrapping the synchronous path in
+    a detached thread or by creating another full-duration timeout.
+
+- [ ] **AL3-RH-004 — Preserve durable-success response semantics.**
+  - A database write failure returns an error response.
+  - Once the SQLite transaction reports a committed write, the API result is
+    `Sent` or `Acknowledged`; hook start, execution, or timeout failures append
+    a caller-visible `WarningEntry` and never turn that durable outcome into an
+    error.
+  - Remove or narrow any final generic deadline check that can reclassify a
+    committed write after the advisory hook has run or been skipped.
+  - Acceptance: tests prove (1) database failure is an error, (2) hook error
+    is success plus warning, (3) hook timeout is success plus warning, and
+    (4) exhausted post-commit hook budget is success plus warning.
+  - Verify the warning uses the existing public response schema and a stable
+    code/recovery message; do not add a peer-only or hook-specific result
+    envelope.
+  - [x] Removed the late generic deadline reclassification after the canonical
+    write route. A committed write now returns its durable `Sent` or
+    `Acknowledged` result; only advisory hook warnings may be appended.
+
+- [ ] **AL3-RH-005 — Budget and regression proof.**
+  - Document the configured end-to-end request deadline per transport and the
+    hook safety cap. Do not assume their values are additive.
+  - Add tests for queue wait consuming the shared budget, exact-zero boundary,
+    a committed write followed by hook timeout, duplicate/no-hook, and no
+    detached task remaining after the response.
+  - Extend the architecture guard to reject independent full-duration hook
+    deadlines and synchronous sleep/poll loops in the production receiver-hook
+    path.
+  - Acceptance: UDS, loopback/TCP, and peer HTTP use the same outcome matrix;
+    the caller receives no false write failure after a reported commit.
+  - Add request-cancellation, socket disconnect, and process-cleanup tests so
+    the worker/executor has no orphaned task, child process, or durable write
+    whose result is unobservable by a still-connected caller.
+
+## Required response matrix
+
+| SQLite outcome | Hook outcome | Caller result |
+|---|---|---|
+| Fails or is rejected before transaction begins | Not run | Error |
+| Commits | Succeeds | Success |
+| Commits | Fails to start, fails, or times out | Success + warning |
+| Commits idempotent duplicate | Not run | Success; no hook warning |
+
+## Deliberate non-goals
+
+- No sender-side notification, retry, replay, or post-send queue.
+- No second listener, peer-only receive route, or schema change solely for hook
+  failure.
+- No daemon dependency on `atm-graft`; Graft remains an independently started
+  receiver implementation injected through the sealed boundary.

--- a/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
+++ b/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
@@ -129,6 +129,10 @@ detached task, retry, queue, or background worker.
   - [x] Removed the late generic deadline reclassification after the canonical
     write route. A committed write now returns its durable `Sent` or
     `Acknowledged` result; only advisory hook warnings may be appended.
+  - [x] Removed the Tokio HTTP adapter's outer timeout around synchronous
+    dispatch. A regression test now proves an already-started route returns
+    its actual successful response after the advisory deadline instead of a
+    synthetic timeout while it continues in the blocking pool.
 
 - [ ] **AL3-RH-005 — Budget and regression proof.**
   - Document the configured end-to-end request deadline per transport and the

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -53,7 +53,12 @@ approved proof round before AM deletion.
 
 ## Architecture
 
-`atm-http-runtime` is a library, not a second daemon executable.
+`atm-http-runtime` is the replacement Tokio implementation and ships the
+active `atm-daemon` executable target. It is not a second concurrently running
+daemon: `crates/atm-daemon` is reference-only legacy source and is never
+started, wrapped, used for smoke/proof, or retained as fallback. Phase AM
+deletes that legacy implementation after the replacement's accepted physical
+proof.
 
 ```text
 atm / atm-graft / cross-host sender
@@ -65,7 +70,8 @@ atm / atm-graft / cross-host sender
                                             └── storage trait
                                             └── MessageReceivedHookEmitter
 
-atm-daemon = composition, listener selection, lifecycle only
+atm-http-runtime = active daemon process, listener selection, lifecycle
+legacy atm-daemon = reference-only source pending AM deletion; never executed
 ```
 
 ### Library choices

--- a/docs/plans/phase-al/sprint-AL1-runtime-contract.md
+++ b/docs/plans/phase-al/sprint-AL1-runtime-contract.md
@@ -25,7 +25,9 @@ ADR-033, ADR-036. See
 
 ## Deliverables
 
-1. Add `crates/atm-http-runtime` to the workspace as a library only.
+1. Add `crates/atm-http-runtime` to the workspace as the replacement runtime
+   library and the sole active `atm-daemon` executable target. It must not
+   launch or wrap the legacy `crates/atm-daemon` implementation.
 2. Add Tokio, Axum/Hyper, Rustls, and one maintained Tokio client behind
    minimal pinned workspace features.
 3. Define a small public composition surface; it accepts the existing core

--- a/docs/plans/phase-al/sprint-AL3-received-hook.md
+++ b/docs/plans/phase-al/sprint-AL3-received-hook.md
@@ -1,6 +1,6 @@
 ---
 title: AL.3 Post-Persistence Received Hook
-status: complete
+status: in_progress
 branch: feature/pal-s3-received-hook
 worktree: ../atm-core-worktrees/feature/pal-s3-received-hook
 target: integrate/phase-al

--- a/docs/plans/phase-al/sprint-AL3-received-hook.md
+++ b/docs/plans/phase-al/sprint-AL3-received-hook.md
@@ -1,6 +1,6 @@
 ---
 title: AL.3 Post-Persistence Received Hook
-status: proposed
+status: complete
 branch: feature/pal-s3-received-hook
 worktree: ../atm-core-worktrees/feature/pal-s3-received-hook
 target: integrate/phase-al

--- a/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
+++ b/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
@@ -22,10 +22,12 @@ shared traceability record.
 
 ## Deliverables
 
-1. Make `atm-daemon` a composition/lifecycle root only: retain existing owner
-   gate, create backend-neutral trait implementations, inject the accepted
-   `MessageReceivedHookEmitter`, select enabled adapters, start the runtime,
-   and perform bounded shutdown.
+1. Activate `atm-http-runtime` as the sole `atm-daemon` process: retain or
+   transplant the existing owner gate, create backend-neutral trait
+   implementations, inject the accepted `MessageReceivedHookEmitter`, select
+   enabled adapters, start the runtime, and perform bounded shutdown. Do not
+   start, wrap, test through, or retain the reference-only legacy
+   `crates/atm-daemon` server as fallback.
 2. Prove no `atm-daemon` or `atm-http-runtime` source/dependency references
    concrete SQLite/Rusqlite, tmux, `atm-graft`, raw HTTP framing, peer-only
    application code, or resend/replay.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1148,7 +1148,7 @@ Sprint line:
 - `AL.1` `sprint-AL1-runtime-contract.md` — runtime contract and archived-hook
   transplant
 - `AL.2 [COMPLETE]` `sprint-AL2-canonical-handler.md` — canonical handler
-- `AL.3` `sprint-AL3-received-hook.md` — received hook wiring
+- `AL.3 [COMPLETE]` `sprint-AL3-received-hook.md` — received hook wiring
 - `AL.4` `sprint-AL4-shared-client.md` — shared client
 - `AL.5` `sprint-AL5-unix-uds.md` — Unix UDS listener
 - `AL.6` `sprint-AL6-loopback-tcp.md` — loopback TCP listener

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3807,9 +3807,11 @@ mail correctness.
   - because team names cannot contain `.`, the inline form splits at the first
     `.` after `@`; the remainder is the host and may be a DNS name or IP
     address containing additional periods
-  - one post-write router selects local nudge for an empty destination host and
-    the HTTPS adapter for every present destination host, including `localhost`
-    and the daemon's own advertised or bound IP address
+  - one post-write router invokes the receiver hook after a newly persisted
+    inbound write (peer provenance or an empty destination host); it emits no
+    second hook for an idempotent duplicate. A host-qualified origin write
+    retains only the temporary peer wake-up until Phase AM deletion, including
+    `localhost` and the daemon's own advertised or bound IP address
   - local CLI HTTP, host-qualified same-host HTTP, and remote peer HTTP submit
     the same canonical write resource and request schema; TLS/authentication
     is adapter work before that resource, never a second write endpoint,
@@ -3828,8 +3830,8 @@ mail correctness.
     `peer_duplicate_write_skipped` with the ULID, both hosts,
     `same_store_peer_receipt=true`, `database_write=skipped`, and
     `delivery=continued`; it skips the second database write without altering origin destination-host
-    metadata; ordinary inbound recipient delivery continues to its post-write
-    local nudge and must not re-enter peer delivery. A later ACK to that
+    metadata; the duplicate emits neither a receiver hook nor another peer
+    wake-up. A later ACK to that
     retained record derives its host-qualified reply target from the preserved
     origin destination metadata and still creates the ordinary canonical ACK
     write


### PR DESCRIPTION
## Summary
- Invoke MessageReceivedHookEmitter only once, from the single newly-persisted inbound write result; duplicate/idempotent writes suppress the hook.
- Hook failures map to retained warning info on the ordinary successful response; schema unchanged.
- Detached local nudge worker removed.

## Sprint doc
docs/plans/phase-al/sprint-AL3-received-hook.md

## Validation (arch-ctm self-report)
just test, just lint all, architecture boundary suite — all passing.

🤖 Generated as part of Phase AL sprint orchestration.