### PR TITLE
Plan: AL.11/AL.12 hardware smoke-dispatch instructions (M5/cwin)

### DIFF
--- a/docs/plans/phase-al/sprint-AL11-m5-hardware-smoke-dispatch.md
+++ b/docs/plans/phase-al/sprint-AL11-m5-hardware-smoke-dispatch.md
@@ -27,7 +27,8 @@
    is the same progressive ladder `docs/peer-pair-smoke.md` defines, not an
    independent smoke choice. The dispatch doc must instruct M5 to also run
    `atm doctor --json` and post the JSON plus generated XHTML evidence panes
-   under `reports/smoke/<feature>/` for every command, along with host/OS
-   version, to PR #779. `peer-preflight` must be confirmed healthy before
+   produced by the repository's `.claude/skills/smoke-test/SKILL.md` skill
+   for every command, along with host/OS version, to PR #779.
+   `peer-preflight` must be confirmed healthy before
    `crosshost-send`/`crosshost-ack` are attempted — a failure at any step
    blocks the later steps and must be posted as-is, not retried silently.

--- a/docs/plans/phase-al/sprint-AL11-m5-hardware-smoke-dispatch.md
+++ b/docs/plans/phase-al/sprint-AL11-m5-hardware-smoke-dispatch.md
@@ -1,0 +1,33 @@
+# AL.11 — M5 (macOS) Hardware Smoke-Dispatch Instructions
+
+**recommended_agent:** team-lead (doc-only, no ATM identity on receiving end).
+**must_follow:** AL.9 (PR #779) — dispatch instructions reference its build/branch.
+**unblocks:** M5 hardware team executing AL.9 smoke validation.
+**parallel_safe:** yes, independent of AL.12 (cwin).
+
+## Deliverables
+
+1. Write `docs/plans/phase-al/AL9-hardware-smoke-dispatch-m5.md`: instructions
+   for the M5 macOS hardware team (no ATM identity, cannot receive task
+   assignments) to run the exact peer-pair procedure AL.9 deliverable 1 already
+   specifies for proving M5 direct cross-host write, per
+   `docs/peer-pair-smoke.md`'s progressive live-daemon commands, against the
+   AL.9 build/branch (PR #779) and its designated peer host `fastpc4.rz.local`
+   (operated by the cwin team, AL.12):
+
+   ```bash
+   just smoke localhost
+   just smoke local-ip
+   just smoke peer-preflight m5 fastpc4
+   just smoke crosshost-send m5 fastpc4
+   just smoke crosshost-ack m5 fastpc4
+   ```
+
+   Each command must be run only after the prior one passes, in order — this
+   is the same progressive ladder `docs/peer-pair-smoke.md` defines, not an
+   independent smoke choice. The dispatch doc must instruct M5 to also run
+   `atm doctor --json` and post the JSON plus generated XHTML evidence panes
+   under `reports/smoke/<feature>/` for every command, along with host/OS
+   version, to PR #779. `peer-preflight` must be confirmed healthy before
+   `crosshost-send`/`crosshost-ack` are attempted — a failure at any step
+   blocks the later steps and must be posted as-is, not retried silently.

--- a/docs/plans/phase-al/sprint-AL12-cwin-hardware-smoke-dispatch.md
+++ b/docs/plans/phase-al/sprint-AL12-cwin-hardware-smoke-dispatch.md
@@ -1,0 +1,30 @@
+# AL.12 — cwin (Windows) Hardware Smoke-Dispatch Instructions
+
+**recommended_agent:** team-lead (doc-only, no ATM identity on receiving end).
+**must_follow:** AL.9 (PR #779) — dispatch instructions reference its build/branch.
+**unblocks:** cwin hardware team executing AL.9 smoke validation.
+**parallel_safe:** yes, independent of AL.11 (M5).
+
+## Deliverables
+
+1. Write `docs/plans/phase-al/AL9-hardware-smoke-dispatch-cwin.md`: instructions
+   for the cwin Windows hardware team (no ATM identity, cannot receive task
+   assignments) to run, on its designated Windows host `fastpc4.rz.local`,
+   against the AL.9 build/branch (PR #779):
+
+   1. The standard local smoke ladder established for cwin by AI.52 — build
+      the branch's release CLI/daemon pair under an isolated ATM home and
+      disposable test database, then run `just smoke`, `just smoke localhost`,
+      `just smoke local-ip`, `just test`, and `atm doctor --json`. A local
+      smoke failure must be fixed and revalidated before step 2.
+   2. Confirm the daemon stays up and reachable as the peer target for M5's
+      (AL.11) `docs/peer-pair-smoke.md` progressive ladder — `just smoke
+      peer-preflight m5 fastpc4`, `just smoke crosshost-send m5 fastpc4`,
+      `just smoke crosshost-ack m5 fastpc4` are run FROM the M5 side and
+      require `fastpc4.rz.local`'s daemon to be healthy and SSH-reachable for
+      the duration; cwin does not run those commands itself.
+
+   The dispatch doc must instruct cwin to post its local-ladder JSON output,
+   `atm doctor --json` output, and host/OS version to PR #779, and to confirm
+   in the PR comment that its daemon window stayed up for M5's cross-host
+   commands (AL.11) to complete against it.

--- a/docs/plans/phase-al/sprint-AL12-cwin-hardware-smoke-dispatch.md
+++ b/docs/plans/phase-al/sprint-AL12-cwin-hardware-smoke-dispatch.md
@@ -24,7 +24,9 @@
       require `fastpc4.rz.local`'s daemon to be healthy and SSH-reachable for
       the duration; cwin does not run those commands itself.
 
-   The dispatch doc must instruct cwin to post its local-ladder JSON output,
-   `atm doctor --json` output, and host/OS version to PR #779, and to confirm
-   in the PR comment that its daemon window stayed up for M5's cross-host
-   commands (AL.11) to complete against it.
+   The dispatch doc must instruct cwin to post its local-ladder JSON output
+   and generated XHTML panes produced by the repository's
+   `.claude/skills/smoke-test/SKILL.md` skill, plus `atm doctor --json` output
+   and host/OS version, to PR #779. It must also confirm in the PR comment
+   that its daemon window stayed up for M5's cross-host commands (AL.11) to
+   complete against it.


### PR DESCRIPTION
## Summary
- Adds AL.11 (M5/macOS) and AL.12 (cwin/Windows) sprint plan docs for dispatching AL.9 physical-proof smoke instructions to hardware teams with no ATM identity.
- Both docs reference arch-ctm's actual specified procedure — `docs/peer-pair-smoke.md`'s progressive peer-pair ladder proving M5 direct cross-host write against peer `fastpc4.rz.local` — rather than a generic `just smoke` placeholder.

## Plan-only
This is a plan doc branch off `develop` per repo convention; no execution artifacts are included. Once merged, the feature worktrees `feature/pal-s11-m5-hardware-smoke-dispatch` and `feature/pal-s12-cwin-hardware-smoke-dispatch` pick up the plan and produce the actual dispatch instruction files.

## Test plan
- [ ] Docs-only change, no build/test impact