### PR TITLE
Codify Tokio/Axum daemon-replacement hard rule (team-lead/arch-ctm/quality-mgr)

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -15,15 +15,18 @@ approval_policy = "on-failure"
 
 [startup.team-lead]
 all = ["Read /graph-orchestration SKILL.md and /triaging-findings SKILL.md",
+       "HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see CLAUDE.md Architecture Direction)",
        "Use native atm send or atm ack for messages to arch-ctm or quality-mgr",
        "Use native atm read to read messages from team-members" ]
 
 [startup.arch-ctm]
-all = ["Use native atm send or atm ack for messages to team-lead or quality-mgr",
+all = ["HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see AGENTS.md hard rule)",
+       "Use native atm send or atm ack for messages to team-lead or quality-mgr",
        "Use native atm read to read messages from team-members" ]
 
 [startup.quality-mgr]
 all = ["read .claude/agents/quality-mgr.md for directive",
+       "HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — classify legacy-daemon runtime findings as non-findings (never Blocking/Important) and reject any reviewer proposal to remodel/patch the old daemon; valid remediation is the AL.5-AL.7 atm-http-runtime cutover",
        "Use native atm send or atm ack for messages to team-lead or arch-ctm",
        "Use native atm read to read messages from team-members" ]
 

--- a/.claude/agents/arch-qa.md
+++ b/.claude/agents/arch-qa.md
@@ -248,6 +248,8 @@ Rules:
 - List each finding with `file:line` and a remediation note.
 - The pre-existing/new distinction is informational only.
 
+**Legacy Daemon Exemption**: Do not file a finding against legacy synchronous-daemon runtime behavior (e.g. a private Tokio runtime bridged via `spawn_blocking`, duplicate sync/async dispatch paths, or the sync daemon's coexistence with `atm-http-runtime`) solely because it predates this sprint. That code is a known, deferred Phase-AM deletion target — the daemon's target architecture is Tokio+Axum (`atm-http-runtime`); remodeling the legacy path invalidates the AM deletion plan. Note it under `notes` instead of `findings`, and never propose remediation that patches or restructures the legacy daemon in place. Exception: a NEW defect introduced by this sprint's diff inside legacy daemon code is still a real finding.
+
 ## Output Contract
 
 Emit a single fenced JSON block:

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -14,6 +14,20 @@ You are the Quality Manager for the `atm-core` repository.
 You are a coordinator only. You do not write code, fix code, or perform the
 primary implementation work yourself.
 
+## ⚠️ HARD RULE: No Daemon Remodeling — Tokio/Axum Only
+
+The daemon's target architecture is **Tokio + Axum (`atm-http-runtime`)** for
+ALL of CLI + graft + cross-host transport. The synchronous daemon is legacy,
+intentionally frozen, and scheduled for wholesale deletion in Phase AM.
+
+**Immediately reject any reviewer finding or proposed fix that remodels,
+patches, or hardens the legacy synchronous daemon.** Legacy daemon runtime
+behavior (e.g. private Tokio runtime bridged via `spawn_blocking`) is known,
+deferred technical debt — classify it as a non-finding, never a Blocking or
+Important item. The only valid remediation direction for daemon-side findings
+is the `atm-http-runtime` cutover (AL.5–AL.7); route such findings there.
+Do not let any reviewer's daemon-remodel proposal reach the merge gate.
+
 ## Required Reading
 
 Always read before starting a QA assignment:

--- a/.claude/agents/rust-service-hardening-agent.md
+++ b/.claude/agents/rust-service-hardening-agent.md
@@ -93,6 +93,8 @@ This agent is not responsible for:
 - The pre-existing/new distinction is informational only.
 - Every finding must include `file:line` when a concrete file location exists, plus a remediation note.
 
+**Legacy Daemon Exemption**: Do not file a finding against legacy synchronous-daemon runtime behavior (e.g. a private Tokio runtime bridged via `spawn_blocking`, or a duplicate sync/async dispatch path) solely because it predates this sprint. That code is a known, deferred Phase-AM deletion target — the daemon's target architecture is Tokio+Axum (`atm-http-runtime`); note it under `notes` instead of `findings`. Exception: a NEW defect introduced by this sprint's diff inside legacy daemon code is still a real finding.
+
 ## Output Contract
 
 Return fenced JSON only.

--- a/.claude/agents/ruthless-boundary-qa.md
+++ b/.claude/agents/ruthless-boundary-qa.md
@@ -85,6 +85,9 @@ When `findings_scope_locked` is absent or `false`, this restriction does not app
    - storage backend code that would block backend replacement
    - state machines that exist only because parallel paths were introduced
    - send/ack splits that should be one path
+
+**Legacy Daemon Exemption**: Do not file a finding against legacy synchronous-daemon runtime behavior (e.g. a private Tokio runtime bridged via `spawn_blocking`, or the sync daemon's coexistence with `atm-http-runtime`) solely because it predates this sprint or duplicates the `atm-http-runtime` path. That coexistence is a known, deferred Phase-AM deletion target, not a parallel-path finding to collapse now — the daemon's target architecture is Tokio+Axum (`atm-http-runtime`). Note it under `notes` instead of `findings`. Exception: a NEW defect introduced by this sprint's diff inside legacy daemon code is still a real finding.
+
 4. Actively hunt tightening opportunities:
    - delete code whose only justification is historical accident or local convenience
    - collapse parallel implementations into one retained path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS Instructions for atm-core
 
+## ⚠️ HARD RULE: No Daemon Remodeling — Tokio/Axum Only
+
+The daemon's target architecture is **Tokio + Axum (`atm-http-runtime`)** for ALL of CLI + graft + cross-host transport. The synchronous daemon is legacy, intentionally frozen, and scheduled for wholesale deletion in Phase AM.
+
+**Immediately reject any thought, finding, fix, or task that remodels, patches, or hardens the current synchronous daemon.** This includes "improving" its runtime behavior (e.g. private Tokio runtime via `spawn_blocking`) — that is known, deferred technical debt, not a defect. The only correct direction for daemon-side work is finishing the `atm-http-runtime` cutover (AL.5–AL.7 adapter activation). If an assignment appears to require touching legacy daemon runtime/dispatch code, stop and raise it with team-lead instead of implementing — rewriting that code invalidates the Phase AM deletion plan (`docs/plans/phase-am/*.md`).
+
 ## MUST READ
 
 Before participating in ATM team work, read:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,17 @@ orchestration alert or sprint-plan violation or merge-conflict notice:
 
 ---
 
+## ⚠️ Architecture Direction — Tokio + Axum (Phase AL/AM)
+
+**The daemon's target architecture is Tokio + Axum (`atm-http-runtime`) for ALL of CLI + graft + cross-host transport.** Tokio was previously a sidelined feature — that is no longer true.
+
+- The synchronous daemon is **legacy code, intentionally left untouched, and scheduled for wholesale deletion in Phase AM**.
+- **Never** patch, harden, or "remodel" the legacy synchronous daemon path — not for QA findings, not for critical-review findings. The correct fix is always finishing the `atm-http-runtime` cutover (AL.5–AL.7 adapter activation).
+- Rewriting legacy daemon code invalidates the Phase AM deletion plan (`docs/plans/phase-am/*.md` targets specific legacy files/patterns). Before dispatching any fix that touches legacy daemon runtime/dispatch code, check it against AM's deletion targets.
+- Findings against legacy daemon runtime behavior (e.g. private Tokio runtime bridged via `spawn_blocking`) are **known, deferred technical debt** — not missed QA.
+
+---
+
 ## Project Plan
 
 **Current Plan**: [`docs/project-plan.md`](./docs/project-plan.md)
@@ -116,6 +127,7 @@ main
 ```
 
 **Rules:**
+- Always merge PRs with a merge commit (`gh pr merge --merge`); never squash
 - Sprint PRs target `integrate/phase-N` (not `develop` directly)
 - After each sprint merges to the integration branch, subsequent sprints merge latest `integrate/phase-N` into their feature branch before creating their PR
 - When all phase sprints are complete, one final PR merges `integrate/phase-N → develop`


### PR DESCRIPTION
## Summary
- Adds a hard rule to `.atm.toml` (team-lead, arch-ctm, quality-mgr startup instructions), `AGENTS.md`, `CLAUDE.md`, and `.claude/agents/quality-mgr.md`
- States explicitly: the daemon's target architecture is Tokio+Axum (`atm-http-runtime`) for all CLI/graft/cross-host transport; the synchronous daemon is frozen legacy slated for wholesale deletion in Phase AM
- Instructs all reviewers/dev agents to reject any finding/fix that remodels or patches the legacy daemon instead of routing the work to the AL.5-AL.7 `atm-http-runtime` cutover

## Why
Recurring QA/dev inertia treats legacy daemon Tokio findings (e.g. private runtime + `spawn_blocking`) as defects to patch in place, rather than recognizing them as known, deferred technical debt already scoped for the AL.5-7 cutover and AM deletion. Rewriting that code in place would invalidate Phase AM's deletion plan.

## Test plan
- [ ] Docs-only change; no build/test impact
- [ ] Confirm `.atm.toml` TOML still parses (`atm` startup instructions load cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)