### PR TITLE
fix(smoke): isolate reports by platform host and run

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smoke-test
-description: Run or inspect the Phase Z smoke harness for atm-core. Use when implementing or operating `just smoke`, `just smoke fast`, or `just smoke thorough`, when rendering `reports/smoke/*`, when checking the frozen Phase Z row map, or when triaging smoke findings against retained logs and report artifacts.
+description: Run or inspect the repo-native smoke harness for atm-core. Use when implementing or operating `just smoke`, including live `localhost` and `local-ip` hardware checks; when rendering or inspecting `site/reports/smoke/*`; or when triaging smoke findings against retained evidence.
 ---
 
 # Smoke Test Skill
@@ -12,13 +12,14 @@ Use this skill for the repo-native smoke harness and its report artifacts.
 - Read `references/level-matrix.md` to select `fast`, `normal`, or `thorough`.
 - Read `references/phase-z-row-map.md` when you need the frozen row IDs and
   level-to-row coverage expectations.
-- Read `references/report-schema.md` when you need the canonical JSON contract
-  or the tracked-latest vs timestamped artifact rules.
+- Read `references/report-schema.md` when you need the canonical evidence
+  layout and JSON contract.
 
 ## Implementation Surface
 
 - runner:
   - `scripts/smoke/run.py`
+  - `scripts/smoke/run_feature_smoke.py`
 - retained-log analysis:
   - `scripts/smoke/analyze_logs.py`
 - fixture and artifact path helpers:
@@ -28,14 +29,19 @@ Use this skill for the repo-native smoke harness and its report artifacts.
 
 ## Artifact Rules
 
-- tracked latest smoke reports:
-  - `reports/smoke/smoke-fast.md`
-  - `reports/smoke/smoke.md`
-  - `reports/smoke/smoke-thorough.md`
-- timestamped smoke markdown and JSON artifacts use the shared
-  `YYYY-MM-DD-HH-MM-SS-*` convention
-- timestamped artifacts are local/transient; tracked latest reports are the
-  committed human-facing snapshots
+- Live hardware smoke uses the fuzz-style, self-contained report layout:
+  `site/reports/smoke/<platform>/<host>/<run-id>-pid<PID>-<feature>/`.
+- The directory contains the JSON result, per-host XHTML panels, feature HTML,
+  and `index.html`. No smoke data or HTML is written to the site root or the
+  top-level `site/reports` directory.
+- `platform` is the operating-system label (`macos`, `windows`, or `linux` as
+  reported by the runner), `host` is the sanitized local hostname, and
+  `run-id` is `ATM_SMOKE_RUN_ID` when supplied or a UTC microsecond timestamp.
+  The PID suffix preserves non-overlap even for simultaneous same-host runs.
+- Report consumers must use the path printed by `just smoke`; never infer a
+  shared “latest” artifact.
+- Fixture levels (`fast`, `normal`, `thorough`) use the same platform/host/run
+  directory layout and retain their Markdown and JSON inside that directory.
 
 ## Notes
 

--- a/.claude/skills/smoke-test/references/report-schema.md
+++ b/.claude/skills/smoke-test/references/report-schema.md
@@ -10,6 +10,15 @@ Canonical payload fields:
 - `rows`
 - `summary`
 
+Live hardware smoke additionally records:
+
+- `feature`
+- `platform`
+- `host`
+- `run_id`
+- `status`
+- `cases`
+
 Every row record may carry:
 
 - `id`
@@ -21,20 +30,19 @@ Every row record may carry:
 - `likely_root_cause`
 - `artifact_pointer`
 
-Tracked latest markdown artifacts:
+## Live hardware artifact layout
 
-- `reports/smoke/smoke-fast.md`
-- `reports/smoke/smoke.md`
-- `reports/smoke/smoke-thorough.md`
+Every live `just smoke localhost`, `just smoke local-ip`, or cross-host run
+owns one directory, following the fuzz-report principle of self-contained
+evidence:
 
-Timestamped markdown artifacts:
+`site/reports/smoke/<platform>/<host>/<run-id>-pid<PID>-<feature>/`
 
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke-fast.md`
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke.md`
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke-thorough.md`
+For example, a Windows local-IP result could be:
 
-Timestamped JSON artifacts:
+`site/reports/smoke/windows/cwin/20260808T001234567890Z-pid4242-local-ip/`
 
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke-fast.json`
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke.json`
-- `reports/smoke/YYYY-MM-DD-HH-MM-SS-smoke-thorough.json`
+That directory contains `<feature>.json`, `<feature>.html`, `index.html`, and
+the XHTML evidence panels. Platform and host are present in both the directory
+path and JSON payload. There are no shared/latest smoke artifacts and no smoke
+files directly in `site/` or `site/reports/`.

--- a/.claude/skills/smoke-test/references/report-schema.md
+++ b/.claude/skills/smoke-test/references/report-schema.md
@@ -1,4 +1,4 @@
-# Smoke Report Schema
+# Smoke Report Schema 
 
 Canonical payload fields:
 

--- a/docs/plans/phase-al/sprint-AL9-physical-proof-ledger-freeze.md
+++ b/docs/plans/phase-al/sprint-AL9-physical-proof-ledger-freeze.md
@@ -59,6 +59,9 @@ ADR-033, ADR-036, and the AL/AM boundary checklist.
 
 - full test, format, lint, dependency/boundary checks
 - physical proof artifacts for every matrix row
+- every live smoke artifact records platform and host and is retained as one
+  self-contained directory beneath `site/reports/smoke/`; no shared/latest
+  report may overwrite a concurrent hardware run
 - M5 clean-checkout artifact or approved SHA-reuse justification
 - baseline/result benchmark artifacts and Windows result
 - independent review of cutover table, reference graph, and ledger freeze

--- a/scripts/smoke/fixtures.py
+++ b/scripts/smoke/fixtures.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 import json
 import os
+import platform
+import re
 import shutil
 import subprocess
 import tempfile
@@ -15,9 +17,9 @@ import tempfile
 class SmokePaths:
     repo_root: Path
     reports_root: Path
-    latest_markdown: Path
-    timestamped_markdown: Path
-    timestamped_json: Path
+    report_dir: Path
+    markdown: Path
+    json: Path
 
 
 @dataclass(frozen=True)
@@ -46,7 +48,17 @@ def repo_root() -> Path:
 
 def timestamp_slug(now: datetime | None = None) -> str:
     moment = now or datetime.now(timezone.utc)
-    return moment.strftime("%Y-%m-%d-%H-%M-%S")
+    return moment.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def report_segment(value: str, label: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value):
+        raise ValueError(f"{label} must contain only letters, numbers, '.', '_', or '-'")
+    return value
+
+
+def operating_system_label() -> str:
+    return {"darwin": "macos"}.get(platform.system().lower(), platform.system().lower())
 
 
 def level_slug(level: str) -> str:
@@ -58,16 +70,19 @@ def level_slug(level: str) -> str:
 
 def smoke_paths(level: str, now: datetime | None = None) -> SmokePaths:
     root = repo_root()
-    reports_root = root / "reports" / "smoke"
+    reports_root = root / "site" / "reports" / "smoke"
     slug = level_slug(level)
-    stamp = timestamp_slug(now)
-    latest_name = f"{slug}.md"
+    platform_label = report_segment(operating_system_label(), "local platform")
+    host_label = report_segment(platform.node(), "local host name")
+    requested_run_id = os.environ.get("ATM_SMOKE_RUN_ID", "").strip()
+    run_id = report_segment(requested_run_id or timestamp_slug(now), "ATM_SMOKE_RUN_ID")
+    report_dir = reports_root / platform_label / host_label / f"{run_id}-pid{os.getpid()}-{slug}"
     return SmokePaths(
         repo_root=root,
         reports_root=reports_root,
-        latest_markdown=reports_root / latest_name,
-        timestamped_markdown=reports_root / f"{stamp}-{slug}.md",
-        timestamped_json=reports_root / f"{stamp}-{slug}.json",
+        report_dir=report_dir,
+        markdown=report_dir / f"{slug}.md",
+        json=report_dir / f"{slug}.json",
     )
 
 

--- a/scripts/smoke/render_report.py
+++ b/scripts/smoke/render_report.py
@@ -45,10 +45,10 @@ def main() -> int:
     markdown = render_markdown(payload)
     if args.write_artifacts:
         paths = smoke_paths(payload["level"])
-        ensure_parent(paths.latest_markdown)
-        write_text_atomic(paths.latest_markdown, markdown)
-        write_text_atomic(paths.timestamped_markdown, markdown)
-        write_json(paths.timestamped_json, payload)
+        ensure_parent(paths.markdown)
+        write_text_atomic(paths.markdown, markdown)
+        write_json(paths.json, payload)
+        print(f"SMOKE evidence: {paths.report_dir}")
     else:
         print(markdown, end="")
     return 0

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -445,6 +445,37 @@ def artifact_segment(value: str, label: str) -> str:
     return value
 
 
+def operating_system_label() -> str:
+    """Return the stable public OS label used by smoke evidence paths."""
+    return {"darwin": "macos"}.get(platform.system().lower(), platform.system().lower())
+
+
+def smoke_report_directory(feature: str) -> tuple[Path, dict[str, str]]:
+    """Return an isolated public report directory for one live smoke run.
+
+    This follows the fuzz-report principle of one self-contained evidence
+    directory. Platform, host, and a process-qualified run ID make M5,
+    Windows, and simultaneous local runs disjoint. Nothing is written to the
+    site root or the top-level ``site/reports`` directory.
+    """
+    platform_label = artifact_segment(operating_system_label(), "local platform")
+    host_label = artifact_segment(platform.node(), "local host name")
+    requested_run_id = os.environ.get("ATM_SMOKE_RUN_ID", "").strip()
+    run_id = artifact_segment(
+        requested_run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ"),
+        "ATM_SMOKE_RUN_ID",
+    )
+    feature_label = artifact_segment(feature, "smoke feature")
+    run_label = f"{run_id}-pid{os.getpid()}-{feature_label}"
+    directory = ROOT / "site" / "reports" / "smoke" / platform_label / host_label / run_label
+    return directory, {
+        "feature": feature_label,
+        "host": host_label,
+        "platform": platform_label,
+        "run_id": run_id,
+    }
+
+
 def send_read_ack(
     cases: list[dict[str, Any]],
     atm: str,
@@ -657,17 +688,23 @@ def crosshost_ack(
 
 
 def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
-    run_id = artifact_segment(
-        os.environ.get("ATM_SMOKE_RUN_ID", "").strip()
-        or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
-        "ATM_SMOKE_RUN_ID",
-    )
-    host = artifact_segment(platform.node(), "local host name")
-    directory = ROOT / "reports" / "smoke" / run_id
+    directory, identity = smoke_report_directory(feature)
+    host = identity["host"]
     directory.mkdir(parents=True, exist_ok=True)
-    report = directory / f"{host}-{feature}.json"
+    report = directory / f"{identity['feature']}.json"
     passed = all(case["status"] == "PASS" for case in cases)
-    report.write_text(json.dumps({"feature": feature, "status": "PASS" if passed else "FAIL", "cases": cases}, indent=2) + "\n", encoding="utf-8")
+    report.write_text(
+        json.dumps(
+            {
+                **identity,
+                "status": "PASS" if passed else "FAIL",
+                "cases": cases,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     hosts = list(dict.fromkeys(case["origin"] for case in cases))
     for destination in (case["destination"] for case in cases):
         if destination not in hosts:

--- a/scripts/smoke/test_fixtures.py
+++ b/scripts/smoke/test_fixtures.py
@@ -1,0 +1,49 @@
+"""Artifact-path tests for the canonical smoke report layout."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from unittest import mock
+import unittest
+
+
+def load_fixtures():
+    path = Path(__file__).with_name("fixtures.py")
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("smoke_fixtures", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+FIXTURES = load_fixtures()
+
+
+class SmokePathsTests(unittest.TestCase):
+    def test_fixture_artifacts_are_platform_host_and_run_isolated_under_site_reports(self):
+        now = datetime(2026, 8, 8, 0, 12, 34, 567890, tzinfo=timezone.utc)
+        with mock.patch.dict(os.environ, {"ATM_SMOKE_RUN_ID": "hardware-run"}, clear=False), mock.patch.object(
+            FIXTURES, "repo_root", return_value=Path("/repo")
+        ), mock.patch.object(FIXTURES.platform, "system", return_value="Windows"), mock.patch.object(
+            FIXTURES.platform, "node", return_value="cwin"
+        ), mock.patch.object(FIXTURES.os, "getpid", return_value=42):
+            paths = FIXTURES.smoke_paths("thorough", now)
+        self.assertEqual(paths.reports_root, Path("/repo/site/reports/smoke"))
+        self.assertEqual(paths.report_dir, Path("/repo/site/reports/smoke/windows/cwin/hardware-run-pid42-smoke-thorough"))
+        self.assertEqual(paths.markdown, paths.report_dir / "smoke-thorough.md")
+        self.assertEqual(paths.json, paths.report_dir / "smoke-thorough.json")
+
+    def test_fixture_run_id_uses_microseconds_when_not_explicitly_supplied(self):
+        now = datetime(2026, 8, 8, 0, 12, 34, 567890, tzinfo=timezone.utc)
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            FIXTURES, "repo_root", return_value=Path("/repo")
+        ), mock.patch.object(FIXTURES.platform, "system", return_value="Darwin"), mock.patch.object(
+            FIXTURES.platform, "node", return_value="m5"
+        ), mock.patch.object(FIXTURES.os, "getpid", return_value=9):
+            paths = FIXTURES.smoke_paths("fast", now)
+        self.assertIn("20260808T001234567890Z-pid9-smoke-fast", str(paths.report_dir))

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 from pathlib import Path
 import sys
@@ -110,11 +111,17 @@ class FeatureSmokeTests(unittest.TestCase):
             with self.assertRaisesRegex(RUNNER.SmokeError, "only valid"):
                 RUNNER.main()
 
-    def test_report_writes_browser_frame_for_xhtml_pane(self):
+    def test_report_writes_browser_frame_in_self_contained_platform_host_run_directory(self):
         with tempfile.TemporaryDirectory() as temp:
             with mock.patch.dict(os.environ, {"ATM_SMOKE_RUN_ID": "smoke-42"}, clear=False):
                 with mock.patch.object(RUNNER, "ROOT", Path(temp)):
-                    with mock.patch.object(RUNNER, "compose") as compose:
+                    with mock.patch.object(RUNNER, "platform") as platform, mock.patch.object(
+                        RUNNER, "os"
+                    ) as os_module, mock.patch.object(RUNNER, "compose") as compose:
+                        platform.system.return_value = "Darwin"
+                        platform.node.return_value = "m5.example.test"
+                        os_module.environ = os.environ
+                        os_module.getpid.return_value = 4242
                         report = RUNNER.write_report(
                             "localhost",
                             [
@@ -128,8 +135,77 @@ class FeatureSmokeTests(unittest.TestCase):
                             ],
                         )
         self.assertEqual(compose.call_count, 3)
+        self.assertEqual(
+            report,
+            Path(temp) / "site/reports/smoke/macos/m5.example.test/smoke-42-pid4242-localhost/localhost.json",
+        )
         self.assertEqual(compose.call_args_list[1].args[2], report.with_suffix(".html"))
         self.assertEqual(compose.call_args_list[2].args[2], report.parent / "index.html")
+
+    def test_report_directory_includes_platform_host_and_process_qualified_run_id(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(RUNNER, "ROOT", Path(temp)), mock.patch.object(
+                RUNNER, "platform"
+            ) as platform, mock.patch.object(RUNNER, "os") as os_module:
+                platform.system.return_value = "Windows"
+                platform.node.return_value = "cwin"
+                os_module.environ = {}
+                os_module.getpid.return_value = 99
+                with mock.patch.object(RUNNER, "datetime") as datetime:
+                    datetime.now.return_value.strftime.return_value = "20260808T001234567890Z"
+                    directory, identity = RUNNER.smoke_report_directory("local-ip")
+        self.assertEqual(
+            identity,
+            {
+                "feature": "local-ip",
+                "host": "cwin",
+                "platform": "windows",
+                "run_id": "20260808T001234567890Z",
+            },
+        )
+        self.assertEqual(
+            directory,
+            Path(temp) / "site/reports/smoke/windows/cwin/20260808T001234567890Z-pid99-local-ip",
+        )
+
+    def test_report_writes_metadata_and_all_rendered_outputs_beneath_its_run_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+
+            def compose_side_effect(_template, _variables, output):
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text("rendered\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"ATM_SMOKE_RUN_ID": "run-1"}, clear=False), mock.patch.object(
+                RUNNER, "ROOT", root
+            ), mock.patch.object(RUNNER, "platform") as platform, mock.patch.object(RUNNER, "os") as os_module, mock.patch.object(
+                RUNNER, "compose", side_effect=compose_side_effect
+            ):
+                platform.system.return_value = "Windows"
+                platform.node.return_value = "cwin"
+                os_module.environ = os.environ
+                os_module.getpid.return_value = 7
+                report = RUNNER.write_report(
+                    "localhost",
+                    [{"name": "doctor", "status": "PASS", "detail": "ready", "origin": "cwin", "destination": "cwin"}],
+                )
+            payload = json.loads(report.read_text(encoding="utf-8"))
+            self.assertEqual(
+                payload,
+                {
+                    "feature": "localhost",
+                    "host": "cwin",
+                    "platform": "windows",
+                    "run_id": "run-1",
+                    "status": "PASS",
+                    "cases": [{"name": "doctor", "status": "PASS", "detail": "ready", "origin": "cwin", "destination": "cwin"}],
+                },
+            )
+            self.assertTrue(report.with_suffix(".html").is_file())
+            self.assertTrue((report.parent / "index.html").is_file())
+            self.assertTrue((report.parent / "cwin-localhost.xhtml").is_file())
+            self.assertFalse((root / "site" / "index.html").exists())
+            self.assertFalse((root / "site" / "reports" / "localhost.json").exists())
 
     def test_feature_pane_renders_each_executed_case(self):
         pane = RUNNER.render_feature_pane(


### PR DESCRIPTION
## Summary
- retain every `just smoke` artifact beneath a unique `site/reports/smoke/<platform>/<host>/<run>/` directory
- preserve XHTML panel/index reporting without writing shared/latest files
- record platform, host, and run metadata; cover paths and rendered artifacts with tests

## Validation
- `just test`