### PR TITLE
docs(al9): document atm send --host flag (HOSTFLAG-SPEC-GAP-AL9)

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -551,6 +551,10 @@ Required behavior:
   `--team <team>` yields logical `agent@team`; adding `--chat-id XXX` yields
   logical `agent:XXX@team`, before a single normalization to the structured
   address
+- for `atm send`, `--host <host>` qualifies the resolved recipient as
+  `agent@team.host`; it is equivalent to spelling that host in the recipient
+  address, and supplying both forms with different hosts fails before daemon
+  dispatch
 - caller chat-id resolution is ordered: qualified `--as <agent>:<chat-id>`,
   then `--chat-id`, then `ATM_CHAT_ID`, then a chat-id embedded in
   `ATM_IDENTITY=<agent>:<chat-id>`, then no chat-id. An explicit unqualified
@@ -1126,8 +1130,9 @@ Retired from the current implementation:
   validation, self-send checks, routing, and audit behavior
 - reject canonical same-team self-addressed sends before any persistence or
   `--dry-run` success reporting only when the resolved destination has no
-  host; every syntactically valid host-qualified destination continues to the
-  ordinary host-routing contract
+  host; `atm send --host <host>` is a second way to produce that qualified
+  destination, and every syntactically valid host-qualified destination
+  continues to the ordinary host-routing contract
 - verify target team existence and target agent membership as part of address
   resolution before mailbox path selection, except for the documented
   `missing-document` fallback in §6.3.1


### PR DESCRIPTION
Fixes HOSTFLAG-SPEC-GAP-AL9 (Important).

`atm send`'s `--host` flag (commit 4bade7c9, merged via PR #779) had zero
documentation trace. This adds two `docs/requirements.md` bullets:

- REQ-CORE-IDENTITY-CHAT-001: `--host <host>` is equivalent to a
  host-qualified recipient address (`agent@team.host`); disagreeing forms
  fail before daemon dispatch.
- Self-send-suppression requirement: `--host` is a second way to produce a
  host-qualified destination alongside spelling it directly in the address.

Scope note: the finding's original text also asked for a `--host` flag on
`atm ack`. That premise was verified false during dev work -- `AckRequest`
has no destination field at all (`crates/atm-core/src/ack/mod.rs:21-32`),
`atm ack` has no recipient argument, and `docs/requirements.md:889` already
specifies that ack's reply target always preserves the original sender's
address. There is no destination argument for `--host` to qualify, so no
`ack.rs` change was made or is needed.

No code changes -- docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)