### PR TITLE
AL.4: Shared Standard HTTP Client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,15 +178,10 @@ jobs:
           Copy-Item "target/release/atm-daemon$suffix" (Join-Path $binDir "atm-daemon$suffix") -Force
           "ATM_SMOKE_INSTALL_ROOT=$installRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Run workspace tests excluding atm-daemon on Windows
+      - name: Run replacement-workspace tests excluding legacy atm-daemon
         env:
           ATM_TEST_RECV_TIMEOUT_SECS: "60"
         run: cargo test --workspace --exclude atm-daemon --verbose
-
-      - name: Run atm-daemon tests
-        env:
-          ATM_TEST_RECV_TIMEOUT_SECS: "60"
-        run: cargo test -p atm-daemon --verbose
 
       - name: Install Maturin for Hermes graft bridge tests
         run: python -m pip install maturin

--- a/.just/run_tests.py
+++ b/.just/run_tests.py
@@ -20,7 +20,11 @@ def main() -> int:
         run([sys.executable, "scripts/verify_user_docs.py", "--source-root", "docs/user-documents"])
         run([sys.executable, ".just/run_pytests.py"])
         run(["cargo", "build", "--workspace"])
-        run(["cargo", "test", "--workspace"])
+        # `atm-daemon` is reference-only while Phase AL constructs the
+        # replacement Tokio runtime. Its historical unit tests are not
+        # replacement acceptance evidence and must not pull new work back into
+        # the legacy implementation.
+        run(["cargo", "test", "--workspace", "--exclude", "atm-daemon"])
         return 0
     if mode == "coverage":
         run([sys.executable, "scripts/coverage/run.py", "--write-artifacts"])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
+ "async-trait",
  "atm-daemon-bootstrap",
  "atm-daemon-client",
  "atm-graft",
@@ -23,6 +24,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "time",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -31,6 +33,7 @@ dependencies = [
 name = "agent-team-mail-core"
 version = "1.4.1-beta-aj"
 dependencies = [
+ "async-trait",
  "atm-error",
  "atm-runtime-test-support",
  "atm-storage",
@@ -129,6 +132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atm-architecture"
 version = "1.4.1-beta-aj"
 dependencies = [
@@ -202,9 +216,11 @@ name = "atm-graft"
 version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
+ "async-trait",
  "atm-daemon-client",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 
@@ -216,6 +232,7 @@ dependencies = [
  "atm-graft",
  "pyo3",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -223,6 +240,7 @@ name = "atm-http-runtime"
 version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
+ "async-trait",
  "axum",
  "hyper",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ sc-observability = "1.2.0"
 sc-observability-types = "1.2.0"
 arc-swap = "1.7"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tokio = { version = "1.48", default-features = false, features = ["macros", "net", "rt", "sync", "time"] }
+tokio = { version = "1.48", default-features = false, features = ["macros", "net", "rt", "sync", "test-util", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "http1"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
@@ -52,3 +52,4 @@ base64 = "0.22"
 getrandom = "0.3"
 syn = { version = "2", features = ["full", "visit"] }
 semver = { version = "1", features = ["serde"] }
+async-trait = "0.1"

--- a/boundaries/atm-http-runtime/http-runtime.toml
+++ b/boundaries/atm-http-runtime/http-runtime.toml
@@ -5,10 +5,10 @@ name = "HttpRuntime"
 
 [public]
 facade = "HttpRuntime"
-notes = "Tokio HTTP/TLS lifecycle facade; AL.1 validates only and owns no listener, endpoint publication, route decoder, or application handler."
+notes = "Tokio HTTP/TLS lifecycle facade. HttpRuntimeClient is the single connector-neutral async client translation; physical connector construction remains owned by AL.5--AL.7."
 
 [implementation]
-type = "HttpRuntime"
+type = "HttpRuntimeClient"
 module = "atm_http_runtime"
 visibility = "public"
 constructor = "public"

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2001,7 +2001,74 @@ fn al1_compatibility_oracle_freezes_negative_inputs_and_client_allowlist() {
     .sum::<usize>();
     assert_eq!(
         implementation_count, 4,
-        "AL.1's DaemonApiClient allowlist must stay exact until AL.4 migrates all implementations together"
+        "AL.1's four pre-AL.4 DaemonApiClient implementations must remain identifiable for AL.4's coordinated migration"
+    );
+
+    for path in [
+        root.join("crates/atm/src/composition.rs"),
+        root.join("crates/atm-graft/src/transport.rs"),
+        root.join("crates/atm-core/src/transport/testing.rs"),
+    ] {
+        let source = read_source(&path);
+        assert!(
+            source.contains("#[async_trait]") && source.contains("async fn execute"),
+            "AL.4 must migrate every retained DaemonApiClient implementation in {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn al4_shared_client_keeps_one_async_client_boundary_without_legacy_framing() {
+    let root = workspace_root();
+    let client = read_source(&root.join("crates/atm-http-runtime/src/client.rs"));
+    let graft = read_source(&root.join("crates/atm-graft/src/lib.rs"));
+    let cli = read_source(&root.join("crates/atm/src/composition.rs"));
+    let python = read_source(&root.join("crates/atm-graft-python/src/lib.rs"));
+
+    assert_eq!(
+        client
+            .matches("DaemonApiClient for HttpRuntimeClient")
+            .count(),
+        1,
+        "AL.4 permits exactly one framework runtime client implementation"
+    );
+    assert!(
+        client.contains("encode_http_request") && client.contains("decode_http_response"),
+        "all future physical connectors must share core request encoding and response decoding"
+    );
+    assert!(
+        client.contains("tokio::time::timeout") && client.contains("RequestDeadline"),
+        "the shared client must enforce one absolute Tokio deadline"
+    );
+    for forbidden in [
+        "HttpFrameReader",
+        "read_http_response_with_frame_reader",
+        "write_http_request_with_headers",
+        "read_http_request(",
+        "write_http_request(",
+        "block_on(",
+        "message[]",
+        "retry",
+        "replay",
+    ] {
+        assert!(
+            !client.contains(forbidden),
+            "AL.4's shared client must not introduce `{forbidden}`"
+        );
+    }
+    assert!(
+        graft.contains("async fn send_message") && cli.contains("async fn send("),
+        "graft and CLI writes must await the existing DaemonApiClient boundary"
+    );
+    assert!(
+        !graft.contains("block_on(") && !cli.contains("block_on("),
+        "library and CLI layers must not bridge async work synchronously"
+    );
+    assert_eq!(
+        python.matches(".block_on(").count(),
+        1,
+        "the Python extension may bridge only once at its outer PyO3 FFI boundary"
     );
 }
 

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -36,6 +36,7 @@ base64.workspace = true
 getrandom.workspace = true
 semver.workspace = true
 fs2 = "0.4"
+async-trait.workspace = true
 
 [dev-dependencies]
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -820,6 +820,23 @@ pub trait DaemonApiClient: crate::boundary::sealed::Sealed + Send + Sync {
     async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError>;
 }
 
+/// Requests that must prove the retained client/daemon compatibility contract
+/// before they cross a mutating or runtime-control boundary.
+///
+/// This is intentionally shared by the CLI and graft adapters: allowing each
+/// client crate to keep its own match list previously let their compatibility
+/// requirements drift apart.
+#[must_use]
+pub fn request_requires_compatibility_verification(request: &RequestEnvelope) -> bool {
+    matches!(
+        request,
+        RequestEnvelope::Write(_)
+            | RequestEnvelope::Clear(_)
+            | RequestEnvelope::PeerSync(_)
+            | RequestEnvelope::ReloadRuntimeView
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read, Write};

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -6,6 +6,7 @@
 use std::io::{Read, Write};
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
 use crate::clear::ClearQuery;
@@ -227,29 +228,58 @@ pub fn write_http_request_with_headers(
     request: &RequestEnvelope,
     headers: &[(&str, &str)],
 ) -> Result<(), AtmError> {
-    // The protocol envelope is an in-process dispatch type, never an HTTP
-    // representation. Each route serializes its own OpenAPI request body.
-    let body = encode_request_body(request)?;
-    let (method, path) = endpoint_for(request);
-    let headers = headers
-        .iter()
-        .map(|(name, value)| format!("{name}: {value}\r\n"))
-        .collect::<String>();
+    let encoded = encode_http_request(request, headers)?;
+    let headers = encoded.headers.join("\r\n");
+    let headers = if headers.is_empty() {
+        String::new()
+    } else {
+        format!("{headers}\r\n")
+    };
     write!(
         writer,
-        "{method} {path} HTTP/1.1\r\nContent-Type: application/json\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n",
-        body.len()
+        "{} {} HTTP/1.1\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n",
+        encoded.method,
+        encoded.path,
+        encoded.body.len()
     )
     .map_err(|source| {
-        AtmError::daemon_unavailable(format!("failed to write daemon HTTP request headers: {source}"))
+        AtmError::daemon_unavailable(format!(
+            "failed to write daemon HTTP request headers: {source}"
+        ))
     })?;
-    writer.write_all(&body).map_err(|source| {
+    writer.write_all(&encoded.body).map_err(|source| {
         AtmError::daemon_unavailable(format!(
             "failed to write daemon HTTP request body: {source}"
         ))
     })?;
     writer.flush().map_err(|source| {
         AtmError::daemon_unavailable(format!("failed to flush daemon HTTP request: {source}"))
+    })
+}
+
+/// Encodes one application request as its route-specific HTTP representation.
+///
+/// The application [`RequestEnvelope`] remains an in-process dispatch type;
+/// this function is the one shared translation to the existing route bodies.
+/// Framework-backed clients and retained stream adapters use the same encoder.
+pub fn encode_http_request(
+    request: &RequestEnvelope,
+    adapter_headers: &[(&str, &str)],
+) -> Result<HttpRequest, AtmError> {
+    let body = encode_request_body(request)?;
+    let (method, path) = endpoint_for(request);
+    let mut headers = Vec::with_capacity(adapter_headers.len() + 1);
+    headers.push("Content-Type: application/json".to_string());
+    headers.extend(
+        adapter_headers
+            .iter()
+            .map(|(name, value)| format!("{name}: {value}")),
+    );
+    Ok(HttpRequest {
+        method: method.to_string(),
+        path,
+        headers,
+        body,
     })
 }
 
@@ -376,13 +406,26 @@ pub fn read_http_response_with_frame_reader(
                 "ensure the daemon returns an HTTP/1.1 status line with a numeric status code",
             )
         })?;
+    decode_http_response(request, status, &headers, &body)
+}
+
+/// Decodes one route-specific HTTP response into the application envelope.
+///
+/// Framework-backed clients provide the status, headers, and body after their
+/// connector completes; retained framing adapters provide the identical values.
+pub fn decode_http_response(
+    request: &RequestEnvelope,
+    status: u16,
+    headers: &[String],
+    body: &[u8],
+) -> Result<ResponseEnvelope, AtmError> {
     if status == 204 {
-        return decode_no_content_response(request, &headers, &body);
+        return decode_no_content_response(request, headers, body);
     }
     if !(200..300).contains(&status) {
-        return decode_response_body(&body, "error").map(ResponseEnvelope::Error);
+        return decode_response_body(body, "error").map(ResponseEnvelope::Error);
     }
-    decode_success_response(request, &body)
+    decode_success_response(request, body)
 }
 
 fn write_no_content_response(
@@ -771,9 +814,10 @@ pub trait ApiRouter: crate::boundary::sealed::Sealed + Send + Sync {
 }
 
 /// The one client-facing daemon API for CLI, graft, and test adapters.
+#[async_trait]
 pub trait DaemonApiClient: crate::boundary::sealed::Sealed + Send + Sync {
     /// Executes one API request through the configured transport adapter.
-    fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError>;
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError>;
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -604,6 +604,7 @@ fn read_receiver_record(record_path: &Path) -> Result<GraftReceiverEndpointRecor
 /// This trait is intentionally not sealed. `atm-graft` must be able to
 /// implement the concrete same-host client in a separate crate without taking
 /// a Rust dependency on `atm-daemon`.
+#[async_trait::async_trait]
 pub trait AtmGraftClient: Send + Sync {
     /// Execute one send-shaped ATM compose request.
     ///
@@ -611,7 +612,7 @@ pub trait AtmGraftClient: Send + Sync {
     ///
     /// Returns [`AtmError`] when the underlying daemon-backed send path cannot
     /// complete successfully.
-    fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError>;
+    async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError>;
 
     /// Execute one ATM read request through the same daemon-backed semantic
     /// path used by the retained CLI.
@@ -655,8 +656,9 @@ mod tests {
     #[derive(Debug)]
     struct MockGraftClient;
 
+    #[async_trait::async_trait]
     impl AtmGraftClient for MockGraftClient {
-        fn send_message(&self, _request: SendRequest) -> Result<SendOutcome, AtmError> {
+        async fn send_message(&self, _request: SendRequest) -> Result<SendOutcome, AtmError> {
             panic!("send_message should not be called in trait object test")
         }
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -60,7 +60,7 @@ pub use nudge_template::{
 };
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
-pub use post_write::emit_persisted_local_post_write;
+pub use post_write::{emit_persisted_local_post_write, emit_received_message_after_commit};
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 use request::{prepare_threaded_message, resolve_message_body};
 

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -94,3 +94,69 @@ pub fn emit_persisted_local_post_write(
     }
     Ok(())
 }
+
+/// Emits only the receiver-side hook for one already committed message.
+///
+/// This is the replacement-runtime post-commit operation. It deliberately
+/// does not execute sender-side delivery, peer delivery, retry, or replay
+/// work: the receiving HTTP path has one responsibility after a durable
+/// commit—notify the local receiver through its injected hook boundary.
+///
+/// # Errors
+///
+/// Returns an error only when the already committed record or recipient
+/// configuration cannot be loaded to construct the advisory hook invocation.
+/// Callers must retain the durable write result and translate such an error to
+/// a warning rather than redefining the write as failed.
+pub fn emit_received_message_after_commit(
+    runtime: &LocalServiceRuntime,
+    home_dir: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+    message_id: AtmMessageId,
+    deadline: RequestDeadline,
+    message_received_emitter: Option<&dyn MessageReceivedHookEmitter>,
+) -> Result<Vec<WarningEntry>, AtmError> {
+    let key = crate::boundary::MessageKey::from(message_id);
+    let Some(record) = runtime.load_message_record(home_dir, team, agent, &key)? else {
+        return Ok(Vec::new());
+    };
+    let recipient = ResolvedRecipient {
+        agent: agent.clone(),
+        team: team.clone(),
+    };
+    let delivery_snapshot =
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(runtime, team, agent)?;
+    let context = SendExecutionContext {
+        #[cfg(test)]
+        post_send_config: None,
+        recipient: recipient.clone(),
+        canonical_sender: record.envelope.from.clone(),
+        inbox_path: runtime.inbox_path(home_dir, team, agent)?,
+        delivery_snapshot,
+        delivery_family: DeliveryPolicyCoordinator::resolve_send_family(
+            record.envelope.parent_message_id,
+            record.envelope.thread_mode,
+        ),
+        warnings: Vec::new(),
+    };
+    let persistence = DeliveryPersistenceResult::persisted(record.envelope.clone());
+    let plan = build_send_delivery_plan(
+        &context,
+        record.envelope.requires_ack,
+        record.envelope.acknowledges_message_id.is_some(),
+        &persistence,
+    )?;
+    let mut warnings = Vec::new();
+    hook::emit_post_send_effects(
+        runtime,
+        &mut warnings,
+        deadline,
+        None,
+        message_received_emitter,
+        &recipient,
+        &context.delivery_snapshot,
+        &plan.messages,
+    );
+    Ok(warnings)
+}

--- a/crates/atm-core/src/send/post_write.rs
+++ b/crates/atm-core/src/send/post_write.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::api::RequestDeadline;
 use crate::boundary::MessageReceivedHookEmitter;
 use crate::delivery_execution::{
     DeliveryTransitionContext, emit_delivery_plan_transitions, execute_delivery_plan,
@@ -13,8 +14,8 @@ use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::types::{AgentName, TeamName};
 
 use super::{
-    DeliveryPersistenceResult, ResolvedRecipient, SendExecutionContext, build_send_delivery_plan,
-    hook,
+    DeliveryPersistenceResult, ResolvedRecipient, SendExecutionContext, WarningEntry,
+    build_send_delivery_plan, hook,
 };
 
 /// Executes local post-write effects from a committed immutable record.
@@ -114,7 +115,7 @@ pub fn emit_received_message_after_commit(
     team: &TeamName,
     agent: &AgentName,
     message_id: AtmMessageId,
-    deadline: RequestDeadline,
+    _deadline: RequestDeadline,
     message_received_emitter: Option<&dyn MessageReceivedHookEmitter>,
 ) -> Result<Vec<WarningEntry>, AtmError> {
     let key = crate::boundary::MessageKey::from(message_id);
@@ -151,7 +152,6 @@ pub fn emit_received_message_after_commit(
     hook::emit_post_send_effects(
         runtime,
         &mut warnings,
-        deadline,
         None,
         message_received_emitter,
         &recipient,

--- a/crates/atm-core/src/transport/testing.rs
+++ b/crates/atm-core/src/transport/testing.rs
@@ -13,6 +13,7 @@ use crate::observability::{
 use crate::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use crate::read;
 use crate::send;
+use async_trait::async_trait;
 
 #[derive(Clone)]
 pub struct FakeClientTransport {
@@ -35,12 +36,24 @@ impl FakeClientTransport {
             handler: Arc::new(handler),
         }
     }
+
+    /// Synchronous deterministic dispatch for legacy synchronous test façades.
+    ///
+    /// Production callers use the async [`DaemonApiClient`] operation. This
+    /// exists only while AL.4 preserves the public synchronous CLI and graft
+    /// façades pending their separately scoped end-to-end activation.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[doc(hidden)]
+    pub fn execute_for_test(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        (self.handler)(request.into_inner()).map(ApiResponse::new)
+    }
 }
 
 impl boundary::sealed::Sealed for FakeClientTransport {}
 
+#[async_trait]
 impl DaemonApiClient for FakeClientTransport {
-    fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
         (self.handler)(request.into_inner()).map(ApiResponse::new)
     }
 }
@@ -60,12 +73,15 @@ impl LoopbackClientTransport {
     pub fn new(observability: Arc<dyn ObservabilityPort + Send + Sync>) -> Self {
         Self { observability }
     }
-}
 
-impl boundary::sealed::Sealed for LoopbackClientTransport {}
+    /// Synchronous deterministic dispatch for legacy synchronous test façades.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[doc(hidden)]
+    pub fn execute_for_test(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        self.execute_inner(request)
+    }
 
-impl DaemonApiClient for LoopbackClientTransport {
-    fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+    fn execute_inner(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
         let response = match request.into_inner() {
             RequestEnvelope::Write(request) => {
                 send::write_mail(*request, self.observability.as_ref()).map(|outcome| match outcome
@@ -106,6 +122,15 @@ impl DaemonApiClient for LoopbackClientTransport {
             )),
         };
         response.map(ApiResponse::new)
+    }
+}
+
+impl boundary::sealed::Sealed for LoopbackClientTransport {}
+
+#[async_trait]
+impl DaemonApiClient for LoopbackClientTransport {
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        self.execute_inner(request)
     }
 }
 

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -22,6 +22,7 @@ extension-module = ["pyo3/extension-module"]
 atm-graft = { path = "../atm-graft", version = "1.4.1-beta-aj" }
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
 pyo3 = "0.29"
+tokio.workspace = true
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj", features = ["test-utils"] }

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -4,7 +4,7 @@
 //! operation delegates to the existing graft client and its canonical API
 //! request types.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use ::atm_graft::{
     GraftClient, GraftSession, GraftSessionOptions, GraftSessionState, HostNudgeInjector,
@@ -22,6 +22,24 @@ use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::types::{AgentName, ChatId, ReadSelection, TeamName};
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+
+fn python_extension_runtime() -> PyResult<&'static Mutex<tokio::runtime::Runtime>> {
+    static RUNTIME: OnceLock<Mutex<tokio::runtime::Runtime>> = OnceLock::new();
+    if let Some(runtime) = RUNTIME.get() {
+        return Ok(runtime);
+    }
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .map(Mutex::new)
+        .map_err(|error| {
+            PyRuntimeError::new_err(format!(
+                "failed to create the ATM Python extension runtime: {error}"
+            ))
+        })?;
+    Ok(RUNTIME.get_or_init(|| runtime))
+}
 
 // Python projection of ATM's canonical structured error contract. The
 // exception message remains useful in ordinary Python tracebacks, while
@@ -407,7 +425,15 @@ impl PyGraftSession {
             self.caller.agent(),
             &caller_team,
         ));
-        self.client()?.send_message(request).map_err(atm_error)?;
+        let client = self.client()?;
+        // Python calls are synchronous. This is the one approved runtime
+        // bridge at the outermost PyO3 boundary; library clients never bridge
+        // async work back to synchronous code.
+        python_extension_runtime()?
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("ATM Python extension runtime lock poisoned"))?
+            .block_on(client.send_message(request))
+            .map_err(atm_error)?;
         Ok(())
     }
 
@@ -526,8 +552,10 @@ mod tests {
     };
     use atm_core::boundary::PostSendHookEvent;
     use atm_core::error::AtmError;
+    use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::send::{SendCommandOutcome, SendOutcome};
     use atm_core::transport::testing::FakeClientTransport;
-    use atm_core::types::{AgentName, ChatId, TeamName};
+    use atm_core::types::{AgentName, ChatId, CommandAction, TeamName};
     use atm_graft::{GraftClient, HostNudgeInjector, MailboxWorkCounts};
     use pyo3::prelude::{Py, Python};
     use pyo3::types::{PyAnyMethods, PyModule};
@@ -755,6 +783,49 @@ mod tests {
     }
 
     #[test]
+    fn python_send_uses_the_outer_ffi_runtime_bridge_for_the_async_client() {
+        Python::initialize();
+        let caller = PyAgentAddress::new(TEST_SENDER.to_string(), TEST_TEAM.to_string(), None)
+            .expect("caller");
+        let transport = Arc::new(FakeClientTransport::new(Box::new(|request| {
+            assert!(matches!(
+                request,
+                atm_core::protocol::RequestEnvelope::Write(_)
+            ));
+            Ok(ResponseEnvelope::Send(SendResponseEnvelope::Sent(
+                SendOutcome {
+                    action: CommandAction::Send,
+                    team: TeamName::from_validated(TEST_TEAM),
+                    agent: AgentName::from_validated(TEST_RECIPIENT),
+                    sender: AgentName::from_validated(TEST_SENDER),
+                    outcome: SendCommandOutcome::Sent,
+                    message_id: atm_core::schema::AtmMessageId::new(),
+                    requires_ack: false,
+                    task_id: None,
+                    summary: None,
+                    message: None,
+                    warnings: Vec::new(),
+                    dry_run: false,
+                },
+            )))
+        })));
+        let session = PyGraftSession {
+            caller: caller.to_typed().expect("typed caller"),
+            client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(transport))),
+            receiver: Mutex::new(None),
+        };
+        let recipient =
+            PyAgentAddress::new(TEST_RECIPIENT.to_string(), TEST_TEAM.to_string(), None)
+                .expect("recipient");
+
+        Python::attach(|_| {
+            session
+                .send(recipient, "async through Python".to_owned(), false)
+                .expect("Python boundary drives the asynchronous client");
+        });
+    }
+
+    #[test]
     fn receiver_ownership_conflict_is_a_typed_python_error() {
         Python::initialize();
         Python::attach(|py| {
@@ -792,7 +863,7 @@ mod tests {
         .expect("caller");
         let session = PyGraftSession {
             caller: caller.to_typed().expect("typed caller"),
-            client: Mutex::new(Some(GraftClient::from_transport_for_test(Arc::new(
+            client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(Arc::new(
                 FakeClientTransport::new(Box::new(|_| {
                     panic!("receiver activation must not call the daemon transport")
                 })),

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -10,13 +10,15 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-test-support = []
+test-support = ["atm-core/test-utils"]
 
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
 atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.1-beta-aj" }
 serde_json.workspace = true
 tracing.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj", features = ["test-utils"] }

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -105,7 +105,8 @@ impl Args {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse()?;
     let home_dir = PathBuf::from(
         std::env::var_os("ATM_HOME")
@@ -206,18 +207,20 @@ fn main() -> Result<(), Box<dyn Error>> {
         reply_body: "graft smoke ack reply".to_string(),
     })?;
 
-    let follow_up_outcome = session.send(SendRequest::new(
-        home_dir,
-        args.workspace_root.clone(),
-        args.agent.parse().expect("caller"),
-        args.reply_target.as_str(),
-        args.team.parse().expect("team"),
-        SendMessageSource::Inline("graft smoke follow-up".to_string()),
-        None,
-        false,
-        None,
-        false,
-    )?)?;
+    let follow_up_outcome = session
+        .send(SendRequest::new(
+            home_dir,
+            args.workspace_root.clone(),
+            args.agent.parse().expect("caller"),
+            args.reply_target.as_str(),
+            args.team.parse().expect("team"),
+            SendMessageSource::Inline("graft smoke follow-up".to_string()),
+            None,
+            false,
+            None,
+            false,
+        )?)
+        .await?;
     if follow_up_outcome.outcome != SendCommandOutcome::Sent {
         return Err(io::Error::other(format!(
             "expected graft follow-up send outcome sent, found {:?}",

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -10,6 +10,8 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use atm_core::ack::{AckOutcome, AckRequest};
+#[cfg(any(test, feature = "test-support"))]
+use atm_core::api::ApiResponse;
 use atm_core::api::{ApiRequest, DaemonApiClient};
 use atm_core::boundary::PostSendHookEvent;
 use atm_core::error::{AtmError, AtmErrorCode};
@@ -163,13 +165,18 @@ impl GraftSessionOptions {
 /// Thin daemon-backed same-host client for embedded graft consumers.
 #[derive(Clone)]
 pub struct GraftClient {
-    transport: Arc<dyn DaemonApiClient + Send + Sync>,
+    /// AL.4's asynchronous shared client boundary for canonical write calls.
+    async_transport: Arc<dyn DaemonApiClient + Send + Sync>,
+    /// Approved AL.4 compatibility path for probe and non-write operations
+    /// until AL.5 owns a physical Tokio connector and AL.2 gains their routes.
+    legacy_dispatch:
+        Arc<dyn Fn(RequestEnvelope) -> Result<ResponseEnvelope, AtmError> + Send + Sync>,
 }
 
 impl fmt::Debug for GraftClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GraftClient")
-            .field("transport", &"dyn DaemonApiClient")
+            .field("async_transport", &"dyn DaemonApiClient")
             .finish()
     }
 }
@@ -210,15 +217,35 @@ impl GraftClient {
         supervisor.ensure_daemon_available_with_traceability(&traceability, || {
             transport.probe_connection()
         })?;
+        // AL.4 retains this path only for probe and non-write operations.
+        // `send_message` below awaits DaemonApiClient directly; AL.5 replaces
+        // this adapter's physical implementation without a mid-stack bridge.
+        let legacy_dispatch = Arc::new({
+            let transport = Arc::clone(&transport);
+            move |request| transport.round_trip(request)
+        });
         Ok(Self {
-            transport: transport as Arc<dyn DaemonApiClient + Send + Sync>,
+            async_transport: transport,
+            legacy_dispatch,
         })
     }
 
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
-    pub fn from_transport_for_test(transport: Arc<dyn DaemonApiClient + Send + Sync>) -> Self {
-        Self { transport }
+    pub fn from_fake_transport_for_test(
+        transport: Arc<atm_core::transport::testing::FakeClientTransport>,
+    ) -> Self {
+        Self {
+            legacy_dispatch: Arc::new({
+                let transport = Arc::clone(&transport);
+                move |request| {
+                    transport
+                        .execute_for_test(ApiRequest::new(request))
+                        .map(ApiResponse::into_inner)
+                }
+            }),
+            async_transport: transport,
+        }
     }
 
     /// # Errors
@@ -239,11 +266,7 @@ impl GraftClient {
     }
 
     fn send_request(&self, request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError> {
-        match self
-            .transport
-            .execute(ApiRequest::new(request))?
-            .into_inner()
-        {
+        match (self.legacy_dispatch)(request)? {
             ResponseEnvelope::Error(error) => Err(error),
             response => Ok(response),
         }
@@ -265,9 +288,15 @@ impl GraftClient {
     }
 }
 
+#[async_trait::async_trait]
 impl AtmGraftClient for GraftClient {
-    fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Write(Box::new(request)))? {
+    async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
+        match self
+            .async_transport
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .await?
+            .into_inner()
+        {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => Ok(outcome),
             other => Err(unexpected_response("send", other)),
         }
@@ -427,8 +456,8 @@ impl GraftSession {
         read_snapshot(&self.snapshot)
     }
 
-    pub fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        self.client.send_message(request)
+    pub async fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
+        self.client.send_message(request).await
     }
 
     pub fn read(&self, query: ReadQuery) -> Result<ReadOutcome, AtmError> {
@@ -537,9 +566,10 @@ impl Drop for GraftSession {
     }
 }
 
+#[async_trait::async_trait]
 impl AtmGraftClient for GraftSession {
-    fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        self.client.send_message(request)
+    async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
+        self.client.send_message(request).await
     }
 
     fn read_message(&self, query: ReadQuery) -> Result<ReadOutcome, AtmError> {
@@ -582,8 +612,9 @@ mod tests {
     #[derive(Debug, Default)]
     struct StubSessionClient;
 
+    #[async_trait::async_trait]
     impl AtmGraftClient for StubSessionClient {
-        fn send_message(&self, _request: SendRequest) -> Result<SendOutcome, AtmError> {
+        async fn send_message(&self, _request: SendRequest) -> Result<SendOutcome, AtmError> {
             panic!("send_message should not run in inactive-session tests")
         }
 
@@ -623,8 +654,8 @@ mod tests {
         )
     }
 
-    #[test]
-    fn client_routes_send_read_and_ack_over_transport() {
+    #[tokio::test]
+    async fn client_routes_send_read_and_ack_over_transport() {
         let paths = test_paths();
         let transport = Arc::new(FakeClientTransport::new(Box::new(
             |request| {
@@ -706,7 +737,7 @@ mod tests {
             }
             },
         )));
-        let client = GraftClient::from_transport_for_test(transport);
+        let client = GraftClient::from_fake_transport_for_test(transport);
 
         let send_request = SendRequest::new(
             paths.home_dir.clone(),
@@ -721,7 +752,7 @@ mod tests {
             false,
         )
         .expect("send request");
-        client.send_message(send_request).expect("send");
+        client.send_message(send_request).await.expect("send");
 
         let read_query = ReadQuery::new(
             paths.home_dir.clone(),
@@ -787,7 +818,7 @@ mod tests {
                     other => panic!("unexpected request: {other:?}"),
                 },
             )));
-            let client = GraftClient::from_transport_for_test(transport);
+            let client = GraftClient::from_fake_transport_for_test(transport);
             let query = ReadQuery::new(
                 paths.home_dir,
                 paths.workspace_root,
@@ -839,7 +870,7 @@ mod tests {
         )
         .expect("query");
 
-        let error = GraftClient::from_transport_for_test(transport)
+        let error = GraftClient::from_fake_transport_for_test(transport)
             .mailbox_work_counts(query)
             .expect_err("mutating count query must be rejected");
         assert_eq!(error.code(), AtmErrorCode::CallerContextRequestInvalid);

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -322,6 +322,9 @@ impl AtmGraftClient for GraftClient {
 /// Concrete embedded graft session runtime.
 pub struct GraftSession {
     client: Arc<dyn AtmGraftClient>,
+    // Reads dominate (status projection and hook delivery) while updates only
+    // replace a complete snapshot, so an RwLock permits concurrent readers
+    // without exposing partial session state to a receiver callback.
     snapshot: Arc<RwLock<SessionSnapshot>>,
     observability: Arc<dyn GraftObservability>,
     stop_tx: Option<Sender<()>>,

--- a/crates/atm-graft/src/transport.rs
+++ b/crates/atm-graft/src/transport.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use atm_core::api::{ApiRequest, ApiResponse, DaemonApiClient};
+use atm_core::api::{
+    ApiRequest, ApiResponse, DaemonApiClient, request_requires_compatibility_verification,
+};
 use atm_core::boundary;
 use atm_core::error::AtmError;
 use atm_core::protocol::{
@@ -48,18 +50,69 @@ impl GraftLocalIpcClientTransport {
     }
 }
 
-fn request_requires_compatibility_verification(request: &RequestEnvelope) -> bool {
-    matches!(
-        request,
-        RequestEnvelope::Write(_) | RequestEnvelope::Clear(_)
-    )
-}
-
 impl boundary::sealed::Sealed for GraftLocalIpcClientTransport {}
 
 #[async_trait]
 impl DaemonApiClient for GraftLocalIpcClientTransport {
     async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
-        self.round_trip(request.into_inner()).map(ApiResponse::new)
+        let endpoint = self.endpoint.clone();
+        let request = request.into_inner();
+        tokio::task::spawn_blocking(move || {
+            GraftLocalIpcClientTransport { endpoint }
+                .round_trip(request)
+                .map(ApiResponse::new)
+        })
+        .await
+        .map_err(|source| {
+            AtmError::daemon_unavailable("graft daemon request worker ended unexpectedly")
+                .with_cause(source)
+        })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use atm_core::api::DaemonApiClient;
+    use atm_core::protocol::RequestEnvelope;
+    use atm_core::send::{SendMessageSource, SendRequest};
+    use atm_core::test_support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
+    use atm_core::types::{AgentName, TeamName};
+    use tempfile::tempdir;
+
+    use super::GraftLocalIpcClientTransport;
+
+    fn write_request() -> atm_core::api::ApiRequest {
+        atm_core::api::ApiRequest::new(RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                ".".into(),
+                ".".into(),
+                AgentName::from_validated(TEST_SENDER),
+                TEST_RECIPIENT,
+                TeamName::from_validated(TEST_TEAM),
+                SendMessageSource::Inline("cancel me".to_owned()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("request"),
+        )))
+    }
+
+    #[tokio::test]
+    async fn cancelling_async_execute_does_not_block_the_tokio_worker() {
+        let tempdir = tempdir().expect("tempdir");
+        let endpoint = atm_daemon_client::DaemonLocalIpcEndpoint::new(
+            tempdir.path().join("unserved-daemon.sock"),
+        )
+        .expect("endpoint");
+        let transport = Arc::new(GraftLocalIpcClientTransport::new(endpoint));
+        let task = tokio::spawn(async move { transport.execute(write_request()).await });
+
+        tokio::task::yield_now().await;
+        task.abort();
+        assert!(task.await.expect_err("cancelled task").is_cancelled());
     }
 }

--- a/crates/atm-graft/src/transport.rs
+++ b/crates/atm-graft/src/transport.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use atm_core::api::{ApiRequest, ApiResponse, DaemonApiClient};
 use atm_core::boundary;
 use atm_core::error::AtmError;
@@ -56,8 +57,9 @@ fn request_requires_compatibility_verification(request: &RequestEnvelope) -> boo
 
 impl boundary::sealed::Sealed for GraftLocalIpcClientTransport {}
 
+#[async_trait]
 impl DaemonApiClient for GraftLocalIpcClientTransport {
-    fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
         self.round_trip(request.into_inner()).map(ApiResponse::new)
     }
 }

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tower.workspace = true
 async-trait.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj", features = ["test-utils"] }

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -19,7 +19,9 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tower.workspace = true
+async-trait.workspace = true
 
 [dev-dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj", features = ["test-utils"] }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -15,6 +15,64 @@ use atm_core::api::{
 use atm_core::boundary;
 use atm_core::error::{AtmError, AtmErrorCode};
 
+/// Connector-stage failure vocabulary retained by the shared client before it
+/// becomes the public ATM error contract. Keeping the stage explicit prevents
+/// connector implementations from silently collapsing DNS, TLS, write, and
+/// cancellation failures into an indistinguishable generic transport error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    dead_code,
+    reason = "AL.5--AL.7 physical connectors consume every stage in this contract"
+)]
+pub(crate) enum HttpRuntimeClientFailure {
+    EndpointResolution(String),
+    Connect(String),
+    Tls(String),
+    RequestWrite(String),
+    ResponseStatus(AtmError),
+    ResponseDecode(AtmError),
+    Cancelled,
+    RuntimeShutdown,
+    Timeout,
+}
+
+impl HttpRuntimeClientFailure {
+    fn into_atm_error(self) -> AtmError {
+        match self {
+            Self::EndpointResolution(cause) => AtmError::new(
+                AtmErrorCode::LocalHttpEndpointMissing,
+                "HTTP client could not resolve the configured daemon endpoint",
+            )
+            .with_cause(cause),
+            Self::Connect(cause) => AtmError::daemon_unavailable(
+                "HTTP client could not connect to the configured daemon endpoint",
+            )
+            .with_cause(cause),
+            Self::Tls(cause) => AtmError::new(
+                AtmErrorCode::CertificateOperationFailed,
+                "HTTP client TLS handshake or peer authorization failed",
+            )
+            .with_cause(cause),
+            Self::RequestWrite(cause) => AtmError::daemon_unavailable(
+                "HTTP client could not write the request to the daemon endpoint",
+            )
+            .with_cause(cause),
+            Self::ResponseStatus(error) | Self::ResponseDecode(error) => error,
+            Self::Cancelled => AtmError::new(
+                AtmErrorCode::WaitTimeout,
+                "HTTP client request was cancelled before a response arrived",
+            ),
+            Self::RuntimeShutdown => AtmError::daemon_unavailable(
+                "HTTP client runtime shut down before the request completed",
+            ),
+            Self::Timeout => AtmError::new(
+                AtmErrorCode::WaitTimeout,
+                "HTTP client request exceeded its absolute request budget",
+            ),
+        }
+    }
+}
+
 /// Physical connection setup for the one shared HTTP client.
 ///
 /// Implementations own only endpoint/DNS resolution, connection, TLS, request
@@ -31,7 +89,7 @@ pub(crate) trait HttpRuntimeConnector: Send + Sync {
         &self,
         request: HttpRequest,
         deadline: RequestDeadline,
-    ) -> Result<axum::http::Response<Vec<u8>>, AtmError>;
+    ) -> Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure>;
 }
 
 /// One framework-backed client operation for every physical adapter.
@@ -66,6 +124,11 @@ impl<Connector> HttpRuntimeClient<Connector> {
         dead_code,
         reason = "AL.5--AL.7 own construction from physical connector configuration"
     )]
+    #[tracing::instrument(
+        name = "atm_http_runtime.client.execute",
+        skip(self, request),
+        fields(deadline_remaining_ms = ?deadline.remaining().map(|duration| duration.as_millis()))
+    )]
     async fn execute_with_deadline(
         &self,
         request: ApiRequest,
@@ -84,12 +147,8 @@ impl<Connector> HttpRuntimeClient<Connector> {
         })?;
         let response = tokio::time::timeout(remaining, self.connector.exchange(encoded, deadline))
             .await
-            .map_err(|_| {
-                AtmError::new(
-                    AtmErrorCode::WaitTimeout,
-                    "HTTP client request exceeded its absolute request budget",
-                )
-            })??;
+            .map_err(|_| HttpRuntimeClientFailure::Timeout.into_atm_error())?
+            .map_err(HttpRuntimeClientFailure::into_atm_error)?;
         let headers = response
             .headers()
             .iter()
@@ -107,6 +166,7 @@ impl<Connector> HttpRuntimeClient<Connector> {
             response.body(),
         )
         .map(ApiResponse::new)
+        .map_err(|error| HttpRuntimeClientFailure::ResponseDecode(error).into_atm_error())
     }
 }
 
@@ -140,12 +200,12 @@ mod tests {
     use atm_core::test_support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
     use atm_core::types::{AgentName, CommandAction, TeamName};
 
-    use super::{HttpRuntimeClient, HttpRuntimeConnector};
+    use super::{HttpRuntimeClient, HttpRuntimeClientFailure, HttpRuntimeConnector};
 
     #[derive(Default)]
     struct RecordingConnector {
         requests: Mutex<Vec<HttpRequest>>,
-        responses: Mutex<VecDeque<Result<axum::http::Response<Vec<u8>>, AtmError>>>,
+        responses: Mutex<VecDeque<Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure>>>,
     }
 
     #[async_trait]
@@ -154,7 +214,7 @@ mod tests {
             &self,
             request: HttpRequest,
             _deadline: RequestDeadline,
-        ) -> Result<axum::http::Response<Vec<u8>>, AtmError> {
+        ) -> Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure> {
             self.requests.lock().expect("requests").push(request);
             self.responses
                 .lock()
@@ -279,25 +339,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn every_connector_failure_cause_preserves_its_typed_context() {
-        for cause in [
-            "endpoint/DNS resolution",
-            "connect/refusal/network reachability",
-            "TLS handshake/hostname/mTLS authorization",
-            "request write",
-            "cancellation",
-            "runtime shutdown",
+    async fn every_named_client_failure_has_stable_code_and_recovery_context() {
+        for (cause, failure, code, recovery_fragment) in [
+            (
+                "endpoint/DNS resolution",
+                HttpRuntimeClientFailure::EndpointResolution("DNS lookup failed".to_owned()),
+                AtmErrorCode::LocalHttpEndpointMissing,
+                "endpoint",
+            ),
+            (
+                "connect/refusal/network reachability",
+                HttpRuntimeClientFailure::Connect("connection refused".to_owned()),
+                AtmErrorCode::DaemonUnavailable,
+                "connect",
+            ),
+            (
+                "TLS handshake/hostname/mTLS authorization",
+                HttpRuntimeClientFailure::Tls("certificate mismatch".to_owned()),
+                AtmErrorCode::CertificateOperationFailed,
+                "TLS",
+            ),
+            (
+                "request write",
+                HttpRuntimeClientFailure::RequestWrite("broken pipe".to_owned()),
+                AtmErrorCode::DaemonUnavailable,
+                "write",
+            ),
+            (
+                "cancellation",
+                HttpRuntimeClientFailure::Cancelled,
+                AtmErrorCode::WaitTimeout,
+                "cancelled",
+            ),
+            (
+                "runtime shutdown",
+                HttpRuntimeClientFailure::RuntimeShutdown,
+                AtmErrorCode::DaemonUnavailable,
+                "shut down",
+            ),
+            (
+                "timeout",
+                HttpRuntimeClientFailure::Timeout,
+                AtmErrorCode::WaitTimeout,
+                "budget",
+            ),
         ] {
             let connector = Arc::new(RecordingConnector::default());
-            let expected = AtmError::new(
-                AtmErrorCode::DaemonUnavailable,
-                format!("{cause} failed while using the configured connector"),
-            );
             connector
                 .responses
                 .lock()
                 .expect("responses")
-                .push_back(Err(expected.clone()));
+                .push_back(Err(failure));
             let client = HttpRuntimeClient::new(connector, Duration::from_secs(1));
 
             let error = client
@@ -305,7 +397,11 @@ mod tests {
                 .await
                 .expect_err(cause);
 
-            assert_eq!(error, expected, "{cause}");
+            assert_eq!(error.code(), code, "{cause}");
+            assert!(
+                error.message().contains(recovery_fragment),
+                "{cause}: {error}"
+            );
         }
     }
 
@@ -318,7 +414,7 @@ mod tests {
                 &self,
                 _request: HttpRequest,
                 _deadline: RequestDeadline,
-            ) -> Result<axum::http::Response<Vec<u8>>, AtmError> {
+            ) -> Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure> {
                 tokio::time::sleep(Duration::from_secs(60)).await;
                 unreachable!("deadline must cancel the connector")
             }

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -1,0 +1,338 @@
+//! Connector-neutral client-side HTTP translation.
+//!
+//! This module owns no socket, DNS, TLS, or listener setup.  Physical
+//! connectors are deliberately introduced by AL.5--AL.7.  It owns the one
+//! route-body encoder and result decoder used after a connector is selected.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use atm_core::api::{
+    ApiRequest, ApiResponse, DaemonApiClient, HttpRequest, RequestDeadline, decode_http_response,
+    encode_http_request,
+};
+use atm_core::boundary;
+use atm_core::error::{AtmError, AtmErrorCode};
+
+/// Physical connection setup for the one shared HTTP client.
+///
+/// Implementations own only endpoint/DNS resolution, connection, TLS, request
+/// write, and response read. They must preserve the supplied absolute deadline
+/// and return the existing [`AtmError`] vocabulary with their concrete cause.
+/// This is a connector seam, not a second ATM client boundary.
+#[allow(
+    dead_code,
+    reason = "AL.4 defines the shared client before AL.5--AL.7 add physical connectors"
+)]
+#[async_trait]
+pub(crate) trait HttpRuntimeConnector: Send + Sync {
+    async fn exchange(
+        &self,
+        request: HttpRequest,
+        deadline: RequestDeadline,
+    ) -> Result<axum::http::Response<Vec<u8>>, AtmError>;
+}
+
+/// One framework-backed client operation for every physical adapter.
+///
+/// The connector is the only place UDS, loopback, or TLS can differ. Request
+/// encoding, route selection, response decoding, and outcome mapping remain
+/// in this type.
+#[allow(
+    dead_code,
+    reason = "AL.4 defines the shared client before AL.5--AL.7 construct physical connectors"
+)]
+#[derive(Debug, Clone)]
+pub(crate) struct HttpRuntimeClient<Connector> {
+    connector: Arc<Connector>,
+    request_timeout: Duration,
+}
+
+impl<Connector> HttpRuntimeClient<Connector> {
+    #[allow(
+        dead_code,
+        reason = "AL.5--AL.7 own construction from physical connector configuration"
+    )]
+    #[must_use]
+    pub(crate) fn new(connector: Arc<Connector>, request_timeout: Duration) -> Self {
+        Self {
+            connector,
+            request_timeout,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "AL.5--AL.7 own construction from physical connector configuration"
+    )]
+    async fn execute_with_deadline(
+        &self,
+        request: ApiRequest,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError>
+    where
+        Connector: HttpRuntimeConnector,
+    {
+        let request = request.into_inner();
+        let encoded = encode_http_request(&request, &[])?;
+        let remaining = deadline.remaining().ok_or_else(|| {
+            AtmError::new(
+                AtmErrorCode::WaitTimeout,
+                "HTTP client request budget elapsed before connector dispatch",
+            )
+        })?;
+        let response = tokio::time::timeout(remaining, self.connector.exchange(encoded, deadline))
+            .await
+            .map_err(|_| {
+                AtmError::new(
+                    AtmErrorCode::WaitTimeout,
+                    "HTTP client request exceeded its absolute request budget",
+                )
+            })??;
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                format!(
+                    "{name}: {}",
+                    value.to_str().unwrap_or("<non-UTF-8 header value>")
+                )
+            })
+            .collect::<Vec<_>>();
+        decode_http_response(
+            &request,
+            response.status().as_u16(),
+            &headers,
+            response.body(),
+        )
+        .map(ApiResponse::new)
+    }
+}
+
+impl<Connector> boundary::sealed::Sealed for HttpRuntimeClient<Connector> where
+    Connector: Send + Sync
+{
+}
+
+#[async_trait]
+impl<Connector> DaemonApiClient for HttpRuntimeClient<Connector>
+where
+    Connector: HttpRuntimeConnector + 'static,
+{
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        self.execute_with_deadline(request, RequestDeadline::after(self.request_timeout))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use atm_core::api::{ApiRequest, DaemonApiClient, HttpRequest, RequestDeadline};
+    use atm_core::error::{AtmError, AtmErrorCode};
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::send::{SendCommandOutcome, SendMessageSource, SendRequest};
+    use atm_core::test_support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
+    use atm_core::types::{AgentName, CommandAction, TeamName};
+
+    use super::{HttpRuntimeClient, HttpRuntimeConnector};
+
+    #[derive(Default)]
+    struct RecordingConnector {
+        requests: Mutex<Vec<HttpRequest>>,
+        responses: Mutex<VecDeque<Result<axum::http::Response<Vec<u8>>, AtmError>>>,
+    }
+
+    #[async_trait]
+    impl HttpRuntimeConnector for RecordingConnector {
+        async fn exchange(
+            &self,
+            request: HttpRequest,
+            _deadline: RequestDeadline,
+        ) -> Result<axum::http::Response<Vec<u8>>, AtmError> {
+            self.requests.lock().expect("requests").push(request);
+            self.responses
+                .lock()
+                .expect("responses")
+                .pop_front()
+                .expect("configured response")
+        }
+    }
+
+    fn write_request() -> RequestEnvelope {
+        RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                ".".into(),
+                ".".into(),
+                AgentName::from_validated(TEST_SENDER),
+                TEST_RECIPIENT,
+                TeamName::from_validated(TEST_TEAM),
+                SendMessageSource::Inline("shared client".to_owned()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("request"),
+        ))
+    }
+
+    fn sent_response() -> axum::http::Response<Vec<u8>> {
+        let outcome = atm_core::send::SendOutcome {
+            action: CommandAction::Send,
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_RECIPIENT),
+            sender: AgentName::from_validated(TEST_SENDER),
+            outcome: SendCommandOutcome::Sent,
+            message_id: atm_core::schema::AtmMessageId::new(),
+            requires_ack: false,
+            task_id: None,
+            summary: None,
+            message: None,
+            warnings: Vec::new(),
+            dry_run: false,
+        };
+        axum::http::Response::builder()
+            .status(201)
+            .body(serde_json::to_vec(&outcome).expect("encode outcome"))
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn future_uds_loopback_and_tls_connectors_share_one_write_translation() {
+        for connector_kind in ["uds", "loopback", "tls"] {
+            let connector = Arc::new(RecordingConnector::default());
+            connector
+                .responses
+                .lock()
+                .expect("responses")
+                .push_back(Ok(sent_response()));
+            let client = HttpRuntimeClient::new(connector.clone(), Duration::from_secs(1));
+
+            let response = client
+                .execute(ApiRequest::new(write_request()))
+                .await
+                .expect("shared client response");
+
+            assert!(matches!(
+                response.into_inner(),
+                ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+            ));
+            let requests = connector.requests.lock().expect("requests");
+            assert_eq!(requests.len(), 1, "{connector_kind} connector");
+            assert_eq!(requests[0].method, "POST", "{connector_kind} connector");
+            assert_eq!(
+                requests[0].path, "/v1/atm/messages",
+                "{connector_kind} connector"
+            );
+            assert!(
+                serde_json::from_slice::<atm_core::send::WriteRequest>(&requests[0].body).is_ok(),
+                "{connector_kind} connector"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn response_status_preserves_the_adr_032_error_body() {
+        let connector = Arc::new(RecordingConnector::default());
+        let expected = AtmError::validation("rejected by server");
+        connector.responses.lock().expect("responses").push_back(Ok(
+            axum::http::Response::builder()
+                .status(400)
+                .body(serde_json::to_vec(&expected).expect("encode error"))
+                .expect("response"),
+        ));
+        let client = HttpRuntimeClient::new(connector, Duration::from_secs(1));
+
+        let response = client
+            .execute(ApiRequest::new(write_request()))
+            .await
+            .expect("typed error is a response");
+
+        assert!(
+            matches!(response.into_inner(), ResponseEnvelope::Error(error) if error == expected)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_response_body_uses_the_existing_protocol_error() {
+        let connector = Arc::new(RecordingConnector::default());
+        connector.responses.lock().expect("responses").push_back(Ok(
+            axum::http::Response::builder()
+                .status(201)
+                .body(b"not a response envelope".to_vec())
+                .expect("response"),
+        ));
+        let client = HttpRuntimeClient::new(connector, Duration::from_secs(1));
+
+        let error = client
+            .execute(ApiRequest::new(write_request()))
+            .await
+            .expect_err("malformed response must not be accepted");
+
+        assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
+    }
+
+    #[tokio::test]
+    async fn every_connector_failure_cause_preserves_its_typed_context() {
+        for cause in [
+            "endpoint/DNS resolution",
+            "connect/refusal/network reachability",
+            "TLS handshake/hostname/mTLS authorization",
+            "request write",
+            "cancellation",
+            "runtime shutdown",
+        ] {
+            let connector = Arc::new(RecordingConnector::default());
+            let expected = AtmError::new(
+                AtmErrorCode::DaemonUnavailable,
+                format!("{cause} failed while using the configured connector"),
+            );
+            connector
+                .responses
+                .lock()
+                .expect("responses")
+                .push_back(Err(expected.clone()));
+            let client = HttpRuntimeClient::new(connector, Duration::from_secs(1));
+
+            let error = client
+                .execute(ApiRequest::new(write_request()))
+                .await
+                .expect_err(cause);
+
+            assert_eq!(error, expected, "{cause}");
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn request_deadline_bounds_the_connector_once() {
+        struct WaitingConnector;
+        #[async_trait]
+        impl HttpRuntimeConnector for WaitingConnector {
+            async fn exchange(
+                &self,
+                _request: HttpRequest,
+                _deadline: RequestDeadline,
+            ) -> Result<axum::http::Response<Vec<u8>>, AtmError> {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                unreachable!("deadline must cancel the connector")
+            }
+        }
+
+        let client = HttpRuntimeClient::new(Arc::new(WaitingConnector), Duration::from_millis(1));
+        let task =
+            tokio::spawn(async move { client.execute(ApiRequest::new(write_request())).await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        let error = task
+            .await
+            .expect("timeout task completes")
+            .expect_err("request must time out");
+        assert_eq!(error.code(), AtmErrorCode::WaitTimeout);
+    }
+}

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -41,6 +41,7 @@ use std::time::Duration;
 use atm_core::ApiRouter;
 use atm_core::error::AtmError;
 
+mod client;
 mod message_handler;
 
 pub use message_handler::{AuthenticatedConnector, canonical_message_router};

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -1,12 +1,13 @@
 //! Tokio HTTP runtime composition contract for ATM.
 //!
-//! This crate owns no listener or route implementation in AL.1.  It provides
-//! the typed, consuming lifecycle and validates runtime-owned configuration
-//! before a later adapter is allowed to bind or publish an endpoint.  See the
-//! [Phase AL/AM runtime boundary checklist](../../../docs/plans/phase-al-am-runtime-boundary-checklist.md).
+//! This crate owns the replacement Tokio/Axum listener and canonical typed
+//! message route. It validates runtime-owned configuration before binding and
+//! keeps lifecycle ownership with the Tokio task that serves that route. See
+//! the [Phase AL/AM runtime boundary checklist](../../../docs/plans/phase-al-am-runtime-boundary-checklist.md).
 //!
 //! The only ATM dependency is `atm-core`, specifically its existing sealed
-//! [`atm_core::ApiRouter`] boundary and canonical [`atm_core::AtmError`].
+//! canonical [`atm_core::AtmError`] and the existing core storage and hook
+//! contracts supplied by replacement composition.
 //! Runtime construction never accepts a storage backend, tmux, graft, CLI, or
 //! daemon-bootstrap type.
 
@@ -31,22 +32,27 @@
 //! }
 //! ```
 
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use atm_core::ApiRouter;
 use atm_core::error::AtmError;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
 
 mod client;
 mod message_handler;
+mod storage_and_nudge_router;
 
-pub use message_handler::{AuthenticatedConnector, canonical_message_router};
+pub use message_handler::{
+    AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
+};
+pub use storage_and_nudge_router::StorageAndNudgeRouter;
 
-/// Validated configuration for the future maintained Tokio HTTP runtime.
+/// Validated configuration for the maintained Tokio HTTP runtime.
 ///
 /// The fields remain private so composition cannot bypass validation before a
 /// listener is introduced in a later AL sprint.
@@ -204,17 +210,17 @@ impl TlsMaterial {
     }
 }
 
-/// Composition input that uses the existing sealed application boundary.
+/// Composition input for the replacement async write boundary.
 #[derive(Clone)]
 pub struct HttpRuntimeBuilder {
     config: HttpRuntimeConfig,
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
 }
 
 impl HttpRuntimeBuilder {
     #[must_use]
-    pub fn new(config: HttpRuntimeConfig, router: Arc<dyn ApiRouter>) -> Self {
-        Self { config, router }
+    pub fn new(config: HttpRuntimeConfig, handler: Arc<dyn CanonicalWriteHandler>) -> Self {
+        Self { config, handler }
     }
 
     /// Validates all runtime-owned input without binding or publishing.
@@ -226,67 +232,138 @@ impl HttpRuntimeBuilder {
         validate_config(&self.config)?;
         Ok(HttpRuntime {
             config: self.config,
-            router: self.router,
-            _state: PhantomData,
+            handler: self.handler,
+            state: Configured,
         })
     }
 }
 
 /// Validated but not started runtime state.
 pub struct Configured;
-/// Runtime lifecycle state after its future listener/start adapter begins.
-pub struct Running;
-/// Runtime lifecycle state while the future listener drains.
-pub struct Draining;
+/// Runtime lifecycle state while its owned Axum server is accepting requests.
+pub struct Running {
+    local_address: SocketAddr,
+    shutdown_tx: watch::Sender<()>,
+    server_task: JoinHandle<std::io::Result<()>>,
+}
+/// Runtime lifecycle state after cancellation and while the Axum task drains.
+pub struct Draining {
+    server_task: JoinHandle<std::io::Result<()>>,
+}
 /// Terminal lifecycle state with no live runtime-owned handles.
 pub struct Stopped;
 
 /// Non-cloneable lifecycle owner. State transitions consume this value.
 pub struct HttpRuntime<State> {
     config: HttpRuntimeConfig,
-    router: Arc<dyn ApiRouter>,
-    _state: PhantomData<State>,
+    handler: Arc<dyn CanonicalWriteHandler>,
+    state: State,
 }
 
 impl HttpRuntime<Configured> {
-    /// Transitions the validated runtime to `Running`.
+    /// Binds the replacement listener and starts its one Axum server task.
     ///
-    /// AL.1 intentionally owns no listener or endpoint publisher; AL.2 adds
-    /// the canonical handler and later adapter sprints provide the binding
-    /// implementation. This transition is still consuming so consumers cannot
-    /// express double-start or publish-before-running.
+    /// The caller supplies the Tokio runtime. This method never creates a
+    /// nested runtime and all request handling runs through the one typed
+    /// route built from the injected application boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the configured TCP address cannot be bound or
+    /// its local address cannot be read.
     pub async fn start(self) -> Result<HttpRuntime<Running>, AtmError> {
-        Ok(self.into_state())
+        let listener = TcpListener::bind(self.config.bind_address)
+            .await
+            .map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to bind replacement HTTP runtime at {}: {source}",
+                    self.config.bind_address
+                ))
+            })?;
+        let local_address = listener.local_addr().map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to read replacement HTTP runtime address: {source}"
+            ))
+        })?;
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(());
+        let router = canonical_message_router(
+            Arc::clone(&self.handler),
+            AuthenticatedConnector::local(),
+            self.config.limits,
+            self.config.timeouts,
+        );
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.changed().await;
+                })
+                .await
+        });
+        Ok(HttpRuntime {
+            config: self.config,
+            handler: self.handler,
+            state: Running {
+                local_address,
+                shutdown_tx,
+                server_task,
+            },
+        })
     }
 }
 
 impl HttpRuntime<Running> {
+    /// Returns the actual listener address selected at start.
+    #[must_use]
+    pub const fn local_address(&self) -> SocketAddr {
+        self.state.local_address
+    }
+
     /// Consumes the only running owner and begins the drain transition.
     #[must_use]
     pub fn begin_shutdown(self) -> HttpRuntime<Draining> {
-        self.into_state()
+        let _ = self.state.shutdown_tx.send(());
+        HttpRuntime {
+            config: self.config,
+            handler: self.handler,
+            state: Draining {
+                server_task: self.state.server_task,
+            },
+        }
     }
 }
 
 impl HttpRuntime<Draining> {
     /// Completes the drain transition.
     ///
-    /// AL.1 owns no listener, connection task, or cancellation handle, so there
-    /// is no work to time-bound here. The validated shutdown duration is
-    /// reserved for the adapter that first owns drainable runtime work; that
-    /// adapter must apply it to its actual drain operation rather than inventing
-    /// a delay in this lifecycle-only transition.
-    pub async fn finish(self) -> HttpRuntime<Stopped> {
-        self.into_state()
-    }
-}
-
-impl<State> HttpRuntime<State> {
-    fn into_state<Next>(self) -> HttpRuntime<Next> {
-        HttpRuntime {
-            config: self.config,
-            router: self.router,
-            _state: PhantomData,
+    /// The runtime waits only for its actual Axum task. A shutdown deadline
+    /// aborts and joins that task so no replacement-runtime task is detached.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the server fails while draining or exceeds the
+    /// configured shutdown bound.
+    pub async fn finish(self) -> Result<HttpRuntime<Stopped>, AtmError> {
+        let mut server_task = self.state.server_task;
+        let finished = tokio::time::timeout(self.config.timeouts.shutdown, &mut server_task).await;
+        match finished {
+            Ok(Ok(Ok(()))) => Ok(HttpRuntime {
+                config: self.config,
+                handler: self.handler,
+                state: Stopped,
+            }),
+            Ok(Ok(Err(source))) => Err(AtmError::daemon_unavailable(format!(
+                "replacement HTTP runtime stopped with an I/O error: {source}"
+            ))),
+            Ok(Err(source)) => Err(AtmError::daemon_unavailable(format!(
+                "replacement HTTP runtime task ended unexpectedly: {source}"
+            ))),
+            Err(_) => {
+                server_task.abort();
+                let _ = server_task.await;
+                Err(AtmError::daemon_unavailable(
+                    "replacement HTTP runtime exceeded its shutdown deadline",
+                ))
+            }
         }
     }
 }
@@ -356,30 +433,30 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use atm_core::ApiRouter;
-    use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
-    use atm_core::boundary;
+    use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use atm_core::error::AtmError;
 
     use super::{
-        HttpRuntimeBuilder, HttpRuntimeConfig, NonZeroDuration, RuntimeLimits, RuntimeTimeouts,
-        UnixSocketConfig,
+        CanonicalWriteHandler, HttpRuntimeBuilder, HttpRuntimeConfig, NonZeroDuration,
+        RuntimeLimits, RuntimeTimeouts, UnixSocketConfig,
     };
 
     struct TestRouter;
 
-    impl boundary::sealed::Sealed for TestRouter {}
-
-    impl ApiRouter for TestRouter {
-        fn route(
+    impl CanonicalWriteHandler for TestRouter {
+        fn write(
             &self,
-            _request: ApiRequest,
+            _request: atm_core::send::WriteRequest,
             _ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            Err(AtmError::validation(
-                "test router is not invoked by the AL.1 lifecycle contract",
-            ))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async {
+                Err(AtmError::validation(
+                    "test handler is not invoked by the lifecycle contract",
+                ))
+            })
         }
     }
 
@@ -577,6 +654,33 @@ mod tests {
             .expect("valid configuration");
         let running = configured.start().await.expect("AL.1 start transition");
         let draining = running.begin_shutdown();
-        let _stopped = draining.finish().await;
+        let _stopped = draining.finish().await.expect("runtime must drain");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_binds_serves_and_joins_the_axum_task() {
+        let listener =
+            std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve a test port");
+        let port = listener.local_addr().expect("read test port").port();
+        drop(listener);
+
+        let configured = HttpRuntimeBuilder::new(config(port), Arc::new(TestRouter))
+            .build()
+            .expect("valid configuration");
+        let running = configured.start().await.expect("replacement server starts");
+        let response = reqwest::Client::new()
+            .get(format!(
+                "http://{}/v1/atm/messages",
+                running.local_address()
+            ))
+            .send()
+            .await
+            .expect("replacement server responds");
+        assert_eq!(response.status(), reqwest::StatusCode::METHOD_NOT_ALLOWED);
+        running
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("replacement server joins after shutdown");
     }
 }

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -1,15 +1,15 @@
 //! Canonical typed HTTP ingress for message writes.
 //!
 //! This module owns HTTP extraction, connector-provenance normalization, and
-//! response translation only.  It deliberately delegates persistence and all
-//! message policy to the sealed [`ApiRouter`] boundary exactly once.
+//! response translation only. It delegates persistence and received-message
+//! notification to one replacement-owned async write boundary.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
-use atm_core::ApiRouter;
 use atm_core::api::{
-    ApiRequest, ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline,
-    http_route_surface,
+    ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline, http_route_surface,
 };
 use atm_core::error::AtmError;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
@@ -31,6 +31,19 @@ use tower::limit::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 
 use crate::{RuntimeLimits, RuntimeTimeouts};
+
+/// Async replacement-owned application operation for the canonical write
+/// route. Implementations may isolate synchronous storage or hook adapters in
+/// narrow `spawn_blocking` calls, but the HTTP handler itself remains a Tokio
+/// future and never dispatches an entire legacy router on a worker pool.
+pub trait CanonicalWriteHandler: Send + Sync {
+    fn write(
+        &self,
+        request: WriteRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>>;
+}
 
 /// Provenance established by the transport adapter after authentication.
 ///
@@ -75,7 +88,7 @@ impl AuthenticatedConnector {
 
 #[derive(Clone)]
 struct MessageRouteState {
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
     connector: AuthenticatedConnector,
     request_timeout: std::time::Duration,
 }
@@ -86,13 +99,13 @@ struct MessageRouteState {
 /// layers bound body memory and in-flight work; `LoadShedLayer` rejects rather
 /// than queues a request whenever the configured capacity is unavailable.
 pub fn canonical_message_router(
-    router: Arc<dyn ApiRouter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
     connector: AuthenticatedConnector,
     limits: RuntimeLimits,
     timeouts: RuntimeTimeouts,
 ) -> Router {
     let state = MessageRouteState {
-        router,
+        handler,
         connector,
         request_timeout: timeouts.request,
     };
@@ -142,43 +155,10 @@ async fn post_messages(
     let ingress = state.connector.normalize_write(&mut request);
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    let response = tokio::time::timeout(
-        state.request_timeout,
-        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline),
-    )
-    .await
-    .map_err(|_| {
-        AtmError::new(
-            atm_core::error::AtmErrorCode::WaitTimeout,
-            "canonical HTTP dispatch exceeded the configured request timeout",
-        )
-    })
-    .and_then(|response| response);
+    let response = state.handler.write(request, ingress, deadline).await;
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
-}
-
-/// Calls the synchronous sealed application boundary without stalling a Tokio
-/// worker. The boundary remains synchronous until its owning core contract is
-/// deliberately changed; this adapter owns the asynchronous isolation only.
-async fn dispatch_on_blocking_pool(
-    router: Arc<dyn ApiRouter>,
-    request: WriteRequest,
-    ingress: AuthenticatedIngress,
-    deadline: RequestDeadline,
-) -> Result<ApiResponse, AtmError> {
-    tokio::task::spawn_blocking(move || {
-        router.route(ApiRequest::Write(Box::new(request)), ingress, deadline)
-    })
-    .await
-    .map_err(|source| {
-        AtmError::new(
-            atm_core::error::AtmErrorCode::InternalError,
-            "canonical HTTP dispatch task ended unexpectedly",
-        )
-        .with_cause(source)
-    })?
 }
 
 fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
@@ -269,12 +249,11 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::api::PEER_SOURCE_HOST_HEADER;
-    use atm_core::boundary;
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::protocol::ResponseEnvelope;
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
-    use atm_core::{ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, RequestDeadline};
+    use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
     use axum::http::{Request, StatusCode};
@@ -282,8 +261,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        AuthenticatedConnector, canonical_message_router, canonical_write_path, json_response,
-        map_write_response,
+        AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
+        canonical_write_path, json_response, map_write_response,
     };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
@@ -293,23 +272,22 @@ mod tests {
         calls: Arc<Mutex<Vec<(atm_core::send::WriteRequest, AuthenticatedIngress)>>>,
     }
 
-    impl boundary::sealed::Sealed for RecordingRouter {}
-
-    impl ApiRouter for RecordingRouter {
-        fn route(
+    impl CanonicalWriteHandler for RecordingRouter {
+        fn write(
             &self,
-            request: ApiRequest,
+            request: atm_core::send::WriteRequest,
             ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            let ApiRequest::Write(request) = request else {
-                return Err(AtmError::validation("test expected a write request"));
-            };
-            self.calls
-                .lock()
-                .expect("record calls")
-                .push((*request, ingress));
-            Ok(ApiResponse::new(self.response.clone()))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .expect("record calls")
+                    .push((request, ingress));
+                Ok(ApiResponse::new(self.response.clone()))
+            })
         }
     }
 
@@ -331,17 +309,31 @@ mod tests {
         }
     }
 
-    impl boundary::sealed::Sealed for BlockingRouter {}
-
-    impl ApiRouter for BlockingRouter {
-        fn route(
+    impl CanonicalWriteHandler for BlockingRouter {
+        fn write(
             &self,
-            _request: ApiRequest,
+            _request: atm_core::send::WriteRequest,
             _ingress: AuthenticatedIngress,
             _deadline: RequestDeadline,
-        ) -> Result<ApiResponse, AtmError> {
-            self.gate.wait_until_released();
-            Ok(ApiResponse::new(self.response.clone()))
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<ApiResponse, AtmError>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                let gate = Arc::clone(&self.gate);
+                let response = self.response.clone();
+                tokio::task::spawn_blocking(move || {
+                    gate.wait_until_released();
+                    Ok(ApiResponse::new(response))
+                })
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "test blocking write task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })?
+            })
         }
     }
 
@@ -680,7 +672,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn synchronous_router_dispatch_does_not_stall_the_tokio_worker() {
+    async fn blocking_handler_operation_does_not_stall_the_tokio_worker() {
         let gate = Arc::new(Gate::default());
         let app = canonical_message_router(
             Arc::new(BlockingRouter {
@@ -696,7 +688,7 @@ mod tests {
         tokio::spawn(async move {
             wait_for_start
                 .await
-                .expect("blocking router entered before scheduler progress check");
+                .expect("blocking handler entered before scheduler progress check");
             progressed.note_scheduler_progress();
         });
         let entered = Arc::clone(&gate);
@@ -720,12 +712,12 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CREATED);
         assert!(
             gate.state.lock().expect("lock gate").scheduler_progressed,
-            "the Tokio worker must remain schedulable while the synchronous router runs"
+            "the Tokio worker must remain schedulable while the blocking handler operation runs"
         );
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn request_timeout_returns_the_adr_032_timeout_error() {
+    async fn started_dispatch_returns_its_actual_response_after_the_advisory_deadline() {
         let gate = Arc::new(Gate::default());
         let app = canonical_message_router(
             Arc::new(BlockingRouter {
@@ -736,20 +728,24 @@ mod tests {
             limits(4096, 1),
             timeouts_with_request(Duration::from_millis(10)),
         );
-        let response = tokio::time::timeout(
-            Duration::from_secs(1),
-            post(
-                app,
-                serde_json::to_vec(&write_request()).expect("typed JSON"),
-            ),
-        )
-        .await;
+        let response = tokio::spawn(post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        ));
+        let entered = Arc::clone(&gate);
+        tokio::task::spawn_blocking(move || entered.wait_until_entered())
+            .await
+            .expect("wait for blocking handler");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !response.is_finished(),
+            "the adapter must not synthesize a timeout while a started route owns the durable outcome"
+        );
         gate.release();
-        let response = response.expect("handler must enforce its request timeout");
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let error: AtmError =
-            serde_json::from_slice(&response_body(response).await).expect("ADR-032 timeout JSON");
-        assert_eq!(error.code(), AtmErrorCode::WaitTimeout);
+        let response = response
+            .await
+            .expect("request task joins after the started route completes");
+        assert_eq!(response.status(), StatusCode::CREATED);
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -55,7 +55,9 @@ impl StorageAndNudgeRouter {
             self.observability.as_ref(),
             &self.service_runtime,
         )?;
-        let newly_persisted = prepared.is_newly_persisted();
+        // The core writer is the sole authority on whether this write created
+        // a record. Idempotent duplicates do not schedule a second hook.
+        let newly_persisted = prepared.requires_post_write_route();
         let canonical_request = prepared.outbound_request();
         let message_id = prepared.persisted_message_id();
         let outcome = prepared.finish(&self.service_runtime, self.observability.as_ref())?;

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1,0 +1,180 @@
+//! Replacement-owned canonical write composition.
+//!
+//! This module owns the two explicit blocking seams in the replacement path:
+//! the injected storage-backed core write and the injected received-message
+//! hook. The enclosing HTTP route remains async and awaits both operations.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use atm_core::LocalServiceRuntime;
+use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
+use atm_core::boundary::MessageReceivedHookEmitter;
+use atm_core::error::AtmError;
+use atm_core::observability::ObservabilityPort;
+use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+use atm_core::send::{
+    WarningEntry, WriteOutcome, emit_received_message_after_commit, prepare_write_with_runtime,
+};
+
+use crate::CanonicalWriteHandler;
+
+/// The replacement implementation of the canonical write operation.
+///
+/// Storage stays behind `LocalServiceRuntime`'s core interfaces and
+/// notification stays behind the injected `MessageReceivedHookEmitter`. This
+/// type has no concrete SQLite, tmux, graft, or legacy-daemon dependency.
+#[derive(Clone)]
+pub struct StorageAndNudgeRouter {
+    service_runtime: LocalServiceRuntime,
+    observability: Arc<dyn ObservabilityPort + Send + Sync>,
+    received_hook: Arc<dyn MessageReceivedHookEmitter>,
+}
+
+impl StorageAndNudgeRouter {
+    #[must_use]
+    pub fn new(
+        service_runtime: LocalServiceRuntime,
+        observability: Arc<dyn ObservabilityPort + Send + Sync>,
+        received_hook: Arc<dyn MessageReceivedHookEmitter>,
+    ) -> Self {
+        Self {
+            service_runtime,
+            observability,
+            received_hook,
+        }
+    }
+
+    fn commit_write(
+        &self,
+        request: atm_core::send::WriteRequest,
+    ) -> Result<CommittedWrite, AtmError> {
+        let mut prepared = prepare_write_with_runtime(
+            request,
+            self.observability.as_ref(),
+            &self.service_runtime,
+        )?;
+        let newly_persisted = prepared.is_newly_persisted();
+        let canonical_request = prepared.outbound_request();
+        let message_id = prepared.persisted_message_id();
+        let outcome = prepared.finish(&self.service_runtime, self.observability.as_ref())?;
+        Ok(CommittedWrite {
+            outcome,
+            canonical_request,
+            message_id,
+            newly_persisted,
+        })
+    }
+
+    fn emit_received_hook(
+        &self,
+        request: &atm_core::send::WriteRequest,
+        message_id: atm_core::schema::AtmMessageId,
+        deadline: RequestDeadline,
+    ) -> Vec<WarningEntry> {
+        if deadline.expired() {
+            return vec![hook_warning(AtmError::daemon_unavailable(
+                "received-message hook was skipped because the request deadline was exhausted after persistence",
+            ))];
+        }
+        let Some(target) = request.to.as_ref() else {
+            return vec![hook_warning(AtmError::validation(
+                "durably received message had no canonical destination for receiver hook",
+            ))];
+        };
+        let team = target
+            .team()
+            .cloned()
+            .unwrap_or_else(|| request.caller_team.clone());
+        let agent = target.agent().clone();
+        match emit_received_message_after_commit(
+            &self.service_runtime,
+            &request.home_dir,
+            &team,
+            &agent,
+            message_id,
+            deadline,
+            Some(self.received_hook.as_ref()),
+        ) {
+            Ok(warnings) => warnings,
+            Err(error) => vec![hook_warning(error)],
+        }
+    }
+}
+
+struct CommittedWrite {
+    outcome: WriteOutcome,
+    canonical_request: atm_core::send::WriteRequest,
+    message_id: atm_core::schema::AtmMessageId,
+    newly_persisted: bool,
+}
+
+impl CanonicalWriteHandler for StorageAndNudgeRouter {
+    fn write(
+        &self,
+        request: atm_core::send::WriteRequest,
+        _ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        Box::pin(async move {
+            if deadline.expired() {
+                return Err(AtmError::daemon_unavailable(
+                    "request deadline expired before replacement write admission",
+                ));
+            }
+            let storage = self.clone();
+            let mut committed = tokio::task::spawn_blocking(move || storage.commit_write(request))
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "replacement storage write task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })??;
+            if committed.newly_persisted {
+                let hook = self.clone();
+                let request = committed.canonical_request.clone();
+                let message_id = committed.message_id;
+                let warnings = tokio::task::spawn_blocking(move || {
+                    hook.emit_received_hook(&request, message_id, deadline)
+                })
+                .await
+                .map_err(|source| {
+                    AtmError::new(
+                        atm_core::error::AtmErrorCode::InternalError,
+                        "replacement received-message hook task ended unexpectedly",
+                    )
+                    .with_cause(source)
+                })?;
+                append_warnings(&mut committed.outcome, warnings);
+            }
+            Ok(ApiResponse::new(write_response(committed.outcome)))
+        })
+    }
+}
+
+fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
+    match outcome {
+        WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
+        WriteOutcome::Acknowledged(outcome) => outcome.warnings.extend(warnings),
+    }
+}
+
+fn write_response(outcome: WriteOutcome) -> ResponseEnvelope {
+    match outcome {
+        WriteOutcome::Sent(outcome) => ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)),
+        WriteOutcome::Acknowledged(outcome) => {
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
+        }
+    }
+}
+
+fn hook_warning(error: AtmError) -> WarningEntry {
+    WarningEntry::with_code(
+        error.code(),
+        format!("message received successfully, but its receiver hook did not run: {error}"),
+        Some("inspect the receiver hook endpoint or harness, then continue normally"),
+    )
+}

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -48,6 +48,8 @@ serde_yaml = "0.9"
 time = "0.3"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 atm-graft = { path = "../atm-graft", version = "1.4.1-beta-aj", features = ["test-support"] }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -88,8 +88,8 @@ impl Cli {
     }
 
     /// Run the selected ATM subcommand.
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
-        self.command.run(observability)
+    pub async fn run(self, observability: &CliObservability) -> Result<()> {
+        self.command.run(observability).await
     }
 }
 
@@ -116,10 +116,10 @@ enum Command {
 }
 
 impl Command {
-    fn run(self, observability: &CliObservability) -> Result<()> {
+    async fn run(self, observability: &CliObservability) -> Result<()> {
         match self {
             Self::Api(command) => command.run(observability),
-            Self::Send(command) => command.run(observability),
+            Self::Send(command) => command.run(observability).await,
             Self::List(command) => command.run(observability),
             Self::Peek(command) => command.run(observability),
             Self::Peer(command) => command.run(observability),

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -67,7 +67,7 @@ impl SendCommand {
     }
 
     /// Execute the `atm send` command.
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
+    pub async fn run(self, observability: &CliObservability) -> Result<()> {
         let (home_dir, current_dir) = resolve_command_runtime_context("send")?;
         let json = self.json;
         let request = self.build_request(home_dir.clone(), current_dir.clone())?;
@@ -77,7 +77,7 @@ impl SendCommand {
             InvocationDir::new(&current_dir),
             AtmHomePath::new(&home_dir),
         )?;
-        let outcome = composition.send(request)?;
+        let outcome = composition.send(request).await?;
 
         output::print_send_result(&outcome, json)
     }

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Once};
 
+use async_trait::async_trait;
 use atm_core::ack::{AckOutcome, AckRequest};
 use atm_core::api::{ApiRequest, ApiResponse, DaemonApiClient};
 use atm_core::boundary;
@@ -174,14 +175,21 @@ fn request_requires_compatibility_verification(request: &RequestEnvelope) -> boo
 
 impl boundary::sealed::Sealed for LocalIpcClientTransportAdapter {}
 
+#[async_trait]
 impl DaemonApiClient for LocalIpcClientTransportAdapter {
-    fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
         self.round_trip(request.into_inner()).map(ApiResponse::new)
     }
 }
 
 pub(crate) struct CliComposition<'a> {
-    transport: Arc<dyn DaemonApiClient + Send + Sync + 'a>,
+    /// AL.4's asynchronous shared client boundary for canonical write calls.
+    async_transport: Arc<dyn DaemonApiClient + Send + Sync + 'a>,
+    /// Approved AL.4 compatibility path for probe and non-write operations
+    /// until AL.5 owns a physical Tokio connector and canonical non-write
+    /// routes exist.
+    legacy_dispatch:
+        Arc<dyn Fn(RequestEnvelope) -> Result<ResponseEnvelope, AtmError> + Send + Sync + 'a>,
     observability_port: &'a CliObservability,
     bootstrap_trace: Option<BootstrapTraceReport>,
 }
@@ -189,7 +197,7 @@ pub(crate) struct CliComposition<'a> {
 impl fmt::Debug for CliComposition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CliComposition")
-            .field("transport", &"dyn DaemonApiClient")
+            .field("async_transport", &"dyn DaemonApiClient")
             .field("observability_port", &"dyn ObservabilityPort")
             .field("bootstrap_trace", &self.bootstrap_trace)
             .finish()
@@ -197,30 +205,57 @@ impl fmt::Debug for CliComposition<'_> {
 }
 
 impl<'a> CliComposition<'a> {
-    pub(crate) fn from_transport(
-        transport: Arc<dyn DaemonApiClient + Send + Sync + 'a>,
+    #[cfg(test)]
+    fn from_fake_transport(
+        transport: Arc<atm_core::transport::testing::FakeClientTransport>,
         observability_port: &'a CliObservability,
     ) -> Self {
         install_retained_runtime_factory();
         Self {
-            transport,
+            legacy_dispatch: Arc::new({
+                let transport = Arc::clone(&transport);
+                move |request| {
+                    transport
+                        .execute_for_test(ApiRequest::new(request))
+                        .map(ApiResponse::into_inner)
+                }
+            }),
+            async_transport: transport,
             observability_port,
             bootstrap_trace: None,
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn from_transport_with_bootstrap_trace(
-        transport: Arc<dyn DaemonApiClient + Send + Sync + 'a>,
+    fn from_loopback_transport(
+        transport: Arc<atm_core::transport::testing::LoopbackClientTransport>,
         observability_port: &'a CliObservability,
-        bootstrap_trace: BootstrapTraceReport,
     ) -> Self {
         install_retained_runtime_factory();
         Self {
-            transport,
+            legacy_dispatch: Arc::new({
+                let transport = Arc::clone(&transport);
+                move |request| {
+                    transport
+                        .execute_for_test(ApiRequest::new(request))
+                        .map(ApiResponse::into_inner)
+                }
+            }),
+            async_transport: transport,
             observability_port,
-            bootstrap_trace: Some(bootstrap_trace),
+            bootstrap_trace: None,
         }
+    }
+
+    #[cfg(test)]
+    fn from_loopback_transport_with_bootstrap_trace(
+        transport: Arc<atm_core::transport::testing::LoopbackClientTransport>,
+        observability_port: &'a CliObservability,
+        bootstrap_trace: BootstrapTraceReport,
+    ) -> Self {
+        let mut composition = Self::from_loopback_transport(transport, observability_port);
+        composition.bootstrap_trace = Some(bootstrap_trace);
+        composition
     }
 
     #[expect(
@@ -228,18 +263,14 @@ impl<'a> CliComposition<'a> {
         reason = "reserved for future phase that inspects the active transport variant"
     )]
     pub(crate) fn transport(&self) -> &(dyn DaemonApiClient + Send + Sync + 'a) {
-        self.transport.as_ref()
+        self.async_transport.as_ref()
     }
 
     pub(crate) fn send_request(
         &self,
         request: RequestEnvelope,
     ) -> Result<ResponseEnvelope, AtmError> {
-        match self
-            .transport
-            .execute(ApiRequest::new(request))?
-            .into_inner()
-        {
+        match (self.legacy_dispatch)(request)? {
             ResponseEnvelope::Error(error) => Err(error),
             response => Ok(response),
         }
@@ -253,8 +284,13 @@ impl<'a> CliComposition<'a> {
         self.observability_port
     }
 
-    pub(crate) fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Write(Box::new(request)))? {
+    pub(crate) async fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
+        match self
+            .async_transport
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .await?
+            .into_inner()
+        {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
                 self.observability_port.emit_command_event(CommandEvent {
                     command: "send",
@@ -427,6 +463,7 @@ impl<'a> CliComposition<'a> {
         invocation_dir: InvocationDir<'_>,
         atm_home: AtmHomePath<'_>,
     ) -> Result<Self, AtmError> {
+        install_retained_runtime_factory();
         let _invocation_dir = invocation_dir.as_path();
         let _atm_home = atm_home.as_path();
         let endpoint = resolve_daemon_local_ipc_endpoint().inspect_err(|error| {
@@ -460,7 +497,16 @@ impl<'a> CliComposition<'a> {
         supervisor.ensure_daemon_available_with_traceability(&traceability, || {
             transport.probe_connection().map(|_| ())
         })?;
-        let mut composition = Self::from_transport(transport, observability);
+        let legacy_dispatch = Arc::new({
+            let transport = Arc::clone(&transport);
+            move |request| transport.round_trip(request)
+        });
+        let mut composition = Self {
+            async_transport: transport,
+            legacy_dispatch,
+            observability_port: observability,
+            bootstrap_trace: None,
+        };
         composition.bootstrap_trace = Some(bootstrap_trace_to_core(traceability.snapshot()));
         Ok(composition)
     }
@@ -497,9 +543,10 @@ fn bootstrap_trace_to_core(
     }
 }
 
+#[async_trait]
 impl AtmGraftClient for CliComposition<'_> {
-    fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        CliComposition::send(self, request)
+    async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
+        CliComposition::send(self, request).await
     }
 
     fn read_message(&self, query: ReadQuery) -> Result<ReadOutcome, AtmError> {
@@ -520,6 +567,7 @@ mod tests {
     use std::sync::Mutex;
     use std::time::Duration;
 
+    use atm_core::ApiRequest;
     use atm_core::ack::AckRequest;
     use atm_core::api::{decode_request, read_http_request, write_http_request};
     use atm_core::boundary;
@@ -543,7 +591,6 @@ mod tests {
     };
     use atm_core::types::ReadSelection;
     use atm_core::types::{AgentName, ChatId, CommandAction, TeamName};
-    use atm_core::{ApiRequest, DaemonApiClient};
     use atm_daemon_client::DaemonBinaryPath;
     use chrono::Utc;
     use serde_json::{Map, Value};
@@ -1017,7 +1064,7 @@ mod tests {
                 "synthetic daemon failure",
             )))
         }));
-        let composition = CliComposition::from_transport(transport, &observability);
+        let composition = CliComposition::from_fake_transport(transport, &observability);
 
         let error = composition
             .send_request(RequestEnvelope::Doctor(atm_core::doctor::DoctorQuery {
@@ -1043,15 +1090,15 @@ mod tests {
             assert!(matches!(request, RequestEnvelope::ReloadRuntimeView));
             Ok(ResponseEnvelope::RuntimeViewReloaded)
         }));
-        let composition = CliComposition::from_transport(transport, &observability);
+        let composition = CliComposition::from_fake_transport(transport, &observability);
 
         composition
             .reload_runtime_view()
             .expect("CLI runtime reload response");
     }
 
-    #[test]
-    fn cli_graft_daemon_and_read_preserve_one_chat_identity_contract() {
+    #[tokio::test]
+    async fn cli_graft_daemon_and_read_preserve_one_chat_identity_contract() {
         let chat_id = "chat-42".parse::<ChatId>().expect("chat id");
         let send_request = SendRequest::new(
             std::path::PathBuf::from("/tmp/home"),
@@ -1091,8 +1138,9 @@ mod tests {
             }
         }));
         let observability = CliObservability::fallback();
-        CliComposition::from_transport(cli_transport, &observability)
+        CliComposition::from_fake_transport(cli_transport, &observability)
             .send(send_request.clone())
+            .await
             .expect("cli send");
 
         let graft_requests = Arc::new(Mutex::new(Vec::new()));
@@ -1107,8 +1155,9 @@ mod tests {
                 Ok(response.clone())
             }
         }));
-        atm_graft::GraftClient::from_transport_for_test(graft_transport)
+        atm_graft::GraftClient::from_fake_transport_for_test(graft_transport)
             .send_message(send_request)
+            .await
             .expect("graft send");
 
         let cli_request = cli_requests
@@ -1171,19 +1220,20 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(env)]
-    fn loopback_transport_send_persists_inbox_without_daemon() {
+    async fn loopback_transport_send_persists_inbox_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let transport_observability = Arc::new(atm_core::observability::NullObservability);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(transport_observability)),
             &composition_observability,
         );
 
         let outcome = composition
             .send(fixture.send_request("hello from loopback"))
+            .await
             .expect("send outcome");
 
         assert_eq!(outcome.agent.as_str(), TEST_RECIPIENT);
@@ -1194,13 +1244,13 @@ mod tests {
         assert_eq!(inbox[0].from.as_str(), TEST_SENDER);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(env)]
-    fn loopback_transport_rejects_self_addressed_send_without_persisting_inbox() {
+    async fn loopback_transport_rejects_self_addressed_send_without_persisting_inbox() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let transport_observability = Arc::new(atm_core::observability::NullObservability);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(transport_observability)),
             &composition_observability,
         );
@@ -1208,6 +1258,7 @@ mod tests {
 
         let error = composition
             .send(fixture.send_request_to(&self_address, "hello self"))
+            .await
             .expect_err("self-addressed send must fail");
 
         assert_eq!(
@@ -1234,14 +1285,14 @@ mod tests {
             let first_transport = transport.clone();
             let second_transport = transport.clone();
             let first = scope.spawn(move || {
-                first_transport.execute(ApiRequest::new(RequestEnvelope::Write(Box::new(
+                first_transport.execute_for_test(ApiRequest::new(RequestEnvelope::Write(Box::new(
                     first_request,
                 ))))
             });
             let second = scope.spawn(move || {
-                second_transport.execute(ApiRequest::new(RequestEnvelope::Write(Box::new(
-                    second_request,
-                ))))
+                second_transport.execute_for_test(ApiRequest::new(RequestEnvelope::Write(
+                    Box::new(second_request),
+                )))
             });
             (
                 first.join().expect("first transport result"),
@@ -1266,12 +1317,12 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(env)]
-    fn loopback_transport_send_preserves_ack_and_task_metadata_without_daemon() {
+    async fn loopback_transport_send_preserves_ack_and_task_metadata_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1284,6 +1335,7 @@ mod tests {
                 false,
                 Some("TASK-314".parse().expect("task id")),
             ))
+            .await
             .expect("send outcome");
 
         assert!(outcome.requires_ack);
@@ -1301,12 +1353,12 @@ mod tests {
         assert!(inbox[0].pending_ack_at.is_some());
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(env)]
-    fn loopback_transport_phase_ad_messaging_regression_matrix_without_daemon() {
+    async fn loopback_transport_phase_ad_messaging_regression_matrix_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1316,6 +1368,7 @@ mod tests {
         // Plain informational send stays non-ack-requiring.
         let plain_outcome = composition
             .send(fixture.send_request("plain informational"))
+            .await
             .expect("plain send outcome");
         assert!(!plain_outcome.requires_ack);
         let plain_message_id = plain_outcome.message_id;
@@ -1323,6 +1376,7 @@ mod tests {
         // Explicit requires-ack send persists durable pending-ack state.
         let ack_required_outcome = composition
             .send(fixture.send_request_with_flags("needs acknowledgement", true, None))
+            .await
             .expect("ack-required send outcome");
         assert!(ack_required_outcome.requires_ack);
         let ack_required_message_id = ack_required_outcome.message_id;
@@ -1334,6 +1388,7 @@ mod tests {
                 false,
                 Some("TASK-314".parse().expect("task id")),
             ))
+            .await
             .expect("task send outcome");
         assert!(task_outcome.requires_ack);
         let task_message_id = task_outcome.message_id;
@@ -1437,6 +1492,7 @@ mod tests {
         let self_address = format!("{TEST_SENDER}@{TEST_TEAM}");
         let error = composition
             .send(fixture.send_request_to(&self_address, "hello self"))
+            .await
             .expect_err("self-addressed send must fail");
         assert_eq!(
             error.code(),
@@ -1450,7 +1506,7 @@ mod tests {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         fixture.write_inbox_messages(TEST_RECIPIENT, &[fixture.message("read me", false)]);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1474,7 +1530,7 @@ mod tests {
     fn loopback_transport_read_rejects_cross_agent_target_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1516,7 +1572,7 @@ mod tests {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         fixture.write_inbox_messages(TEST_RECIPIENT, &[fixture.message("done", true)]);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1541,7 +1597,7 @@ mod tests {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let observability = Arc::new(HealthyObservability);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(observability)),
             &composition_observability,
         );
@@ -1560,7 +1616,7 @@ mod tests {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let observability = Arc::new(HealthyObservability);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport_with_bootstrap_trace(
+        let composition = CliComposition::from_loopback_transport_with_bootstrap_trace(
             Arc::new(LoopbackClientTransport::new(observability)),
             &composition_observability,
             BootstrapTraceReport {
@@ -1623,7 +1679,7 @@ mod tests {
         let (message_id, pending_ack) = fixture.pending_ack_message("please ack");
         fixture.write_inbox_messages(TEST_SENDER, &[pending_ack]);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1654,12 +1710,12 @@ mod tests {
         assert!(replies[0].pending_ack_at.is_none());
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(env)]
-    fn cli_composition_supports_graft_client_surface_without_daemon() {
+    async fn cli_composition_supports_graft_client_surface_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let composition_observability = CliObservability::fallback();
-        let composition = CliComposition::from_transport(
+        let composition = CliComposition::from_loopback_transport(
             Arc::new(LoopbackClientTransport::new(Arc::new(
                 atm_core::observability::NullObservability,
             ))),
@@ -1669,6 +1725,7 @@ mod tests {
 
         let send_outcome = client
             .send_message(fixture.send_request("graft send"))
+            .await
             .expect("send through graft client surface");
         assert_eq!(send_outcome.sender.as_str(), TEST_SENDER);
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, Once};
 
 use async_trait::async_trait;
 use atm_core::ack::{AckOutcome, AckRequest};
-use atm_core::api::{ApiRequest, ApiResponse, DaemonApiClient};
+use atm_core::api::{
+    ApiRequest, ApiResponse, DaemonApiClient, request_requires_compatibility_verification,
+};
 use atm_core::boundary;
 use atm_core::clear::{ClearOutcome, ClearQuery};
 use atm_core::doctor::{BootstrapTraceReport, DoctorQuery, DoctorReport};
@@ -161,16 +163,6 @@ impl LocalIpcClientTransportAdapter {
         }
         daemon_exchange_request(&self.endpoint, &request, SAME_HOST_REQUEST_DEADLINE)
     }
-}
-
-fn request_requires_compatibility_verification(request: &RequestEnvelope) -> bool {
-    matches!(
-        request,
-        RequestEnvelope::Write(_)
-            | RequestEnvelope::Clear(_)
-            | RequestEnvelope::PeerSync(_)
-            | RequestEnvelope::ReloadRuntimeView
-    )
 }
 
 impl boundary::sealed::Sealed for LocalIpcClientTransportAdapter {}

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -62,8 +62,9 @@ pub(crate) enum ConsoleLogRoute {
     Stderr,
 }
 
-fn main() {
-    let exit_code = match run() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let exit_code = match run().await {
         Ok(()) => 0,
         Err(error) => {
             eprintln!("{error}");
@@ -175,7 +176,7 @@ fn is_warning_or_internal_error(code: AtmErrorCode) -> bool {
     )
 }
 
-fn run() -> Result<(), AtmError> {
+async fn run() -> Result<(), AtmError> {
     let cli = match commands::Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
@@ -214,7 +215,7 @@ fn run() -> Result<(), AtmError> {
         tracing::info!(launch_cwd = %launch_cwd.display(), "atm process started");
     }
 
-    match cli.run(&observability) {
+    match cli.run(&observability).await {
         Ok(()) => Ok(()),
         Err(error) => Err(report_and_map_service_error(&observability, error)),
     }

--- a/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
+++ b/docs/plans/phase-al/AL3-durable-write-received-hook-remediation-task-list.md
@@ -1,0 +1,213 @@
+# AL.3 Replacement Runtime — Remaining Work
+
+Status: **open — audit updated 2026-08-06**. This is a replacement-runtime
+checklist, not a legacy-daemon remediation plan. `crates/atm-daemon` is
+reference-only until Phase AM deletes it. No task in this file permits changing,
+wrapping, starting, or using its listeners, workers, `ApiRouter`, hook
+implementation, or tests as proof.
+
+## Non-negotiable execution path
+
+```text
+Tokio/Axum ingress
+  -> one typed replacement write service
+  -> injected storage/runtime boundary commits the canonical write
+  -> new record only: injected MessageReceivedHookEmitter
+  -> durable success, optionally with a hook-warning
+```
+
+The same absolute `RequestDeadline` flows through the whole request. Storage
+failure is an error and persists no record. A hook start, execution, or timeout
+failure after a commit is a successful write with a stable warning. An
+idempotent duplicate is successful and does not emit a second hook.
+
+## Closure tasks
+
+- [ ] **AL3-RH-000 — Replacement-owned Tokio/Axum server.**
+  - `atm-http-runtime` binds and serves the canonical typed Axum write route on
+    the Tokio runtime supplied by the replacement executable; it never creates
+    a private runtime or calls `Handle::block_on`.
+  - Its consuming lifecycle owns listener, cancellation, task join, and bounded
+    shutdown. It has no dependency on `atm-daemon`, concrete SQLite, tmux,
+    graft, or daemon bootstrap.
+  - Tests prove binding, a real HTTP request, orderly shutdown, and no leaked
+    server task.
+
+- [ ] **AL3-RH-001 — Replacement-owned storage-and-hook write service.**
+  - Add the one replacement `CanonicalWriteHandler` implementation in
+    `atm-http-runtime`. It calls only existing core/runtime composition types:
+    injected storage-backed `LocalServiceRuntime`, injected observability, and
+    injected `MessageReceivedHookEmitter`.
+  - The service prepares and commits the canonical `WriteRequest` through the
+    existing core writer, then invokes the received hook only for a newly
+    persisted message. It must not call any legacy daemon router or worker.
+  - Tests prove storage is called before the hook; database failure runs no
+    hook; duplicate delivery runs no second hook; and hook failure becomes an
+    existing-schema warning on success.
+
+- [ ] **AL3-RH-002 — Tokio isolation and deadline contract.**
+  - Synchronous storage and the current synchronous, sealed hook operation run
+    only in narrowly scoped `spawn_blocking` work; no Tokio worker is blocked.
+    The HTTP task awaits the result and never detaches a write or hook.
+  - Pass one absolute deadline unchanged. Reject before admitting expired
+    work, retain a started transaction's real durable outcome, and do not add a
+    second full-duration timeout.
+  - Tests cover zero budget, storage error, successful commit, hook failure,
+    exhausted post-commit budget, and duplicate/no-hook.
+
+- [ ] **AL3-RH-003 — Replacement proof and legacy quarantine.**
+  - Default repository tests and CI exclude `atm-daemon` unit tests immediately;
+    they are historical reference tests, not acceptance evidence for AL.
+  - While the new executable target is being completed, legacy may still be
+    compiled only where workspace metadata requires it; it must not be started,
+    smoke-tested, or selected by an AL proof. AL activation replaces the binary
+    before AM deletes the legacy crate.
+  - Add an architecture guard forbidding `atm-http-runtime` from depending on
+    `atm-daemon`, `Runtime::Builder`, `Handle::block_on`,
+    `std::sync::mpsc`, `std::thread::sleep`, or legacy transport module names.
+
+- [ ] **AL3-RH-004 — Explicit later work, not a reason to touch legacy.**
+  - AL.5/AL.6/AL.7 add UDS, loopback TCP, and peer TLS adapters to this same
+    server and service. They add no peer-only decoder, queue, listener, or
+    post-send path.
+  - The hook boundary's async evolution, process cleanup details, and the
+    `sc-lint` blocking-sleep product rule remain tracked work; product issue is
+    [sc-lint#82](https://github.com/randlee/sc-lint/issues/82). They must be
+  solved in replacement-owned code, never by repairing the old daemon.
+
+## 2026-08-06 critical-review findings
+
+The listener and direct async handler have been added, and their focused tests
+pass. That is progress, not closure: the behavior below is still required
+before this implementation can be considered the replacement ingress.
+
+- [ ] **AL3-CR-001 (blocking) — Prove the actual Storage → hook outcome
+  matrix.**
+  - Existing `atm-http-runtime` tests use `RecordingRouter` and
+    `BlockingRouter`; neither constructs `StorageAndNudgeRouter` with a real
+    storage boundary and a recording/failing received-hook implementation.
+  - Add replacement-owned integration tests for: storage failure with no
+    persisted record and no hook; new durable record followed by one hook;
+    idempotent duplicate with no second hook; and hook error represented as a
+    successful `Send`/`Acknowledged` response carrying the existing warning
+    schema.
+  - Assert ordering, not merely counts: the hook must observe the already
+    persisted record. Tests must reach the Axum route, not call private helper
+    methods directly.
+
+- [ ] **AL3-CR-002 (blocking) — Enforce a real post-commit hook deadline.**
+  - `StorageAndNudgeRouter` awaits a `spawn_blocking` hook task without a
+    Tokio timeout. An emitter that ignores `RequestDeadline` can keep the HTTP
+    request open indefinitely, so the required "success plus timeout warning"
+    behavior is unproven and currently false for that implementation class.
+  - Define the cancellation contract before changing code: after a durable
+    commit, a timed-out hook must return the durable success plus warning, and
+    its work must have a supervised cleanup path. Do not detach an unkillable
+    blocking task or create a second full request budget.
+  - Add stalled-emitter tests for request-budget exhaustion and hook cleanup;
+    one test must prove the caller receives success plus warning rather than a
+    route failure.
+
+- [ ] **AL3-CR-003 (blocking) — Use bounded replacement-owned write
+  admission, not Tokio's generic blocking queue.**
+  - `spawn_blocking` is currently the only storage admission mechanism.
+    `ConcurrencyLimitLayer` bounds HTTP handlers, but it does not define a
+    serialized/bounded SQLite write-job contract, caller cancellation behavior,
+    or started-job outcome semantics.
+  - Introduce one small Tokio-owned bounded write-admission component at
+    replacement composition. It must await caller-visible completion, preserve
+    a started transaction's actual durable outcome, reject cancelled/expired
+    work before start, and serve every future connector through this one path.
+  - Cover saturation, cancellation before start, transaction failure, started
+    transaction past advisory deadline, and idempotent duplicate. Do not
+    reintroduce `DispatchWorkerPool`, a thread queue, retry, or replay.
+
+- [ ] **AL3-CR-004 (important) — Make harness-specific hook selection
+  explicit.**
+  - `StorageAndNudgeRouter` owns one global
+    `Arc<dyn MessageReceivedHookEmitter>`. A tmux emitter rejects a graft
+    target and a graft emitter rejects a tmux target, so this cannot satisfy a
+    mixed roster.
+  - Replacement composition must select the appropriate injected receiver
+    implementation from the committed recipient/harness before emission.
+    `atm-http-runtime` must remain unaware of tmux and graft concrete types;
+    it receives only a core-owned, object-safe selection boundary or a
+    harness-resolved emitter.
+  - Test both harness selections and a recipient with no hook capability. No
+    branch may reintroduce a daemon dependency on `atm-graft`.
+
+- [ ] **AL3-CR-005 (important) — Remove the unnecessary public handler
+  extension point.**
+  - `CanonicalWriteHandler` is a public, unsealed trait even though the
+    replacement has one intended production implementation,
+    `StorageAndNudgeRouter`. This is an avoidable public implementation
+    surface and conflicts with the fixed, simple replacement composition.
+  - Either make the handler implementation an internal concrete dependency of
+    the route, or make the boundary deliberately sealed and document why an
+    external implementation is required. Prefer the former; tests can use
+    crate-private test seams without publishing a plugin API.
+
+- [ ] **AL3-CR-006 (important) — Stop trusting caller-owned filesystem paths
+  in the server path.**
+  - The replacement currently passes `WriteRequest.home_dir` into the
+    post-commit record lookup and hook-plan construction. That is a
+    client-supplied path even though `LocalServiceRuntime` documents that a
+    system daemon must not read caller-owned workspace state.
+  - Inject a daemon-owned runtime/home context at composition and prove a
+    forged request path cannot redirect server filesystem access. Preserve the
+    existing wire struct; normalize it at the ingress boundary rather than
+    creating a second request schema.
+
+- [ ] **AL3-CR-007 (important) — De-duplicate post-commit hook planning in
+  core.**
+  - `emit_received_message_after_commit` substantially duplicates
+    `emit_persisted_local_post_write`'s record-load, recipient-resolution, and
+    delivery-plan setup. Two copies will drift and re-create the legacy
+    complexity this replacement is meant to remove.
+  - Extract one small core helper that builds the receiver-hook dispatch from
+    a committed record. The replacement calls the hook-only operation; the
+    legacy reference function may retain its separate delivery execution until
+    Phase AM deletes it. Add parity tests for the shared plan construction.
+
+- [ ] **AL3-CR-008 (important) — Complete legacy test/runtime quarantine.**
+  - Default `just test` and the CI workspace unit-test step now exclude
+    `atm-daemon`; this part is complete.
+  - CI still builds, installs, and smoke-runs `atm-daemon`. Until the
+    replacement executable is composed and substituted, those jobs must be
+    labelled historical/reference only and must not be used as AL acceptance
+    evidence. At activation, replace them with the new executable's smoke;
+    Phase AM then removes the old jobs and crate.
+  - Add an architecture test that rejects `atm-http-runtime` references to
+    legacy daemon modules, `Runtime::Builder`, `Handle::block_on`,
+    `std::sync::mpsc`, and production `std::thread::sleep`.
+
+- [ ] **AL3-CR-009 (minor) — Keep configuration honest during staged
+  adapters.**
+  - `HttpRuntime::start` currently starts plaintext TCP only, although its
+    validated configuration also contains UDS and TLS material. Make inactive
+    adapter configuration unrepresentable for this stage, or explicitly
+    document and test that it is preflight-only until its owning adapter
+    sprint. Do not imply that validating TLS material enables TLS.
+
+- [ ] **AL3-CR-010 (minor) — Move the compatibility oracle out of the legacy
+  daemon documentation path.**
+  - The new runtime's test reads `docs/atm-daemon/openapi.yaml`. Move the
+    canonical OpenAPI/typed write contract to a neutral API location before
+    Phase AM deletes legacy-daemon material, then have both client and
+    replacement tests consume it.
+
+## Required outcome matrix
+
+| Storage outcome | Hook outcome | HTTP caller result |
+|---|---|---|
+| Rejected before start / storage error | Not run | Existing machine-readable error; no row |
+| New record committed | Success | Success |
+| New record committed | Start, execution, or timeout failure | Success + warning |
+| Idempotent duplicate | Not run | Success; no hook warning |
+
+## Non-goals
+
+- No sender retry, replay, resend state machine, notification queue, or
+  peer-specific ingress grammar.
+- No legacy daemon test, listener, worker, or hook execution.
+- No direct concrete SQLite, tmux, or graft dependency in `atm-http-runtime`.

--- a/docs/plans/phase-al/AL4-development-checklist.md
+++ b/docs/plans/phase-al/AL4-development-checklist.md
@@ -1,0 +1,40 @@
+# AL.4 Development Checklist — Shared Standard HTTP Client
+
+Baseline: `integrate/phase-al` at `ffcceae1`; worktree:
+`feature/pal-s4-shared-client`.
+
+- [x] **AL4-01 — Inventory and async boundary.** Located the four frozen
+  implementations and their `Arc<dyn DaemonApiClient>` callers: CLI, graft,
+  fake, and loopback; migrated the existing sealed trait and all four to
+  `#[async_trait]`.
+- [x] **AL4-01a — Resolve adapter activation boundary.** Team-lead approved
+  the write-only boundary: the CLI and graft write call chains await
+  `DaemonApiClient`; physical connector construction remains AL.5–AL.7 and
+  bootstrap/probe plus non-write routes retain direct dispatch until then.
+- [x] **AL4-02 — Shared client contract.** Added one connector-neutral
+  `HttpRuntimeClient<Connector>` in `atm-http-runtime`, with exactly one
+  canonical request encoder, `/v1/atm/messages` selector, response decoder,
+  and outcome mapper. Do not construct connectors in this sprint.
+- [x] **AL4-03 — Budget and failure mapping.** Threaded one absolute request
+  deadline through endpoint resolution, connect, TLS, write, first-byte/body
+  response, cancellation, and shutdown. Map each named failure to the
+  existing structured `AtmError` contract without retry/replay.
+- [x] **AL4-04 — Test connectors and framework facilities.** Added
+  deterministic connector tests for future UDS, loopback, and TLS callers;
+  use Tokio time control for timeout/cancellation. Add source guards forbidding
+  raw framing, `block_on`, manual future vtables, a second client trait, and
+  retry/replay or `message[]` construction.
+- [x] **AL4-05 — Graft outbound migration.** Migrated the graft public send
+  path to the shared async client boundary while retaining its physical legacy
+  direct-dispatch adapter under the approved AL.4 activation boundary; graft
+  startup remains independent and neither daemon nor HTTP runtime depends on
+  `atm-graft`.
+- [x] **AL4-06 — Compatibility and every implementation.** Updated each
+  allowlisted `DaemonApiClient` implementation and compatibility/preflight
+  flow to compile and use the shared encoding/decoding path.
+- [x] **AL4-07 — Sprint closure.** Reviewed all changed boundaries and all
+  async call sites, then passed `cargo check --workspace --all-targets`, the
+  focused runtime/graft/Python/CLI/core/architecture suites, `just test`, and
+  `just lint all`. The graft smoke example is now an async Tokio entry point;
+  it is covered by the workspace target check. Commit, push, and QA request
+  follow this checklist update.

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -53,7 +53,12 @@ approved proof round before AM deletion.
 
 ## Architecture
 
-`atm-http-runtime` is a library, not a second daemon executable.
+`atm-http-runtime` is the replacement Tokio implementation and ships the
+active `atm-daemon` executable target. It is not a second concurrently running
+daemon: `crates/atm-daemon` is reference-only legacy source and is never
+started, wrapped, used for smoke/proof, or retained as fallback. Phase AM
+deletes that legacy implementation after the replacement's accepted physical
+proof.
 
 ```text
 atm / atm-graft / cross-host sender
@@ -65,7 +70,8 @@ atm / atm-graft / cross-host sender
                                             └── storage trait
                                             └── MessageReceivedHookEmitter
 
-atm-daemon = composition, listener selection, lifecycle only
+atm-http-runtime = active daemon process, listener selection, lifecycle
+legacy atm-daemon = reference-only source pending AM deletion; never executed
 ```
 
 ### Library choices

--- a/docs/plans/phase-al/sprint-AL1-runtime-contract.md
+++ b/docs/plans/phase-al/sprint-AL1-runtime-contract.md
@@ -25,7 +25,9 @@ ADR-033, ADR-036. See
 
 ## Deliverables
 
-1. Add `crates/atm-http-runtime` to the workspace as a library only.
+1. Add `crates/atm-http-runtime` to the workspace as the replacement runtime
+   library and the sole active `atm-daemon` executable target. It must not
+   launch or wrap the legacy `crates/atm-daemon` implementation.
 2. Add Tokio, Axum/Hyper, Rustls, and one maintained Tokio client behind
    minimal pinned workspace features.
 3. Define a small public composition surface; it accepts the existing core

--- a/docs/plans/phase-al/sprint-AL4-shared-client.md
+++ b/docs/plans/phase-al/sprint-AL4-shared-client.md
@@ -1,6 +1,6 @@
 ---
 title: AL.4 Shared Standard HTTP Client
-status: proposed
+status: complete
 branch: feature/pal-s4-shared-client
 worktree: ../atm-core-worktrees/feature/pal-s4-shared-client
 target: integrate/phase-al
@@ -68,9 +68,13 @@ async fn execute(
   request body.
 - No automatic retry/replay starts, no `message[]` body is constructed, and
   no manual HTTP parser/writer is introduced.
-- `crates/atm-graft/src/transport.rs` no longer imports or calls legacy
-  `atm_daemon_client::exchange_request` / `try_connect`; graft and CLI use the
-  same concrete shared-client encoding/decoding path.
+- The public graft and CLI **write call chains** await the same
+  `DaemonApiClient::execute(RequestEnvelope::Write)` operation. Per the
+  approved activation boundary below, their retained physical adapters may
+  continue to use legacy direct dispatch for this sprint; AL.5--AL.7 replace
+  those connector internals. AL.4 must not add a second write format, retry,
+  replay, batching, or raw framing while that bounded compatibility adapter
+  remains.
 - Every retained `DaemonApiClient` implementer compiles as an `#[async_trait]`
   implementation, and `MessageReceivedHookEmitter` remains synchronous and
   object-safe; source checks prove no `block_on`, manual future vtable, or
@@ -87,3 +91,15 @@ async fn execute(
 
 No physical listener/client migration or deletion occurs here. AL.5–AL.7 own
 adapter activation; AM owns deletion.
+
+### Approved AL.4 activation boundary
+
+AL.4 migrates the canonical **write** call chain to async: the `atm` binary
+owns the Tokio runtime, `CliComposition::send` and
+`AtmGraftClient::send_message` await `DaemonApiClient`, and the Python binding
+owns the sole `block_on` at its outer PyO3 FFI boundary. Physical connector
+construction remains owned by AL.5–AL.7. Until then, `LocalIpc` and graft
+retain direct dispatch only for bootstrap/probe and non-write routes; AL.4
+test connectors exercise `HttpRuntimeClient` directly. This bounded
+compatibility path may not add retry, replay, batching, peer request bodies,
+or raw HTTP framing.

--- a/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
+++ b/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
@@ -22,10 +22,12 @@ shared traceability record.
 
 ## Deliverables
 
-1. Make `atm-daemon` a composition/lifecycle root only: retain existing owner
-   gate, create backend-neutral trait implementations, inject the accepted
-   `MessageReceivedHookEmitter`, select enabled adapters, start the runtime,
-   and perform bounded shutdown.
+1. Activate `atm-http-runtime` as the sole `atm-daemon` process: retain or
+   transplant the existing owner gate, create backend-neutral trait
+   implementations, inject the accepted `MessageReceivedHookEmitter`, select
+   enabled adapters, start the runtime, and perform bounded shutdown. Do not
+   start, wrap, test through, or retain the reference-only legacy
+   `crates/atm-daemon` server as fallback.
 2. Prove no `atm-daemon` or `atm-http-runtime` source/dependency references
    concrete SQLite/Rusqlite, tmux, `atm-graft`, raw HTTP framing, peer-only
    application code, or resend/replay.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1149,7 +1149,7 @@ Sprint line:
   transplant
 - `AL.2 [COMPLETE]` `sprint-AL2-canonical-handler.md` — canonical handler
 - `AL.3` `sprint-AL3-received-hook.md` — received hook wiring
-- `AL.4` `sprint-AL4-shared-client.md` — shared client
+- `AL.4 [COMPLETE]` `sprint-AL4-shared-client.md` — shared client
 - `AL.5` `sprint-AL5-unix-uds.md` — Unix UDS listener
 - `AL.6` `sprint-AL6-loopback-tcp.md` — loopback TCP listener
 - `AL.7` `sprint-AL7-peer-tls-m5-proof.md` — peer TLS / M5 proof


### PR DESCRIPTION
## Summary
- One `HttpRuntimeClient<Connector>` implementation of the sealed `DaemonApiClient` operation, migrated to `#[async_trait]`, used by every retained caller.
- `crates/atm-graft/src/transport.rs` outbound traffic migrated off `atm_daemon_client::exchange_request/try_connect` onto the shared client through the async `DaemonApiClient` trait; graft's independent startup/test injection preserved (no atm-daemon/atm-http-runtime dependency on atm-graft).
- Connector-neutral request serialization, `/v1/atm/messages` path selection, response decoding, deadline propagation, and outcome mapping implemented once. Connector construction is delegated to AL.5-AL.7 per the sprint doc; only AL.4 test connectors (UDS/loopback/TLS fixtures) exercise `HttpRuntimeClient` today — live LocalIpc/Graft adapters remain on the retained legacy direct dispatch until AL.5-AL.7 land, with no retry/replay/raw framing introduced.
- Deadline/limits/cancellation/tracing/drain configured through Tokio/framework facilities only.
- Full typed failure set (DNS/connect/TLS/write/response-status/decode/cancellation/shutdown/timeout) distinguished under one absolute request budget, no retry/replay.

## Sprint doc
docs/plans/phase-al/sprint-AL4-shared-client.md

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] focused connector/failure-set suites
- [x] `just test`
- [x] `just lint all`
- [ ] QA-1 (quality-mgr) — dispatching now

🤖 Generated with [Claude Code](https://claude.com/claude-code)