### PR TITLE
AL.8: Daemon composition proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Run just lint
         run: just lint
 
+      - name: Show clippy diagnostics on lint failure
+        if: failure()
+        shell: bash
+        run: |
+          clippy_log="$(ls -t .just/logs/*-clippy.log 2>/dev/null | head -n 1)"
+          test -n "$clippy_log"
+          cat "$clippy_log"
+
       - name: Run cargo audit
         run: cargo audit
 

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -48,6 +48,7 @@ allowed_paths = [
   "crates/atm-daemon/src/runtime_health.rs",
   "crates/atm-daemon/src/runtime_health/dispatch.rs",
   "crates/atm-daemon/src/runtime_status_cache.rs",
+  "crates/atm-http-runtime/src/runtime_health.rs",
   "crates/atm/src/commands/members.rs",
 ]
 
@@ -74,6 +75,10 @@ symbol = "DaemonRequestDispatcher"
 [[runtime-observation-boundary.required_positive]]
 path = "crates/atm-daemon/src/runtime_status_cache.rs"
 symbol = "merge_observation"
+
+[[runtime-observation-boundary.required_positive]]
+path = "crates/atm-http-runtime/src/runtime_health.rs"
+symbol = "RuntimeHealth"
 
 [line_counts]
 max_total_lines = 0

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -110,6 +110,11 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\bdirect_socket_io\b",
     ),
     "direct_sqlite_io": (r"\b(?:rusqlite|sqlx)::", r"\b(?:Sqlite|SQLite)[A-Za-z0-9_]*\b", r"\bdirect_sqlite_io\b"),
+    "direct_rusqlite_calls": (
+        r"\brusqlite::",
+        r"\bSqlite(?:Connection|Transaction|Statement|Database)\b",
+    ),
+    "graft_crate_dependency": (r"\batm[_-]graft\b",),
     "graft_session_runtime": (r"\bgraft_session_runtime\b", r"\bGraftSession\b"),
     "inbox_jsonl": (r"\binbox[^\n]*\.jsonl\b", r"\b(?:append|write)_[A-Za-z0-9_]*inbox[A-Za-z0-9_]*\s*\("),
     "mailbox_storage_selection": (r"\bmailbox_storage_selection\b", r"\b(?:select|choose)_[A-Za-z0-9_]*mailbox[A-Za-z0-9_]*\s*\("),
@@ -126,9 +131,23 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\b(?:deliver_graft_post_send|deliver_published_receiver_hook|GraftPostSendRequest)\b",
     ),
     "hook_execution": (r"\b(?:emit_post_send_effects|load_post_send_config_for_sender)\b",),
+    "http_server": (
+        r"\baxum::serve\s*\(",
+        r"\bserve_(?:loopback|unix)_http1\s*\(",
+        r"\bhyper::server\b",
+    ),
     "process_spawn": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
     "process_spawn_for_notifications": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
     "process_spawn_outside_owned_runtime_path": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
+    "raw_http_framing": (
+        r"\bHttpFrameReader\b",
+        r"\b(?:read|write)_http_(?:request|response)\s*\(",
+        r"\bwrite_http_request_with_headers\s*\(",
+    ),
+    "replay_or_resend": (
+        r"\b(?:Peer)?(?:Replay|Resend)[A-Za-z0-9_]*\b",
+        r"\bPeerDrainCoordinator\b",
+    ),
     "receipt": (r"\breceipt\b", r"\bReceipt\b"),
     "recipient_routing": (
         r"\brecipient_routing\b",
@@ -149,6 +168,12 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\bsocket_io\b",
     ),
     "tls": (r"\b(?:TlsConnector|TlsAcceptor|rustls|ServerName)\b",),
+    "tls_adapter": (r"\b(?:TlsConnector|TlsAcceptor|rustls|ServerName)\b",),
+    "peer_only_ingress": (
+        r"\bPeerMessageArray\b",
+        r"\bpeer_(?:delivery|http_listener)\b",
+        r"\bAuthenticatedConnector::peer\b",
+    ),
     "sqlite": (
         r"\b(?:rusqlite|sqlx)::",
         r"\b(?:Sqlite|SQLite)(?:Connection|Transaction|Store|Database|Pool|Backend)\b",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,15 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,25 +148,8 @@ name = "atm-daemon"
 version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
- "arc-swap",
  "atm-daemon-bootstrap",
- "atm-daemon-client",
- "atm-runtime",
- "atm-runtime-test-support",
- "atm-storage",
- "chrono",
- "fs2",
- "interprocess",
- "sc-observability",
- "sc-observability-types",
- "serde_json",
- "serial_test",
- "signal-hook",
- "tempfile",
  "tokio",
- "tracing",
- "ulid",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -183,9 +157,14 @@ name = "atm-daemon-bootstrap"
 version = "1.4.1-beta-aj"
 dependencies = [
  "agent-team-mail-core",
+ "atm-http-runtime",
  "atm-runtime",
  "atm-storage",
  "atm-storage-rusqlite",
+ "fs2",
+ "tempfile",
+ "tokio",
+ "ulid",
 ]
 
 [[package]]
@@ -242,10 +221,10 @@ dependencies = [
  "atm-runtime-test-support",
  "atm-storage",
  "axum",
+ "base64",
  "hyper",
  "hyper-util",
  "reqwest",
- "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1861,16 +1840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2044,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,8 @@ tracing-subscriber = "0.3"
 cargo_metadata = "0.23"
 sc-observability = "1.2.0"
 sc-observability-types = "1.2.0"
-arc-swap = "1.7"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tokio = { version = "1.48", default-features = false, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "test-util", "time"] }
+tokio = { version = "1.48", default-features = false, features = ["macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "server", "http1"] }
 hyper-util = { version = "0.1", default-features = false, features = ["server", "service", "tokio"] }

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -1,0 +1,48 @@
+boundary_id = "BOUNDARY-ReplacementDaemonBootstrap"
+owner_package = "atm-daemon-bootstrap"
+owner_crate_path = "atm_daemon_bootstrap"
+name = "ReplacementDaemonBootstrap"
+
+[public]
+facade = "run_replacement_daemon"
+notes = "The only active atm-daemon composition root. It selects the approved concrete storage factory once, injects the sealed receiver-hook selector, and starts the Tokio/Axum runtime."
+
+[implementation]
+type = "DaemonOwnerGuard"
+module = "atm_daemon_bootstrap"
+visibility = "public"
+constructor = "public"
+
+[composition]
+roots = ["atm_daemon_bootstrap::run_replacement_daemon"]
+
+[ownership]
+io_owns = ["singleton_owner_lock", "concrete_backend_selection", "receiver_hook_harness_selection", "shutdown_signal_wait"]
+io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "graft_crate_dependency", "replay_or_resend", "tls_adapter"]
+
+[dependencies]
+allowed_dependents = ["atm", "atm-daemon"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-http-runtime", "tokio", "fs2", "ulid"]
+forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["core RuntimeAssembly inputs", "core sealed MessageReceivedHookSelector"]
+response_types = ["typed runtime lifecycle outcome"]
+error_types = ["AtmError"]
+notes = ["The concrete storage factory is legal only at this composition boundary; atm-daemon and atm-http-runtime remain backend-neutral."]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["legacy_daemon_server", "legacy_dispatcher", "raw_http_listener"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-REPLACEMENT-DAEMON-COMPOSITION"]
+review_gates = ["owner_before_bind", "one_runtime_root", "framework_adapters_only", "no_legacy_fallback"]
+
+[status]
+state = "active"
+notes = ["AL.8 active composition boundary. The old atm-daemon source tree remains reference-only until Phase AM removes it."]

--- a/boundaries/atm-daemon/admission-runtime-view.toml
+++ b/boundaries/atm-daemon/admission-runtime-view.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-ADMISSION-RUNTIME-VIEW"]
 review_gates = ["no_workspace_config_read_on_admission", "no_delivery_io_on_admission"]
 
 [status]
-state = "active"
-notes = ["AI.31: this immutable daemon-owned view is the only synchronous dependency source for local write admission."]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8 activates StorageAndNudgeRouter in atm-http-runtime; this synchronous legacy admission view is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/daemon-config-ingress.toml
+++ b/boundaries/atm-daemon/daemon-config-ingress.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-CONFIG-INGRESS-DAEMON-EDGES", "LINT-BOUNDARY-CONFIG
 review_gates = ["no_public_impl", "no_public_constructor", "no_direct_config_parser_calls", "no_generic_runtime_team_lookup"]
 
 [status]
-state = "active"
-notes = ["atm_core owns the contract; daemon runtime now supplies the crate-root adapter implementation", "daemon-side generic team-config lookup was removed during Phase Z Z.7 so this adapter stays workspace-config-only", "runtime-owned durable state and SQLite composition now stay outside this daemon adapter boundary so the seam remains config-only"]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8 routes retained configuration-bearing requests through the backend-neutral replacement runtime; this adapter is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/daemon-non-claude-outbound.toml
+++ b/boundaries/atm-daemon/daemon-non-claude-outbound.toml
@@ -43,5 +43,5 @@ lint_rules = ["LINT-BOUNDARY-NON-CLAUDE-OUTBOUND-DAEMON-REFERENCES"]
 review_gates = ["no_public_impl"]
 
 [status]
-state = "concrete_landed"
-notes = ["Implemented in Phase Yb Y.9 as atm_daemon::non_claude_outbound_runtime::DaemonNonClaudeOutbound.", "The compose_runtime phantom ownership field was removed in follow-up fix-r3 because delivery wiring stays on the retained runtime seam rather than direct daemon composition ownership."]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8 selects LocalFileNonClaudeOutbound through the replacement bootstrap's backend-neutral RuntimeAssembly; this legacy adapter is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/daemon-non-claude-outbound.toml
+++ b/boundaries/atm-daemon/daemon-non-claude-outbound.toml
@@ -32,7 +32,7 @@ forbidden = ["DaemonNonClaudeOutbound", "std::process::Command"]
 request_types = ["logical message delivery requests"]
 response_types = ["typed non-Claude delivery results"]
 error_types = ["AtmError"]
-notes = ["The daemon-owned adapter is wired into the production retained runtime via atm_daemon::runtime_health::daemon_local_runtime(), which installs Arc::new(DaemonNonClaudeOutbound::new()) in the shared delivery-boundary constructor."]
+notes = ["Historical legacy-daemon contract only. The retired adapter is not part of active composition; AL.8 selects LocalFileNonClaudeOutbound through the replacement bootstrap's backend-neutral RuntimeAssembly."]
 
 [testing]
 allowed_test_double_paths = []

--- a/boundaries/atm-daemon/daemon-status-source.toml
+++ b/boundaries/atm-daemon/daemon-status-source.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-STATUS-SOURCE-DAEMON-EDGES", "LINT-BOUNDARY-STATUS-
 review_gates = ["no_public_impl", "no_status_leakage_into_roster_store", "runtime_observation_non_authoritative"]
 
 [status]
-state = "active"
-notes = ["crate-root daemon adapter is assembled through atm_daemon::composition", "runtime status is served from the daemon-memory status cache rather than the atm_core::boundary_support placeholder helper", "runtime observation is non-authoritative: cache merge and snapshot projection may inspect it; routing, nudge, notification, retry, admission, delivery, and policy must not", "the runtime_observation_non_authoritative review gate is enforced by the passing runtime-observation-boundary lint"]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8's RuntimeHealth supplies the existing doctor/runtime-status payload from the active Tokio lifecycle; this legacy status cache is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/host-ownership-daemon.toml
+++ b/boundaries/atm-daemon/host-ownership-daemon.toml
@@ -68,9 +68,9 @@ review_gates = [
 ]
 
 [status]
-state = "concrete_landed"
+state = "retired"
 notes = [
-  "Phase R embeds host ownership inside the runtime lifecycle controller",
+  "Historical legacy-daemon record. AL.8's DaemonOwnerGuard is the active singleton gate; this HostOwnershipAdapter is reference-only until Phase AM deletes it.",
   "Phase S pulls host ownership into an explicit portability boundary so file-locking and teardown semantics can be reviewed independently on Unix and Windows",
   "the boundary uses stable permanent lock-file paths under ~/.atm/daemon/ rather than lock-path deletion as the ownership signal",
   "the preferred implementation foundation is one whole-file exclusive-lock contract on launch.lock and owner.lock",

--- a/boundaries/atm-daemon/lifecycle-control-source.toml
+++ b/boundaries/atm-daemon/lifecycle-control-source.toml
@@ -70,9 +70,9 @@ review_gates = [
 ]
 
 [status]
-state = "concrete_landed"
+state = "retired"
 notes = [
-  "the extracted boundary now lives under atm_daemon::lifecycle_control with Unix hook installation hidden inside the adapter",
+  "Historical legacy-daemon record. AL.8 waits on Tokio's process signal facility in the active replacement bootstrap; this lifecycle-control adapter is reference-only until Phase AM deletes it.",
   "the accepted Phase S mapping is Unix SIGINT/SIGTERM -> terminate, Unix SIGHUP -> reload, Windows terminate events -> terminate, and Windows SIGBREAK/CTRL_BREAK_EVENT -> reload",
   "same-host daemon hosting now keeps lifecycle control behind one daemon-private contract on Unix and Windows",
   "S.4 restored full Windows workspace clippy and added a dedicated same-host-portability lint guard for the shared host shell",

--- a/boundaries/atm-daemon/post-commit-work-queue.toml
+++ b/boundaries/atm-daemon/post-commit-work-queue.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-POST-COMMIT-WORK-QUEUE"]
 review_gates = ["identifier_only", "no_admission_wait", "no_direct_sqlite", "no_received_hook"]
 
 [status]
-state = "active"
-notes = ["AL.3: only immutable message identifiers and legacy peer wake-up keys cross this seam. Received-message hooks are never queued here."]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8 does not compose peer wake-up, resend, or replay work; this queue is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/post-write-router.toml
+++ b/boundaries/atm-daemon/post-write-router.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-POST-WRITE-ROUTER"]
 review_gates = ["new_persistence_only", "single_received_hook_call_site", "no_direct_peer_transport", "no_hook_queue"]
 
 [status]
-state = "active"
-notes = ["AL.3: newly persisted inbound writes synchronously invoke the sealed received-hook boundary and retain failures as warnings. Host-qualified origin writes retain only the temporary legacy peer wake-up until AM deletion."]
+state = "retired"
+notes = ["Historical legacy-daemon record. AL.8 invokes the sealed received-hook selector only from StorageAndNudgeRouter after a newly durable write; this legacy post-write router is reference-only until Phase AM deletes it."]

--- a/boundaries/atm-daemon/runtime-lifecycle-daemon.toml
+++ b/boundaries/atm-daemon/runtime-lifecycle-daemon.toml
@@ -68,12 +68,7 @@ review_gates = [
 ]
 
 [status]
-state = "active"
+state = "retired"
 notes = [
-  "lifecycle controller is a daemon-private control-plane facade rather than a shared cross-crate trait",
-  "production-readiness review must cover this struct explicitly because B-003 originated here",
-  "R.13 wired host-wide admission, lifecycle transitions, and startup/shutdown ownership through this control-plane facade",
-  "Phase S separates host ownership and lifecycle-control sourcing into review-visible portability boundaries under this controller",
-  "Phase S also requires runtime composition above those boundaries to stay platform-neutral across supported operating systems",
-  "crate-private helper methods are intentional so run_daemon and lifecycle tests can enter the single owned runtime path without exposing it cross-crate",
+  "Historical legacy-daemon record. AL.8 activates HttpRuntime's consuming Tokio lifecycle and its five-second drain bound; RuntimeComposition is reference-only until Phase AM deletes it.",
 ]

--- a/boundaries/atm-http-runtime/http-runtime.toml
+++ b/boundaries/atm-http-runtime/http-runtime.toml
@@ -5,7 +5,7 @@ name = "HttpRuntime"
 
 [public]
 facade = "HttpRuntime"
-notes = "Tokio HTTP/TLS lifecycle facade. HttpRuntimeClient is the single connector-neutral async client translation; physical connector construction remains owned by AL.5--AL.7."
+notes = "Tokio/Axum lifecycle facade. HttpRuntimeClient is the one connector-neutral async client translation; AL.8 activates only UDS and capability-authenticated loopback TCP. TLS remains isolated and deferred."
 
 [implementation]
 type = "HttpRuntimeClient"
@@ -14,15 +14,20 @@ visibility = "public"
 constructor = "public"
 
 [composition]
-roots = []
+roots = [
+  "atm_http_runtime::HttpRuntimeBuilder::build",
+  "atm_http_runtime::HttpRuntime::start",
+  "atm_http_runtime::canonical_api_router",
+  "atm_http_runtime::StorageAndNudgeRouter",
+]
 
 [ownership]
-io_owns = ["maintained_http_tls_runtime_mechanics"]
-io_forbidden = ["direct_sqlite_io", "daemon_request_dispatch"]
+io_owns = ["tokio_axum_listener_lifecycle", "capability_authenticated_loopback", "unix_uds_adapter", "typed_http_translation", "bounded_blocking_storage_admission"]
+io_forbidden = ["direct_sqlite_io", "daemon_request_dispatch", "raw_http_framing", "peer_only_ingress", "replay_or_resend", "tls_adapter"]
 
 [dependencies]
-allowed_dependents = []
-allowed_dependencies = ["atm-core", "tokio", "axum", "hyper", "rustls", "reqwest", "ulid", "windows-sys"]
+allowed_dependents = ["atm-daemon-bootstrap"]
+allowed_dependencies = ["atm-core", "tokio", "axum", "hyper", "hyper-util", "reqwest", "tower", "ulid", "windows-sys"]
 forbidden_edges = ["atm-http-runtime -> atm-storage-rusqlite", "atm-http-runtime -> atm-graft", "atm-http-runtime -> atm", "atm-http-runtime -> atm-daemon-bootstrap"]
 
 [references]
@@ -30,10 +35,10 @@ scope = "outside_owner_crate"
 forbidden = []
 
 [contracts]
-request_types = ["existing atm-core ApiRouter input only"]
-response_types = ["AtmError"]
+request_types = ["existing atm-core ApiRequest only"]
+response_types = ["existing atm-core ApiResponse only"]
 error_types = ["AtmError"]
-notes = ["No runtime-private request, response, error, or persistence type is authorized."]
+notes = ["No runtime-private request, response, error, or persistence type is authorized.", "Received-message hooks cross only the sealed core selector/emitter boundary after a newly durable write; their failure is a response warning, never a write failure."]
 
 [testing]
 allowed_test_double_paths = ["crate::tests::TestRouter"]
@@ -41,8 +46,8 @@ forbidden_test_bypasses = ["listener_bind", "endpoint_publication"]
 
 [enforcement]
 lint_rules = ["LINT-BOUNDARY-HTTP-RUNTIME-DEPENDENCIES"]
-review_gates = ["core_contracts_only", "typestate_lifecycle", "no_raw_http"]
+review_gates = ["core_contracts_only", "typestate_lifecycle", "all_routes_from_core_table", "no_raw_http", "no_tls_adapter", "no_legacy_daemon_composition"]
 
 [status]
 state = "active"
-notes = ["AL.1 introduced the construction facade and its dependency boundary."]
+notes = ["AL.1 introduced the construction facade and its dependency boundary.", "AL.8 makes this the active daemon runtime with framework-managed UDS and loopback adapters; the legacy daemon server is reference-only until AM deletion."]

--- a/boundaries/atm-runtime/runtime-composition.toml
+++ b/boundaries/atm-runtime/runtime-composition.toml
@@ -5,7 +5,7 @@ name = "RuntimeAssembly"
 
 [public]
 facade = "RuntimeAssembly"
-notes = "Phase AA concrete composition seam that assembles storage-neutral runtime inputs for atm and atm-daemon"
+notes = "Phase AA concrete composition seam that assembles storage-neutral runtime inputs for replacement daemon composition"
 
 [implementation]
 type = "RuntimeAssembly"
@@ -21,7 +21,7 @@ io_owns = ["runtime_dependency_assembly", "config_doctor_assembly"]
 io_forbidden = ["daemon_transport", "daemon_lifecycle", "direct_socket_io"]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime-test-support"]
 allowed_dependencies = ["atm-core", "atm-storage"]
 forbidden_edges = [
   "atm -> atm-storage-rusqlite",
@@ -51,6 +51,6 @@ review_gates = ["no_direct_backend_leakage", "no_runtime_to_daemon_backedge"]
 state = "concrete_landed"
 notes = [
   "AI.2 leaves runtime backend-neutral; concrete backend selection lives outside this crate",
-  "daemon startup remains fail-closed on any RuntimeAssembly failure",
+  "replacement daemon startup remains fail-closed on any RuntimeAssembly failure",
   "the sqlite boundary TOMLs and runtime composition record agree on the forbidden atm-daemon -> atm-storage-rusqlite edge",
 ]

--- a/boundaries/atm-storage/message-store.toml
+++ b/boundaries/atm-storage/message-store.toml
@@ -19,7 +19,7 @@ io_owns = ["durable_message_state", "canonical_message_records"]
 io_forbidden = ["socket_io", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core"]
 

--- a/boundaries/atm-storage/nudge-template-override-store.toml
+++ b/boundaries/atm-storage/nudge-template-override-store.toml
@@ -19,7 +19,7 @@ io_owns = ["built_in_nudge_template_override_lookup_contract", "durable_ack_requ
 io_forbidden = ["direct_sqlite_io", "socket_io", "process_spawn", "template_rendering"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-daemon", "atm-storage -> atm-storage-rusqlite"]
 

--- a/boundaries/atm-storage/outbound-message-query.toml
+++ b/boundaries/atm-storage/outbound-message-query.toml
@@ -19,7 +19,7 @@ io_owns = ["canonical_outbound_message_query"]
 io_forbidden = ["socket_io", "tls_handshake", "nudge", "router", "retry_queue", "cursor", "receipt", "delivery_state"]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 

--- a/boundaries/atm-storage/peer-config-store.toml
+++ b/boundaries/atm-storage/peer-config-store.toml
@@ -19,7 +19,7 @@ io_owns = ["https_interface_configuration", "certificate_reference_metadata", "t
 io_forbidden = ["socket_io", "tls_handshake", "message_delivery", "retry_queue", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-peer-tls-interop", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-peer-tls-interop", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 

--- a/boundaries/atm-storage/roster-store.toml
+++ b/boundaries/atm-storage/roster-store.toml
@@ -19,7 +19,7 @@ io_owns = ["durable_roster_state", "canonical_roster_records"]
 io_forbidden = ["socket_io", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core"]
 

--- a/boundaries/atm-storage/storage-notifier.toml
+++ b/boundaries/atm-storage/storage-notifier.toml
@@ -19,7 +19,7 @@ io_owns = ["message_received_notifications", "roster_changed_notifications"]
 io_forbidden = ["task_changed_notifications", "socket_io"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-daemon-client", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core"]
 

--- a/boundaries/atm-storage/tls.toml
+++ b/boundaries/atm-storage/tls.toml
@@ -21,7 +21,7 @@ io_owns = ["certificate_parsing", "certificate_fingerprint_normalization", "trus
 io_forbidden = ["socket_io", "message_delivery", "recipient_routing", "retry_queue", "nudge_emission", "background_work", "process_spawn", "daemon_lifecycle"]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-peer-tls-interop"]
+allowed_dependents = ["atm-peer-tls-interop"]
 allowed_dependencies = ["atm-error", "rustls", "sha2"]
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -17,6 +17,7 @@ use syn::visit::Visit;
 const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm", "atm-daemon"),
     ("atm", "atm-storage-rusqlite"),
+    ("atm-daemon", "atm-runtime"),
     ("atm-daemon", "atm-storage-rusqlite"),
     ("atm-runtime", "atm-storage-rusqlite"),
     ("atm-storage", "atm-core"),
@@ -26,6 +27,7 @@ const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm-graft", "atm-daemon-bootstrap"),
     ("atm-graft", "atm-storage-rusqlite"),
     ("atm-graft", "interprocess"),
+    ("atm-daemon-bootstrap", "atm-graft"),
     ("atm-http-runtime", "atm"),
     ("atm-http-runtime", "atm-daemon-bootstrap"),
     ("atm-http-runtime", "atm-graft"),
@@ -1195,10 +1197,12 @@ fn atm_must_not_depend_on_atm_storage_rusqlite() {
 fn guarded_runtime_boundaries_forbid_their_declared_crate_edges() {
     for (source, target) in [
         ("atm", "atm-daemon"),
+        ("atm-daemon", "atm-runtime"),
         ("atm-http-runtime", "atm"),
         ("atm-http-runtime", "atm-daemon-bootstrap"),
         ("atm-http-runtime", "atm-graft"),
         ("atm-http-runtime", "atm-storage-rusqlite"),
+        ("atm-daemon-bootstrap", "atm-graft"),
     ] {
         assert_forbidden_edge_absent(source, target);
     }
@@ -2487,6 +2491,7 @@ fn guarded_boundary_files() -> Vec<PathBuf> {
         root.join("boundaries/atm-daemon/socket-server-transport.toml"),
         root.join("boundaries/atm-graft/shared-client-consumer.toml"),
         root.join("boundaries/atm-http-runtime/http-runtime.toml"),
+        root.join("boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml"),
         root.join("boundaries/atm-runtime/runtime-composition.toml"),
         root.join("boundaries/atm-storage/tls.toml"),
     ];

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1704,6 +1704,40 @@ impl<'ast> Visit<'ast> for ProductionApiRouterImplementationDetector {
     }
 }
 
+fn production_runtime_identifier_findings(path: &Path, prohibited: &[&str]) -> Vec<String> {
+    let source = read_source(path);
+    let syntax = syn::parse_file(&source)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()));
+    let mut detector = ProductionRuntimeIdentifierDetector {
+        prohibited: prohibited.iter().copied().collect(),
+        findings: BTreeSet::new(),
+    };
+    detector.visit_file(&syntax);
+    detector.findings.into_iter().collect()
+}
+
+struct ProductionRuntimeIdentifierDetector<'a> {
+    prohibited: BTreeSet<&'a str>,
+    findings: BTreeSet<String>,
+}
+
+impl<'ast> Visit<'ast> for ProductionRuntimeIdentifierDetector<'_> {
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        if item.attrs.iter().any(is_test_configuration_attribute) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, item);
+    }
+
+    fn visit_ident(&mut self, ident: &'ast syn::Ident) {
+        let value = ident.to_string();
+        if self.prohibited.contains(value.as_str()) {
+            self.findings.insert(value);
+        }
+        syn::visit::visit_ident(self, ident);
+    }
+}
+
 fn is_test_configuration_attribute(attribute: &syn::Attribute) -> bool {
     attribute.path().is_ident("cfg")
         && attribute
@@ -1853,19 +1887,7 @@ fn al1_http_runtime_is_core_contract_only_and_excludes_retired_transport_shapes(
                 .is_file(),
         "the public runtime crate documentation must link the shared AL/AM boundary checklist"
     );
-    let code = ["lib.rs", "message_handler.rs"]
-        .into_iter()
-        .map(|file| read_source(&runtime_root.join(file)))
-        .flat_map(|source| {
-            source
-                .lines()
-                .filter(|line| !line.trim_start().starts_with("//"))
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    for prohibited in [
+    let prohibited = [
         "rusqlite",
         "tmux",
         "atm_graft",
@@ -1873,10 +1895,15 @@ fn al1_http_runtime_is_core_contract_only_and_excludes_retired_transport_shapes(
         "PeerResendScheduler",
         "PeerDrainCoordinator",
         "HttpFrameReader",
-    ] {
+    ];
+    let mut sources = Vec::new();
+    collect_rust_files(&runtime_root, &mut sources);
+    for source_path in sources {
+        let findings = production_runtime_identifier_findings(&source_path, &prohibited);
         assert!(
-            !code.contains(prohibited),
-            "AL.1 HTTP runtime must not contain prohibited `{prohibited}`"
+            findings.is_empty(),
+            "AL.1 HTTP runtime {} must not contain prohibited production identifiers: {findings:?}",
+            source_path.display()
         );
     }
 }
@@ -2004,18 +2031,19 @@ fn al5_uds_is_a_framework_adapter_over_the_one_client_and_router() {
     let runtime = read_source(&root.join("crates/atm-http-runtime/src/lib.rs"));
     let http1_server = read_source(&root.join("crates/atm-http-runtime/src/http1_server.rs"));
     let staging = read_source(&root.join("crates/atm-http-runtime/src/private_staging.rs"));
+    let unix_socket = read_source(&root.join("crates/atm-http-runtime/src/unix_socket.rs"));
     let client = read_source(&root.join("crates/atm-http-runtime/src/client.rs"));
-    let combined = format!("{runtime}\n{http1_server}\n{client}");
+    let combined = format!("{runtime}\n{unix_socket}\n{http1_server}\n{client}");
 
     assert!(
-        runtime.contains("UnixListener")
-            && runtime.contains("serve_unix_http1(")
-            && runtime.contains("UnixSocketPathGuard")
-            && runtime.contains("spawn_blocking(move || bind_unix_listener(&socket))")
-            && runtime.contains("drain_server_pair(")
-            && runtime.contains("PrivateStagingDirectory::create(parent)")
-            && runtime.contains("publish_prepared_unix_socket")
-            && runtime.contains("std::fs::rename(&staged_path, &socket.path)"),
+        combined.contains("UnixListener")
+            && combined.contains("serve_unix_http1(")
+            && combined.contains("UnixSocketPathGuard")
+            && combined.contains("spawn_blocking(move || bind_unix_listener(&socket))")
+            && combined.contains("drain_server_pair(")
+            && combined.contains("PrivateStagingDirectory::create(parent)")
+            && combined.contains("publish_prepared_unix_socket")
+            && combined.contains("std::fs::rename(&staged_path, &socket.path)"),
         "AL.5 must own UDS lifecycle through Tokio, Axum/Hyper, blocking-pool setup, sibling drain, and inode-safe endpoint cleanup"
     );
     assert!(
@@ -2027,8 +2055,8 @@ fn al5_uds_is_a_framework_adapter_over_the_one_client_and_router() {
     );
     assert!(
         staging.contains("pub(crate) fn allocate")
-            && runtime.contains("private_staging::allocate(parent, \"uds\"")
-            && !runtime.contains("UDS_STAGING_DIRECTORY_COUNTER"),
+            && combined.contains("private_staging::allocate(parent, \"uds\"")
+            && !combined.contains("UDS_STAGING_DIRECTORY_COUNTER"),
         "runtime-owned UDS staging allocation must use the one shared private-staging owner"
     );
     assert!(

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1181,7 +1181,7 @@ fn storage_tls_boundary_lists_only_current_tls_consumers() {
         .expect("storage TLS boundary must be valid TOML");
     assert_eq!(
         boundary.dependencies.allowed_dependents,
-        vec!["atm-daemon".to_string(), "atm-peer-tls-interop".to_string()],
+        vec!["atm-peer-tls-interop".to_string()],
         "storage TLS helpers must name only crates that consume the TLS API"
     );
 }
@@ -1255,7 +1255,22 @@ fn daemon_boundary_tomls_must_not_allow_atm_storage_rusqlite() {
 
     assert!(
         violations.is_empty(),
-        "daemon boundary TOMLs must not allow atm-storage-rusqlite directly; violating files: {violations:?}"
+        "reference-only daemon boundaries must not select atm-storage-rusqlite; violating files: {violations:?}"
+    );
+
+    let root = workspace_root();
+    let replacement_bootstrap =
+        root.join("boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml");
+    let contents = fs::read_to_string(&replacement_bootstrap)
+        .expect("replacement bootstrap boundary must be readable");
+    let boundary: BoundaryToml =
+        toml::from_str(&contents).expect("replacement bootstrap boundary must remain valid TOML");
+    assert!(
+        boundary
+            .dependencies
+            .allowed_dependencies
+            .contains(&"atm-storage-rusqlite".to_string()),
+        "AL.8 must document the one approved concrete storage selection point"
     );
 }
 
@@ -2053,7 +2068,7 @@ fn al6_loopback_tcp_is_capability_authentication_over_the_one_client_and_router(
     let combined = format!("{runtime}\n{http1_server}\n{adapter}\n{client}");
 
     assert!(
-        runtime.contains("canonical_message_router(")
+        runtime.contains("canonical_api_router(")
             && runtime
                 .contains("authenticated_loopback_router(canonical_router.clone(), capability)")
             && http1_server.contains("into_make_service_with_connect_info::<SocketAddr>()")
@@ -2101,6 +2116,106 @@ fn al6_loopback_tcp_is_capability_authentication_over_the_one_client_and_router(
             "AL.6 loopback adapter must not introduce `{prohibited}`"
         );
     }
+}
+
+#[test]
+fn al8_active_daemon_root_cannot_reach_frozen_server_composition() {
+    let root = workspace_root();
+    let manifest = read_source(&root.join("crates/atm-daemon/Cargo.toml"));
+    let entrypoint = read_source(&root.join("crates/atm-daemon/src/main.rs"));
+    let bootstrap = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
+    let owner_gate = read_source(&root.join("crates/atm-daemon-bootstrap/src/owner_gate.rs"));
+    let active_root = format!("{entrypoint}\n{bootstrap}\n{owner_gate}");
+
+    assert!(
+        manifest.contains("autolib = false")
+            && entrypoint.contains("atm_daemon_bootstrap::run_replacement_daemon().await")
+            && !entrypoint.contains("atm_daemon::"),
+        "AL.8 must compile atm-daemon as the replacement binary only; its frozen library cannot remain an active server fallback"
+    );
+    assert!(
+        bootstrap.contains("HttpRuntimeBuilder::new(config, handler)")
+            && bootstrap.contains(".start()")
+            && bootstrap.contains("ReplacementReceivedHookSelector::new")
+            && bootstrap.contains("DaemonOwnerGuard::acquire_at")
+            && bootstrap.contains("Duration::from_secs(5)"),
+        "AL.8 must acquire the owner gate, inject the received-hook selector, start the Tokio runtime, and retain the one five-second drain bound"
+    );
+    for forbidden in [
+        "run_daemon_with_observability",
+        "RuntimeComposition",
+        "LocalIpcServerTransportAdapter",
+        "DaemonRequestDispatcher",
+        "DispatchWorkerPool",
+        "HttpFrameReader",
+        "PeerResendScheduler",
+        "peer_delivery",
+    ] {
+        assert!(
+            !active_root.contains(forbidden),
+            "AL.8 active daemon root must not reach frozen legacy construct `{forbidden}`"
+        );
+    }
+    assert_forbidden_edge_absent("atm-daemon", "atm-storage-rusqlite");
+    assert_forbidden_edge_absent("atm-daemon", "atm-peer-tls-interop");
+
+    let dependencies = direct_normal_workspace_dependencies();
+    assert_eq!(
+        dependencies
+            .get("atm-daemon")
+            .expect("active daemon package must exist"),
+        &BTreeSet::from([
+            "agent-team-mail-core".to_string(),
+            "atm-daemon-bootstrap".to_string(),
+        ]),
+        "the active daemon executable may reach ATM code only through core contracts and the replacement bootstrap"
+    );
+
+    let selector =
+        read_source(&root.join("crates/atm-daemon-bootstrap/src/received_hook_selector.rs"));
+    let active_sources = format!("{active_root}\n{selector}");
+    for forbidden in [
+        "Runtime::Builder",
+        "Handle::block_on",
+        "std::thread::spawn",
+        "std::thread::sleep",
+        "HttpFrameReader",
+        "read_http_request(",
+        "write_http_request(",
+        "PeerResendScheduler",
+        "PeerDrainCoordinator",
+    ] {
+        assert!(
+            !active_sources.contains(forbidden),
+            "AL.8 active composition must not restore `{forbidden}`"
+        );
+    }
+}
+
+#[test]
+fn al8_marks_the_replacement_bootstrap_as_the_only_active_daemon_boundary() {
+    let root = workspace_root();
+    let active = daemon_boundary_files()
+        .into_iter()
+        .filter_map(|path| {
+            let contents = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            let boundary: BoundaryToml = toml::from_str(&contents)
+                .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()));
+            (boundary.status.state == "active").then_some(path)
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        active.is_empty(),
+        "AL.8 keeps every legacy daemon boundary reference-only until Phase AM deletion: {active:?}"
+    );
+    let replacement_bootstrap =
+        root.join("boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml");
+    let contents = fs::read_to_string(&replacement_bootstrap)
+        .expect("replacement bootstrap boundary must be readable");
+    let boundary: BoundaryToml =
+        toml::from_str(&contents).expect("replacement bootstrap boundary must remain valid TOML");
+    assert_eq!(boundary.status.state, "active");
 }
 
 #[test]

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -29,7 +29,10 @@ pub const MAX_HTTP_REQUEST_BODY_BYTES: usize = 1_048_576;
 /// Version of the daemon's HTTP request contract.
 pub const HTTP_API_VERSION: &str = crate::protocol::HTTP_API_VERSION;
 const MAX_HTTP_HEADER_BYTES: usize = 16 * 1024;
-const CLEAR_OUTCOME_HEADER: &str = "X-ATM-Clear-Outcome";
+/// HTTP response header carrying the canonical clear outcome for the `204`
+/// clear route. Framework adapters use this shared contract instead of
+/// inventing a JSON body for a no-content response.
+pub const CLEAR_OUTCOME_HEADER: &str = "X-ATM-Clear-Outcome";
 /// Adapter-owned provenance header for the explicit plaintext peer smoke mode.
 pub const PEER_SOURCE_HOST_HEADER: &str = "X-ATM-Peer-Source-Host";
 const MESSAGES_PATH: &str = "/v1/atm/messages";

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -29,6 +29,17 @@ pub struct ClearQuery {
     pub dry_run: bool,
 }
 
+impl ClearQuery {
+    /// Replaces caller-supplied filesystem roots with the daemon-owned root
+    /// before a request crosses the long-lived service boundary.
+    #[must_use]
+    pub fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.home_dir = daemon_home.clone();
+        self.current_dir = daemon_home;
+        self
+    }
+}
+
 /// Counts of removed mailbox messages by ATM display class.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RemovedByClass {

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -51,6 +51,17 @@ pub struct DoctorQuery {
     pub caller_identity: Option<AgentName>,
 }
 
+impl DoctorQuery {
+    /// Replaces caller-supplied filesystem roots with the daemon-owned root
+    /// before a request crosses the long-lived service boundary.
+    #[must_use]
+    pub fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.home_dir = daemon_home.clone();
+        self.current_dir = daemon_home;
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct RuntimeDoctorPorts {
     pub config_doctor: Arc<dyn ConfigDoctor + Send + Sync>,

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -53,6 +53,10 @@ pub enum GraftPostSendResponse {
 
 const RECEIVER_HOOK_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 const RECEIVER_HOOK_IO_DEADLINE: Duration = Duration::from_secs(3);
+/// The outer replacement-runtime hook owner needs time to receive the blocking
+/// Graft result and turn it into a durable-success warning. Socket I/O must
+/// therefore end before, rather than race, the inherited absolute deadline.
+const RECEIVER_HOOK_RESULT_HANDOFF_GRACE: Duration = Duration::from_millis(100);
 
 /// Delivers one serialized receiver event to an independently published Graft
 /// endpoint. This is endpoint transport, not a daemon-side hook implementation.
@@ -118,11 +122,12 @@ fn remaining_hook_budget(
 ) -> Result<Duration, AtmError> {
     deadline
         .remaining()
+        .and_then(|remaining| remaining.checked_sub(RECEIVER_HOOK_RESULT_HANDOFF_GRACE))
         .map(|remaining| remaining.min(safety_cap))
         .ok_or_else(|| {
             AtmError::new(
                 AtmErrorCode::PostSendGraftUnavailable,
-                "received-message hook request deadline expired before endpoint delivery began",
+                "received-message hook does not retain enough request budget for endpoint delivery and result handoff",
             )
         })
 }
@@ -706,10 +711,12 @@ mod tests {
     use super::{
         AtmGraftClient, GRAFT_RECEIVER_RECORD_SCHEMA_VERSION, GraftPostSendRequest,
         GraftPostSendResponse, GraftReceiverEndpointRecord, GraftReceiverListener,
-        deliver_graft_post_send, graft_receiver_record_path_from_home, read_receiver_record,
+        RECEIVER_HOOK_RESULT_HANDOFF_GRACE, deliver_graft_post_send,
+        graft_receiver_record_path_from_home, read_receiver_record, remaining_hook_budget,
         write_receiver_record,
     };
     use crate::ack::{AckOutcome, AckRequest};
+    use crate::api::RequestDeadline;
     use crate::boundary::PostSendHookEvent;
     use crate::error::AtmError;
     use crate::read::{ReadOutcome, ReadQuery};
@@ -744,6 +751,24 @@ mod tests {
     fn atm_graft_client_trait_is_object_safe() {
         let client: &dyn AtmGraftClient = &MockGraftClient;
         let _ = client;
+    }
+
+    #[test]
+    fn graft_hook_budget_reserves_time_for_the_outer_result_handoff() {
+        let short = remaining_hook_budget(
+            RequestDeadline::after(RECEIVER_HOOK_RESULT_HANDOFF_GRACE),
+            Duration::from_secs(1),
+        )
+        .expect_err("a deadline with no handoff margin must not start socket I/O");
+        assert!(short.message().contains("result handoff"));
+
+        let budget = remaining_hook_budget(
+            RequestDeadline::after(Duration::from_secs(1)),
+            Duration::from_secs(1),
+        )
+        .expect("larger request deadline retains socket budget");
+        assert!(budget < Duration::from_secs(1));
+        assert!(budget <= Duration::from_secs(1) - RECEIVER_HOOK_RESULT_HANDOFF_GRACE);
     }
 
     fn test_event() -> PostSendHookEvent {

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -56,6 +56,19 @@ const RECEIVER_HOOK_IO_DEADLINE: Duration = Duration::from_secs(3);
 
 /// Delivers one serialized receiver event to an independently published Graft
 /// endpoint. This is endpoint transport, not a daemon-side hook implementation.
+/// Delivers one received-message hook through the recipient's independently
+/// published Graft endpoint.
+///
+/// Replacement composition invokes this only from its narrow blocking seam;
+/// the Tokio HTTP runtime itself remains independent of Graft.
+pub fn deliver_published_receiver_hook_from_local_runtime(
+    runtime: &crate::LocalServiceRuntime,
+    dispatch: &BuiltInPostSendDispatch,
+    deadline: RequestDeadline,
+) -> Result<PostSendEmissionPath, AtmError> {
+    deliver_published_receiver_hook(runtime, dispatch, deadline)
+}
+
 pub(crate) fn deliver_published_receiver_hook<R>(
     runtime: &R,
     dispatch: &BuiltInPostSendDispatch,

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -40,6 +40,15 @@ pub struct ListQuery {
 }
 
 impl ListQuery {
+    /// Replaces caller-supplied filesystem roots with the daemon-owned root
+    /// before a request crosses the long-lived service boundary.
+    #[must_use]
+    pub fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.home_dir = daemon_home.clone();
+        self.current_dir = daemon_home;
+        self
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         home_dir: PathBuf,

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -129,6 +129,12 @@ pub struct MailboxQueryFields {
     pub(crate) timeout_secs: Option<u64>,
 }
 impl MailboxQueryFields {
+    fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.home_dir = daemon_home.clone();
+        self.current_dir = daemon_home;
+        self
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         home_dir: PathBuf,
@@ -172,6 +178,14 @@ pub struct PeekQuery {
     pub(crate) caller_team: TeamName,
 }
 impl PeekQuery {
+    /// Replaces caller-supplied filesystem roots with the daemon-owned root
+    /// before a request crosses the long-lived service boundary.
+    #[must_use]
+    pub fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.mailbox = self.mailbox.with_daemon_paths(daemon_home);
+        self
+    }
+
     pub fn from_filters(
         home_dir: PathBuf,
         current_dir: PathBuf,
@@ -251,6 +265,14 @@ pub struct ReadQuery {
     pub activity_observation: Option<ActivityObservation>,
 }
 impl ReadQuery {
+    /// Replaces caller-supplied filesystem roots with the daemon-owned root
+    /// before a request crosses the long-lived service boundary.
+    #[must_use]
+    pub fn with_daemon_paths(mut self, daemon_home: PathBuf) -> Self {
+        self.mailbox = self.mailbox.with_daemon_paths(daemon_home);
+        self
+    }
+
     #[expect(
         clippy::too_many_arguments,
         reason = "the request boundary keeps caller, selection, and mutation state explicit; all optional filters are named in MailboxQueryFilters"

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -43,8 +43,20 @@ fn send_non_claude_success_delivers_original_via_outbound_boundary() {
     assert_eq!(deliveries[0].messages.len(), 1);
     assert_eq!(deliveries[0].messages[0].from.as_str(), TEST_SENDER);
     drop(deliveries);
+    let emitted = post_send_emitter.emitted();
+    assert_eq!(emitted.len(), 1);
+    let message_id = emitted[0].event.message_id.to_string();
     let events = super::tests::read_notification_events(&home_dir);
-    let event = events.last().expect("notification event");
+    let event = events
+        .iter()
+        .rev()
+        .find(|event| {
+            super::tests::notification_detail(event)
+                .get("message_id")
+                .and_then(serde_json::Value::as_str)
+                == Some(message_id.as_str())
+        })
+        .expect("notification event for the sent message");
     assert_eq!(event.kind, NotificationKind::Delivery);
     assert_eq!(
         super::tests::notification_detail(event)
@@ -53,8 +65,6 @@ fn send_non_claude_success_delivers_original_via_outbound_boundary() {
         Some(TEST_SENDER)
     );
     assert_eq!(event.team.as_ref().map(TeamName::as_str), Some("test-team"));
-    let emitted = post_send_emitter.emitted();
-    assert_eq!(emitted.len(), 1);
     assert_eq!(emitted[0].event.sender.as_str(), TEST_SENDER);
     assert_eq!(emitted[0].event.description, "hello");
 }

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -11,6 +11,13 @@ homepage.workspace = true
 
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.1-beta-aj" }
 atm-runtime = { path = "../atm-runtime", version = "1.4.1-beta-aj" }
 atm-storage = { path = "../atm-storage", version = "1.4.1-beta-aj" }
 atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.1-beta-aj" }
+tokio.workspace = true
+fs2 = "0.4"
+ulid.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -4,7 +4,9 @@
 )]
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::num::{NonZeroU32, NonZeroUsize};
+#[cfg(unix)]
+use std::num::NonZeroU32;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::{Arc, Once};
 use std::time::Duration;
@@ -12,7 +14,9 @@ use std::time::Duration;
 use atm_core::LocalFileNonClaudeOutbound;
 use atm_core::boundary::{NonClaudeOutbound, RosterStore};
 use atm_core::error::AtmError;
-use atm_core::home::{HOST_RUNTIME_SOCKET_FILE, current_host_runtime_scope};
+#[cfg(unix)]
+use atm_core::home::HOST_RUNTIME_SOCKET_FILE;
+use atm_core::home::current_host_runtime_scope;
 use atm_core::local_http::LOCAL_HTTP_RECORD_FILENAME;
 use atm_core::observability::NullObservability;
 use atm_core::types::{AgentName, TeamName};

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -3,18 +3,35 @@
     reason = "daemon bootstrap still forwards the legacy atm-core roster boundary while retained callers migrate to canonical storage seams"
 )]
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::sync::{Arc, Once};
+use std::time::Duration;
 
 use atm_core::LocalFileNonClaudeOutbound;
 use atm_core::boundary::{NonClaudeOutbound, RosterStore};
 use atm_core::error::AtmError;
-use atm_core::home::current_host_runtime_scope;
+use atm_core::home::{HOST_RUNTIME_SOCKET_FILE, current_host_runtime_scope};
+use atm_core::local_http::LOCAL_HTTP_RECORD_FILENAME;
+use atm_core::observability::NullObservability;
 use atm_core::types::{AgentName, TeamName};
+use atm_http_runtime::{
+    HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig, NonZeroDuration, RuntimeHealth,
+    RuntimeLimits, RuntimeTimeouts, StorageAndNudgeRouter,
+};
 use atm_runtime::{RuntimeAssembly, RuntimeAssemblyInputs, assemble_runtime};
 use atm_storage_rusqlite::SqliteStorageFactory;
 
+mod owner_gate;
+mod received_hook_selector;
+
+pub use owner_gate::DaemonOwnerGuard;
+pub use received_hook_selector::ReplacementReceivedHookSelector;
+
 static INSTALL_RETAINED_RUNTIME_FACTORY: Once = Once::new();
+/// Architecture §21.6.4's single replacement-daemon drain deadline.
+pub const REPLACEMENT_DRAIN_DEADLINE: Duration = Duration::from_secs(5);
 
 /// Identity values captured once at the daemon bootstrap boundary.
 ///
@@ -73,6 +90,129 @@ pub fn assemble_default_runtime() -> Result<RuntimeAssembly, AtmError> {
     )
 }
 
+/// Starts the replacement Tokio/Axum daemon as the only active serving path.
+///
+/// The singleton guard is acquired before validation or binding. The runtime
+/// owns its listener lifecycle; this bootstrap owns only concrete backend and
+/// harness selection. No legacy daemon server, dispatcher, worker, or framing
+/// module is referenced from this path.
+pub async fn run_replacement_daemon() -> Result<(), AtmError> {
+    let scope = current_host_runtime_scope()?;
+    let _owner = DaemonOwnerGuard::acquire_at(scope.owner_lock.clone())?;
+    let runtime_health = RuntimeHealth::with_owner(std::process::id());
+    let assembly = assemble_default_runtime()?.for_daemon();
+    let selector = Arc::new(ReplacementReceivedHookSelector::new(
+        assembly.service_runtime.clone(),
+    ));
+    let handler = Arc::new(
+        StorageAndNudgeRouter::new(
+            assembly.service_runtime,
+            Arc::new(NullObservability),
+            selector,
+            atm_core::home::atm_home()?,
+        )
+        .with_runtime_health(runtime_health.clone(), assembly.doctor_ports),
+    );
+    let loopback = LoopbackTcpConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        scope.runtime_root.as_ref().join(LOCAL_HTTP_RECORD_FILENAME),
+        _owner.instance_id(),
+    );
+    let config = HttpRuntimeConfig::new(
+        loopback,
+        unix_socket_config(&scope)?,
+        RuntimeLimits::new(
+            NonZeroUsize::new(1_048_576).expect("non-zero body limit"),
+            NonZeroUsize::new(128).expect("non-zero connection limit"),
+        ),
+        RuntimeTimeouts::new(
+            NonZeroDuration::new(Duration::from_secs(3)).expect("non-zero request timeout"),
+            NonZeroDuration::new(REPLACEMENT_DRAIN_DEADLINE).expect("non-zero shutdown timeout"),
+        ),
+    );
+    let mut running = HttpRuntimeBuilder::new(config, handler)
+        .with_runtime_health(runtime_health)
+        .build()?
+        .start()
+        .await?;
+    tokio::select! {
+        signal = wait_for_shutdown_signal() => signal?,
+        _ = running.wait_for_server_stop() => {
+            return match running.begin_shutdown().finish().await {
+                Ok(_) => Err(AtmError::daemon_unavailable(
+                    "replacement HTTP runtime server stopped unexpectedly",
+                )),
+                Err(error) => Err(error),
+            };
+        }
+    }
+    let _stopped = running.begin_shutdown().finish().await?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn unix_socket_config(
+    scope: &atm_core::home::HostRuntimeScope,
+) -> Result<Option<atm_http_runtime::UnixSocketConfig>, AtmError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let uid = std::fs::metadata(scope.runtime_root.as_ref())
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to inspect daemon runtime directory ownership")
+                .with_cause(source)
+        })?
+        .uid();
+    Ok(unix_socket_config_for_uid(scope.runtime_root.as_ref(), uid))
+}
+
+#[cfg(unix)]
+fn unix_socket_config_for_uid(
+    runtime_root: &std::path::Path,
+    uid: u32,
+) -> Option<atm_http_runtime::UnixSocketConfig> {
+    // `UnixSocketOwnerUid` deliberately excludes uid 0 so a socket cannot be
+    // accidentally configured for a synthetic/unowned principal. A daemon
+    // running as root still has a safe MVP listener: authenticated loopback.
+    // Do not make that optional local adapter prevent process startup.
+    let uid = NonZeroU32::new(uid)?;
+    let mode = NonZeroU32::new(0o600).expect("owner-only socket mode is non-zero");
+    Some(atm_http_runtime::UnixSocketConfig::new(
+        runtime_root.join(HOST_RUNTIME_SOCKET_FILE),
+        atm_http_runtime::UnixSocketOwnerUid::new(uid),
+        atm_http_runtime::UnixSocketMode::new(mode),
+    ))
+}
+
+#[cfg(not(unix))]
+fn unix_socket_config(
+    _scope: &atm_core::home::HostRuntimeScope,
+) -> Result<Option<atm_http_runtime::UnixSocketConfig>, AtmError> {
+    Ok(None)
+}
+
+async fn wait_for_shutdown_signal() -> Result<(), AtmError> {
+    // AL.8 uses Tokio's process signal facility so the replacement process has
+    // no dedicated signal thread or blocking shutdown worker.
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut terminate = signal(SignalKind::terminate()).map_err(|source| {
+            AtmError::daemon_unavailable("failed to install replacement daemon SIGTERM handler")
+                .with_cause(source)
+        })?;
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+    Ok(())
+}
+
 fn default_local_runtime() -> Result<atm_core::LocalServiceRuntime, AtmError> {
     assemble_default_runtime().map(|assembly| assembly.service_runtime)
 }
@@ -114,4 +254,22 @@ pub fn with_default_peer_config_store<T>(
 ) -> Result<T, AtmError> {
     let assembly = assemble_default_runtime()?;
     f(assembly.peer_config_store().as_ref())
+}
+
+#[cfg(test)]
+mod replacement_runtime_tests {
+    use std::time::Duration;
+
+    use super::REPLACEMENT_DRAIN_DEADLINE;
+
+    #[test]
+    fn replacement_runtime_uses_the_architecture_drain_deadline() {
+        assert_eq!(REPLACEMENT_DRAIN_DEADLINE, Duration::from_secs(5));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_uses_authenticated_loopback_without_making_uds_startup_mandatory() {
+        assert!(super::unix_socket_config_for_uid(std::path::Path::new("/tmp"), 0).is_none());
+    }
 }

--- a/crates/atm-daemon-bootstrap/src/owner_gate.rs
+++ b/crates/atm-daemon-bootstrap/src/owner_gate.rs
@@ -1,0 +1,107 @@
+//! Minimal process-lifetime singleton guard for the replacement daemon.
+//!
+//! The operating system releases an advisory file lock when its owning process
+//! exits. That lets the Tokio replacement avoid the frozen daemon's polling
+//! stale-owner recovery thread while retaining the owner-record schema that
+//! binds `local-http.json` to the active daemon instance.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use atm_core::error::AtmError;
+use fs2::FileExt;
+use ulid::Ulid;
+
+#[derive(Debug)]
+pub struct DaemonOwnerGuard {
+    lock_file: File,
+    lock_path: PathBuf,
+    instance_id: Ulid,
+}
+
+impl DaemonOwnerGuard {
+    /// Acquires the OS-user-scoped owner lock before a listener can bind.
+    pub fn acquire_at(lock_path: PathBuf) -> Result<Self, AtmError> {
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| {
+                AtmError::daemon_unavailable("failed to create daemon owner-lock directory")
+                    .with_cause(source)
+            })?;
+        }
+        let mut lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|source| {
+                AtmError::daemon_unavailable("failed to open daemon owner lock").with_cause(source)
+            })?;
+        lock_file.try_lock_exclusive().map_err(|source| {
+            AtmError::daemon_serving_state_rejected(format!(
+                "an ATM daemon already owns {}: {source}",
+                lock_path.display()
+            ))
+        })?;
+        let instance_id = Ulid::new();
+        let token = Ulid::new();
+        let record = format!("{}:{token}:{instance_id}\n", std::process::id());
+        lock_file.set_len(0).map_err(|source| {
+            AtmError::daemon_unavailable("failed to reset daemon owner record").with_cause(source)
+        })?;
+        lock_file.seek(SeekFrom::Start(0)).map_err(|source| {
+            AtmError::daemon_unavailable("failed to seek daemon owner record").with_cause(source)
+        })?;
+        lock_file.write_all(record.as_bytes()).map_err(|source| {
+            AtmError::daemon_unavailable("failed to write daemon owner record").with_cause(source)
+        })?;
+        lock_file.sync_data().map_err(|source| {
+            AtmError::daemon_unavailable("failed to commit daemon owner record").with_cause(source)
+        })?;
+        Ok(Self {
+            lock_file,
+            lock_path,
+            instance_id,
+        })
+    }
+
+    #[must_use]
+    pub const fn instance_id(&self) -> Ulid {
+        self.instance_id
+    }
+}
+
+impl Drop for DaemonOwnerGuard {
+    fn drop(&mut self) {
+        let _ = self.lock_file.set_len(0);
+        let _ = self.lock_file.seek(SeekFrom::Start(0));
+        let _ = self.lock_file.sync_data();
+        let _ = self.lock_file.unlock();
+        let _ = &self.lock_path;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DaemonOwnerGuard;
+
+    #[test]
+    fn owner_record_uses_the_local_http_instance_schema() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let lock = temporary_directory.path().join("owner.lock");
+        let guard = DaemonOwnerGuard::acquire_at(lock.clone()).expect("acquire owner");
+        let record = std::fs::read_to_string(&lock).expect("read owner record");
+        assert!(record.contains(&guard.instance_id().to_string()));
+        assert_eq!(record.trim().split(':').count(), 3);
+    }
+
+    #[test]
+    fn a_second_replacement_owner_cannot_acquire_the_live_lock() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let lock = temporary_directory.path().join("owner.lock");
+        let _first = DaemonOwnerGuard::acquire_at(lock.clone()).expect("first owner acquires");
+        let error = DaemonOwnerGuard::acquire_at(lock).expect_err("second owner is rejected");
+        assert_eq!(error.code().as_str(), "ATM_DAEMON_SERVING_STATE_REJECTED");
+    }
+}

--- a/crates/atm-daemon-bootstrap/src/owner_gate.rs
+++ b/crates/atm-daemon-bootstrap/src/owner_gate.rs
@@ -84,14 +84,24 @@ impl Drop for DaemonOwnerGuard {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Seek, SeekFrom};
+
     use super::DaemonOwnerGuard;
 
     #[test]
     fn owner_record_uses_the_local_http_instance_schema() {
         let temporary_directory = tempfile::tempdir().expect("temporary directory");
         let lock = temporary_directory.path().join("owner.lock");
-        let guard = DaemonOwnerGuard::acquire_at(lock.clone()).expect("acquire owner");
-        let record = std::fs::read_to_string(&lock).expect("read owner record");
+        let mut guard = DaemonOwnerGuard::acquire_at(lock).expect("acquire owner");
+        guard
+            .lock_file
+            .seek(SeekFrom::Start(0))
+            .expect("seek owner record");
+        let mut record = String::new();
+        guard
+            .lock_file
+            .read_to_string(&mut record)
+            .expect("read owner record through the owner handle");
         assert!(record.contains(&guard.instance_id().to_string()));
         assert_eq!(record.trim().split(':').count(), 3);
     }

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -1,0 +1,224 @@
+//! Composition-owned receiver-hook implementations for the replacement daemon.
+//!
+//! This module is deliberately outside `atm-http-runtime`: the runtime sees
+//! only the sealed selector/emitter boundary. Graft remains an independently
+//! running receiver reached through its already-published endpoint; no daemon
+//! crate imports `atm-graft`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use atm_core::LocalServiceRuntime;
+use atm_core::RequestDeadline;
+use atm_core::boundary::{
+    self, AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, MessageReceivedHookSelector,
+    PostSendBuiltInTarget, PostSendEmissionPath,
+};
+use atm_core::error::{AtmError, AtmErrorCode};
+
+const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);
+
+/// Selects the receiver implementation from the post-persistence dispatch
+/// target already planned by core. It owns no application routing or storage.
+#[derive(Clone)]
+pub struct ReplacementReceivedHookSelector {
+    tmux: TokioTmuxReceivedHook,
+    graft: PublishedGraftReceivedHook,
+}
+
+impl ReplacementReceivedHookSelector {
+    #[must_use]
+    pub fn new(service_runtime: LocalServiceRuntime) -> Self {
+        Self {
+            tmux: TokioTmuxReceivedHook,
+            graft: PublishedGraftReceivedHook { service_runtime },
+        }
+    }
+}
+
+impl boundary::sealed::Sealed for ReplacementReceivedHookSelector {}
+
+impl MessageReceivedHookSelector for ReplacementReceivedHookSelector {
+    fn select_emitter(
+        &self,
+        dispatch: &BuiltInPostSendDispatch,
+    ) -> Option<&dyn AsyncMessageReceivedHookEmitter> {
+        match dispatch.target {
+            PostSendBuiltInTarget::LocalTmux(_) => Some(&self.tmux),
+            PostSendBuiltInTarget::Graft(_) => Some(&self.graft),
+        }
+    }
+}
+
+/// Tokio-native tmux receiver emitter. It never polls a child or blocks a
+/// runtime worker: each command and the retained inter-key delay are awaited.
+#[derive(Clone, Copy)]
+struct TokioTmuxReceivedHook;
+
+impl boundary::sealed::Sealed for TokioTmuxReceivedHook {}
+
+impl AsyncMessageReceivedHookEmitter for TokioTmuxReceivedHook {
+    fn emit_received_message(
+        &self,
+        dispatch: BuiltInPostSendDispatch,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<PostSendEmissionPath, AtmError>> + Send + '_>> {
+        Box::pin(async move {
+            let PostSendBuiltInTarget::LocalTmux(target) = dispatch.target else {
+                return Err(AtmError::validation(
+                    "tmux receiver hook received a non-tmux dispatch",
+                ));
+            };
+            run_tmux(
+                [
+                    "send-keys",
+                    "-t",
+                    target.pane_id.as_str(),
+                    "-l",
+                    &target.rendered_nudge,
+                ],
+                deadline,
+            )
+            .await?;
+            run_tmux(
+                ["send-keys", "-t", target.pane_id.as_str(), "Enter"],
+                deadline,
+            )
+            .await?;
+            let delay = deadline
+                .remaining()
+                .ok_or_else(|| hook_deadline_error("before tmux's second Enter"))?
+                .min(TMUX_DOUBLE_ENTER_DELAY);
+            tokio::time::sleep(delay).await;
+            run_tmux(
+                ["send-keys", "-t", target.pane_id.as_str(), "Enter"],
+                deadline,
+            )
+            .await?;
+            Ok(PostSendEmissionPath::LocalTmux)
+        })
+    }
+}
+
+async fn run_tmux<const N: usize>(
+    arguments: [&str; N],
+    deadline: RequestDeadline,
+) -> Result<(), AtmError> {
+    let remaining = deadline
+        .remaining()
+        .ok_or_else(|| hook_deadline_error("before tmux command start"))?;
+    let output = tokio::time::timeout(
+        remaining,
+        tokio::process::Command::new("tmux")
+            .args(arguments)
+            .output(),
+    )
+    .await
+    .map_err(|_| hook_deadline_error("while executing tmux"))?
+    .map_err(|source| {
+        AtmError::new(
+            AtmErrorCode::PostSendTmuxSendFailed,
+            "failed to start tmux received-message hook command",
+        )
+        .with_cause(source)
+    })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(AtmError::new(
+            AtmErrorCode::PostSendTmuxSendFailed,
+            "tmux received-message hook command failed",
+        ))
+    }
+}
+
+fn hook_deadline_error(stage: &'static str) -> AtmError {
+    AtmError::new(
+        AtmErrorCode::PostSendTmuxSendFailed,
+        format!("received-message hook deadline expired {stage}"),
+    )
+}
+
+/// Graft remains receiver-owned. The existing endpoint operation has bounded
+/// socket timeouts derived from the inherited absolute deadline, so the only
+/// blocking seam is awaited rather than detached.
+#[derive(Clone)]
+struct PublishedGraftReceivedHook {
+    service_runtime: LocalServiceRuntime,
+}
+
+impl boundary::sealed::Sealed for PublishedGraftReceivedHook {}
+
+impl AsyncMessageReceivedHookEmitter for PublishedGraftReceivedHook {
+    fn emit_received_message(
+        &self,
+        dispatch: BuiltInPostSendDispatch,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<PostSendEmissionPath, AtmError>> + Send + '_>> {
+        let service_runtime = self.service_runtime.clone();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                atm_core::graft::deliver_published_receiver_hook_from_local_runtime(
+                    &service_runtime,
+                    &dispatch,
+                    deadline,
+                )
+            })
+            .await
+            .map_err(|source| {
+                AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "published Graft receiver hook task ended unexpectedly",
+                )
+                .with_cause(source)
+            })?
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use atm_core::RequestDeadline;
+    use atm_core::boundary::{
+        AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, LocalTmuxNudgeTarget,
+        PostSendBuiltInTarget, PostSendHookEvent,
+    };
+    use atm_core::types::{AgentName, PaneId, TeamName};
+
+    use super::TokioTmuxReceivedHook;
+
+    fn tmux_dispatch() -> BuiltInPostSendDispatch {
+        BuiltInPostSendDispatch {
+            event: PostSendHookEvent {
+                sender: "sender".parse::<AgentName>().expect("agent"),
+                sender_chat_id: None,
+                sender_team: "team".parse::<TeamName>().expect("team"),
+                recipient: "receiver".parse::<AgentName>().expect("agent"),
+                recipient_team: "team".parse::<TeamName>().expect("team"),
+                message_id: "01KZ0000000000000000000000".parse().expect("message"),
+                description: "test".to_owned(),
+                requires_ack: false,
+                is_ack: false,
+                task_id: None,
+                recipient_pane_id: Some(PaneId::from_cli("%1").expect("pane")),
+            },
+            target: PostSendBuiltInTarget::LocalTmux(LocalTmuxNudgeTarget {
+                pane_id: PaneId::from_cli("%1").expect("pane"),
+                rendered_nudge: "test".to_owned(),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_hook_budget_does_not_start_a_tmux_process() {
+        let error = TokioTmuxReceivedHook
+            .emit_received_message(tmux_dispatch(), RequestDeadline::after(Duration::ZERO))
+            .await
+            .expect_err("expired deadline must fail before command spawn");
+
+        assert!(error.message().contains("deadline expired"));
+    }
+}

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "atm-daemon"
+autolib = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -11,32 +12,5 @@ homepage.workspace = true
 
 [dependencies]
 tokio.workspace = true
-ulid.workspace = true
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
 atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.1-beta-aj" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.1-beta-aj" }
-atm-storage = { path = "../atm-storage", version = "1.4.1-beta-aj" }
-arc-swap.workspace = true
-chrono = { version = "0.4", features = ["serde"] }
-fs2 = "0.4"
-interprocess = "2.4.2"
-sc-observability.workspace = true
-sc-observability-types.workspace = true
-serde_json.workspace = true
-tracing.workspace = true
-
-[target.'cfg(unix)'.dependencies]
-signal-hook = "0.3"
-
-[target.'cfg(windows)'.dependencies]
-signal-hook = "0.3"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Memory"] }
-
-[dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj", features = ["test-utils"] }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.1-beta-aj" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.1-beta-aj", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-sc-observability = { workspace = true, features = ["fault-injection"] }
-serial_test = "3"
-tempfile = "3"

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -1,28 +1,30 @@
-use std::sync::Arc;
-
 use atm_core::error::AtmError;
-use sc_observability as _;
 
-mod daemon_observability;
-
-use daemon_observability::DaemonObservability;
-
-const _: Option<fn(sc_observability::Logger)> = None;
-
-fn main() {
-    let exit_code = match run() {
+#[tokio::main]
+async fn main() {
+    let exit_code = match atm_daemon_bootstrap::run_replacement_daemon().await {
         Ok(()) => 0,
         Err(error) => {
             eprintln!("{error}");
-            atm_daemon::daemon_exit_code_for_error(&error).as_i32()
+            replacement_exit_code(&error)
         }
     };
     std::process::exit(exit_code);
 }
 
-fn run() -> Result<(), AtmError> {
-    atm_daemon_bootstrap::install_sqlite_retained_runtime_factory();
-    let observability: Arc<dyn atm_daemon::DaemonRuntimeObservability> =
-        Arc::new(DaemonObservability::bootstrap()?);
-    atm_daemon::run_daemon_with_observability(observability)
+fn replacement_exit_code(error: &AtmError) -> i32 {
+    if error.is_validation()
+        || matches!(
+            error.code(),
+            atm_core::error::AtmErrorCode::ConfigParseFailed
+                | atm_core::error::AtmErrorCode::ConfigHomeUnavailable
+                | atm_core::error::AtmErrorCode::DaemonServingStateRejected
+        )
+    {
+        64
+    } else if error.code() == atm_core::error::AtmErrorCode::DaemonUnavailable {
+        70
+    } else {
+        1
+    }
 }

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace = true
 
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.1-beta-aj" }
+base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 reqwest.workspace = true
-rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -24,52 +24,31 @@ use reqwest::header::{HeaderName, HeaderValue};
 /// connector implementations from silently collapsing DNS, TLS, write, and
 /// cancellation failures into an indistinguishable generic transport error.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(
-    dead_code,
-    reason = "AL.5--AL.7 physical connectors consume every stage in this contract"
-)]
 pub(crate) enum HttpRuntimeClientFailure {
-    EndpointResolution(String),
     EndpointRecord(AtmError),
     Connect(String),
-    Tls(String),
     RequestWrite(String),
-    ResponseStatus(AtmError),
     ResponseDecode(AtmError),
     Cancelled,
-    RuntimeShutdown,
     Timeout,
 }
 
 impl HttpRuntimeClientFailure {
     fn into_atm_error(self) -> AtmError {
         match self {
-            Self::EndpointResolution(cause) => AtmError::new(
-                AtmErrorCode::LocalHttpEndpointMissing,
-                "HTTP client could not resolve the configured daemon endpoint",
-            )
-            .with_cause(cause),
             Self::EndpointRecord(error) => error,
             Self::Connect(cause) => AtmError::daemon_unavailable(
                 "HTTP client could not connect to the configured daemon endpoint",
-            )
-            .with_cause(cause),
-            Self::Tls(cause) => AtmError::new(
-                AtmErrorCode::CertificateOperationFailed,
-                "HTTP client TLS handshake or peer authorization failed",
             )
             .with_cause(cause),
             Self::RequestWrite(cause) => AtmError::daemon_unavailable(
                 "HTTP client could not write the request to the daemon endpoint",
             )
             .with_cause(cause),
-            Self::ResponseStatus(error) | Self::ResponseDecode(error) => error,
+            Self::ResponseDecode(error) => error,
             Self::Cancelled => AtmError::new(
                 AtmErrorCode::WaitTimeout,
                 "HTTP client request was cancelled before a response arrived",
-            ),
-            Self::RuntimeShutdown => AtmError::daemon_unavailable(
-                "HTTP client runtime shut down before the request completed",
             ),
             Self::Timeout => AtmError::new(
                 AtmErrorCode::WaitTimeout,
@@ -210,10 +189,6 @@ fn load_active_loopback_endpoint_blocking(
 /// write, and response read. They must preserve the supplied absolute deadline
 /// and return the existing [`AtmError`] vocabulary with their concrete cause.
 /// This is a connector seam, not a second ATM client boundary.
-#[allow(
-    dead_code,
-    reason = "AL.4 defines the shared client before AL.5--AL.7 add physical connectors"
-)]
 #[async_trait]
 pub(crate) trait HttpRuntimeConnector: Send + Sync {
     async fn exchange(
@@ -363,10 +338,6 @@ async fn execute_reqwest_request(
 /// The connector is the only place UDS, loopback, or TLS can differ. Request
 /// encoding, route selection, response decoding, and outcome mapping remain
 /// in this type.
-#[allow(
-    dead_code,
-    reason = "AL.4 defines the shared client before AL.5--AL.7 construct physical connectors"
-)]
 #[derive(Debug, Clone)]
 pub(crate) struct HttpRuntimeClient<Connector> {
     connector: Arc<Connector>,
@@ -374,10 +345,6 @@ pub(crate) struct HttpRuntimeClient<Connector> {
 }
 
 impl<Connector> HttpRuntimeClient<Connector> {
-    #[allow(
-        dead_code,
-        reason = "AL.5--AL.7 own construction from physical connector configuration"
-    )]
     #[must_use]
     pub(crate) fn new(connector: Arc<Connector>, request_timeout: Duration) -> Self {
         Self {
@@ -386,10 +353,6 @@ impl<Connector> HttpRuntimeClient<Connector> {
         }
     }
 
-    #[allow(
-        dead_code,
-        reason = "AL.5--AL.7 own construction from physical connector configuration"
-    )]
     #[tracing::instrument(
         name = "atm_http_runtime.client.execute",
         skip(self, request),
@@ -530,8 +493,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn future_uds_loopback_and_tls_connectors_share_one_write_translation() {
-        for connector_kind in ["uds", "loopback", "tls"] {
+    async fn uds_and_loopback_connectors_share_one_write_translation() {
+        for connector_kind in ["uds", "loopback"] {
             let connector = Arc::new(RecordingConnector::default());
             connector
                 .responses
@@ -608,22 +571,10 @@ mod tests {
     async fn every_named_client_failure_has_stable_code_and_recovery_context() {
         for (cause, failure, code, recovery_fragment) in [
             (
-                "endpoint/DNS resolution",
-                HttpRuntimeClientFailure::EndpointResolution("DNS lookup failed".to_owned()),
-                AtmErrorCode::LocalHttpEndpointMissing,
-                "endpoint",
-            ),
-            (
                 "connect/refusal/network reachability",
                 HttpRuntimeClientFailure::Connect("connection refused".to_owned()),
                 AtmErrorCode::DaemonUnavailable,
                 "connect",
-            ),
-            (
-                "TLS handshake/hostname/mTLS authorization",
-                HttpRuntimeClientFailure::Tls("certificate mismatch".to_owned()),
-                AtmErrorCode::CertificateOperationFailed,
-                "TLS",
             ),
             (
                 "request write",
@@ -636,12 +587,6 @@ mod tests {
                 HttpRuntimeClientFailure::Cancelled,
                 AtmErrorCode::WaitTimeout,
                 "cancelled",
-            ),
-            (
-                "runtime shutdown",
-                HttpRuntimeClientFailure::RuntimeShutdown,
-                AtmErrorCode::DaemonUnavailable,
-                "shut down",
             ),
             (
                 "timeout",

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -69,6 +69,11 @@ use loopback_tcp::{
 #[cfg(unix)]
 use unix_socket::{UnixSocketPathGuard, bind_unix_listener};
 
+/// An aborted Tokio task should stop at its next cancellation point. Keep this
+/// grace deliberately short and fixed so a pathological task cannot extend the
+/// configured shutdown deadline without bound.
+const ABORT_JOIN_GRACE: Duration = Duration::from_millis(100);
+
 pub use client::loopback_tcp_client;
 #[cfg(unix)]
 pub use client::unix_socket_client;
@@ -677,7 +682,8 @@ impl HttpRuntime<Draining> {
     /// Completes the drain transition.
     ///
     /// The runtime waits only for its actual Axum task. A shutdown deadline
-    /// aborts and joins that task so no replacement-runtime task is detached.
+    /// aborts that task and gives cancellation one short, bounded join grace
+    /// before endpoint cleanup proceeds.
     ///
     /// # Errors
     ///
@@ -701,7 +707,15 @@ impl HttpRuntime<Draining> {
             .with_cause(source)),
             Err(_) => {
                 server_task.abort();
-                let _ = server_task.await;
+                if tokio::time::timeout(ABORT_JOIN_GRACE, &mut server_task)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(
+                        abort_join_grace_ms = ABORT_JOIN_GRACE.as_millis(),
+                        "replacement HTTP runtime task exceeded the bounded abort-join grace"
+                    );
+                }
                 Err(AtmError::daemon_unavailable(
                     "replacement HTTP runtime exceeded its shutdown deadline",
                 ))

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -32,7 +32,6 @@
 //! }
 //! ```
 
-#[cfg(unix)]
 use std::future::Future;
 use std::net::SocketAddr;
 use std::num::{NonZeroU32, NonZeroUsize};
@@ -55,6 +54,7 @@ mod http1_server;
 mod loopback_tcp;
 mod message_handler;
 mod private_staging;
+mod runtime_health;
 mod storage_and_nudge_router;
 
 use http1_server::serve_loopback_http1;
@@ -70,8 +70,9 @@ pub use client::loopback_tcp_client;
 pub use client::unix_socket_client;
 pub use loopback_tcp::LoopbackTcpConfig;
 pub use message_handler::{
-    AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
+    AuthenticatedConnector, CanonicalWriteHandler, canonical_api_router, canonical_message_router,
 };
+pub use runtime_health::RuntimeHealth;
 pub use storage_and_nudge_router::StorageAndNudgeRouter;
 
 /// Validated configuration for the maintained Tokio HTTP runtime.
@@ -242,12 +243,25 @@ impl RuntimeTimeouts {
 pub struct HttpRuntimeBuilder {
     config: HttpRuntimeConfig,
     handler: Arc<dyn CanonicalWriteHandler>,
+    health: RuntimeHealth,
 }
 
 impl HttpRuntimeBuilder {
     #[must_use]
     pub fn new(config: HttpRuntimeConfig, handler: Arc<dyn CanonicalWriteHandler>) -> Self {
-        Self { config, handler }
+        Self {
+            config,
+            handler,
+            health: RuntimeHealth::default(),
+        }
+    }
+
+    /// Attaches the one process-owned health projection to lifecycle
+    /// transitions. The caller keeps a clone for the doctor/status route.
+    #[must_use]
+    pub fn with_runtime_health(mut self, health: RuntimeHealth) -> Self {
+        self.health = health;
+        self
     }
 
     /// Validates all runtime-owned input without binding or publishing.
@@ -256,10 +270,14 @@ impl HttpRuntimeBuilder {
     ///
     /// Returns the existing configuration error with the invalid field and cause.
     pub fn build(self) -> Result<HttpRuntime<Configured>, AtmError> {
-        validate_config(&self.config)?;
+        if let Err(error) = validate_config(&self.config) {
+            self.health.mark_not_ready(error.to_string());
+            return Err(error);
+        }
         Ok(HttpRuntime {
             config: self.config,
             handler: self.handler,
+            health: self.health,
             state: Configured,
         })
     }
@@ -271,6 +289,7 @@ pub struct Configured;
 pub struct Running {
     local_address: SocketAddr,
     shutdown_tx: watch::Sender<()>,
+    server_stopped_rx: watch::Receiver<bool>,
     server_task: JoinHandle<std::io::Result<()>>,
     endpoint_record: LoopbackEndpointRecordGuard,
 }
@@ -286,6 +305,7 @@ pub struct Stopped;
 pub struct HttpRuntime<State> {
     config: HttpRuntimeConfig,
     handler: Arc<dyn CanonicalWriteHandler>,
+    health: RuntimeHealth,
     state: State,
 }
 
@@ -303,41 +323,17 @@ impl HttpRuntime<Configured> {
     /// configured Unix socket is bound additively and uses the same router as
     /// the authenticated loopback listener.
     pub async fn start(self) -> Result<HttpRuntime<Running>, AtmError> {
-        let listener = TcpListener::bind(self.config.loopback_tcp.bind_address)
-            .await
-            .map_err(|source| {
-                AtmError::daemon_unavailable(format!(
-                    "failed to bind replacement HTTP runtime at {}",
-                    self.config.loopback_tcp.bind_address
-                ))
-                .with_cause(source)
-            })?;
-        let local_address = listener.local_addr().map_err(|source| {
-            AtmError::daemon_unavailable("failed to read replacement HTTP runtime address")
-                .with_cause(source)
-        })?;
-        if !local_address.ip().is_loopback() {
-            return Err(AtmError::local_http_endpoint_non_loopback(
-                "replacement HTTP runtime bound a non-loopback TCP address",
-            ));
-        }
-        let capability = LocalCapability::generate()?;
-        let endpoint_record = {
-            let config = self.config.loopback_tcp.clone();
-            let capability = capability.clone();
-            tokio::task::spawn_blocking(move || {
-                publish_loopback_endpoint_record(&config, local_address, &capability)
-            })
-            .await
-            .map_err(|source| {
-                AtmError::daemon_unavailable(
-                    "replacement loopback endpoint publication task ended unexpectedly",
-                )
-                .with_cause(source)
-            })??
-        };
+        let (listener, local_address) = bind_loopback_listener(&self.config, &self.health).await?;
+        // Every enabled listener must be bound before publishing the loopback
+        // endpoint record.  Otherwise a client could observe a Ready-looking
+        // record while the additive UDS adapter still fails to start.
+        #[cfg(unix)]
+        let unix_listener = bind_configured_unix_listener(&self.config, &self.health).await?;
+        let (capability, endpoint_record) =
+            publish_loopback_endpoint(&self.config, local_address, &self.health).await?;
         let (shutdown_tx, shutdown_rx) = watch::channel(());
-        let canonical_router = canonical_message_router(
+        let (server_stopped_tx, server_stopped_rx) = watch::channel(false);
+        let canonical_router = canonical_api_router(
             Arc::clone(&self.handler),
             AuthenticatedConnector::local(),
             self.config.limits,
@@ -348,26 +344,33 @@ impl HttpRuntime<Configured> {
             listener,
             loopback_router,
             canonical_router,
-            unix_socket: self.config.unix_socket.clone(),
+            #[cfg(unix)]
+            unix_listener,
             max_connections: self.config.limits.max_connections,
             header_read_timeout: self.config.timeouts.request,
             shutdown_tx: shutdown_tx.clone(),
             shutdown_rx,
+            server_stopped_tx,
+            health: self.health.clone(),
         })
         .await
         {
             Ok(server_task) => server_task,
             Err(error) => {
                 let _ = cleanup_loopback_endpoint_record(endpoint_record).await;
+                self.health.mark_not_ready(error.to_string());
                 return Err(error);
             }
         };
+        self.health.mark_ready();
         Ok(HttpRuntime {
             config: self.config,
             handler: self.handler,
+            health: self.health,
             state: Running {
                 local_address,
                 shutdown_tx,
+                server_stopped_rx,
                 server_task,
                 endpoint_record,
             },
@@ -375,15 +378,136 @@ impl HttpRuntime<Configured> {
     }
 }
 
+async fn bind_loopback_listener(
+    config: &HttpRuntimeConfig,
+    health: &RuntimeHealth,
+) -> Result<(TcpListener, SocketAddr), AtmError> {
+    let listener = TcpListener::bind(config.loopback_tcp.bind_address)
+        .await
+        .map_err(|source| {
+            let error = AtmError::daemon_unavailable(format!(
+                "failed to bind replacement HTTP runtime at {}",
+                config.loopback_tcp.bind_address
+            ))
+            .with_cause(source);
+            health.mark_not_ready(error.to_string());
+            error
+        })?;
+    let local_address = listener.local_addr().map_err(|source| {
+        let error = AtmError::daemon_unavailable("failed to read replacement HTTP runtime address")
+            .with_cause(source);
+        health.mark_not_ready(error.to_string());
+        error
+    })?;
+    if !local_address.ip().is_loopback() {
+        let error = AtmError::local_http_endpoint_non_loopback(
+            "replacement HTTP runtime bound a non-loopback TCP address",
+        );
+        health.mark_not_ready(error.to_string());
+        return Err(error);
+    }
+    Ok((listener, local_address))
+}
+
+#[cfg(unix)]
+async fn bind_configured_unix_listener(
+    config: &HttpRuntimeConfig,
+    health: &RuntimeHealth,
+) -> Result<Option<(UnixListener, UnixSocketPathGuard)>, AtmError> {
+    let Some(socket) = config.unix_socket.clone() else {
+        return Ok(None);
+    };
+    match tokio::task::spawn_blocking(move || bind_unix_listener(&socket)).await {
+        Ok(Ok(listener)) => Ok(Some(listener)),
+        Ok(Err(error)) => {
+            health.mark_not_ready(error.to_string());
+            Err(error)
+        }
+        Err(source) => {
+            let error = AtmError::daemon_unavailable(
+                "replacement Unix HTTP socket setup task ended unexpectedly",
+            )
+            .with_cause(source);
+            health.mark_not_ready(error.to_string());
+            Err(error)
+        }
+    }
+}
+
+async fn publish_loopback_endpoint(
+    config: &HttpRuntimeConfig,
+    local_address: SocketAddr,
+    health: &RuntimeHealth,
+) -> Result<(LocalCapability, LoopbackEndpointRecordGuard), AtmError> {
+    let capability = LocalCapability::generate()
+        .inspect_err(|error| health.mark_not_ready(error.to_string()))?;
+    let record_config = config.loopback_tcp.clone();
+    let record_capability = capability.clone();
+    let publication = tokio::task::spawn_blocking(move || {
+        publish_loopback_endpoint_record(&record_config, local_address, &record_capability)
+    })
+    .await
+    .map_err(|source| {
+        let error = AtmError::daemon_unavailable(
+            "replacement loopback endpoint publication task ended unexpectedly",
+        )
+        .with_cause(source);
+        health.mark_not_ready(error.to_string());
+        error
+    })?;
+    let endpoint_record =
+        publication.inspect_err(|error| health.mark_not_ready(error.to_string()))?;
+    Ok((capability, endpoint_record))
+}
+
 struct ServerTaskInputs {
     listener: TcpListener,
     loopback_router: axum::Router,
     canonical_router: axum::Router,
-    unix_socket: Option<UnixSocketConfig>,
+    #[cfg(unix)]
+    unix_listener: Option<(UnixListener, UnixSocketPathGuard)>,
     max_connections: usize,
     header_read_timeout: Duration,
     shutdown_tx: watch::Sender<()>,
     shutdown_rx: watch::Receiver<()>,
+    server_stopped_tx: watch::Sender<bool>,
+    health: RuntimeHealth,
+}
+
+/// Marks the process-owned status projection when the one managed server task
+/// leaves supervision, including task cancellation. The bootstrap observes the
+/// paired watch receiver and exits through the normal endpoint-cleanup path.
+struct ServerTaskTerminationGuard {
+    health: RuntimeHealth,
+    server_stopped_tx: watch::Sender<bool>,
+}
+
+impl Drop for ServerTaskTerminationGuard {
+    fn drop(&mut self) {
+        self.health
+            .mark_not_ready("replacement HTTP runtime server task stopped");
+        let _ = self.server_stopped_tx.send(true);
+    }
+}
+
+fn spawn_supervised_server<F>(
+    health: RuntimeHealth,
+    server_stopped_tx: watch::Sender<bool>,
+    server: F,
+) -> JoinHandle<std::io::Result<()>>
+where
+    F: Future<Output = std::io::Result<()>> + Send + 'static,
+{
+    // Construct the guard before spawning: an abort that wins before Tokio
+    // first polls the task still drops this captured value and revokes Ready.
+    let termination = ServerTaskTerminationGuard {
+        health,
+        server_stopped_tx,
+    };
+    tokio::spawn(async move {
+        let _termination = termination;
+        server.await
+    })
 }
 
 #[cfg(unix)]
@@ -394,30 +518,19 @@ async fn start_server_task(
         listener,
         loopback_router,
         canonical_router,
-        unix_socket,
+        unix_listener,
         max_connections,
         header_read_timeout,
         shutdown_tx,
         shutdown_rx,
+        server_stopped_tx,
+        health,
     } = inputs;
-    let unix_listener = match unix_socket {
-        Some(socket) => Some(
-            tokio::task::spawn_blocking(move || bind_unix_listener(&socket))
-                .await
-                .map_err(|source| {
-                    AtmError::daemon_unavailable(
-                        "replacement Unix HTTP socket setup task ended unexpectedly",
-                    )
-                    .with_cause(source)
-                })??,
-        ),
-        None => None,
-    };
     Ok(
         if let Some((unix_listener, socket_cleanup)) = unix_listener {
             let tcp_shutdown = shutdown_rx.clone();
             let tcp_router = loopback_router;
-            tokio::spawn(async move {
+            spawn_supervised_server(health, server_stopped_tx, async move {
                 // The guard owns cleanup for precisely the inode bound by this
                 // runtime. It cannot unlink a replacement socket.
                 let _socket_cleanup = socket_cleanup;
@@ -447,7 +560,7 @@ async fn start_server_task(
                 .await
             })
         } else {
-            tokio::spawn(async move {
+            spawn_supervised_server(health, server_stopped_tx, async move {
                 serve_loopback_http1(
                     listener,
                     loopback_router,
@@ -469,22 +582,27 @@ async fn start_server_task(
         listener,
         loopback_router,
         canonical_router: _,
-        unix_socket: _,
         max_connections,
         header_read_timeout,
         shutdown_tx: _,
         shutdown_rx,
+        server_stopped_tx,
+        health,
     } = inputs;
-    Ok(tokio::spawn(async move {
-        serve_loopback_http1(
-            listener,
-            loopback_router,
-            max_connections,
-            header_read_timeout,
-            shutdown_rx,
-        )
-        .await
-    }))
+    Ok(spawn_supervised_server(
+        health,
+        server_stopped_tx,
+        async move {
+            serve_loopback_http1(
+                listener,
+                loopback_router,
+                max_connections,
+                header_read_timeout,
+                shutdown_rx,
+            )
+            .await
+        },
+    ))
 }
 
 /// Joins the additive physical listeners without abandoning a healthy sibling
@@ -769,13 +887,28 @@ impl HttpRuntime<Running> {
         self.state.local_address
     }
 
+    /// Waits until the one framework-managed server task has stopped.
+    ///
+    /// The running owner remains usable for the normal consuming shutdown
+    /// transition afterwards, which performs endpoint-record cleanup and joins
+    /// the already-completed task. This is used by process composition to
+    /// avoid advertising a live daemon after its only server exits.
+    pub async fn wait_for_server_stop(&mut self) {
+        if *self.state.server_stopped_rx.borrow() {
+            return;
+        }
+        let _ = self.state.server_stopped_rx.changed().await;
+    }
+
     /// Consumes the only running owner and begins the drain transition.
     #[must_use]
     pub fn begin_shutdown(self) -> HttpRuntime<Draining> {
         let _ = self.state.shutdown_tx.send(());
+        self.health.begin_drain();
         HttpRuntime {
             config: self.config,
             handler: self.handler,
+            health: self.health,
             state: Draining {
                 server_task: self.state.server_task,
                 endpoint_record: self.state.endpoint_record,
@@ -819,11 +952,13 @@ impl HttpRuntime<Draining> {
             }
         };
         let cleanup_result = cleanup_loopback_endpoint_record(endpoint_record).await;
-        server_result?;
-        cleanup_result?;
+        let result = server_result.and(cleanup_result);
+        self.health.mark_stopped();
+        result?;
         Ok(HttpRuntime {
             config: self.config,
             handler: self.handler,
+            health: self.health,
             state: Stopped,
         })
     }
@@ -892,15 +1027,15 @@ mod tests {
     use atm_core::error::AtmError;
     use atm_core::home::HOST_RUNTIME_OWNER_LOCK_FILE;
     use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
-    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, RuntimeReadinessState};
     use atm_core::send::{SendMessageSource, SendRequest};
     use atm_core::test_support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
     use atm_core::types::{AgentName, TeamName};
 
     use super::{
         CanonicalWriteHandler, HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig,
-        NonZeroDuration, RuntimeLimits, RuntimeTimeouts, UnixSocketConfig, UnixSocketMode,
-        UnixSocketOwnerUid,
+        NonZeroDuration, RuntimeHealth, RuntimeLimits, RuntimeTimeouts, UnixSocketConfig,
+        UnixSocketMode, UnixSocketOwnerUid,
     };
     use ulid::Ulid;
 
@@ -1166,10 +1301,12 @@ mod tests {
 
     #[test]
     fn invalid_configuration_fails_before_lifecycle_start() {
+        let health = RuntimeHealth::with_owner(99);
         let error = match HttpRuntimeBuilder::new(
             config_with_record(0, std::path::PathBuf::new()),
             Arc::new(TestRouter),
         )
+        .with_runtime_health(health.clone())
         .build()
         {
             Ok(_) => panic!("invalid bind configuration must fail before any listener exists"),
@@ -1184,6 +1321,11 @@ mod tests {
         );
         assert!(!error.message().contains("reinstall/restart daemon"));
         assert_eq!(error.cause(), Some("must not be empty"));
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable,
+            "invalid configuration never reports Ready"
+        );
     }
 
     #[test]
@@ -1219,6 +1361,47 @@ mod tests {
         assert!(NonZeroUsize::new(0).is_none());
         assert!(NonZeroU32::new(0).is_none());
         assert!(NonZeroDuration::new(Duration::ZERO).is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_health_becomes_ready_only_after_all_enabled_binds_and_not_ready_during_drain()
+    {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let record_path = temporary_directory.path().join("local-http.json");
+        let instance_id = Ulid::new();
+        write_owner_record(&record_path, instance_id);
+        let health = RuntimeHealth::with_owner(99);
+        let configured = HttpRuntimeBuilder::new(
+            loopback_runtime_config(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                record_path,
+                instance_id,
+                None,
+                1024,
+            ),
+            Arc::new(TestRouter),
+        )
+        .with_runtime_health(health.clone())
+        .build()
+        .expect("valid runtime configuration");
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
+        );
+
+        let running = configured.start().await.expect("all listeners bind");
+        assert_eq!(health.snapshot().readiness, RuntimeReadinessState::Ready);
+
+        let draining = running.begin_shutdown();
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
+        );
+        draining.finish().await.expect("runtime drains");
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
+        );
     }
 
     #[cfg(unix)]
@@ -1496,6 +1679,8 @@ mod tests {
         let socket_path = temporary_directory.path().join("atm-http-runtime.sock");
         let actual_owner = owner_uid(temporary_directory.path()).get();
         let configured_owner = if actual_owner == 1 { 2 } else { 1 };
+        let health = RuntimeHealth::with_owner(99);
+        let record_path = socket_path.with_file_name("local-http.json");
         let configured = HttpRuntimeBuilder::new(
             uds_config(
                 socket_path.clone(),
@@ -1503,6 +1688,7 @@ mod tests {
             ),
             Arc::new(CanonicalUdsRouter),
         )
+        .with_runtime_health(health.clone())
         .build()
         .expect("configuration shape is valid before bind ownership check");
 
@@ -1515,6 +1701,14 @@ mod tests {
         assert!(
             !socket_path.exists(),
             "failed UDS startup must not leave a reachable endpoint"
+        );
+        assert!(
+            !record_path.exists(),
+            "the loopback record is not published before every enabled listener binds"
+        );
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
         );
     }
 
@@ -1607,6 +1801,43 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_unexpected_server_task_exit_revokes_readiness_and_cleans_the_endpoint() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let endpoint_record = temporary_directory.path().join("local-http.json");
+        let health = RuntimeHealth::with_owner(99);
+        let mut running = HttpRuntimeBuilder::new(
+            config_with_record(0, endpoint_record.clone()),
+            Arc::new(TestRouter),
+        )
+        .with_runtime_health(health.clone())
+        .build()
+        .expect("valid configuration")
+        .start()
+        .await
+        .expect("runtime starts");
+
+        running.state.server_task.abort();
+        tokio::time::timeout(Duration::from_secs(1), running.wait_for_server_stop())
+            .await
+            .expect("supervision observes the stopped server task");
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable,
+            "a daemon without its server is never Ready"
+        );
+
+        let error = match running.begin_shutdown().finish().await {
+            Ok(_) => panic!("an aborted server task reports a typed runtime failure"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code().as_str(), "ATM_DAEMON_UNAVAILABLE");
+        assert!(
+            !endpoint_record.exists(),
+            "the normal drain cleanup removes the stale endpoint record"
+        );
+    }
+
     #[cfg(not(unix))]
     #[test]
     fn unix_socket_configuration_is_rejected_on_non_unix_targets() {
@@ -1678,7 +1909,10 @@ mod tests {
             .send()
             .await
             .expect("replacement server responds");
-        assert_eq!(response.status(), reqwest::StatusCode::METHOD_NOT_ALLOWED);
+        // `GET /messages` is a retained core route. An empty request body is
+        // therefore a typed request-validation failure, rather than proof
+        // that the replacement exposed only the old write route.
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
         running
             .begin_shutdown()
             .finish()

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -2228,6 +2228,58 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn loopback_shutdown_deadline_aborts_an_in_flight_request_and_cleans_up() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let record_path = temporary_directory.path().join("local-http.json");
+        let instance_id = Ulid::new();
+        write_owner_record(&record_path, instance_id);
+        let handler = Arc::new(CountingLoopbackRouter::new());
+        let configured = HttpRuntimeBuilder::new(
+            HttpRuntimeConfig::new(
+                loopback_tcp_with_instance(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    record_path.clone(),
+                    instance_id,
+                ),
+                None,
+                limits(1024, 8),
+                timeouts(Duration::from_secs(1), Duration::from_millis(1)),
+            ),
+            handler.clone(),
+        )
+        .build()
+        .expect("valid short-shutdown runtime configuration");
+        let running = configured.start().await.expect("loopback runtime starts");
+        let client = super::loopback_tcp_client(&record_path, Duration::from_secs(1))
+            .expect("shared loopback client");
+        let request =
+            tokio::spawn(async move { client.execute(ApiRequest::new(write_request())).await });
+
+        handler.wait_until_entered().await;
+        let shutdown =
+            tokio::time::timeout(Duration::from_secs(1), running.begin_shutdown().finish())
+                .await
+                .expect("forced-abort shutdown completes within a bounded test window");
+        let error = match shutdown {
+            Ok(_) => panic!("an in-flight request exceeds the configured shutdown deadline"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code().as_str(), "ATM_DAEMON_UNAVAILABLE");
+        assert!(
+            !record_path.exists(),
+            "forced abort removes the endpoint record after owning the server task"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), request)
+                .await
+                .expect("aborted request task joins")
+                .expect("request task itself joins")
+                .is_err(),
+            "the aborted in-flight request cannot report a successful response"
+        );
+    }
+
     #[cfg(windows)]
     #[tokio::test(flavor = "current_thread")]
     async fn windows_loopback_fixture_uses_the_same_capability_authenticated_route() {

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -56,6 +56,8 @@ mod message_handler;
 mod private_staging;
 mod runtime_health;
 mod storage_and_nudge_router;
+#[cfg(unix)]
+mod unix_socket;
 
 use http1_server::serve_loopback_http1;
 #[cfg(unix)]
@@ -64,6 +66,8 @@ use loopback_tcp::{
     LoopbackEndpointRecordGuard, authenticated_loopback_router, cleanup_loopback_endpoint_record,
     publish_loopback_endpoint_record, validate_loopback_config,
 };
+#[cfg(unix)]
+use unix_socket::{UnixSocketPathGuard, bind_unix_listener};
 
 pub use client::loopback_tcp_client;
 #[cfg(unix)]
@@ -628,254 +632,6 @@ where
         unix_result = &mut unix_server => {
             let _ = shutdown_tx.send(());
             unix_result.and(tcp_server.await)
-        }
-    }
-}
-
-#[cfg(unix)]
-fn bind_unix_listener(
-    socket: &UnixSocketConfig,
-) -> Result<(UnixListener, UnixSocketPathGuard), AtmError> {
-    let parent = validate_unix_socket_parent(socket)?;
-    ensure_unix_socket_path_unoccupied(&socket.path)?;
-    let (listener, staging) = bind_prepared_unix_socket(socket, parent)?;
-    publish_prepared_unix_socket(socket, staging)?;
-    let cleanup = UnixSocketPathGuard::capture(&socket.path).inspect_err(|_| {
-        let _ = std::fs::remove_file(&socket.path);
-    })?;
-    Ok((listener, cleanup))
-}
-
-#[cfg(unix)]
-fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmError> {
-    use std::fs;
-    use std::os::unix::fs::MetadataExt;
-
-    let parent = socket
-        .path
-        .parent()
-        .filter(|path| !path.as_os_str().is_empty())
-        .ok_or_else(|| {
-            AtmError::config("Unix HTTP socket path must have an owner-controlled parent")
-        })?;
-    let metadata = fs::metadata(parent).map_err(|source| {
-        AtmError::config("cannot inspect Unix HTTP socket parent directory").with_cause(source)
-    })?;
-    if metadata.uid() != socket.owner_uid.get() {
-        return Err(
-            AtmError::config("Unix HTTP socket parent owner does not match configuration")
-                .with_cause(format!(
-                    "configured uid {} but parent `{}` is owned by uid {}",
-                    socket.owner_uid.get(),
-                    parent.display(),
-                    metadata.uid()
-                )),
-        );
-    }
-    if metadata.mode() & 0o022 != 0 {
-        return Err(
-            AtmError::config("Unix HTTP socket parent must not be writable by others").with_cause(
-                format!(
-                    "parent `{}` mode {:o} permits group or other writes",
-                    parent.display(),
-                    metadata.mode() & 0o777
-                ),
-            ),
-        );
-    }
-    Ok(parent)
-}
-
-#[cfg(unix)]
-fn ensure_unix_socket_path_unoccupied(path: &Path) -> Result<(), AtmError> {
-    use std::fs;
-    use std::io::ErrorKind;
-
-    match fs::symlink_metadata(path) {
-        Ok(_) => Err(AtmError::config("Unix HTTP socket path is already occupied").with_cause(
-            format!(
-                "refusing to replace existing path `{}`; remove only the stale owner-owned socket before retrying",
-                path.display()
-            ),
-        )),
-        Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
-        Err(source) => {
-            Err(AtmError::config("cannot inspect Unix HTTP socket path").with_cause(source))
-        }
-    }
-}
-
-#[cfg(unix)]
-fn bind_prepared_unix_socket(
-    socket: &UnixSocketConfig,
-    parent: &Path,
-) -> Result<(UnixListener, PrivateStagingDirectory), AtmError> {
-    use std::fs;
-    use std::os::unix::fs::PermissionsExt;
-
-    // Bind below a newly-created `0700` staging directory. The socket cannot
-    // be connected before its final owner-only mode is verified and atomically
-    // published, without changing the process-global umask.
-    let staging = PrivateStagingDirectory::create(parent)?;
-    let staged_path = staging.path().join("listener.sock");
-    let listener = UnixListener::bind(&staged_path).map_err(|source| {
-        AtmError::daemon_unavailable("failed to bind replacement Unix HTTP socket")
-            .with_cause(source)
-    })?;
-    fs::set_permissions(&staged_path, fs::Permissions::from_mode(socket.mode.get())).map_err(
-        |source| {
-            AtmError::daemon_unavailable("failed to set replacement Unix HTTP socket permissions")
-                .with_cause(source)
-        },
-    )?;
-    verify_prepared_unix_socket(socket, &staged_path)?;
-    Ok((listener, staging))
-}
-
-#[cfg(unix)]
-fn verify_prepared_unix_socket(socket: &UnixSocketConfig, path: &Path) -> Result<(), AtmError> {
-    use std::fs;
-    use std::os::unix::fs::MetadataExt;
-
-    let metadata = fs::metadata(path).map_err(|source| {
-        AtmError::daemon_unavailable("failed to inspect replacement Unix HTTP socket permissions")
-            .with_cause(source)
-    })?;
-    if metadata.uid() != socket.owner_uid.get() {
-        return Err(AtmError::config(
-            "replacement Unix HTTP socket owner does not match configuration",
-        )
-        .with_cause(format!(
-            "configured uid {} but bound socket is owned by uid {}",
-            socket.owner_uid.get(),
-            metadata.uid()
-        )));
-    }
-    if metadata.mode() & 0o777 != socket.mode.get() {
-        return Err(AtmError::config(
-            "replacement Unix HTTP socket permissions do not match configuration",
-        )
-        .with_cause(format!(
-            "configured mode {:o} but bound socket mode is {:o}",
-            socket.mode.get(),
-            metadata.mode() & 0o777
-        )));
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn publish_prepared_unix_socket(
-    socket: &UnixSocketConfig,
-    staging: PrivateStagingDirectory,
-) -> Result<(), AtmError> {
-    let staged_path = staging.path().join("listener.sock");
-    std::fs::rename(&staged_path, &socket.path).map_err(|source| {
-        AtmError::daemon_unavailable("failed to publish replacement Unix HTTP socket")
-            .with_cause(source)
-    })
-}
-
-/// Owner-checked, uniquely named staging directory used only until an already
-/// permissioned UDS inode is atomically published at its configured path.
-#[cfg(unix)]
-#[derive(Debug)]
-struct PrivateStagingDirectory {
-    path: PathBuf,
-    device: u64,
-    inode: u64,
-}
-
-#[cfg(unix)]
-impl PrivateStagingDirectory {
-    fn create(parent: &Path) -> Result<Self, AtmError> {
-        use std::fs;
-        use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
-
-        let (path, ()) = crate::private_staging::allocate(parent, "uds", |path| {
-            fs::DirBuilder::new().mode(0o700).create(path)
-        })
-        .map_err(|source| {
-            AtmError::daemon_unavailable(
-                "failed to create private Unix HTTP socket staging directory",
-            )
-            .with_cause(source)
-        })?;
-        if let Err(source) = fs::set_permissions(&path, fs::Permissions::from_mode(0o700)) {
-            let _ = fs::remove_dir(&path);
-            return Err(AtmError::daemon_unavailable(
-                "failed to protect Unix HTTP socket staging directory",
-            )
-            .with_cause(source));
-        }
-        let metadata = fs::metadata(&path).map_err(|source| {
-            let _ = fs::remove_dir(&path);
-            AtmError::daemon_unavailable("failed to inspect Unix HTTP socket staging directory")
-                .with_cause(source)
-        })?;
-        Ok(Self {
-            path,
-            device: metadata.dev(),
-            inode: metadata.ino(),
-        })
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-#[cfg(unix)]
-impl Drop for PrivateStagingDirectory {
-    fn drop(&mut self) {
-        use std::fs;
-        use std::os::unix::fs::MetadataExt;
-
-        let is_our_directory = fs::metadata(&self.path)
-            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode);
-        if is_our_directory {
-            let _ = fs::remove_dir_all(&self.path);
-        }
-    }
-}
-
-/// Removes only the socket inode created by this runtime during shutdown.
-#[cfg(unix)]
-#[derive(Debug)]
-struct UnixSocketPathGuard {
-    path: PathBuf,
-    device: u64,
-    inode: u64,
-}
-
-#[cfg(unix)]
-impl UnixSocketPathGuard {
-    fn capture(path: &std::path::Path) -> Result<Self, AtmError> {
-        use std::fs;
-        use std::os::unix::fs::MetadataExt;
-
-        let metadata = fs::metadata(path).map_err(|source| {
-            AtmError::daemon_unavailable("failed to inspect bound Unix HTTP socket")
-                .with_cause(source)
-        })?;
-        Ok(Self {
-            path: path.to_path_buf(),
-            device: metadata.dev(),
-            inode: metadata.ino(),
-        })
-    }
-}
-
-#[cfg(unix)]
-impl Drop for UnixSocketPathGuard {
-    fn drop(&mut self) {
-        use std::fs;
-        use std::os::unix::fs::MetadataExt;
-
-        let is_our_socket = fs::metadata(&self.path)
-            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode);
-        if is_our_socket {
-            let _ = fs::remove_file(&self.path);
         }
     }
 }
@@ -1752,7 +1508,7 @@ mod tests {
         use std::os::unix::fs::MetadataExt;
 
         let parent = tempfile::tempdir().expect("temporary staging parent");
-        let staging = super::PrivateStagingDirectory::create(parent.path())
+        let staging = super::unix_socket::PrivateStagingDirectory::create(parent.path())
             .expect("allocate private staging directory");
         let path = staging.path().to_path_buf();
         let metadata = std::fs::metadata(&path).expect("staging directory metadata");

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -172,13 +172,6 @@ impl UnixSocketConfig {
 #[derive(Debug, Clone, Copy)]
 pub struct UnixSocketOwnerUid(NonZeroU32);
 
-#[cfg_attr(
-    not(unix),
-    expect(
-        dead_code,
-        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; ownership application is Unix-only"
-    )
-)]
 impl UnixSocketOwnerUid {
     #[must_use]
     pub const fn new(value: NonZeroU32) -> Self {
@@ -186,6 +179,7 @@ impl UnixSocketOwnerUid {
     }
 
     #[must_use]
+    #[cfg(unix)]
     const fn get(self) -> u32 {
         self.0.get()
     }
@@ -202,13 +196,6 @@ impl UnixSocketOwnerUid {
 #[derive(Debug, Clone, Copy)]
 pub struct UnixSocketMode(NonZeroU32);
 
-#[cfg_attr(
-    not(unix),
-    expect(
-        dead_code,
-        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; permission application is Unix-only"
-    )
-)]
 impl UnixSocketMode {
     #[must_use]
     pub const fn new(value: NonZeroU32) -> Self {
@@ -216,6 +203,7 @@ impl UnixSocketMode {
     }
 
     #[must_use]
+    #[cfg(unix)]
     const fn get(self) -> u32 {
         self.0.get()
     }
@@ -380,11 +368,13 @@ impl HttpRuntime<Configured> {
         let server_task = match start_server_task(ServerTaskInputs {
             listener,
             loopback_router,
+            #[cfg(unix)]
             canonical_router,
             #[cfg(unix)]
             unix_listener,
             max_connections: self.config.limits.max_connections,
             header_read_timeout: self.config.timeouts.request,
+            #[cfg(unix)]
             shutdown_tx: shutdown_tx.clone(),
             shutdown_rx,
             server_stopped_tx,
@@ -500,11 +490,13 @@ async fn publish_loopback_endpoint(
 struct ServerTaskInputs {
     listener: TcpListener,
     loopback_router: axum::Router,
+    #[cfg(unix)]
     canonical_router: axum::Router,
     #[cfg(unix)]
     unix_listener: Option<(UnixListener, UnixSocketPathGuard)>,
     max_connections: usize,
     header_read_timeout: Duration,
+    #[cfg(unix)]
     shutdown_tx: watch::Sender<()>,
     shutdown_rx: watch::Receiver<()>,
     server_stopped_tx: watch::Sender<bool>,
@@ -618,10 +610,8 @@ async fn start_server_task(
     let ServerTaskInputs {
         listener,
         loopback_router,
-        canonical_router: _,
         max_connections,
         header_read_timeout,
-        shutdown_tx: _,
         shutdown_rx,
         server_stopped_tx,
         health,

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -162,9 +162,23 @@ impl UnixSocketConfig {
 
 /// Validated Unix socket owner identity, kept distinct from its mode so
 /// composition cannot accidentally swap two numeric configuration values.
+#[cfg_attr(
+    not(unix),
+    expect(
+        dead_code,
+        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; ownership application is Unix-only"
+    )
+)]
 #[derive(Debug, Clone, Copy)]
 pub struct UnixSocketOwnerUid(NonZeroU32);
 
+#[cfg_attr(
+    not(unix),
+    expect(
+        dead_code,
+        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; ownership application is Unix-only"
+    )
+)]
 impl UnixSocketOwnerUid {
     #[must_use]
     pub const fn new(value: NonZeroU32) -> Self {
@@ -178,9 +192,23 @@ impl UnixSocketOwnerUid {
 }
 
 /// Configured Unix socket permission bits, distinct from the owner identity.
+#[cfg_attr(
+    not(unix),
+    expect(
+        dead_code,
+        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; permission application is Unix-only"
+    )
+)]
 #[derive(Debug, Clone, Copy)]
 pub struct UnixSocketMode(NonZeroU32);
 
+#[cfg_attr(
+    not(unix),
+    expect(
+        dead_code,
+        reason = "AL.5 retains Unix socket configuration for cross-platform decoding; permission application is Unix-only"
+    )
+)]
 impl UnixSocketMode {
     #[must_use]
     pub const fn new(value: NonZeroU32) -> Self {

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -9,20 +9,21 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use atm_core::api::{
-    ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline, http_route_surface,
+    ApiRequest, ApiResponse, AuthenticatedIngress, CLEAR_OUTCOME_HEADER, HttpRequest,
+    PEER_SOURCE_HOST_HEADER, RequestDeadline, decode_request, http_route_surface,
 };
 use atm_core::error::AtmError;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
 use atm_core::send::WriteRequest;
 use atm_core::types::HostName;
-use axum::body::Body;
+use axum::body::{Body, Bytes};
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::header::{CONTENT_TYPE, LOCATION};
-use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use axum::response::Response;
-use axum::routing::post;
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::Serialize;
 use tower::BoxError;
@@ -49,6 +50,29 @@ pub trait CanonicalWriteHandler: atm_core::boundary::sealed::Sealed + Send + Syn
         ingress: AuthenticatedIngress,
         deadline: RequestDeadline,
     ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>>;
+
+    /// Dispatches a route decoded by the core-owned HTTP codec.
+    ///
+    /// Existing focused write implementations retain the default, which keeps
+    /// the AL.2 write-only router useful in unit tests. The production
+    /// replacement composition overrides this method so every retained route
+    /// reaches one framework router without falling back to the frozen daemon.
+    fn dispatch(
+        &self,
+        request: ApiRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        match request {
+            ApiRequest::Write(request) => self.write(*request, ingress, deadline),
+            request => Box::pin(async move {
+                Err(AtmError::validation(format!(
+                    "replacement HTTP route is not implemented for {:?}",
+                    request.into_inner()
+                )))
+            }),
+        }
+    }
 }
 
 /// Provenance established by the transport adapter after authentication.
@@ -90,6 +114,16 @@ impl AuthenticatedConnector {
             }
         }
     }
+
+    fn normalize_request(&self, request: &mut ApiRequest) -> AuthenticatedIngress {
+        match request {
+            ApiRequest::Write(write) => self.normalize_write(write),
+            _ => match self {
+                Self::Local => AuthenticatedIngress::Local,
+                Self::Peer { .. } => AuthenticatedIngress::Peer,
+            },
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -125,6 +159,47 @@ pub fn canonical_message_router(
     Router::new()
         .route(canonical_write_path(), post(post_messages).layer(admission))
         .layer(DefaultBodyLimit::max(limits.max_body_bytes))
+        .with_state(state)
+}
+
+/// Builds the production framework router for the complete retained core HTTP
+/// route surface. Each route is registered from [`http_route_surface`] and is
+/// decoded by `atm_core::api::decode_request`, so the loopback and UDS
+/// connectors share the exact route/body contract with their clients.
+///
+/// This is deliberately distinct from [`canonical_message_router`]: focused
+/// AL.2 tests can exercise the typed write handler alone, while the active
+/// daemon must expose every retained contract route through this one Axum
+/// router. It never invokes the frozen daemon dispatcher.
+pub fn canonical_api_router(
+    handler: Arc<dyn CanonicalWriteHandler>,
+    connector: AuthenticatedConnector,
+    limits: RuntimeLimits,
+    timeouts: RuntimeTimeouts,
+) -> Router {
+    let state = MessageRouteState {
+        handler,
+        connector,
+        request_timeout: timeouts.request,
+    };
+    let admission = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|error: BoxError| async move {
+            overload_response(error).await
+        }))
+        .layer(LoadShedLayer::new())
+        .layer(ConcurrencyLimitLayer::new(limits.max_connections));
+
+    http_route_surface()
+        .fold(
+            Router::new().layer(DefaultBodyLimit::max(limits.max_body_bytes)),
+            |router, route| match route.method {
+                "GET" => router.route(route.path_template, get(dispatch_request)),
+                "POST" => router.route(route.path_template, post(dispatch_request)),
+                "DELETE" => router.route(route.path_template, delete(dispatch_request)),
+                method => panic!("core HTTP route surface has unsupported method {method}"),
+            },
+        )
+        .route_layer(admission)
         .with_state(state)
 }
 
@@ -167,6 +242,52 @@ async fn post_messages(
         .unwrap_or_else(error_response)
 }
 
+async fn dispatch_request(
+    State(state): State<MessageRouteState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(error) = validate_request_headers(&headers) {
+        return error_response(error);
+    }
+    let headers = match canonical_headers(&headers) {
+        Ok(headers) => headers,
+        Err(error) => return error_response(error),
+    };
+    let mut request = match decode_request(HttpRequest {
+        method: method.as_str().to_owned(),
+        path: uri.path().to_owned(),
+        headers,
+        body: body.to_vec(),
+    }) {
+        Ok(request) => request,
+        Err(error) => return error_response(error),
+    };
+    let ingress = state.connector.normalize_request(&mut request);
+    let deadline = RequestDeadline::after(state.request_timeout);
+    state
+        .handler
+        .dispatch(request, ingress, deadline)
+        .await
+        .and_then(map_api_response)
+        .unwrap_or_else(error_response)
+}
+
+fn canonical_headers(headers: &HeaderMap) -> Result<Vec<String>, AtmError> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let value = value.to_str().map_err(|source| {
+                AtmError::validation("canonical HTTP request contains a non-text header value")
+                    .with_cause(source)
+            })?;
+            Ok(format!("{name}: {value}"))
+        })
+        .collect()
+}
+
 fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
     if headers.contains_key(PEER_SOURCE_HOST_HEADER) {
         return Err(AtmError::validation(format!(
@@ -204,6 +325,50 @@ fn map_write_response(response: ApiResponse) -> Result<Response, AtmError> {
             "canonical message route received a non-write application response",
         )),
     }
+}
+
+fn map_api_response(response: ApiResponse) -> Result<Response, AtmError> {
+    match response.into_inner() {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => json_response(
+            StatusCode::CREATED,
+            &outcome,
+            Some(outcome.message_id.to_string()),
+        ),
+        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => json_response(
+            StatusCode::CREATED,
+            &outcome,
+            Some(outcome.message_id.to_string()),
+        ),
+        ResponseEnvelope::CompatibilityVerdict(value) => {
+            json_response(StatusCode::OK, &value, None)
+        }
+        ResponseEnvelope::Heartbeat(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::List(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::Peek(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::Receive(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::Clear(value) => clear_response(&value),
+        ResponseEnvelope::Doctor(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::RuntimeViewReloaded => json_response(StatusCode::OK, &(), None),
+        ResponseEnvelope::Error(error) => Ok(error_response(error)),
+    }
+}
+
+fn clear_response(outcome: &atm_core::clear::ClearOutcome) -> Result<Response, AtmError> {
+    use base64::Engine as _;
+
+    let encoded = serde_json::to_vec(outcome).map_err(AtmError::from)?;
+    let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(encoded);
+    let header = HeaderValue::from_str(&header).map_err(|source| {
+        AtmError::new(
+            atm_core::error::AtmErrorCode::SerializationFailed,
+            "failed to serialize canonical clear outcome header",
+        )
+        .with_cause(source)
+    })?;
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    response.headers_mut().insert(CLEAR_OUTCOME_HEADER, header);
+    Ok(response)
 }
 
 pub(crate) fn error_response(error: AtmError) -> Response {
@@ -272,8 +437,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        AuthenticatedConnector, CanonicalWriteHandler, canonical_message_router,
-        canonical_write_path, json_response, map_write_response,
+        AuthenticatedConnector, CanonicalWriteHandler, canonical_api_router,
+        canonical_message_router, canonical_write_path, json_response, map_write_response,
     };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
@@ -534,6 +699,48 @@ mod tests {
             Some("trusted.example.test".parse().expect("host"))
         );
         assert_eq!(peer_calls[0].1, AuthenticatedIngress::Peer);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn production_router_registers_every_route_from_the_core_contract() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let app = canonical_api_router(
+            Arc::new(RecordingRouter {
+                response: sent_response(),
+                calls,
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 2),
+            timeouts(),
+        );
+
+        for route in atm_core::api::http_route_surface() {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(route.method)
+                        .uri(route.path_template)
+                        .body(Body::empty())
+                        .expect("core route request"),
+                )
+                .await
+                .expect("infallible Axum service");
+            assert_ne!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{} {} must be registered by the production router",
+                route.method,
+                route.path_template
+            );
+            assert_ne!(
+                response.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{} {} must retain its core method",
+                route.method,
+                route.path_template
+            );
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-http-runtime/src/runtime_health.rs
+++ b/crates/atm-http-runtime/src/runtime_health.rs
@@ -1,0 +1,272 @@
+//! In-memory lifecycle and heartbeat projection for the replacement runtime.
+//!
+//! This is intentionally small: it retains no listener, storage, or harness
+//! implementation.  Listener lifecycle drives readiness; authenticated local
+//! heartbeats only enrich the existing doctor/status payload.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use atm_core::protocol::{
+    HeartbeatActivity, RuntimeLivenessState, RuntimeMemberObservation, RuntimeMemberState,
+    RuntimeObservationSource, RuntimeReadinessState, RuntimeStatusCounts, RuntimeStatusSnapshot,
+    TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
+};
+use atm_core::types::{AgentName, IsoTimestamp, SessionId, TeamName};
+
+/// The bounded runtime-member projection is observability, not durable state.
+pub const MAX_RUNTIME_STATUS_MEMBERS: usize = 4096;
+
+#[derive(Clone, Default)]
+pub struct RuntimeHealth {
+    inner: Arc<Mutex<RuntimeHealthState>>,
+}
+
+#[derive(Default)]
+struct RuntimeHealthState {
+    lifecycle: Lifecycle,
+    detail: Option<String>,
+    owner_pid: Option<u32>,
+    members: HashMap<MemberKey, MemberRecord>,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum Lifecycle {
+    #[default]
+    NotReady,
+    Ready,
+    Draining,
+    Stopped,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct MemberKey {
+    team: TeamName,
+    member: AgentName,
+}
+
+#[derive(Clone)]
+struct MemberRecord {
+    pid: Option<u32>,
+    session_id: Option<SessionId>,
+    state: RuntimeMemberState,
+    last_active_at: Option<IsoTimestamp>,
+    state_changed_at: Option<IsoTimestamp>,
+    session_changed_at: Option<IsoTimestamp>,
+}
+
+impl RuntimeHealth {
+    #[must_use]
+    pub fn with_owner(owner_pid: u32) -> Self {
+        let health = Self::default();
+        health.set_owner(owner_pid);
+        health
+    }
+
+    pub fn set_owner(&self, owner_pid: u32) {
+        let mut state = self.lock();
+        state.owner_pid = Some(owner_pid);
+        state.lifecycle = Lifecycle::NotReady;
+        state.detail = Some("validating replacement runtime configuration".to_owned());
+    }
+
+    pub fn mark_ready(&self) {
+        let mut state = self.lock();
+        state.lifecycle = Lifecycle::Ready;
+        state.detail = None;
+    }
+
+    pub fn mark_not_ready(&self, detail: impl Into<String>) {
+        let mut state = self.lock();
+        state.lifecycle = Lifecycle::NotReady;
+        state.detail = Some(detail.into());
+    }
+
+    pub fn begin_drain(&self) {
+        let mut state = self.lock();
+        state.lifecycle = Lifecycle::Draining;
+        state.detail = Some("replacement runtime is draining".to_owned());
+    }
+
+    pub fn mark_stopped(&self) {
+        let mut state = self.lock();
+        state.lifecycle = Lifecycle::Stopped;
+        state.detail = Some("replacement runtime is stopped".to_owned());
+    }
+
+    /// Record an already-authorized local heartbeat.
+    ///
+    /// The brief mutex protects only in-memory status fields; storage and
+    /// process work remain outside this critical section.
+    pub fn record_heartbeat(
+        &self,
+        request: &TeamMemberHeartbeatRequest,
+    ) -> TeamMemberHeartbeatResponse {
+        let mut state = self.lock();
+        let key = MemberKey {
+            team: request.team.clone(),
+            member: request.member.clone(),
+        };
+        if !state.members.contains_key(&key) && state.members.len() == MAX_RUNTIME_STATUS_MEMBERS {
+            // Observability must never become an unbounded in-process cache.
+            // Prefer evicting an inactive observation; all entries are
+            // non-authoritative and can be restored by the next heartbeat.
+            if let Some(evicted) = state
+                .members
+                .iter()
+                .min_by_key(|(_, record)| record.last_active_at.or(record.state_changed_at))
+                .map(|(key, _)| key.clone())
+            {
+                state.members.remove(&evicted);
+            }
+        }
+        let record = state.members.entry(key).or_insert(MemberRecord {
+            pid: None,
+            session_id: None,
+            state: RuntimeMemberState::Unknown,
+            last_active_at: None,
+            state_changed_at: None,
+            session_changed_at: None,
+        });
+        let next_state = match request.activity {
+            HeartbeatActivity::ActiveToolUse => RuntimeMemberState::Active,
+            HeartbeatActivity::Idle => RuntimeMemberState::Idle,
+            HeartbeatActivity::SessionEnded => RuntimeMemberState::Offline,
+        };
+        if record.state != next_state {
+            record.state = next_state;
+            record.state_changed_at = Some(request.observed_at);
+        }
+        if next_state == RuntimeMemberState::Active {
+            record.last_active_at = Some(request.observed_at);
+        }
+        let previous_pid = record.pid;
+        record.pid = Some(request.pid);
+        if request.session_id.is_some() && record.session_id != request.session_id {
+            record.session_id = request.session_id.clone();
+            record.session_changed_at = Some(request.observed_at);
+        }
+        TeamMemberHeartbeatResponse {
+            team: request.team.clone(),
+            member: request.member.clone(),
+            pid: request.pid,
+            pid_changed: previous_pid.is_some_and(|pid| pid != request.pid),
+            state: next_state,
+            last_active_at: record.last_active_at,
+            session_id: record.session_id.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> RuntimeStatusSnapshot {
+        let state = self.lock();
+        let mut members: Vec<_> = state
+            .members
+            .iter()
+            .map(|(key, record)| RuntimeMemberObservation {
+                team: key.team.clone(),
+                member: key.member.clone(),
+                state: record.state,
+                session_id: record.session_id.clone(),
+                pid: record.pid,
+                last_active_at: record.last_active_at,
+                state_changed_by: Some(RuntimeObservationSource::Heartbeat),
+                state_changed_at: record.state_changed_at,
+                session_changed_by: record
+                    .session_changed_at
+                    .map(|_| RuntimeObservationSource::Heartbeat),
+                session_changed_at: record.session_changed_at,
+            })
+            .collect();
+        members.sort_by(|left, right| {
+            left.team
+                .as_str()
+                .cmp(right.team.as_str())
+                .then_with(|| left.member.as_str().cmp(right.member.as_str()))
+        });
+        let mut counts = RuntimeStatusCounts::default();
+        for member in &members {
+            match member.state {
+                RuntimeMemberState::Active => counts.active_members += 1,
+                RuntimeMemberState::Idle => counts.idle_members += 1,
+                RuntimeMemberState::Offline => counts.offline_members += 1,
+                RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
+                    counts.unknown_members += 1;
+                }
+            }
+        }
+        let (liveness, readiness) = match state.lifecycle {
+            Lifecycle::Ready => (RuntimeLivenessState::Running, RuntimeReadinessState::Ready),
+            Lifecycle::NotReady | Lifecycle::Draining => (
+                RuntimeLivenessState::Running,
+                RuntimeReadinessState::Unavailable,
+            ),
+            Lifecycle::Stopped => (
+                RuntimeLivenessState::Unavailable,
+                RuntimeReadinessState::Unavailable,
+            ),
+        };
+        RuntimeStatusSnapshot {
+            liveness,
+            readiness,
+            detail: state.detail.clone(),
+            singleton_owner_pid: state.owner_pid,
+            degraded_ingest: false,
+            member_counts: counts,
+            members,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, RuntimeHealthState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeHealth;
+    use atm_core::protocol::{
+        HeartbeatActivity, RuntimeLivenessState, RuntimeMemberState, RuntimeReadinessState,
+        TeamMemberHeartbeatRequest,
+    };
+    use atm_core::types::{AgentName, IsoTimestamp, TeamName};
+
+    fn heartbeat(pid: u32, activity: HeartbeatActivity) -> TeamMemberHeartbeatRequest {
+        TeamMemberHeartbeatRequest {
+            team: TeamName::from_validated("runtime-team"),
+            member: AgentName::from_validated("runtime-agent"),
+            pid,
+            observed_at: IsoTimestamp::now(),
+            activity,
+            session_id: None,
+        }
+    }
+
+    #[test]
+    fn readiness_tracks_listener_lifecycle_not_member_activity() {
+        let health = RuntimeHealth::with_owner(42);
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
+        );
+        health.mark_ready();
+        let first = health.record_heartbeat(&heartbeat(10, HeartbeatActivity::ActiveToolUse));
+        assert!(!first.pid_changed);
+        let second = health.record_heartbeat(&heartbeat(11, HeartbeatActivity::SessionEnded));
+        assert!(second.pid_changed);
+        assert_eq!(second.state, RuntimeMemberState::Offline);
+        assert_eq!(health.snapshot().readiness, RuntimeReadinessState::Ready);
+        health.begin_drain();
+        assert_eq!(
+            health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable
+        );
+        health.mark_stopped();
+        assert_eq!(
+            health.snapshot().liveness,
+            RuntimeLivenessState::Unavailable
+        );
+    }
+}

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -545,9 +545,10 @@ mod tests {
         PostSendEmissionPath, PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind,
     };
     use atm_core::observability::NullObservability;
+    #[cfg(unix)]
+    use atm_core::protocol::SendResponseEnvelope;
     use atm_core::protocol::{
-        HeartbeatActivity, ResponseEnvelope, RuntimeReadinessState, SendResponseEnvelope,
-        TeamMemberHeartbeatRequest,
+        HeartbeatActivity, ResponseEnvelope, RuntimeReadinessState, TeamMemberHeartbeatRequest,
     };
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{SendMessageSource, WriteRequest};
@@ -563,9 +564,13 @@ mod tests {
 
     use super::{StorageAndNudgeRouter, WriteAdmission};
     use crate::{
-        AuthenticatedConnector, CanonicalWriteHandler, HttpRuntimeBuilder, HttpRuntimeConfig,
-        LoopbackTcpConfig, NonZeroDuration, RuntimeHealth, RuntimeLimits, RuntimeTimeouts,
-        UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid, canonical_message_router,
+        AuthenticatedConnector, CanonicalWriteHandler, NonZeroDuration, RuntimeHealth,
+        RuntimeLimits, RuntimeTimeouts, canonical_message_router,
+    };
+    #[cfg(unix)]
+    use crate::{
+        HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig, UnixSocketConfig, UnixSocketMode,
+        UnixSocketOwnerUid,
     };
 
     struct RecordingReceivedHook {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -11,17 +11,24 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use atm_core::LocalServiceRuntime;
-use atm_core::api::{ApiResponse, AuthenticatedIngress, RequestDeadline};
+use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
 use atm_core::boundary::MessageReceivedHookSelector;
+use atm_core::clear::ClearQuery;
+use atm_core::doctor::DoctorQuery;
 use atm_core::error::AtmError;
+use atm_core::list::ListQuery;
 use atm_core::observability::ObservabilityPort;
-use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+use atm_core::protocol::{
+    CompatibilityVerdict, ReleaseVersion, ResponseEnvelope, SendResponseEnvelope,
+};
+use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::send::{
     WarningEntry, WriteOutcome, build_received_message_hook_dispatches_after_commit,
     prepare_write_with_runtime,
 };
 
 use crate::CanonicalWriteHandler;
+use crate::RuntimeHealth;
 
 /// Replacement-owned admission for synchronous SQLite write jobs.
 ///
@@ -90,6 +97,8 @@ pub struct StorageAndNudgeRouter {
     received_hook_selector: Arc<dyn MessageReceivedHookSelector>,
     write_admission: WriteAdmission,
     daemon_home: PathBuf,
+    runtime_health: RuntimeHealth,
+    doctor_ports: Option<atm_core::doctor::RuntimeDoctorPorts>,
 }
 
 impl StorageAndNudgeRouter {
@@ -106,7 +115,23 @@ impl StorageAndNudgeRouter {
             received_hook_selector,
             write_admission: WriteAdmission::new(NonZeroUsize::new(1).expect("one SQLite writer")),
             daemon_home,
+            runtime_health: RuntimeHealth::default(),
+            doctor_ports: None,
         }
+    }
+
+    /// Adds the existing core doctor ports and the process-owned lifecycle
+    /// projection. Both stay behind core interfaces; the HTTP runtime never
+    /// learns a concrete storage backend.
+    #[must_use]
+    pub fn with_runtime_health(
+        mut self,
+        runtime_health: RuntimeHealth,
+        doctor_ports: atm_core::doctor::RuntimeDoctorPorts,
+    ) -> Self {
+        self.runtime_health = runtime_health;
+        self.doctor_ports = Some(doctor_ports);
+        self
     }
 
     fn commit_write(
@@ -184,6 +209,195 @@ impl StorageAndNudgeRouter {
         }
         warnings
     }
+
+    async fn dispatch_non_write(
+        &self,
+        request: ApiRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        if deadline.expired() {
+            return Err(AtmError::daemon_unavailable(
+                "request deadline expired before replacement route dispatch",
+            ));
+        }
+        match request {
+            ApiRequest::Write(_) => unreachable!("writes use the canonical write path"),
+            ApiRequest::Messages(request) => match *request {
+                atm_core::api::MessageCollectionRequest::List(query) => {
+                    self.list_messages(query, deadline).await
+                }
+                atm_core::api::MessageCollectionRequest::Peek(query) => {
+                    self.peek_messages(query, deadline).await
+                }
+                atm_core::api::MessageCollectionRequest::Receive(query) => {
+                    self.receive_messages(query, deadline).await
+                }
+            },
+            ApiRequest::Clear(query) => self.clear_messages(query, deadline).await,
+            ApiRequest::Doctor(query) => self.doctor(query, deadline).await,
+            ApiRequest::CompatibilityPreflight(preflight) => Ok(ApiResponse::new(
+                ResponseEnvelope::CompatibilityVerdict(compatibility_verdict(preflight)),
+            )),
+            ApiRequest::Heartbeat(request) => self.heartbeat(request, ingress, deadline).await,
+            ApiRequest::ReloadRuntimeView => self.reload_runtime_view(ingress),
+        }
+    }
+
+    async fn list_messages(
+        &self,
+        query: ListQuery,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let runtime = self.service_runtime.clone();
+        let observability = Arc::clone(&self.observability);
+        let home = self.daemon_home.clone();
+        self.write_admission
+            .run(deadline, move || {
+                atm_core::list::list_mail_with_runtime(
+                    query.with_daemon_paths(home),
+                    observability.as_ref(),
+                    &runtime,
+                )
+                .map(ResponseEnvelope::List)
+                .map(ApiResponse::new)
+            })
+            .await
+    }
+
+    async fn peek_messages(
+        &self,
+        query: PeekQuery,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let runtime = self.service_runtime.clone();
+        let observability = Arc::clone(&self.observability);
+        let home = self.daemon_home.clone();
+        self.write_admission
+            .run(deadline, move || {
+                atm_core::read::peek_mail_with_runtime(
+                    query.with_daemon_paths(home),
+                    observability.as_ref(),
+                    &runtime,
+                )
+                .map(Box::new)
+                .map(ResponseEnvelope::Peek)
+                .map(ApiResponse::new)
+            })
+            .await
+    }
+
+    async fn receive_messages(
+        &self,
+        query: ReadQuery,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let runtime = self.service_runtime.clone();
+        let observability = Arc::clone(&self.observability);
+        let home = self.daemon_home.clone();
+        self.write_admission
+            .run(deadline, move || {
+                atm_core::read::read_mail_with_runtime(
+                    query.with_daemon_paths(home),
+                    observability.as_ref(),
+                    &runtime,
+                )
+                .map(Box::new)
+                .map(ResponseEnvelope::Receive)
+                .map(ApiResponse::new)
+            })
+            .await
+    }
+
+    async fn clear_messages(
+        &self,
+        query: ClearQuery,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let runtime = self.service_runtime.clone();
+        let observability = Arc::clone(&self.observability);
+        let home = self.daemon_home.clone();
+        self.write_admission
+            .run(deadline, move || {
+                atm_core::clear::clear_mail_with_runtime(
+                    query.with_daemon_paths(home),
+                    observability.as_ref(),
+                    &runtime,
+                )
+                .map(ResponseEnvelope::Clear)
+                .map(ApiResponse::new)
+            })
+            .await
+    }
+
+    async fn doctor(
+        &self,
+        query: DoctorQuery,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let runtime = self.service_runtime.clone();
+        let observability = Arc::clone(&self.observability);
+        let home = self.daemon_home.clone();
+        let runtime_health = self.runtime_health.clone();
+        let doctor_ports = self.doctor_ports.clone();
+        self.write_admission
+            .run(deadline, move || {
+                let query = query.with_daemon_paths(home);
+                let mut report = match doctor_ports {
+                    Some(ports) => atm_core::doctor::run_doctor_with_runtime_ports(
+                        query,
+                        observability.as_ref(),
+                        &runtime,
+                        &ports,
+                        None,
+                    ),
+                    None => atm_core::doctor::run_doctor_with_runtime(
+                        query,
+                        observability.as_ref(),
+                        &runtime,
+                    ),
+                }?;
+                report.runtime_status = Some(runtime_health.snapshot());
+                Ok(ApiResponse::new(ResponseEnvelope::Doctor(Box::new(report))))
+            })
+            .await
+    }
+
+    async fn heartbeat(
+        &self,
+        request: atm_core::protocol::TeamMemberHeartbeatRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        if ingress != AuthenticatedIngress::Local {
+            return Err(AtmError::validation(
+                "heartbeats are available only through authenticated local HTTP adapters",
+            ));
+        }
+        let runtime = self.service_runtime.clone();
+        let health = self.runtime_health.clone();
+        self.write_admission
+            .run(deadline, move || {
+                validate_heartbeat_member(runtime, &request)?;
+                Ok(request)
+            })
+            .await
+            .map(|request| {
+                ApiResponse::new(ResponseEnvelope::Heartbeat(
+                    health.record_heartbeat(&request),
+                ))
+            })
+    }
+
+    fn reload_runtime_view(&self, ingress: AuthenticatedIngress) -> Result<ApiResponse, AtmError> {
+        if ingress != AuthenticatedIngress::Local {
+            return Err(AtmError::validation(
+                "runtime reload is available only through authenticated local HTTP adapters",
+            ));
+        }
+        self.service_runtime.clear_roster_cache();
+        Ok(ApiResponse::new(ResponseEnvelope::RuntimeViewReloaded))
+    }
 }
 
 struct CommittedWrite {
@@ -230,6 +444,63 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             Ok(ApiResponse::new(write_response(committed.outcome)))
         })
     }
+
+    fn dispatch(
+        &self,
+        request: ApiRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        Box::pin(async move {
+            match request {
+                ApiRequest::Write(request) => self.write(*request, ingress, deadline).await,
+                request => self.dispatch_non_write(request, ingress, deadline).await,
+            }
+        })
+    }
+}
+
+fn compatibility_verdict(
+    preflight: atm_core::protocol::CompatibilityPreflight,
+) -> CompatibilityVerdict {
+    let daemon_release = ReleaseVersion::current();
+    let daemon_schema_version = atm_core::protocol::CLI_SCHEMA_VERSION;
+    let daemon_http_api_version = atm_core::protocol::HttpApiVersion::current();
+    if preflight.cli_schema_version == daemon_schema_version
+        && preflight.http_api_version.major() == daemon_http_api_version.major()
+    {
+        CompatibilityVerdict::Compatible {
+            daemon_release,
+            daemon_schema_version,
+            daemon_http_api_version,
+        }
+    } else {
+        CompatibilityVerdict::Incompatible {
+            client_release: preflight.client_release,
+            daemon_release,
+            client_schema_version: preflight.cli_schema_version,
+            daemon_schema_version,
+            client_http_api_version: preflight.http_api_version,
+            daemon_http_api_version,
+            code: atm_core::error::AtmErrorCode::ClientDaemonVersionIncompatible,
+        }
+    }
+}
+
+fn validate_heartbeat_member(
+    runtime: LocalServiceRuntime,
+    request: &atm_core::protocol::TeamMemberHeartbeatRequest,
+) -> Result<(), AtmError> {
+    if runtime
+        .load_roster_member(&request.team, &request.member)?
+        .is_none()
+    {
+        return Err(AtmError::agent_not_found(
+            request.member.as_str(),
+            request.team.as_str(),
+        ));
+    }
+    Ok(())
 }
 
 fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
@@ -274,7 +545,10 @@ mod tests {
         PostSendEmissionPath, PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind,
     };
     use atm_core::observability::NullObservability;
-    use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::protocol::{
+        HeartbeatActivity, ResponseEnvelope, RuntimeReadinessState, SendResponseEnvelope,
+        TeamMemberHeartbeatRequest,
+    };
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{SendMessageSource, WriteRequest};
     use atm_core::types::{AgentName, ModelName, PaneId, TeamName};
@@ -289,9 +563,9 @@ mod tests {
 
     use super::{StorageAndNudgeRouter, WriteAdmission};
     use crate::{
-        AuthenticatedConnector, HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig,
-        NonZeroDuration, RuntimeLimits, RuntimeTimeouts, UnixSocketConfig, UnixSocketMode,
-        UnixSocketOwnerUid, canonical_message_router,
+        AuthenticatedConnector, CanonicalWriteHandler, HttpRuntimeBuilder, HttpRuntimeConfig,
+        LoopbackTcpConfig, NonZeroDuration, RuntimeHealth, RuntimeLimits, RuntimeTimeouts,
+        UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid, canonical_message_router,
     };
 
     struct RecordingReceivedHook {
@@ -460,12 +734,14 @@ mod tests {
         let current_dir = temporary_root.path().join("workspace");
         fs::create_dir_all(&home_dir).expect("create fixture home");
         fs::create_dir_all(&current_dir).expect("create fixture workspace");
+        let health = RuntimeHealth::with_owner(99);
         let router = StorageAndNudgeRouter::new(
             assembly.service_runtime,
             Arc::new(NullObservability),
             select(received_hook.clone()),
             home_dir.clone(),
-        );
+        )
+        .with_runtime_health(health, assembly.doctor_ports);
         Fixture {
             _temporary_root: temporary_root,
             router,
@@ -743,6 +1019,60 @@ mod tests {
         assert!(
             error.message().contains("intentional storage failure"),
             "the storage error is returned unchanged instead of being replaced by an admission error"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticated_heartbeat_is_retained_without_affecting_runtime_readiness() {
+        let fixture = fixture(true, None, None);
+        let first = TeamMemberHeartbeatRequest {
+            team: "test-team".parse().expect("team"),
+            member: "recipient".parse().expect("agent"),
+            pid: 41,
+            observed_at: atm_core::types::IsoTimestamp::now(),
+            activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
+        };
+        let first_response = fixture
+            .router
+            .dispatch(
+                ApiRequest::new(atm_core::protocol::RequestEnvelope::Heartbeat(
+                    first.clone(),
+                )),
+                atm_core::AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("authorized heartbeat");
+        assert!(matches!(
+            first_response.into_inner(),
+            ResponseEnvelope::Heartbeat(response) if !response.pid_changed
+        ));
+
+        let second = TeamMemberHeartbeatRequest {
+            pid: 42,
+            activity: HeartbeatActivity::SessionEnded,
+            ..first
+        };
+        let second_response = fixture
+            .router
+            .dispatch(
+                ApiRequest::new(atm_core::protocol::RequestEnvelope::Heartbeat(second)),
+                atm_core::AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("second authorized heartbeat");
+        assert!(matches!(
+            second_response.into_inner(),
+            ResponseEnvelope::Heartbeat(response) if response.pid_changed
+        ));
+        // Health remains listener-owned. A member becoming offline does not
+        // make a process that is still serving local adapters become NotReady.
+        assert_eq!(
+            fixture.router.runtime_health.snapshot().readiness,
+            RuntimeReadinessState::Unavailable,
+            "the fixture has no running listener; heartbeat cannot claim readiness"
         );
     }
 

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -1,0 +1,247 @@
+//! Unix-domain-socket listener setup and owner-safe cleanup.
+//!
+//! This physical adapter is deliberately separate from runtime composition:
+//! it validates, stages, publishes, and tears down only the UDS endpoint.
+
+use std::path::{Path, PathBuf};
+
+use atm_core::error::AtmError;
+use tokio::net::UnixListener;
+
+use super::UnixSocketConfig;
+
+pub(super) fn bind_unix_listener(
+    socket: &UnixSocketConfig,
+) -> Result<(UnixListener, UnixSocketPathGuard), AtmError> {
+    let parent = validate_unix_socket_parent(socket)?;
+    ensure_unix_socket_path_unoccupied(&socket.path)?;
+    let (listener, staging) = bind_prepared_unix_socket(socket, parent)?;
+    publish_prepared_unix_socket(socket, staging)?;
+    let cleanup = UnixSocketPathGuard::capture(&socket.path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&socket.path);
+    })?;
+    Ok((listener, cleanup))
+}
+
+fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmError> {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    let parent = socket
+        .path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| {
+            AtmError::config("Unix HTTP socket path must have an owner-controlled parent")
+        })?;
+    let metadata = fs::metadata(parent).map_err(|source| {
+        AtmError::config("cannot inspect Unix HTTP socket parent directory").with_cause(source)
+    })?;
+    if metadata.uid() != socket.owner_uid.get() {
+        return Err(
+            AtmError::config("Unix HTTP socket parent owner does not match configuration")
+                .with_cause(format!(
+                    "configured uid {} but parent `{}` is owned by uid {}",
+                    socket.owner_uid.get(),
+                    parent.display(),
+                    metadata.uid()
+                )),
+        );
+    }
+    if metadata.mode() & 0o022 != 0 {
+        return Err(
+            AtmError::config("Unix HTTP socket parent must not be writable by others").with_cause(
+                format!(
+                    "parent `{}` mode {:o} permits group or other writes",
+                    parent.display(),
+                    metadata.mode() & 0o777
+                ),
+            ),
+        );
+    }
+    Ok(parent)
+}
+
+fn ensure_unix_socket_path_unoccupied(path: &Path) -> Result<(), AtmError> {
+    use std::fs;
+    use std::io::ErrorKind;
+
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(AtmError::config("Unix HTTP socket path is already occupied").with_cause(
+            format!(
+                "refusing to replace existing path `{}`; remove only the stale owner-owned socket before retrying",
+                path.display()
+            ),
+        )),
+        Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
+        Err(source) => {
+            Err(AtmError::config("cannot inspect Unix HTTP socket path").with_cause(source))
+        }
+    }
+}
+
+fn bind_prepared_unix_socket(
+    socket: &UnixSocketConfig,
+    parent: &Path,
+) -> Result<(UnixListener, PrivateStagingDirectory), AtmError> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Bind below a newly-created `0700` staging directory. The socket cannot
+    // be connected before its final owner-only mode is verified and atomically
+    // published, without changing the process-global umask.
+    let staging = PrivateStagingDirectory::create(parent)?;
+    let staged_path = staging.path().join("listener.sock");
+    let listener = UnixListener::bind(&staged_path).map_err(|source| {
+        AtmError::daemon_unavailable("failed to bind replacement Unix HTTP socket")
+            .with_cause(source)
+    })?;
+    fs::set_permissions(&staged_path, fs::Permissions::from_mode(socket.mode.get())).map_err(
+        |source| {
+            AtmError::daemon_unavailable("failed to set replacement Unix HTTP socket permissions")
+                .with_cause(source)
+        },
+    )?;
+    verify_prepared_unix_socket(socket, &staged_path)?;
+    Ok((listener, staging))
+}
+
+fn verify_prepared_unix_socket(socket: &UnixSocketConfig, path: &Path) -> Result<(), AtmError> {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = fs::metadata(path).map_err(|source| {
+        AtmError::daemon_unavailable("failed to inspect replacement Unix HTTP socket permissions")
+            .with_cause(source)
+    })?;
+    if metadata.uid() != socket.owner_uid.get() {
+        return Err(AtmError::config(
+            "replacement Unix HTTP socket owner does not match configuration",
+        )
+        .with_cause(format!(
+            "configured uid {} but bound socket is owned by uid {}",
+            socket.owner_uid.get(),
+            metadata.uid()
+        )));
+    }
+    if metadata.mode() & 0o777 != socket.mode.get() {
+        return Err(AtmError::config(
+            "replacement Unix HTTP socket permissions do not match configuration",
+        )
+        .with_cause(format!(
+            "configured mode {:o} but bound socket mode is {:o}",
+            socket.mode.get(),
+            metadata.mode() & 0o777
+        )));
+    }
+    Ok(())
+}
+
+fn publish_prepared_unix_socket(
+    socket: &UnixSocketConfig,
+    staging: PrivateStagingDirectory,
+) -> Result<(), AtmError> {
+    let staged_path = staging.path().join("listener.sock");
+    std::fs::rename(&staged_path, &socket.path).map_err(|source| {
+        AtmError::daemon_unavailable("failed to publish replacement Unix HTTP socket")
+            .with_cause(source)
+    })
+}
+
+/// Owner-checked, uniquely named staging directory used only until an already
+/// permissioned UDS inode is atomically published at its configured path.
+#[derive(Debug)]
+pub(super) struct PrivateStagingDirectory {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl PrivateStagingDirectory {
+    pub(super) fn create(parent: &Path) -> Result<Self, AtmError> {
+        use std::fs;
+        use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+        let (path, ()) = super::private_staging::allocate(parent, "uds", |path| {
+            fs::DirBuilder::new().mode(0o700).create(path)
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable(
+                "failed to create private Unix HTTP socket staging directory",
+            )
+            .with_cause(source)
+        })?;
+        if let Err(source) = fs::set_permissions(&path, fs::Permissions::from_mode(0o700)) {
+            let _ = fs::remove_dir(&path);
+            return Err(AtmError::daemon_unavailable(
+                "failed to protect Unix HTTP socket staging directory",
+            )
+            .with_cause(source));
+        }
+        let metadata = fs::metadata(&path).map_err(|source| {
+            let _ = fs::remove_dir(&path);
+            AtmError::daemon_unavailable("failed to inspect Unix HTTP socket staging directory")
+                .with_cause(source)
+        })?;
+        Ok(Self {
+            path,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for PrivateStagingDirectory {
+    fn drop(&mut self) {
+        use std::fs;
+        use std::os::unix::fs::MetadataExt;
+
+        let is_our_directory = fs::metadata(&self.path)
+            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode);
+        if is_our_directory {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+/// Removes only the socket inode created by this runtime during shutdown.
+#[derive(Debug)]
+pub(super) struct UnixSocketPathGuard {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl UnixSocketPathGuard {
+    fn capture(path: &Path) -> Result<Self, AtmError> {
+        use std::fs;
+        use std::os::unix::fs::MetadataExt;
+
+        let metadata = fs::metadata(path).map_err(|source| {
+            AtmError::daemon_unavailable("failed to inspect bound Unix HTTP socket")
+                .with_cause(source)
+        })?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    }
+}
+
+impl Drop for UnixSocketPathGuard {
+    fn drop(&mut self) {
+        use std::fs;
+        use std::os::unix::fs::MetadataExt;
+
+        let is_our_socket = fs::metadata(&self.path)
+            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode);
+        if is_our_socket {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -6,10 +6,12 @@
 use std::path::{Path, PathBuf};
 
 use atm_core::error::AtmError;
+#[cfg(unix)]
 use tokio::net::UnixListener;
 
 use super::UnixSocketConfig;
 
+#[cfg(unix)]
 pub(super) fn bind_unix_listener(
     socket: &UnixSocketConfig,
 ) -> Result<(UnixListener, UnixSocketPathGuard), AtmError> {
@@ -23,6 +25,7 @@ pub(super) fn bind_unix_listener(
     Ok((listener, cleanup))
 }
 
+#[cfg(unix)]
 fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmError> {
     use std::fs;
     use std::os::unix::fs::MetadataExt;
@@ -62,6 +65,7 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
     Ok(parent)
 }
 
+#[cfg(unix)]
 fn ensure_unix_socket_path_unoccupied(path: &Path) -> Result<(), AtmError> {
     use std::fs;
     use std::io::ErrorKind;
@@ -80,6 +84,7 @@ fn ensure_unix_socket_path_unoccupied(path: &Path) -> Result<(), AtmError> {
     }
 }
 
+#[cfg(unix)]
 fn bind_prepared_unix_socket(
     socket: &UnixSocketConfig,
     parent: &Path,
@@ -106,6 +111,7 @@ fn bind_prepared_unix_socket(
     Ok((listener, staging))
 }
 
+#[cfg(unix)]
 fn verify_prepared_unix_socket(socket: &UnixSocketConfig, path: &Path) -> Result<(), AtmError> {
     use std::fs;
     use std::os::unix::fs::MetadataExt;
@@ -137,6 +143,7 @@ fn verify_prepared_unix_socket(socket: &UnixSocketConfig, path: &Path) -> Result
     Ok(())
 }
 
+#[cfg(unix)]
 fn publish_prepared_unix_socket(
     socket: &UnixSocketConfig,
     staging: PrivateStagingDirectory,
@@ -150,6 +157,7 @@ fn publish_prepared_unix_socket(
 
 /// Owner-checked, uniquely named staging directory used only until an already
 /// permissioned UDS inode is atomically published at its configured path.
+#[cfg(unix)]
 #[derive(Debug)]
 pub(super) struct PrivateStagingDirectory {
     path: PathBuf,
@@ -157,6 +165,7 @@ pub(super) struct PrivateStagingDirectory {
     inode: u64,
 }
 
+#[cfg(unix)]
 impl PrivateStagingDirectory {
     pub(super) fn create(parent: &Path) -> Result<Self, AtmError> {
         use std::fs;
@@ -195,6 +204,7 @@ impl PrivateStagingDirectory {
     }
 }
 
+#[cfg(unix)]
 impl Drop for PrivateStagingDirectory {
     fn drop(&mut self) {
         use std::fs;
@@ -209,6 +219,7 @@ impl Drop for PrivateStagingDirectory {
 }
 
 /// Removes only the socket inode created by this runtime during shutdown.
+#[cfg(unix)]
 #[derive(Debug)]
 pub(super) struct UnixSocketPathGuard {
     path: PathBuf,
@@ -216,6 +227,7 @@ pub(super) struct UnixSocketPathGuard {
     inode: u64,
 }
 
+#[cfg(unix)]
 impl UnixSocketPathGuard {
     fn capture(path: &Path) -> Result<Self, AtmError> {
         use std::fs;
@@ -233,6 +245,7 @@ impl UnixSocketPathGuard {
     }
 }
 
+#[cfg(unix)]
 impl Drop for UnixSocketPathGuard {
     fn drop(&mut self) {
         use std::fs;

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -1,20 +1,33 @@
 # ATM-Daemon Boundary Inventory
 
-> **Phase AI target — not yet implemented:** the daemon consumes storage traits and may
-> not acquire a SQLite/replay boundary through `atm-runtime` or another
-> indirection. ADR-036 is the governing crate-topology decision.
+> **Phase AL active composition:** `atm-daemon` is a thin Tokio process root.
+> It invokes `atm-daemon-bootstrap::run_replacement_daemon`, which acquires the
+> owner lock, selects the approved storage factory once, injects the sealed
+> received-message hook selector, and starts `atm-http-runtime`'s Axum router.
+> The runtime exposes only framework-managed UDS (where supported) and
+> capability-authenticated loopback TCP. TLS, replay, and resend are not active
+> daemon dependencies. `crates/atm-daemon`'s historical server source is
+> reference-only until Phase AM deletes it.
 
-This document captures runtime-owned concrete adapters established in Phase R
-and tightened for the Phase S cross-platform daemon host line.
+The active machine-readable composition record is
+[`../../boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml`](../../boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml).
 
-Current design assumption:
-- `atm-daemon` is the production runtime composition root
-- `allowed_dependents: []` means no external crate should depend on these
-  daemon-private concrete adapters
-- after `AA.5`, `atm-daemon` reaches SQLite-backed stores only through
-  `atm-runtime`; a direct `atm-daemon -> atm-storage-rusqlite` dependency is a
-  boundary violation guarded by both the boundary TOMLs and
-  `cargo test --package atm-architecture`
+## Historical legacy-daemon inventory
+
+The remainder of this document records pre-AL daemon-private boundaries for
+Phase AM deletion planning. They do not describe an active process path.
+
+This historical inventory captures runtime-owned concrete adapters established
+in Phase R and tightened for the Phase S cross-platform daemon host line.
+
+Historical pre-AL design assumption (not active composition):
+- `atm_daemon::RuntimeComposition` was the legacy server root. It is now
+  reference-only; the active root is the replacement-bootstrap boundary above.
+- `allowed_dependents: []` describes the retained legacy types while Phase AM
+  prepares their deletion; it does not authorize their use by the executable.
+- Direct `atm-daemon -> atm-storage-rusqlite` remains a boundary violation.
+  The sole approved concrete factory selection is
+  `atm-daemon-bootstrap`, whose active manifest records that exception.
 - Phase AD retired the watch/reconcile runtime lanes; any retained
   watch/reconcile/notifier references in older planning material are
   historical only and must not be treated as accepted production subsystem
@@ -30,25 +43,25 @@ Current design assumption:
   `atm-core` delivery policy module, which owns message delivery-plan
   decisions inside the reusable service library.
 
-Important daemon-private control-plane structs that must stay visible in review,
+Historical daemon-private control-plane structs retained for AM deletion review,
 even though they are not public cross-crate traits:
 - `RuntimeComposition` in `atm_daemon::composition`
-  - owns startup/shutdown sequencing and lifecycle state transitions
-  - must not be skipped in boundary or production-readiness review just because
-    it is not itself a public trait boundary
+  - formerly owned startup/shutdown sequencing and lifecycle state transitions
+  - must not be selected by active composition; it remains visible solely so
+    Phase AM can delete it without losing its provenance
 - `LifecycleControlSourceAdapter` / `HostOwnershipAdapter` in `atm_daemon`
-  - own process-lifecycle admission and shutdown mechanics
+  - formerly owned process-lifecycle admission and shutdown mechanics
   - the Unix signal-hook implementation is now hidden inside the extracted
     lifecycle-control adapter rather than referenced directly from runtime
     orchestration
-  - must remain runtime-private and must not be bypassed by transport or
+  - are reference-only and must not be reached by active transport or
     business-logic code
 - `PreparedRuntimeServer` / `ActiveConnectionRegistry` in `atm_daemon`
-  - own listener accept, active connection tracking, drain sequencing, and
-    force-cancel escalation
-  - must remain runtime-private and must not absorb dispatcher or store logic
+  - formerly owned listener accept, active connection tracking, drain
+    sequencing, and force-cancel escalation
+  - are reference-only; HttpRuntime owns the active framework lifecycle
 - `RuntimeStatusCache` in `atm_daemon::runtime_health`
-  - owns live daemon-memory member state and cache-cap semantics
+  - formerly owned live daemon-memory member state and cache-cap semantics
   - hydrates durable team/member truth only through `RosterStore`; it must not
     rediscover teams by walking `ATM_HOME/.claude/teams`
   - must remain separate from socket serving code
@@ -67,10 +80,10 @@ even though they are not public cross-crate traits:
     non-authoritative rule in the `DaemonStatusSourceAdapter` section below.
     The boundary/isolation contract is lint-verified.
 
-## Planned R.20 partition map
+## Historical R.20 partition map
 
-The current daemon implementation remains one crate, but the review-visible
-daemon-private ownership map is:
+The historical daemon implementation remains one crate; its review-visible
+daemon-private ownership map was:
 - `ownership`
   - `HostOwnershipAdapter`, lock-path helpers, stale-owner recovery
 - `server_runtime`
@@ -100,25 +113,25 @@ Observability note:
 - the authoritative design contract is
   [`./observability.md`](./observability.md)
 
-## RuntimeLifecycleController
+## Historical RuntimeLifecycleController
 
 Canonical machine-readable boundary source:
 - [../../boundaries/atm-daemon/runtime-lifecycle-daemon.toml](../../boundaries/atm-daemon/runtime-lifecycle-daemon.toml)
 
-Purpose:
-- Own the daemon-private runtime lifecycle/admission controller that coordinates
-  startup, shutdown, and singleton ownership.
+Historical purpose:
+- Owned the legacy daemon-private lifecycle/admission controller. AL.8 has
+  replaced it with the typed HttpRuntime lifecycle.
 
 Notes:
 - This record exists so the control-plane struct is treated as an architectural
   boundary surface even though it is not a public shared trait today.
-- The active implementation is `RuntimeComposition` plus the crate-private
-  `RuntimeLifecycle` state machine plus the runtime-owned
-  `LifecycleControlSourceAdapter` and `HostOwnershipAdapter`.
-- `run_daemon()` must enter the daemon only through this lifecycle boundary;
-  direct listener bootstrap is a boundary violation.
+- The historical implementation was `RuntimeComposition` plus the
+  crate-private `RuntimeLifecycle` state machine and related adapters.
+- Active composition must enter only through
+  `atm_daemon_bootstrap::run_replacement_daemon`; use of `run_daemon()` is a
+  boundary violation.
 
-## Local transport adapters
+## Historical local transport adapters
 
 Canonical machine-readable boundary source:
 - [../../boundaries/atm-daemon/socket-server-transport.toml](../../boundaries/atm-daemon/socket-server-transport.toml)

--- a/docs/plans/phase-al/AL8-composition-inventory.md
+++ b/docs/plans/phase-al/AL8-composition-inventory.md
@@ -1,0 +1,67 @@
+# AL.8 composition inventory
+
+Captured from the AL.6 parent at `93bb2faf` before the AL.8 composition
+cutover. This is an observed source inventory, not AM's deletion ledger.
+
+## Active executable before AL.8
+
+`crates/atm-daemon/src/main.rs` calls
+`atm_daemon::run_daemon_with_observability`, which enters
+`crates/atm-daemon/src/composition.rs::RuntimeComposition::start`.
+
+The resulting active call graph is legacy and must not remain selected:
+
+```text
+atm-daemon main
+  -> atm-daemon RuntimeComposition
+      -> LocalIpcServerTransportAdapter
+          -> legacy local IPC/TCP HTTP workers and raw framing
+      -> DaemonRequestDispatcher
+          -> legacy runtime-health/post-write execution
+      -> legacy 2 s graceful + 3 s force-cancel lifecycle hooks
+```
+
+The owner gate is implemented in
+`crates/atm-daemon/src/host_ownership.rs`; its `HostOwnershipAdapter::acquire`
+must be retained or transplanted before the replacement binds an adapter or
+publishes the loopback endpoint record.
+
+## Replacement graph to activate
+
+```text
+atm-daemon replacement entrypoint
+  -> owner gate
+  -> backend-neutral RuntimeAssembly from the approved bootstrap boundary
+  -> injected MessageReceivedHookSelector
+  -> StorageAndNudgeRouter
+  -> HttpRuntime<Configured>::start
+      -> Unix UDS (where supported) and/or loopback TCP
+      -> canonical_api_router (all retained typed HTTP routes)
+      -> one typed API handler (write remains the sole post-persist hook path)
+      -> sealed storage/runtime + received-hook boundaries
+```
+
+`atm-http-runtime` already owns the canonical Axum route, UDS listener,
+loopback listener, capability endpoint record, typed client operation, bounded
+write admission, and post-persistence warning semantics. It has no concrete
+SQLite/Rusqlite, tmux, graft, bootstrap, raw-frame, peer-only, or replay
+dependency.
+
+## Composition gaps opened by this inventory
+
+1. The `atm-daemon` executable still selects legacy composition and must be
+   reduced to replacement startup/shutdown only.
+2. A replacement composition-owned `MessageReceivedHookSelector` is required.
+   It must be injected without adding a concrete tmux or graft dependency to
+   `atm-http-runtime`; graft remains independently owned.
+3. The runtime lifecycle needs the owner gate and existing readiness/status
+   publication linked to its consuming Tokio lifecycle, with the architecture
+   5 s drain bound replacing the legacy 2 s/3 s pair.
+4. AL.8's static guards must distinguish the unreferenced historical source
+   (left for AM deletion) from active executable dependencies, while rejecting
+   any active legacy listener/worker/dispatcher edge.
+5. The replacement needs route-by-route proof that every retained core HTTP
+   operation preserves its response schema and daemon-owned filesystem-root
+   policy. The `canonical_api_router` now registers the core route table; the
+   active-composition and route-contract tests remain required before this
+   graph can be treated as live.

--- a/docs/plans/phase-al/AL8-development-checklist.md
+++ b/docs/plans/phase-al/AL8-development-checklist.md
@@ -1,0 +1,158 @@
+# AL.8 development checklist
+
+This checklist is the implementation and closure ledger for AL.8. It is
+derived from `sprint-AL8-daemon-composition-proof.md`; items stay open until
+their code, tests, boundary proof, and required validation are complete.
+
+## Entry and scope
+
+- [x] Merge the AL.6 pushed parent (`93bb2faf`) into this worktree.
+- [x] Record the active-parent state: AL.7 mTLS is deferred because TLS is
+  not MVP scope and the repository already retains an isolated TLS crate for a
+  future authorized feature. AL.8 must not introduce a new TLS adapter,
+  listener, client, or proof requirement.
+- [x] Reconcile the AL.8 sprint's AL.7 dependency with that MVP decision in
+  the sprint/phase documentation before calling AL.8 complete.
+
+## Active Tokio/Axum daemon composition
+
+- [x] Inventory the current `atm-daemon` executable entrypoint, ownership
+  gate, status/readiness surface, adapter selection, storage construction, and
+  received-hook construction. Record each legacy-server call edge that must be
+  removed from active composition. Evidence: `AL8-composition-inventory.md`.
+- [x] Make `atm-http-runtime` the only server started by `atm-daemon`; do not
+  wrap, start, probe through, or retain the legacy `crates/atm-daemon` server
+  as a fallback.
+- [x] Retain or transplant the existing singleton/owner gate before any
+  listener bind or endpoint publication.
+- [x] Construct only backend-neutral core storage/router implementations and
+  inject the accepted `MessageReceivedHookEmitter` from composition. Runtime
+  code must not import SQLite/Rusqlite, tmux, or `atm-graft`.
+- [x] **AL8-F001 — production async receiver-hook injection:** provide the
+  composition-owned `MessageReceivedHookSelector` required by
+  `StorageAndNudgeRouter`. It must select the injected receiver implementation
+  by the already-planned harness target, use the inherited absolute deadline,
+  and preserve post-persistence success-plus-warning behavior. A test-only
+  selector or a permanent `None` selector is not sufficient. Neither
+  `atm-http-runtime` nor active daemon composition may import tmux or
+  `atm-graft` concrete code.
+- [x] Select enabled MVP local adapters (Unix UDS where supported and
+  loopback TCP) through typed runtime configuration; no platform-specific
+  application route, codec, or listener root is permitted.
+
+## Lifecycle and health
+
+- [x] Wire the existing health/readiness surface to the runtime lifecycle.
+  `Ready` requires owner gate, AL.1 validation, canonical router construction,
+  and every selected listener bind. `NotReady` applies before start, failed
+  startup, and drain. `Live` reflects runtime supervision.
+- [x] Return a typed startup cause for failed configuration/bind and prove
+  endpoint records are not published before `Running`.
+- [x] Use the architecture's single 5-second graceful-drain deadline:
+  stop accepts, drain tracked requests, cancel remaining work at deadline, then
+  transition to `NotReady`. No detached helper may extend it.
+- [x] Add deterministic lifecycle tests for ready ordering, failed start,
+  drain/cancel behavior, and the retained five-second bound.
+
+## Canonical semantics and static boundaries
+
+- [x] **AL8-F003 — retained route completeness:** the current replacement
+  listener exposes only `POST /v1/atm/messages`, while the frozen core HTTP
+  route table also contains list, clear, inspect, read, doctor, runtime reload,
+  compatibility, and heartbeat routes. Before activating the replacement
+  executable, migrate every retained route through the same framework router
+  and connector-neutral client codec, or obtain an explicit MVP API-removal
+  decision with matching public-schema/CLI changes. A legacy-server fallback
+  is prohibited.
+- [x] Prove local adapters reach the one AL.2 canonical handler, the sealed
+  storage trait, and the post-persist received-hook call site.
+- [x] Cover new write, idempotent duplicate (no second hook), and hook failure
+  (durable success plus warning) through active daemon composition.
+- [x] Add or update architecture guards proving active `atm-daemon` and
+  `atm-http-runtime` contain no raw HTTP framing, peer-only ingress/decoder,
+  resend/replay, concrete SQLite/Rusqlite, tmux, `atm-graft`, or legacy-server
+  composition dependency.
+- [x] **AL8-F002 — active-root guard:** make the boundary test inspect the
+  executable's selected composition root and its Cargo dependency closure,
+  rather than treating unreferenced historical files as active code. It must
+  fail if the executable reaches a legacy listener, worker, dispatcher,
+  framing module, replay code, or concrete storage backend.
+- [x] Capture a source-level live-reference graph for AM.1 that names the
+  active executable, runtime, listeners, canonical handler, storage trait,
+  received-hook boundary, and clients. The graph is evidence only; it does not
+  freeze AM's removal ledger.
+
+## Closure
+
+- [x] Update boundary manifests and human boundary documents only alongside
+  implemented composition changes.
+- [x] Update sprint/project-plan status only after every checklist item has
+  evidence.
+- [x] Run `just fmt`, `just lint`, `just test`, dependency/boundary checks,
+  public-schema snapshot checks, and the independent checklist/live-reference
+  review. Exact closeout evidence:
+  - `just fmt` — passed.
+  - `just lint` — passed all 25 checks, including dependency, boundary,
+    runtime-wait, fixed-sleep, manifest, and public-schema checks.
+  - `just test` — passed: 421 Python tests and the full Rust workspace
+    (`atm-daemon` excluded because `autolib = false` leaves its legacy source
+    reference-only).
+  - `cargo test -p atm-http-runtime --lib` — passed 62 tests.
+  - `cargo test -p atm-daemon-bootstrap` — passed 5 tests.
+  - `cargo test -p atm-architecture --test boundary_enforcement` — passed 48
+    tests.
+  - `git diff --check` — passed.
+
+## Critical review round 1
+
+- [x] **AL8-CR-001 — composition-boundary ownership:** the active composition
+  manifest was initially placed under `boundaries/atm-daemon`, which would
+  falsely make the frozen legacy package appear active. Move it to
+  `boundaries/atm-daemon-bootstrap`, make all legacy daemon manifests
+  reference-only, and test that the bootstrap is the sole active root.
+- [x] **AL8-CR-002 — maintainable runtime methods:** split the 127-line
+  lifecycle start method and 146-line retained-route dispatcher into focused
+  binding/publication and route-operation methods. This preserves the
+  consuming lifecycle and one canonical handler while keeping the function
+  length guard green.
+- [x] **AL8-CR-003 — enforce every newly declared boundary capability:** add
+  source-pattern mappings for all AL.8 `io_forbidden` tags and remove stale
+  legacy-daemon dependent declarations so boundary validation fails closed.
+- [x] **AL8-CR-004 — production signal-driven drain:** the architecture names
+  Unix `SIGTERM` as a daemon control signal. The replacement bootstrap now
+  awaits `SIGINT` or `SIGTERM` through Tokio and then consumes the same
+  five-second `HttpRuntime` drain transition; no signal thread is introduced.
+- [x] **AL8-CR-005 — listener-task supervision:** an unexpected exit of the
+  one managed Axum task previously left the bootstrap waiting for a signal
+  while health could remain `Ready`. The task now has a cancellation-safe
+  termination guard, revokes readiness, wakes bootstrap supervision, and
+  reaches the normal endpoint cleanup path. A deterministic abort test proves
+  the transition and record cleanup.
+
+## Validation finding
+
+- [x] **AL8-GATE-001 — shared notification-log test correlation:** the full
+  workspace suite exposed a test that assumed its delivery notification was
+  the final record in the host-scoped log. Real concurrent ATM traffic makes
+  that assumption false. The test now locates its event by its unique message
+  ID, preserving the assertion without treating a shared production log as a
+  private fixture.
+- [x] **AL8-GATE-002 — stale TLS-boundary expectation:** the active daemon no
+  longer consumes the isolated TLS helper boundary, but an architecture test
+  still expected it in `allowed_dependents`. The guard now expects only the
+  remaining TLS interop consumer while separately retaining the daemon's
+  forbidden TLS edge.
+
+## Critical review round 2
+
+- [x] Re-read the AL.8 sprint against the active executable, Cargo graph,
+  canonical route table, lifecycle transitions, and boundary manifests after
+  all fixes. The executable is a thin Tokio entrypoint; its selected bootstrap
+  is the sole allowed concrete storage composition point; and
+  `atm-http-runtime` has no SQLite, tmux, graft, raw-frame, peer-only, or
+  replay dependency.
+- [x] Review the active server-supervision path. **AL8-CR-005** was the only
+  gap found and is fixed above. A final re-read after that fix found no further
+  AL.8-scope issue. Legacy daemon source still contains old framing and thread
+  code, but `autolib = false`, static active-root guards, and the live graph
+  prove it is reference-only pending Phase AM deletion.

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -276,13 +276,16 @@ dispatch as local traffic. It is not a resend/replay proof.
 
 ### AL.8 — Daemon composition and static boundary proof
 
-**Depends on:** AL.3, AL.5, AL.6, and AL.7. Each parent integration commit
-must be pushed and merged forward before a development/fix round; parent PR
-merge is not required.
+**Depends on:** AL.3, AL.5, and AL.6. Each parent integration commit must be
+pushed and merged forward before a development/fix round; parent PR merge is
+not required. AL.7's peer TLS adapter is deferred because it is not MVP scope;
+the isolated TLS crate is retained for a future authorized phase.
 
 - Reduce `atm-daemon` integration to building trait implementations,
   selecting listener/connector configuration, starting the runtime, and
   graceful shutdown.
+- Activate only Unix UDS (where supported) and loopback TCP in this MVP
+  composition. AL.8 neither configures nor activates peer TLS.
 - Prove in-process composition and static source/dependency boundaries:
   the daemon constructs only allowed trait implementations, selects
   adapters, starts the runtime after the existing owner gate, and uses no

--- a/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
+++ b/docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md
@@ -1,6 +1,6 @@
 ---
 title: AL.8 Daemon Composition and Static Boundary Proof
-status: proposed
+status: complete
 branch: feature/pal-s8-daemon-composition-proof
 worktree: ../atm-core-worktrees/feature/pal-s8-daemon-composition-proof
 target: integrate/phase-al
@@ -9,9 +9,11 @@ target: integrate/phase-al
 # AL.8 — Daemon Composition and Static Boundary Proof
 
 **recommended_agent:** arch-ctm/deep-reasoning
-**must_follow:** AL.3, AL.5, AL.6, and AL.7. Merge each parent's pushed
-integration commit before each development/fix round; parent PR merges are not
-required.
+**must_follow:** AL.3, AL.5, and AL.6. Merge each parent's pushed integration
+commit before each development/fix round; parent PR merges are not required.
+AL.7's peer TLS work is deferred: TLS is not MVP scope and the repository's
+isolated TLS crate remains the only future TLS implementation source. AL.8
+must not add, activate, or prove a TLS adapter.
 **unblocks:** AL.9 only. AM deletion remains blocked on AL.9 acceptance.
 **parallel_safe:** AM.1 inventory only.
 
@@ -36,7 +38,7 @@ shared traceability record.
    the ledger here.
 4. Publish runtime health through the existing daemon status/readiness surface,
    not a second server: `Ready` only after owner gate, AL.1 validation, router
-   construction, and every enabled listener bind succeeds; `NotReady` before
+  construction, and every enabled MVP local listener bind succeeds; `NotReady` before
    start and throughout drain; `Live` reflects process/runtime supervision.
    A failed bind/TLS/configuration start remains `NotReady` with a typed cause.
 5. Adopt the architecture contract's **5s** daemon graceful-drain deadline
@@ -52,6 +54,9 @@ shared traceability record.
 - The active daemon starts only after its existing singleton gate and publishes
   no listener earlier; shutdown stops accepts and drains/cancels tracked work
   within the documented bound.
+- AL.8 activates only the framework-managed Unix UDS (where supported) and
+  loopback TCP adapters. Peer TLS remains deferred and cannot become an
+  implicit startup dependency.
 - The static route/composition trace identifies the common handler, storage
   trait, and received-hook call site without a second listener/client root.
 - Boundary searches prove no raw framing, peer-only ingress, replay, concrete


### PR DESCRIPTION
## Summary
- Tokio/Axum (atm-http-runtime) is the sole active daemon path
- Legacy daemon source is `autolib=false`, reference-only
- Owner gate, lifecycle/health supervision, canonical retained routes implemented
- UDS + loopback TCP wired, injected receiver hooks
- Static guards + live-reference inventory added

## Validation (arch-ctm self-report)
- `just lint` 25/25
- `just test`
- focused runtime tests: 62
- bootstrap tests: 5
- architecture tests: 48
- diff check clean

Sprint doc: docs/plans/phase-al/sprint-AL8-daemon-composition-proof.md