### PR TITLE
fix(smoke): index every hardware smoke run

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -32,8 +32,10 @@ Use this skill for the repo-native smoke harness and its report artifacts.
 - Live hardware smoke uses the fuzz-style, self-contained report layout:
   `site/reports/smoke/<platform>/<host>/<run-id>-pid<PID>-<feature>/`.
 - The directory contains the JSON result, per-host XHTML panels, feature HTML,
-  and `index.html`. No smoke data or HTML is written to the site root or the
-  top-level `site/reports` directory.
+  its own `index.html`, and a `smoke.envelope.json` registration record. The
+  generated master navigation at `site/reports/index.html` links every run;
+  no smoke payload or panel is written to the site root or top-level
+  `site/reports` directory.
 - `platform` is the operating-system label (`macos`, `windows`, or `linux` as
   reported by the runner), `host` is the sanitized local hostname, and
   `run-id` is `ATM_SMOKE_RUN_ID` when supplied or a UTC microsecond timestamp.

--- a/.claude/skills/smoke-test/references/report-schema.md
+++ b/.claude/skills/smoke-test/references/report-schema.md
@@ -42,7 +42,9 @@ For example, a Windows local-IP result could be:
 
 `site/reports/smoke/windows/cwin/20260808T001234567890Z-pid4242-local-ip/`
 
-That directory contains `<feature>.json`, `<feature>.html`, `index.html`, and
-the XHTML evidence panels. Platform and host are present in both the directory
-path and JSON payload. There are no shared/latest smoke artifacts and no smoke
-files directly in `site/` or `site/reports/`.
+That directory contains `<feature>.json`, `<feature>.html`, `index.html`,
+`smoke.envelope.json`, and the XHTML evidence panels. Platform and host are
+present in both the directory path and JSON payload. The envelope registers
+the run in the generated master navigation at `site/reports/index.html`; there
+are no shared/latest smoke artifacts and no smoke payload or panel directly in
+`site/` or `site/reports/`.

--- a/.just/generate_report_index.py
+++ b/.just/generate_report_index.py
@@ -2,9 +2,9 @@
 """Generate and validate the durable public verification-report index.
 
 Report producers may place one envelope at ``site/reports/<name>.json`` or
-store run envelopes inside the same-named evidence directory.  Every envelope
-points at a root-level ``<name>.html`` and its same-named evidence directory.
-Ordinary evidence JSON without envelope fields is not a discovery input.
+store a run envelope beside a nested report index. Every envelope points at a
+safe HTML path relative to ``site/reports``. Ordinary evidence JSON without
+envelope fields is not a discovery input.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from typing import Any, Iterable
 
 
 SCHEMA_VERSION = 1
-REPORT_TYPES = ("benchmark", "fuzz")
+REPORT_TYPES = ("benchmark", "fuzz", "smoke")
 REPORTS_RELATIVE = Path("site/reports")
 INDEX_NAME = "index.html"
 HOST_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
@@ -29,6 +29,7 @@ REPORT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 REQUIRED_FIELDS = frozenset(
     {"schema_version", "report_type", "generated_at", "host_label", "report_html"}
 )
+SMOKE_STATUS_VALUES = frozenset({"PASS", "FAIL"})
 
 
 class ReportIndexError(ValueError):
@@ -44,6 +45,7 @@ class Envelope:
     host_label: str
     report_html: str
     source: Path
+    status: str | None = None
 
 
 @dataclass(frozen=True)
@@ -54,6 +56,7 @@ class ReportEntry:
     generated_at_text: str
     host_labels: tuple[str, ...]
     run_count: int
+    status: str | None
 
 
 def _ensure_inside(path: Path, root: Path, description: str) -> None:
@@ -86,9 +89,9 @@ def _safe_relative_html(value: Any, source: Path) -> str:
     path = PurePosixPath(value)
     if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
         raise ReportIndexError(f"{source}: report_html is not a safe relative path: {value!r}")
-    if len(path.parts) != 1 or path.suffix.lower() != ".html":
-        raise ReportIndexError(f"{source}: report_html must be a root-level .html file")
-    name = path.name[:-5]
+    if path.suffix.lower() != ".html":
+        raise ReportIndexError(f"{source}: report_html must be an .html file")
+    name = path.stem
     if not REPORT_NAME_RE.fullmatch(name):
         raise ReportIndexError(f"{source}: report_html has an unsafe report name: {value!r}")
     return path.as_posix()
@@ -102,6 +105,30 @@ def _safe_host_label(value: Any, source: Path) -> str:
     return value
 
 
+def _smoke_status(value: Any, source: Path) -> str:
+    if value not in SMOKE_STATUS_VALUES:
+        raise ReportIndexError(
+            f"{source}: smoke status must be one of {', '.join(sorted(SMOKE_STATUS_VALUES))}"
+        )
+    return value
+
+
+def _smoke_run_timestamp(value: Any, source: Path) -> tuple[datetime, str]:
+    if not isinstance(value, str):
+        raise ReportIndexError(f"{source}: smoke run_id must be a string")
+    match = re.fullmatch(r"(\d{8}T\d{6})(\d{0,6})Z", value)
+    if match is None:
+        raise ReportIndexError(f"{source}: smoke run_id is not a UTC timestamp")
+    try:
+        timestamp = datetime.strptime(match.group(1), "%Y%m%dT%H%M%S").replace(
+            tzinfo=timezone.utc,
+            microsecond=int(match.group(2).ljust(6, "0") or "0"),
+        )
+    except ValueError as exc:
+        raise ReportIndexError(f"{source}: smoke run_id is not a valid timestamp") from exc
+    return timestamp, timestamp.isoformat().replace("+00:00", "Z")
+
+
 def parse_envelope(source: Path, reports_root: Path) -> Envelope:
     _ensure_inside(source, reports_root, "envelope")
     try:
@@ -113,7 +140,13 @@ def parse_envelope(source: Path, reports_root: Path) -> Envelope:
     missing = REQUIRED_FIELDS - payload.keys()
     if missing:
         raise ReportIndexError(f"{source}: missing envelope fields: {', '.join(sorted(missing))}")
-    unexpected_fields = set(payload) - REQUIRED_FIELDS
+    report_type = payload["report_type"]
+    if report_type not in REPORT_TYPES:
+        raise ReportIndexError(
+            f"{source}: report_type must be one of {', '.join(REPORT_TYPES)}"
+        )
+    allowed_fields = REQUIRED_FIELDS | ({"status"} if report_type == "smoke" else set())
+    unexpected_fields = set(payload) - allowed_fields
     if unexpected_fields:
         raise ReportIndexError(
             f"{source}: unsupported public fields: {', '.join(sorted(unexpected_fields))}"
@@ -122,11 +155,6 @@ def parse_envelope(source: Path, reports_root: Path) -> Envelope:
     if schema_version != SCHEMA_VERSION or isinstance(schema_version, bool):
         raise ReportIndexError(
             f"{source}: schema_version must be integer {SCHEMA_VERSION}"
-        )
-    report_type = payload["report_type"]
-    if report_type not in REPORT_TYPES:
-        raise ReportIndexError(
-            f"{source}: report_type must be one of {', '.join(REPORT_TYPES)}"
         )
     generated_at, generated_at_text = _utc_timestamp(payload["generated_at"], source)
     host_label = _safe_host_label(payload["host_label"], source)
@@ -137,9 +165,13 @@ def parse_envelope(source: Path, reports_root: Path) -> Envelope:
     _ensure_inside(evidence_dir, reports_root, "evidence directory")
     if not html_path.is_file():
         raise ReportIndexError(f"{source}: missing report HTML: {report_html}")
-    if not evidence_dir.is_dir():
+    if report_type != "smoke" and not evidence_dir.is_dir():
         raise ReportIndexError(
             f"{source}: missing same-named evidence directory: {evidence_dir.name}/"
+        )
+    if report_type == "smoke" and source.parent != html_path.parent:
+        raise ReportIndexError(
+            f"{source}: smoke envelope must be stored beside its run index"
         )
     return Envelope(
         schema_version=schema_version,
@@ -149,6 +181,33 @@ def parse_envelope(source: Path, reports_root: Path) -> Envelope:
         host_label=host_label,
         report_html=report_html,
         source=source,
+        status=_smoke_status(payload["status"], source) if report_type == "smoke" else None,
+    )
+
+
+def parse_smoke_result(source: Path, reports_root: Path, payload: dict[str, Any]) -> Envelope:
+    """Adapt a pre-envelope smoke result so historical runs remain browseable."""
+    _ensure_inside(source, reports_root, "smoke result")
+    required = {"feature", "platform", "host", "run_id", "status", "cases"}
+    if not required.issubset(payload):
+        missing = ", ".join(sorted(required - payload.keys()))
+        raise ReportIndexError(f"{source}: smoke result is missing fields: {missing}")
+    host_label = _safe_host_label(payload["host"], source)
+    _safe_host_label(payload["platform"], source)
+    timestamp, timestamp_text = _smoke_run_timestamp(payload["run_id"], source)
+    html_path = source.parent / "index.html"
+    _ensure_inside(html_path, reports_root, "smoke report HTML")
+    if not html_path.is_file():
+        raise ReportIndexError(f"{source}: missing smoke run index.html")
+    return Envelope(
+        schema_version=SCHEMA_VERSION,
+        report_type="smoke",
+        generated_at=timestamp,
+        generated_at_text=timestamp_text,
+        host_label=host_label,
+        report_html=html_path.relative_to(reports_root).as_posix(),
+        source=source,
+        status=_smoke_status(payload["status"], source),
     )
 
 
@@ -175,6 +234,12 @@ def discover_envelopes(reports_root: Path) -> list[Envelope]:
             continue
         if is_root_envelope or is_explicit_envelope or {"report_type", "report_html"} & payload.keys():
             envelopes.append(parse_envelope(source, reports_root))
+        elif (
+            source.parent.parent.parent.parent.name == "smoke"
+            and not (source.parent / "smoke.envelope.json").is_file()
+            and {"feature", "platform", "host", "run_id", "status", "cases"}.issubset(payload)
+        ):
+            envelopes.append(parse_smoke_result(source, reports_root, payload))
     return envelopes
 
 
@@ -193,6 +258,7 @@ def aggregate_entries(envelopes: Iterable[Envelope]) -> list[ReportEntry]:
                 generated_at_text=newest.generated_at_text,
                 host_labels=tuple(sorted({item.host_label for item in group})),
                 run_count=len(group),
+                status=newest.status,
             )
         )
     return sorted(
@@ -202,10 +268,16 @@ def aggregate_entries(envelopes: Iterable[Envelope]) -> list[ReportEntry]:
 
 
 def _entry_html(entry: ReportEntry) -> str:
-    report_name = Path(entry.report_html).stem
+    report_name = (
+        entry.report_html.removesuffix("/index.html")
+        if entry.report_type == "smoke"
+        else Path(entry.report_html).stem
+    )
     details = [html.escape(entry.report_type)]
     if entry.run_count != 1:
         details.append(f"{entry.run_count} runs")
+    if entry.status is not None:
+        details.append(entry.status)
     details.append("hosts: " + ", ".join(html.escape(label) for label in entry.host_labels))
     return (
         "      <li>"

--- a/.just/tests/test_generate_report_index.py
+++ b/.just/tests/test_generate_report_index.py
@@ -36,15 +36,38 @@ def write_envelope(root: Path, name: str, report_type: str, generated_at: str, h
     )
 
 
+def write_smoke_envelope(root: Path, platform: str, host: str, run: str) -> str:
+    reports = root / "site/reports"
+    report_dir = reports / "smoke" / platform / host / run
+    report_dir.mkdir(parents=True)
+    (report_dir / "index.html").write_text("<html>smoke</html>\n", encoding="utf-8")
+    report_html = report_dir.relative_to(reports).joinpath("index.html").as_posix()
+    (report_dir / "smoke.envelope.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_type": "smoke",
+                "generated_at": "2026-08-08T04:00:00Z",
+                "host_label": host,
+                "report_html": report_html,
+                "status": "PASS",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return report_html
+
+
 class GenerateReportIndexTests(unittest.TestCase):
-    def test_empty_input_has_both_groups(self) -> None:
+    def test_empty_input_has_every_report_group(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             (root / "site/reports").mkdir(parents=True)
             index = build_index(root / "site/reports")
             self.assertIn("<h2>Benchmark</h2>", index)
             self.assertIn("<h2>Fuzz</h2>", index)
-            self.assertEqual(index.count("No reports available."), 2)
+            self.assertIn("<h2>Smoke</h2>", index)
+            self.assertEqual(index.count("No reports available."), 3)
 
     def test_aggregates_benchmark_and_orders_entries_newest_first(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -143,6 +166,80 @@ class GenerateReportIndexTests(unittest.TestCase):
             index = build_index(reports)
             self.assertIn('href="campaign.html"', index)
             self.assertNotIn("metrics", index)
+
+    def test_discovers_every_nested_smoke_run_as_a_browsable_master_link(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            first = write_smoke_envelope(
+                root,
+                "windows",
+                "FastPC4",
+                "20260808T032327Z-pid22208-localhost",
+            )
+            second = write_smoke_envelope(
+                root,
+                "macos",
+                "rand-m4",
+                "20260808T040000Z-pid19288-local-ip",
+            )
+
+            index = build_index(root / "site/reports")
+
+            self.assertIn("<h2>Smoke</h2>", index)
+            self.assertIn(f'href="{first}"', index)
+            self.assertIn(f'href="{second}"', index)
+            self.assertIn(first.removesuffix("/index.html"), index)
+            self.assertIn(second.removesuffix("/index.html"), index)
+
+    def test_rejects_smoke_envelope_outside_its_run_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            report_dir = reports / "smoke" / "windows" / "FastPC4" / "run"
+            report_dir.mkdir(parents=True)
+            (report_dir / "index.html").write_text("<html>smoke</html>\n", encoding="utf-8")
+            (reports / "wrong-place.envelope.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "report_type": "smoke",
+                        "generated_at": "2026-08-08T04:00:00Z",
+                        "host_label": "FastPC4",
+                        "report_html": "smoke/windows/FastPC4/run/index.html",
+                        "status": "PASS",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ReportIndexError, "stored beside"):
+                build_index(reports)
+
+    def test_discovers_legacy_smoke_result_without_a_new_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            report_dir = reports / "smoke" / "windows" / "FastPC4" / "20260808T032327Z-pid1-localhost"
+            report_dir.mkdir(parents=True)
+            (report_dir / "index.html").write_text("<html>smoke</html>\n", encoding="utf-8")
+            (report_dir / "localhost.json").write_text(
+                json.dumps(
+                    {
+                        "feature": "localhost",
+                        "platform": "windows",
+                        "host": "FastPC4",
+                        "run_id": "20260808T032327Z",
+                        "status": "FAIL",
+                        "cases": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            index = build_index(reports)
+
+            self.assertIn('href="smoke/windows/FastPC4/20260808T032327Z-pid1-localhost/index.html"', index)
+            self.assertIn("FAIL", index)
 
     def test_check_detects_stale_index(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -750,7 +750,38 @@ def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
         },
         directory / "index.html",
     )
+    reports_root = ROOT / "site" / "reports"
+    envelope = directory / "smoke.envelope.json"
+    envelope.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_type": "smoke",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "host_label": host,
+                "report_html": (directory / "index.html").relative_to(reports_root).as_posix(),
+                "status": "PASS" if passed else "FAIL",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    update_master_report_index()
     return report
+
+
+def update_master_report_index() -> None:
+    """Register every completed smoke run in the shared reports navigation."""
+    completed = subprocess.run(
+        [sys.executable, str(ROOT / ".just" / "generate_report_index.py"), "--root", str(ROOT)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown report-index error"
+        raise SmokeError(f"failed to update the master smoke report index: {detail}")
 
 
 def smoke_repetitions() -> int:

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -117,7 +117,9 @@ class FeatureSmokeTests(unittest.TestCase):
                 with mock.patch.object(RUNNER, "ROOT", Path(temp)):
                     with mock.patch.object(RUNNER, "platform") as platform, mock.patch.object(
                         RUNNER, "os"
-                    ) as os_module, mock.patch.object(RUNNER, "compose") as compose:
+                    ) as os_module, mock.patch.object(RUNNER, "compose") as compose, mock.patch.object(
+                        RUNNER, "update_master_report_index"
+                    ) as update_index:
                         platform.system.return_value = "Darwin"
                         platform.node.return_value = "m5.example.test"
                         os_module.environ = os.environ
@@ -141,6 +143,7 @@ class FeatureSmokeTests(unittest.TestCase):
         )
         self.assertEqual(compose.call_args_list[1].args[2], report.with_suffix(".html"))
         self.assertEqual(compose.call_args_list[2].args[2], report.parent / "index.html")
+        update_index.assert_called_once_with()
 
     def test_report_directory_includes_platform_host_and_process_qualified_run_id(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -168,6 +171,25 @@ class FeatureSmokeTests(unittest.TestCase):
             Path(temp) / "site/reports/smoke/windows/cwin/20260808T001234567890Z-pid99-local-ip",
         )
 
+    def test_master_index_update_uses_the_existing_generator_and_fails_closed(self):
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(RUNNER.subprocess, "run", return_value=completed) as run:
+            RUNNER.update_master_report_index()
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                RUNNER.sys.executable,
+                str(RUNNER.ROOT / ".just" / "generate_report_index.py"),
+                "--root",
+                str(RUNNER.ROOT),
+            ],
+        )
+
+        failed = mock.Mock(returncode=1, stdout="", stderr="report-index: error: malformed envelope")
+        with mock.patch.object(RUNNER.subprocess, "run", return_value=failed):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "master smoke report index"):
+                RUNNER.update_master_report_index()
+
     def test_report_writes_metadata_and_all_rendered_outputs_beneath_its_run_directory(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -180,7 +202,7 @@ class FeatureSmokeTests(unittest.TestCase):
                 RUNNER, "ROOT", root
             ), mock.patch.object(RUNNER, "platform") as platform, mock.patch.object(RUNNER, "os") as os_module, mock.patch.object(
                 RUNNER, "compose", side_effect=compose_side_effect
-            ):
+            ), mock.patch.object(RUNNER, "update_master_report_index") as update_index:
                 platform.system.return_value = "Windows"
                 platform.node.return_value = "cwin"
                 os_module.environ = os.environ
@@ -204,6 +226,15 @@ class FeatureSmokeTests(unittest.TestCase):
             self.assertTrue(report.with_suffix(".html").is_file())
             self.assertTrue((report.parent / "index.html").is_file())
             self.assertTrue((report.parent / "cwin-localhost.xhtml").is_file())
+            envelope = json.loads((report.parent / "smoke.envelope.json").read_text(encoding="utf-8"))
+            self.assertEqual(envelope["report_type"], "smoke")
+            self.assertEqual(envelope["host_label"], "cwin")
+            self.assertEqual(envelope["status"], "PASS")
+            self.assertEqual(
+                envelope["report_html"],
+                "smoke/windows/cwin/run-1-pid7-localhost/index.html",
+            )
+            update_index.assert_called_once_with()
             self.assertFalse((root / "site" / "index.html").exists())
             self.assertFalse((root / "site" / "reports" / "localhost.json").exists())
 

--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -21,5 +21,8 @@
       <li><a href="20260801-1-fuzz-report.html">20260801-1-fuzz-report</a><time datetime="2026-08-01T03:30:00Z">2026-08-01T03:30:00Z</time><span class="report-meta">fuzz · hosts: mac-arm64</span></li>
     </ul>
   </section>
+  <section><h2>Smoke</h2>
+    <p class="empty">No reports available.</p>
+  </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- register each self-contained hardware smoke run in the generated `site/reports/index.html` master navigation
- retain the `site/reports/smoke/<platform>/<host>/<run>/` layout; master index is navigation only
- make pre-envelope historical smoke results browseable too
- document the canonical report contract in `/smoke-test`

## Verification
- `python3 .just/tests/test_generate_report_index.py`
- `python3 scripts/smoke/test_run_feature_smoke.py`
- `python3 .just/generate_report_index.py --root . --check`
- `just test`

Targets `develop` so the smoke-test skill and report behavior are available without waiting for the Phase AL integration branch.