### PR TITLE
plan(al): direct M5 cwin hardware smoke evidence

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -15,6 +15,16 @@ Use this skill for the repo-native smoke harness and its report artifacts.
 - Read `references/report-schema.md` when you need the canonical evidence
   layout and JSON contract.
 
+## Live daemon prerequisite
+
+Before any live `just smoke localhost`, `local-ip`, `peer-preflight`,
+`crosshost-send`, or `crosshost-ack` run, use the
+[`/daemon-switch`](../daemon-switch/SKILL.md) skill. It selects the matching
+CLI and daemon as one pair, restarts only the one managed daemon, and requires
+`atm doctor --json` to report the selected pair ready. Do not manually start a
+daemon, point a service at a worktree binary, or run smoke with a split
+CLI/daemon pair.
+
 ## Implementation Surface
 
 - runner:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,34 @@ on:
     branches: [develop, main]
 
 jobs:
+  ci-scope:
+    name: Classify CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.scope.outputs.runtime }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: scope
+        shell: bash
+        run: |
+          # Pushes always exercise the runtime.  A pull request containing only
+          # documentation or skill Markdown does not change executable code, so
+          # it does not run the long-lived daemon smoke matrix.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "runtime=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "$GITHUB_SHA")"
+          if [[ -z "$changed_files" ]] || grep -qvE '^(docs/|site/|.*\.md$)' <<< "$changed_files"; then
+            echo "runtime=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "runtime=false" >> "$GITHUB_OUTPUT"
+          fi
+
   just-lint:
     name: Just lint (${{ matrix.os }})
     strategy:
@@ -119,8 +147,8 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
-    needs: [clippy]
-    if: ${{ always() && !cancelled() }}
+    needs: [clippy, ci-scope]
+    if: ${{ !cancelled() && needs.clippy.result == 'success' && needs.ci-scope.outputs.runtime == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
           changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "$GITHUB_SHA")"
-          if [[ -z "$changed_files" ]] || grep -qvE '^(docs/|site/|.*\.md$)' <<< "$changed_files"; then
+          if [[ -z "$changed_files" ]] || grep -qvE '^(docs/|site/|\.github/workflows/ci\.yml|.*\.md$)' <<< "$changed_files"; then
             echo "runtime=true" >> "$GITHUB_OUTPUT"
           else
             echo "runtime=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,54 +148,68 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     needs: [clippy, ci-scope]
-    if: ${{ !cancelled() && needs.clippy.result == 'success' && needs.ci-scope.outputs.runtime == 'true' }}
+    if: ${{ !cancelled() && needs.clippy.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Documentation-only runtime skip
+        if: ${{ needs.ci-scope.outputs.runtime != 'true' }}
+        run: echo "Runtime tests are intentionally skipped for documentation-only changes."
+
       - uses: actions/checkout@v4
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
 
       - name: Install Rust toolchain
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
           components: clippy, rustfmt
 
       - name: Install Python
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install Python test dependencies
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -m pip install 'pydantic>=2.12,<3'
 
       - name: Cache cargo registry
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build workspace
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: cargo build --verbose
 
       - name: Build release smoke binaries
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: cargo build --release -p agent-team-mail -p atm-daemon --verbose
 
       - name: Prepare installed smoke binaries
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         shell: pwsh
         run: |
           $installRoot = Join-Path $env:RUNNER_TEMP "atm-smoke-install"
@@ -207,27 +221,33 @@ jobs:
           "ATM_SMOKE_INSTALL_ROOT=$installRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run workspace tests excluding atm-daemon on Windows
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         env:
           ATM_TEST_RECV_TIMEOUT_SECS: "60"
         run: cargo test --workspace --exclude atm-daemon --verbose
 
       - name: Run atm-daemon tests
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         env:
           ATM_TEST_RECV_TIMEOUT_SECS: "60"
         run: cargo test -p atm-daemon --verbose
 
       - name: Install Maturin for Hermes graft bridge tests
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -m pip install maturin
 
       - name: Run Hermes graft steer boundary tests
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python .just/run_hermes_graft_bridge_tests.py
 
       - name: Test admission-capacity benchmark runner
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -m unittest scripts/smoke/test_run_admission_capacity.py
 
       - name: Run graft receiver crash/reclaim proof
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python scripts/graft_receiver_reclaim.py
 
       - name: Run isolated shared-host singleton smoke
-        if: ${{ always() }}
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python scripts/smoke/run_thorough_shared_host.py

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -315,6 +315,26 @@ start until AL.9's proof and frozen-ledger inputs are accepted.
 evidence is valid or explicitly reused under the rule above, the cutover table
 has one active publisher per endpoint, and AM.1's ledger input is frozen.
 
+### AL.13–AL.15 — Direct M5/cwin hardware-smoke continuation
+
+AL.13, AL.14, and AL.15 are post-AL.9 hardware-evidence sprints. They do not
+reopen AL.7's TLS scope or create a new transport feature. They use the
+canonical `/smoke-test` skill and `just smoke` ladder to prove the existing
+direct peer send path on real M5 and cwin machines:
+
+- **AL.13:** M5 owns its local ladder and the M5-initiated direct peer
+  send/read/ack evidence.
+- **AL.14:** cwin owns its local Windows ladder and the cwin-initiated
+  symmetric direct peer send/read/ack evidence.
+- **AL.15:** consumes only the retained evidence and reports an unambiguous
+  PASS or BLOCKED/FAIL outcome.
+
+Every hardware operator works from its named home sprint branch, retains each
+run in the platform/host/run report layout, and opens a PR with both the
+status report and the evidence. The direct proof uses ordinary public `atm`
+commands and a configured peer endpoint. It excludes TLS/curl diagnostics,
+raw sockets, retry/replay, payload mutation, and legacy-daemon work.
+
 ## Explicitly deferred
 
 - Automatic resend, heartbeat-driven recovery, cursor tracking, batching, and

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -335,6 +335,15 @@ status report and the evidence. The direct proof uses ordinary public `atm`
 commands and a configured peer endpoint. It excludes TLS/curl diagnostics,
 raw sockets, retry/replay, payload mutation, and legacy-daemon work.
 
+Before either host starts, AL.13 records one immutable tested-candidate
+manifest: the exact tested SHA, its HTTP-runtime candidate ancestor, and
+`faf0c24b2743274590de4607bfc07654bff63709` (the report-index merge) as an
+ancestor. AL.14 reproduces the same manifest; AL.15 rejects a mismatch. The
+only valid direct features are `localhost`, `local-ip`, `peer-preflight`,
+`crosshost-send`, and `crosshost-ack`. Each sprint's acceptance criteria
+enforce that feature set and reject a prohibited code/configuration change,
+rather than treating the exclusions as advisory prose.
+
 ## Explicitly deferred
 
 - Automatic resend, heartbeat-driven recovery, cursor tracking, batching, and

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -331,18 +331,11 @@ direct peer send path on real M5 and cwin machines:
 
 Every hardware operator works from its named home sprint branch, retains each
 run in the platform/host/run report layout, and opens a PR with both the
-status report and the evidence. The direct proof uses ordinary public `atm`
-commands and a configured peer endpoint. It excludes TLS/curl diagnostics,
-raw sockets, retry/replay, payload mutation, and legacy-daemon work.
-
-Before either host starts, AL.13 records one immutable tested-candidate
-manifest: the exact tested SHA, its HTTP-runtime candidate ancestor, and
-`faf0c24b2743274590de4607bfc07654bff63709` (the report-index merge) as an
-ancestor. AL.14 reproduces the same manifest; AL.15 rejects a mismatch. The
-only valid direct features are `localhost`, `local-ip`, `peer-preflight`,
-`crosshost-send`, and `crosshost-ack`. Each sprint's acceptance criteria
-enforce that feature set and reject a prohibited code/configuration change,
-rather than treating the exclusions as advisory prose.
+status report and the evidence. The authoritative tested-candidate manifest,
+allowed `just smoke` feature set, exclusion scope gate, and closeout review
+are defined only by the AL.13, AL.14, and AL.15 sprint documents. Those docs
+require the report-index merge from PR #788 and reject a mismatched candidate
+or prohibited transport change.
 
 ## Explicitly deferred
 

--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -14,6 +14,38 @@ or unavailable peer); otherwise AL.14 may still establish the other direction.
 **parallel_safe:** local preparation may run with AL.14. The two hosts must not
 run cross-host sends simultaneously against the same disposable identities.
 
+## Tested-candidate manifest and scope gate
+
+Before M5 builds or switches binaries, the coordinator records this immutable
+three-SHA manifest in the AL.13 PR description.  It is the one source for the
+run; a branch name is never evidence.
+
+| Field | Required value and check |
+|---|---|
+| `tested_sha` | The exact commit built and selected on both hosts. `git rev-parse HEAD` on M5 must equal it before the first smoke command. |
+| `runtime_candidate_sha` | The exact accepted HTTP-runtime candidate being tested. `git merge-base --is-ancestor <runtime_candidate_sha> <tested_sha>` must exit zero. |
+| `report_index_sha` | `faf0c24b2743274590de4607bfc07654bff63709` (PR #788). `git merge-base --is-ancestor <report_index_sha> <tested_sha>` must exit zero. |
+| `home_branch` | Exactly `feature/al-13-smoke`; `git branch --show-current` must report it before evidence is committed. |
+
+The M5 operator copies this manifest unchanged to the cwin operator before
+AL.14 starts. A different SHA, version, runtime candidate, or report-index
+ancestor is a blocked run, not an equivalent test.
+
+The only valid live feature names are `localhost`, `local-ip`,
+`peer-preflight`, `crosshost-send`, and `crosshost-ack`. The run is out of
+scope if an artifact or PR status report names `crosshost`,
+`crosshost-curl-plain`, `crosshost-curl-tls`, a raw socket probe, or an
+operator-issued `atm send`/`atm read` outside the repository runner. The
+runner-generated message body and ID are the only payload evidence; no
+operator-supplied or transformed body is acceptable.
+
+For every code-bearing AL.13 fix, review the diff from `tested_sha` before
+rerunning. It fails this sprint's scope gate if it changes
+`crates/atm-daemon/**`, adds a TLS/certificate/peer-wire-security setting, or
+adds resend/replay/retry/heartbeat/cursor/scheduler/batch behavior. The
+reviewer records that result in the PR. A needed change in any of those areas
+is a separate decision, not a hardware-smoke fix.
+
 ## Purpose
 
 Prove minimal direct delivery between the M5 and its configured peer using the
@@ -29,11 +61,9 @@ already written by the smoke runner.
 
 ## Fixed operating rules
 
-- The coordinator names one **testing ref** before either operator builds. It
-  must contain the tested HTTP-runtime candidate and `faf0c24b` (PR #788's
-  smoke-skill/report-index merge), or a reviewed equivalent merge-forward.
-  Neither host may silently test an older runtime branch that lacks the report
-  contract. The actual SHA, not a moving branch name, is the evidence key.
+- The coordinator creates the tested-candidate manifest above before either
+  operator builds. Neither host may silently test an older runtime branch that
+  lacks the report contract.
 - Work from the M5 home sprint branch `feature/al-13-smoke`; the resulting PR
   contains only the M5 evidence, an explicit status summary, and any narrowly
   necessary fix. Do not put M5 evidence on an unrelated branch.
@@ -41,8 +71,11 @@ already written by the smoke runner.
   Do not create a second shell script, raw-socket probe, curl-based proof, or
   a manual inbox mutation.
 - Use `/daemon-switch` to select the matched `atm` and daemon binaries as one
-  computer-wide pair. Query with `status --doctor` first; after every switch,
-  verify `atm doctor --json`. There must be exactly one managed daemon.
+  computer-wide pair. Run
+  `python3 .claude/skills/daemon-switch/scripts/daemon-switch.py status --doctor`
+  before the switch and retain its output with the post-switch `atm doctor
+  --json` output. There must be exactly one managed daemon before and after
+  the run.
 - The direct proof is plaintext as selected by the currently tested runtime.
   This sprint must not configure, require, or claim TLS/mTLS. The
   `crosshost-curl-plain` and `crosshost-curl-tls` diagnostic features are out
@@ -55,10 +88,10 @@ already written by the smoke runner.
 1. Use `/sc-git-worktree` to select or create M5's home worktree
    `feature/al-13-smoke` from the named testing ref. Do not run from a random
    checkout, `develop`, or a previous evidence directory.
-2. Record the tested commit, client/daemon version, operating-system version,
-   M5 hostname, peer SSH alias, and the exact selected CLI/daemon pair in the
-   M5 PR description. Redact addresses, credentials, certificates, and private
-   configuration values.
+2. Record the tested-candidate manifest, client/daemon version,
+   operating-system version, M5 hostname, peer SSH alias, and the exact
+   selected CLI/daemon pair in the M5 PR description. Redact addresses,
+   credentials, certificates, and private configuration values.
 3. Build/select that same release pair on M5. Run `atm doctor --json` and stop
    if its client and daemon versions differ from the recorded tested version or
    readiness is not `ready`.
@@ -107,7 +140,8 @@ already written by the smoke runner.
   against a healthy configured peer; the retained evidence proves both
   directions, exact message IDs/bodies, and acknowledgement linkage.
 - The output shows no retry/replay/reconciliation action and no second
-  transport route, raw socket, curl proof, or TLS claim.
+  transport route, raw socket, curl proof, TLS claim, payload mutation, or
+  legacy-daemon change; the tested-candidate manifest and scope gate pass.
 - Every evidence run is linked from `site/reports/index.html`, preserves its
   platform and host path, and is accompanied by an M5 PR status summary.
 - A failure is recorded as a failure with its first failing stage and exact

--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -1,0 +1,131 @@
+# AL.13 — M5 Direct Cross-Host Hardware Smoke
+
+**branch:** `feature/al-13-smoke`
+**worktree:** `../atm-core-worktrees/feature/al-13-smoke`
+**recommended_agent:** M5 hardware operator, with an M4/cwin operator
+available as the already-running peer.
+**must_follow:** AL.9's accepted runtime composition and the `develop`
+smoke-skill/report-index contract. Before a run, the coordinator records one
+exact tested commit and requires both hosts to select binaries built from that
+same commit.
+**unblocks:** AL.15 evidence review.  A failure blocks AL.14's symmetric run
+only when it identifies a shared precondition (for example, a version mismatch
+or unavailable peer); otherwise AL.14 may still establish the other direction.
+**parallel_safe:** local preparation may run with AL.14. The two hosts must not
+run cross-host sends simultaneously against the same disposable identities.
+
+## Purpose
+
+Prove minimal direct delivery between the M5 and its configured peer using the
+same public CLI path used by a normal `atm send`. This is a hardware-evidence
+sprint, not a transport implementation sprint. It proves the current runtime
+as installed on real hosts; it does not add a listener, a peer protocol, TLS,
+curl probes, retry, replay, batching, or a nudge-specific path.
+
+The peer's SSH alias and the two test identities are supplied by the operators
+from their existing ATM configuration. They are not committed in this plan,
+source tree, shell history, or report metadata beyond the sanitized evidence
+already written by the smoke runner.
+
+## Fixed operating rules
+
+- The coordinator names one **testing ref** before either operator builds. It
+  must contain the tested HTTP-runtime candidate and `faf0c24b` (PR #788's
+  smoke-skill/report-index merge), or a reviewed equivalent merge-forward.
+  Neither host may silently test an older runtime branch that lacks the report
+  contract. The actual SHA, not a moving branch name, is the evidence key.
+- Work from the M5 home sprint branch `feature/al-13-smoke`; the resulting PR
+  contains only the M5 evidence, an explicit status summary, and any narrowly
+  necessary fix. Do not put M5 evidence on an unrelated branch.
+- Use the repository's `/smoke-test` skill and the `just smoke` commands below.
+  Do not create a second shell script, raw-socket probe, curl-based proof, or
+  a manual inbox mutation.
+- Use `/daemon-switch` to select the matched `atm` and daemon binaries as one
+  computer-wide pair. Query with `status --doctor` first; after every switch,
+  verify `atm doctor --json`. There must be exactly one managed daemon.
+- The direct proof is plaintext as selected by the currently tested runtime.
+  This sprint must not configure, require, or claim TLS/mTLS. The
+  `crosshost-curl-plain` and `crosshost-curl-tls` diagnostic features are out
+  of scope and do not substitute for an `atm send` proof.
+- Direct failure is final for this sprint: do not add or enable resend,
+  replay, heartbeat, cursor, queue, scheduler, or a mutated message body.
+
+## Deliverables
+
+1. Use `/sc-git-worktree` to select or create M5's home worktree
+   `feature/al-13-smoke` from the named testing ref. Do not run from a random
+   checkout, `develop`, or a previous evidence directory.
+2. Record the tested commit, client/daemon version, operating-system version,
+   M5 hostname, peer SSH alias, and the exact selected CLI/daemon pair in the
+   M5 PR description. Redact addresses, credentials, certificates, and private
+   configuration values.
+3. Build/select that same release pair on M5. Run `atm doctor --json` and stop
+   if its client and daemon versions differ from the recorded tested version or
+   readiness is not `ready`.
+4. Establish the local ladder, in order:
+
+   ```bash
+   just smoke localhost
+   just smoke local-ip
+   ```
+
+   Each command must pass before the next begins. A local failure is a local
+   runtime defect or setup defect, not a reason to attempt cross-host traffic.
+5. With the peer daemon already healthy and SSH-reachable, set only the remote
+   recipient context required by the runner, then run the direct peer ladder:
+
+   ```bash
+   export ATM_SMOKE_REMOTE_IDENTITY='<configured-peer-agent>'
+   export ATM_SMOKE_REMOTE_TEAM='<configured-peer-team>'
+   just smoke peer-preflight <peer-ssh-alias>
+   just smoke crosshost-send <peer-ssh-alias>
+   just smoke crosshost-ack <peer-ssh-alias>
+   ```
+
+   `peer-preflight` must pass first. `crosshost-send` proves exact message ID
+   and body visibility in both M5→peer and peer→M5 directions. `crosshost-ack`
+   adds the requires-ack and acknowledgement-reply round trip in both
+   directions. The runner invokes only public `atm` commands on the peer; it
+   must not start, stop, configure, or repair the remote daemon.
+6. Retain every generated self-contained run directory under
+   `site/reports/smoke/<platform>/<host>/<run>/`. The runner updates the
+   generated `site/reports/index.html`; verify the master page links each M5
+   run and each page opens its XHTML evidence panels. Commit the retained
+   evidence only to the M5 home sprint branch.
+7. Open or update the M5 PR with a status report: commands attempted in order,
+   PASS/FAIL result for every command, tested SHA/version, report links,
+   observed failure text (if any), and the next blocked action. If a narrowly
+   scoped code/configuration defect is found, fix it on the same home branch,
+   rerun from the first affected ladder stage, and explain the exact change in
+   the PR. Escalate ambiguous architecture decisions to Rand rather than
+   inventing a fallback path.
+
+## Acceptance criteria
+
+- Both M5 local stages pass using one matched CLI/daemon pair.
+- `peer-preflight`, `crosshost-send`, and `crosshost-ack` pass in that order
+  against a healthy configured peer; the retained evidence proves both
+  directions, exact message IDs/bodies, and acknowledgement linkage.
+- The output shows no retry/replay/reconciliation action and no second
+  transport route, raw socket, curl proof, or TLS claim.
+- Every evidence run is linked from `site/reports/index.html`, preserves its
+  platform and host path, and is accompanied by an M5 PR status summary.
+- A failure is recorded as a failure with its first failing stage and exact
+  output; later stages are marked blocked rather than silently retried.
+
+## Required validation
+
+- `just test` before hardware execution when code changes are present; no
+  code-only PR may claim a hardware result.
+- `atm doctor --json` on M5 and the peer before cross-host execution.
+- The full progressive command sequence above, with generated report pages
+  inspected through the master reports index.
+- Review of the M5 PR by the cwin operator for peer availability and by the
+  coordinator for version/SHA parity.
+
+## Non-closure
+
+AL.13 does not prove Windows-specific behavior by itself, does not test a
+different client transport, and does not authorize a recovery feature. AL.15
+owns combined evidence acceptance only after the cwin symmetric run is
+available.

--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -1,169 +1,56 @@
-# AL.13 — M5 Direct Cross-Host Hardware Smoke
+# AL.13 — M5 Cross-Host Smoke
 
 **branch:** `feature/al-13-smoke`
 **worktree:** `../atm-core-worktrees/feature/al-13-smoke`
-**recommended_agent:** M5 hardware operator, with an M4/cwin operator
-available as the already-running peer.
-**must_follow:** AL.9's accepted runtime composition and the `develop`
-smoke-skill/report-index contract. Before a run, the coordinator records one
-exact tested commit and requires both hosts to select binaries built from that
-same commit.
-**unblocks:** AL.15 evidence review.  A failure blocks AL.14's symmetric run
-only when it identifies a shared precondition (for example, a version mismatch
-or unavailable peer); otherwise AL.14 may still establish the other direction.
-**parallel_safe:** local preparation may run with AL.14. The two hosts must not
-run cross-host sends simultaneously against the same disposable identities.
+**base:** current `origin/integrate/phase-al`
+**owner:** M5 operator
+**peer:** cwin operator
+**unblocks:** AL.15
 
-## Tested-candidate manifest and scope gate
+## Goal
 
-Before M5 builds or switches binaries, the coordinator records this immutable
-three-SHA manifest in the AL.13 PR description.  It is the one source for the
-run; a branch name is never evidence.
+Create or refresh `feature/al-13-smoke` from current
+`origin/integrate/phase-al` with `/sc-git-worktree`, then run the repository
+smoke harness from M5 against the current ATM runtime and cwin peer. This
+sprint is evidence only: use the existing `/smoke-test` skill and its `just
+smoke` commands; do not create another runner.
 
-| Field | Required value and check |
+## Required tests
+
+Run these rows in order using the M5 home worktree. `/smoke-test` owns the
+matched CLI/daemon selection and readiness prerequisite:
+
+| Row | Required proof |
 |---|---|
-| `tested_sha` | The exact commit built and selected on both hosts. `git rev-parse HEAD` on M5 must equal it before the first smoke command. |
-| `runtime_candidate_sha` | The exact accepted HTTP-runtime candidate being tested. `git merge-base --is-ancestor <runtime_candidate_sha> <tested_sha>` must exit zero. |
-| `report_index_sha` | `faf0c24b2743274590de4607bfc07654bff63709` (PR #788). `git merge-base --is-ancestor <report_index_sha> <tested_sha>` must exit zero. |
-| `home_branch` | Exactly `feature/al-13-smoke`; `git branch --show-current` must report it before evidence is committed. |
+| Runtime health | `atm doctor --json` reports the selected pair ready. |
+| Localhost | `just smoke localhost` passes. |
+| Local IP | `just smoke local-ip` passes. |
+| Peer readiness | The skill's peer-preflight against cwin passes. |
+| Direct send | The skill's cross-host send row proves M5→cwin and cwin→M5 delivery. |
+| Acknowledgement | The skill's cross-host acknowledgement row proves both requires-ack/reply directions. |
+| Benchmark | After the smoke ladder, `just benchmark` and `just benchmark-report` complete and retain the standard benchmark report. |
 
-The M5 operator copies this manifest unchanged to the cwin operator before
-AL.14 starts. A different SHA, version, runtime candidate, or report-index
-ancestor is a blocked run, not an equivalent test.
+Use the existing configured peer identity and endpoint. Do not hard-code host
+addresses in the repository. The benchmark runner owns an isolated daemon and
+database; do not run it beside the live daemon selected for smoke.
 
-The only valid live feature names are `localhost`, `local-ip`,
-`peer-preflight`, `crosshost-send`, and `crosshost-ack`. The run is out of
-scope if an artifact or PR status report names `crosshost`,
-`crosshost-curl-plain`, `crosshost-curl-tls`, a raw socket probe, or an
-operator-issued `atm send`/`atm read` outside the repository runner. The
-runner-generated message body and ID are the only payload evidence; no
-operator-supplied or transformed body is acceptable.
+## Report and PR
 
-For every code-bearing AL.13 fix, review the diff from `tested_sha` before
-rerunning. It fails this sprint's scope gate if it changes
-`crates/atm-daemon/**`, adds a TLS/certificate/peer-wire-security setting, or
-adds resend/replay/retry/heartbeat/cursor/scheduler/batch behavior. The
-reviewer records that result in the PR. A needed change in any of those areas
-is a separate decision, not a hardware-smoke fix.
+Follow `/smoke-test` so every smoke run produces its self-contained report
+under `site/reports/smoke/` and is registered in `site/reports/index.html`.
+`just benchmark-report` retains the benchmark artifact through the same master
+reports navigation. Open a PR from `feature/al-13-smoke` to
+`integrate/phase-al` containing the retained artifacts and a short status
+report with the tested commit, platform, command-row results, report links,
+and the first failure if any.
 
-## Purpose
+Fix a defect on this home branch when it is safe and in scope, then rerun from
+the first affected row. Ask Rand before changing transport behavior.
 
-Prove minimal direct delivery between the M5 and its configured peer using the
-same public CLI path used by a normal `atm send`. This is a hardware-evidence
-sprint, not a transport implementation sprint. It proves the current runtime
-as installed on real hosts; it does not add a listener, a peer protocol, TLS,
-curl probes, retry, replay, batching, or a nudge-specific path.
+## Acceptance
 
-The peer's SSH alias and the two test identities are supplied by the operators
-from their existing ATM configuration. They are not committed in this plan,
-source tree, shell history, or report metadata beyond the sanitized evidence
-already written by the smoke runner.
-
-## Fixed operating rules
-
-- The coordinator creates the tested-candidate manifest above before either
-  operator builds. Neither host may silently test an older runtime branch that
-  lacks the report contract.
-- Work from the M5 home sprint branch `feature/al-13-smoke`; the resulting PR
-  contains only the M5 evidence, an explicit status summary, and any narrowly
-  necessary fix. Do not put M5 evidence on an unrelated branch.
-- Use the repository's `/smoke-test` skill and the `just smoke` commands below.
-  Do not create a second shell script, raw-socket probe, curl-based proof, or
-  a manual inbox mutation.
-- Use `/daemon-switch` to select the matched `atm` and daemon binaries as one
-  computer-wide pair. Run
-  `python3 .claude/skills/daemon-switch/scripts/daemon-switch.py status --doctor`
-  before the switch and retain its output with the post-switch `atm doctor
-  --json` output. There must be exactly one managed daemon before and after
-  the run.
-- The direct proof is plaintext as selected by the currently tested runtime.
-  This sprint must not configure, require, or claim TLS/mTLS. The
-  `crosshost-curl-plain` and `crosshost-curl-tls` diagnostic features are out
-  of scope and do not substitute for an `atm send` proof.
-- Direct failure is final for this sprint: do not add or enable resend,
-  replay, heartbeat, cursor, queue, scheduler, or a mutated message body.
-
-## Deliverables
-
-1. Use `/sc-git-worktree` to select or create M5's home worktree
-   `feature/al-13-smoke` from the named testing ref. Do not run from a random
-   checkout, `develop`, or a previous evidence directory.
-2. Record the tested-candidate manifest, client/daemon version,
-   operating-system version, M5 hostname, peer SSH alias, and the exact
-   selected CLI/daemon pair in the M5 PR description. Redact addresses,
-   credentials, certificates, and private configuration values.
-3. Build/select that same release pair on M5. Run `atm doctor --json` and stop
-   if its client and daemon versions differ from the recorded tested version or
-   readiness is not `ready`.
-4. Establish the local ladder, in order:
-
-   ```bash
-   just smoke localhost
-   just smoke local-ip
-   ```
-
-   Each command must pass before the next begins. A local failure is a local
-   runtime defect or setup defect, not a reason to attempt cross-host traffic.
-5. With the peer daemon already healthy and SSH-reachable, set only the remote
-   recipient context required by the runner, then run the direct peer ladder:
-
-   ```bash
-   export ATM_SMOKE_REMOTE_IDENTITY='<configured-peer-agent>'
-   export ATM_SMOKE_REMOTE_TEAM='<configured-peer-team>'
-   just smoke peer-preflight <peer-ssh-alias>
-   just smoke crosshost-send <peer-ssh-alias>
-   just smoke crosshost-ack <peer-ssh-alias>
-   ```
-
-   `peer-preflight` must pass first. `crosshost-send` proves exact message ID
-   and body visibility in both M5→peer and peer→M5 directions. `crosshost-ack`
-   adds the requires-ack and acknowledgement-reply round trip in both
-   directions. The runner invokes only public `atm` commands on the peer; it
-   must not start, stop, configure, or repair the remote daemon.
-6. Retain every generated self-contained run directory under
-   `site/reports/smoke/<platform>/<host>/<run>/`. The runner updates the
-   generated `site/reports/index.html`; verify the master page links each M5
-   run and each page opens its XHTML evidence panels. Commit the retained
-   evidence only to the M5 home sprint branch.
-7. Open or update the M5 PR with a status report: commands attempted in order,
-   PASS/FAIL result for every command, tested SHA/version, report links,
-   observed failure text (if any), and the next blocked action. If a narrowly
-   scoped code/configuration defect is found, fix it on the same home branch,
-   rerun from the first affected ladder stage, and explain the exact change in
-   the PR. Escalate ambiguous architecture decisions to Rand rather than
-   inventing a fallback path.
-
-## Acceptance criteria
-
-- Both M5 local stages pass using one matched CLI/daemon pair.
-- `peer-preflight`, `crosshost-send`, and `crosshost-ack` pass in that order
-  against a healthy configured peer; the retained evidence proves both
-  directions, exact message IDs/bodies, and acknowledgement linkage.
-- The output shows no retry/replay/reconciliation action and no second
-  transport route, raw socket, curl proof, TLS claim, payload mutation, or
-  legacy-daemon change; the tested-candidate manifest and scope gate pass.
-- Every evidence run is linked from `site/reports/index.html`, preserves its
-  platform and host path, and is accompanied by an M5 PR status summary.
-- A failure is recorded as a failure with its first failing stage and exact
-  output; later stages are marked blocked rather than silently retried.
-
-## Required validation
-
-- `just test` before hardware execution when code changes are present; no
-  code-only PR may claim a hardware result.
-- `atm doctor --json` on M5 and the peer before cross-host execution.
-- The full progressive command sequence above, with generated report pages
-  inspected through the master reports index.
-- Diff review of `tested_sha..HEAD`, recorded in the PR, confirming no
-  `crates/atm-daemon/**` change, no added TLS/certificate/peer-wire-security
-  setting, and no added resend/replay/retry/heartbeat/cursor/scheduler/batch
-  behavior.
-- Review of the M5 PR by the cwin operator for peer availability and by the
-  coordinator for version/SHA parity.
-
-## Non-closure
-
-AL.13 does not prove Windows-specific behavior by itself, does not test a
-different client transport, and does not authorize a recovery feature. AL.15
-owns combined evidence acceptance only after the cwin symmetric run is
-available.
+- Every required row has a retained PASS report, or the PR records its first
+  failing row and blocks the later rows.
+- The M5 smoke and benchmark reports are reachable from
+  `site/reports/index.html`.
+- The PR truthfully reports the M5 result; it does not claim cwin completion.

--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -154,6 +154,10 @@ already written by the smoke runner.
 - `atm doctor --json` on M5 and the peer before cross-host execution.
 - The full progressive command sequence above, with generated report pages
   inspected through the master reports index.
+- Diff review of `tested_sha..HEAD`, recorded in the PR, confirming no
+  `crates/atm-daemon/**` change, no added TLS/certificate/peer-wire-security
+  setting, and no added resend/replay/retry/heartbeat/cursor/scheduler/batch
+  behavior.
 - Review of the M5 PR by the cwin operator for peer availability and by the
   coordinator for version/SHA parity.
 

--- a/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
@@ -1,144 +1,56 @@
-# AL.14 — cwin Direct Cross-Host Hardware Smoke
+# AL.14 — cwin Cross-Host Smoke
 
 **branch:** `feature/al-14-smoke`
 **worktree:** `../atm-core-worktrees/feature/al-14-smoke`
-**recommended_agent:** cwin hardware operator, with the M5 operator available
-as the already-running peer.
-**must_follow:** AL.13's recorded tested commit and smoke-runner contract. The
-same SHA/version is required on both hosts; AL.14 never proves a mixed build.
-**unblocks:** AL.15 combined hardware-evidence review.
-**parallel_safe:** local setup may run in parallel with AL.13. Run the direct
-cross-host ladder only in a scheduled window, not concurrently with AL.13's
-peer-send ladder.
+**base:** current `origin/integrate/phase-al`
+**owner:** cwin operator
+**peer:** M5 operator
+**unblocks:** AL.15
 
-## Tested-candidate manifest and scope gate
+## Goal
 
-AL.14 consumes the immutable three-SHA manifest first recorded by AL.13. It
-must reproduce the following checks in the cwin PR before it builds or runs:
+Create or refresh `feature/al-14-smoke` from current
+`origin/integrate/phase-al` with `/sc-git-worktree`, then run the repository
+smoke harness from cwin against the current ATM runtime and M5 peer. This is
+the Windows-originating evidence lane. Use the existing `/smoke-test` skill
+and its `just smoke` commands; do not create another runner.
 
-| Field | Required value and check |
+## Required tests
+
+Run these rows in order using the cwin home worktree. `/smoke-test` owns the
+matched CLI/daemon selection and readiness prerequisite:
+
+| Row | Required proof |
 |---|---|
-| `tested_sha` | The exact commit built and selected on both hosts. `git rev-parse HEAD` on cwin must equal it before the first smoke command. |
-| `runtime_candidate_sha` | The AL.13 runtime candidate. `git merge-base --is-ancestor <runtime_candidate_sha> <tested_sha>` must exit zero. |
-| `report_index_sha` | `faf0c24b2743274590de4607bfc07654bff63709` (PR #788). `git merge-base --is-ancestor <report_index_sha> <tested_sha>` must exit zero. |
-| `home_branch` | Exactly `feature/al-14-smoke`; `git branch --show-current` must report it before evidence is committed. |
+| Runtime health | `atm doctor --json` reports the selected pair ready. |
+| Localhost | `just smoke localhost` passes. |
+| Local IP | `just smoke local-ip` passes. |
+| Peer readiness | The skill's peer-preflight against M5 passes. |
+| Direct send | The skill's cross-host send row proves cwin→M5 and M5→cwin delivery. |
+| Acknowledgement | The skill's cross-host acknowledgement row proves both requires-ack/reply directions. |
+| Benchmark | After the smoke ladder, `just benchmark` and `just benchmark-report` complete and retain the standard benchmark report. |
 
-The only valid live feature names are `localhost`, `local-ip`,
-`peer-preflight`, `crosshost-send`, and `crosshost-ack`. The run is invalid if
-an artifact or PR status report names `crosshost`, `crosshost-curl-plain`,
-`crosshost-curl-tls`, a raw socket probe, or an operator-issued `atm send`/
-`atm read` outside the repository runner. The runner-generated body and ID are
-the only valid payload evidence.
+Use the existing configured peer identity and endpoint. Do not hard-code host
+addresses in the repository. The benchmark runner owns an isolated daemon and
+database; do not run it beside the live daemon selected for smoke.
 
-For every code-bearing AL.14 fix, review the diff from `tested_sha` before
-rerunning. It fails this sprint's scope gate if it changes
-`crates/atm-daemon/**`, adds a TLS/certificate/peer-wire-security setting, or
-adds resend/replay/retry/heartbeat/cursor/scheduler/batch behavior. Record the
-review in the PR. Any required change in those areas needs a separate decision
-and cannot be smuggled into this Windows evidence sprint.
+## Report and PR
 
-## Purpose
+Follow `/smoke-test` so every smoke run produces its self-contained report
+under `site/reports/smoke/` and is registered in `site/reports/index.html`.
+`just benchmark-report` retains the benchmark artifact through the same master
+reports navigation. Open a PR from `feature/al-14-smoke` to
+`integrate/phase-al` containing the retained artifacts and a short status
+report with the tested commit, Windows platform, command-row results, report
+links, and the first failure if any.
 
-Provide the Windows-originating half of the minimal direct M5↔cwin proof. The
-test is deliberately the same public `atm` send/read/ack behavior as AL.13,
-not a Windows-specific protocol or a different server path. It confirms that
-the configured direct peer endpoint is reachable from Windows and that the
-same request body/result semantics hold in both directions.
+Fix a defect on this home branch when it is safe and in scope, then rerun from
+the first affected row. Ask Rand before changing transport behavior.
 
-## Fixed operating rules
+## Acceptance
 
-- Use AL.13's tested-candidate manifest exactly. Record its immutable SHA in
-  every artifact; a moving branch name or a pre-index smoke checkout is not
-  valid evidence.
-- Work from cwin's home sprint branch `feature/al-14-smoke`; open a PR with
-  evidence and status rather than depositing output in another host's branch.
-- Use `/smoke-test` and `just smoke` only. PowerShell wrappers may set the two
-  documented environment variables, but must not replace the runner, issue
-  raw HTTP, or manipulate SQLite/inboxes directly.
-- Select one matched Windows CLI/daemon pair with `/daemon-switch`. Use its
-  Windows selector-symlink workflow; never overwrite installed executables or
-  run a second daemon. Retain the `daemon-switch.py status --doctor` output
-  before selection and confirm the selected pair with `atm doctor --json`.
-- This proof exercises direct plaintext delivery selected by the tested
-  runtime. Do not add TLS/mTLS configuration, curl diagnostics, certificates,
-  or an alternate listener. Those are separate, non-required work.
-- Do not introduce or enable replay, retry, recovery timers, cursors, batches,
-  or post-send background delivery. An unavailable peer is a typed direct-send
-  result, not a reason to change the test payload or delivery path.
-
-## Deliverables
-
-1. Use `/sc-git-worktree` to select or create cwin's home worktree
-   `feature/al-14-smoke` from the named testing ref. Do not run the candidate
-   from an arbitrary checkout or a stale local clone.
-2. Record the tested-candidate manifest, client/daemon version, Windows
-   version, sanitized hostname, M5 SSH alias, and the selected pair in the
-   cwin PR. Confirm it exactly matches AL.13's recorded manifest/version
-   before continuing.
-3. Build/select the pair, then run `atm doctor --json`. Stop for any unhealthy
-   daemon, version mismatch, or competing service.
-4. Run the local Windows ladder in order:
-
-   ```powershell
-   just smoke localhost
-   just smoke local-ip
-   ```
-
-   The Windows local-IP row is mandatory; it proves the runner uses the
-   Windows TCP adapter before a peer test is attempted.
-5. During the agreed M5 availability window, configure only the existing
-   recipient context and execute the same direct peer ladder from cwin:
-
-   ```powershell
-   $env:ATM_SMOKE_REMOTE_IDENTITY = '<configured-m5-agent>'
-   $env:ATM_SMOKE_REMOTE_TEAM = '<configured-m5-team>'
-   just smoke peer-preflight <m5-ssh-alias>
-   just smoke crosshost-send <m5-ssh-alias>
-   just smoke crosshost-ack <m5-ssh-alias>
-   ```
-
-   A pass requires the runner's forward and reverse exact-ID/body proof. The
-   acknowledgement stage additionally requires both acknowledgement replies
-   to arrive with correct source linkage. A peer-preflight failure blocks the
-   send and ack stages; do not replace it with a manual connection test.
-6. Retain the self-contained reports under
-   `site/reports/smoke/windows/<host>/<run>/`, confirm each is linked from
-   `site/reports/index.html`, and commit them on `feature/al-14-smoke`.
-7. Post a cwin PR status report with all command results, tested SHA/version,
-   master-index and per-run evidence links, failures/blocked stages, and any
-   narrow fix made before rerunning. Ask Rand for a decision if the only
-   apparent workaround changes endpoint selection, message serialization, or
-   direct-send semantics.
-
-## Acceptance criteria
-
-- cwin runs a healthy, version-matched single daemon and passes localhost plus
-  local-IP smoke before cross-host work.
-- The cwin-initiated direct ladder passes in order and the evidence proves the
-  same exact send/read and ack/reply behavior both directions with M5.
-- No Windows-only wire format, local daemon proxy, TLS/curl diagnostic, retry,
-  replay, message mutation, second listener, or legacy-daemon change is used;
-  the tested-candidate manifest and scope gate pass.
-- The master report index links every retained cwin run, each report includes
-  Windows platform and host identity, and the cwin PR describes the result.
-
-## Required validation
-
-- `just test` for any code change before the live run.
-- `atm doctor --json` on cwin and M5 before each cross-host ladder.
-- The complete ordered cwin sequence above, plus manual browser navigation
-  from `site/reports/index.html` to every generated evidence page.
-- Diff review of `tested_sha..HEAD`, recorded in the PR, confirming no
-  `crates/atm-daemon/**` change, no added TLS/certificate/peer-wire-security
-  setting, and no added resend/replay/retry/heartbeat/cursor/scheduler/batch
-  behavior.
-- Cross-check that the M5 and cwin reports name the same tested SHA/version
-  and report the same message IDs for the shared run window.
-- Review of the cwin PR by the M5 operator for peer availability and by the
-  coordinator for version/SHA parity and the recorded scope-gate diff result.
-
-## Non-closure
-
-AL.14 does not replace the M5-originating proof, test recovery after a network
-outage, or approve any resend/replay behavior. AL.15 evaluates only the
-retained evidence from the two direct lanes.
+- Every required row has a retained PASS report, or the PR records its first
+  failing row and blocks the later rows.
+- The cwin smoke and benchmark reports are reachable from
+  `site/reports/index.html`.
+- The PR truthfully reports the cwin result; it does not claim M5 completion.

--- a/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
@@ -11,6 +11,32 @@ same SHA/version is required on both hosts; AL.14 never proves a mixed build.
 cross-host ladder only in a scheduled window, not concurrently with AL.13's
 peer-send ladder.
 
+## Tested-candidate manifest and scope gate
+
+AL.14 consumes the immutable three-SHA manifest first recorded by AL.13. It
+must reproduce the following checks in the cwin PR before it builds or runs:
+
+| Field | Required value and check |
+|---|---|
+| `tested_sha` | The exact commit built and selected on both hosts. `git rev-parse HEAD` on cwin must equal it before the first smoke command. |
+| `runtime_candidate_sha` | The AL.13 runtime candidate. `git merge-base --is-ancestor <runtime_candidate_sha> <tested_sha>` must exit zero. |
+| `report_index_sha` | `faf0c24b2743274590de4607bfc07654bff63709` (PR #788). `git merge-base --is-ancestor <report_index_sha> <tested_sha>` must exit zero. |
+| `home_branch` | Exactly `feature/al-14-smoke`; `git branch --show-current` must report it before evidence is committed. |
+
+The only valid live feature names are `localhost`, `local-ip`,
+`peer-preflight`, `crosshost-send`, and `crosshost-ack`. The run is invalid if
+an artifact or PR status report names `crosshost`, `crosshost-curl-plain`,
+`crosshost-curl-tls`, a raw socket probe, or an operator-issued `atm send`/
+`atm read` outside the repository runner. The runner-generated body and ID are
+the only valid payload evidence.
+
+For every code-bearing AL.14 fix, review the diff from `tested_sha` before
+rerunning. It fails this sprint's scope gate if it changes
+`crates/atm-daemon/**`, adds a TLS/certificate/peer-wire-security setting, or
+adds resend/replay/retry/heartbeat/cursor/scheduler/batch behavior. Record the
+review in the PR. Any required change in those areas needs a separate decision
+and cannot be smuggled into this Windows evidence sprint.
+
 ## Purpose
 
 Provide the Windows-originating half of the minimal direct M5↔cwin proof. The
@@ -21,10 +47,9 @@ same request body/result semantics hold in both directions.
 
 ## Fixed operating rules
 
-- The named testing ref must contain the tested HTTP-runtime candidate and
-  `faf0c24b` (PR #788's smoke-skill/report-index merge), or a reviewed
-  equivalent merge-forward. Record its immutable SHA in every artifact; a
-  moving branch name or a pre-index smoke checkout is not valid evidence.
+- Use AL.13's tested-candidate manifest exactly. Record its immutable SHA in
+  every artifact; a moving branch name or a pre-index smoke checkout is not
+  valid evidence.
 - Work from cwin's home sprint branch `feature/al-14-smoke`; open a PR with
   evidence and status rather than depositing output in another host's branch.
 - Use `/smoke-test` and `just smoke` only. PowerShell wrappers may set the two
@@ -32,7 +57,8 @@ same request body/result semantics hold in both directions.
   raw HTTP, or manipulate SQLite/inboxes directly.
 - Select one matched Windows CLI/daemon pair with `/daemon-switch`. Use its
   Windows selector-symlink workflow; never overwrite installed executables or
-  run a second daemon. Confirm the selected pair with `atm doctor --json`.
+  run a second daemon. Retain the `daemon-switch.py status --doctor` output
+  before selection and confirm the selected pair with `atm doctor --json`.
 - This proof exercises direct plaintext delivery selected by the tested
   runtime. Do not add TLS/mTLS configuration, curl diagnostics, certificates,
   or an alternate listener. Those are separate, non-required work.
@@ -45,9 +71,10 @@ same request body/result semantics hold in both directions.
 1. Use `/sc-git-worktree` to select or create cwin's home worktree
    `feature/al-14-smoke` from the named testing ref. Do not run the candidate
    from an arbitrary checkout or a stale local clone.
-2. Record cwin's tested SHA, client/daemon version, Windows version, sanitized
-   hostname, M5 SSH alias, and the selected pair in the cwin PR. Confirm it
-   exactly matches AL.13's recorded SHA/version before continuing.
+2. Record the tested-candidate manifest, client/daemon version, Windows
+   version, sanitized hostname, M5 SSH alias, and the selected pair in the
+   cwin PR. Confirm it exactly matches AL.13's recorded manifest/version
+   before continuing.
 3. Build/select the pair, then run `atm doctor --json`. Stop for any unhealthy
    daemon, version mismatch, or competing service.
 4. Run the local Windows ladder in order:
@@ -90,7 +117,8 @@ same request body/result semantics hold in both directions.
 - The cwin-initiated direct ladder passes in order and the evidence proves the
   same exact send/read and ack/reply behavior both directions with M5.
 - No Windows-only wire format, local daemon proxy, TLS/curl diagnostic, retry,
-  replay, message mutation, or second listener is used.
+  replay, message mutation, second listener, or legacy-daemon change is used;
+  the tested-candidate manifest and scope gate pass.
 - The master report index links every retained cwin run, each report includes
   Windows platform and host identity, and the cwin PR describes the result.
 

--- a/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
@@ -128,8 +128,14 @@ same request body/result semantics hold in both directions.
 - `atm doctor --json` on cwin and M5 before each cross-host ladder.
 - The complete ordered cwin sequence above, plus manual browser navigation
   from `site/reports/index.html` to every generated evidence page.
+- Diff review of `tested_sha..HEAD`, recorded in the PR, confirming no
+  `crates/atm-daemon/**` change, no added TLS/certificate/peer-wire-security
+  setting, and no added resend/replay/retry/heartbeat/cursor/scheduler/batch
+  behavior.
 - Cross-check that the M5 and cwin reports name the same tested SHA/version
   and report the same message IDs for the shared run window.
+- Review of the cwin PR by the M5 operator for peer availability and by the
+  coordinator for version/SHA parity and the recorded scope-gate diff result.
 
 ## Non-closure
 

--- a/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL14-cwin-direct-crosshost-smoke.md
@@ -1,0 +1,110 @@
+# AL.14 — cwin Direct Cross-Host Hardware Smoke
+
+**branch:** `feature/al-14-smoke`
+**worktree:** `../atm-core-worktrees/feature/al-14-smoke`
+**recommended_agent:** cwin hardware operator, with the M5 operator available
+as the already-running peer.
+**must_follow:** AL.13's recorded tested commit and smoke-runner contract. The
+same SHA/version is required on both hosts; AL.14 never proves a mixed build.
+**unblocks:** AL.15 combined hardware-evidence review.
+**parallel_safe:** local setup may run in parallel with AL.13. Run the direct
+cross-host ladder only in a scheduled window, not concurrently with AL.13's
+peer-send ladder.
+
+## Purpose
+
+Provide the Windows-originating half of the minimal direct M5↔cwin proof. The
+test is deliberately the same public `atm` send/read/ack behavior as AL.13,
+not a Windows-specific protocol or a different server path. It confirms that
+the configured direct peer endpoint is reachable from Windows and that the
+same request body/result semantics hold in both directions.
+
+## Fixed operating rules
+
+- The named testing ref must contain the tested HTTP-runtime candidate and
+  `faf0c24b` (PR #788's smoke-skill/report-index merge), or a reviewed
+  equivalent merge-forward. Record its immutable SHA in every artifact; a
+  moving branch name or a pre-index smoke checkout is not valid evidence.
+- Work from cwin's home sprint branch `feature/al-14-smoke`; open a PR with
+  evidence and status rather than depositing output in another host's branch.
+- Use `/smoke-test` and `just smoke` only. PowerShell wrappers may set the two
+  documented environment variables, but must not replace the runner, issue
+  raw HTTP, or manipulate SQLite/inboxes directly.
+- Select one matched Windows CLI/daemon pair with `/daemon-switch`. Use its
+  Windows selector-symlink workflow; never overwrite installed executables or
+  run a second daemon. Confirm the selected pair with `atm doctor --json`.
+- This proof exercises direct plaintext delivery selected by the tested
+  runtime. Do not add TLS/mTLS configuration, curl diagnostics, certificates,
+  or an alternate listener. Those are separate, non-required work.
+- Do not introduce or enable replay, retry, recovery timers, cursors, batches,
+  or post-send background delivery. An unavailable peer is a typed direct-send
+  result, not a reason to change the test payload or delivery path.
+
+## Deliverables
+
+1. Use `/sc-git-worktree` to select or create cwin's home worktree
+   `feature/al-14-smoke` from the named testing ref. Do not run the candidate
+   from an arbitrary checkout or a stale local clone.
+2. Record cwin's tested SHA, client/daemon version, Windows version, sanitized
+   hostname, M5 SSH alias, and the selected pair in the cwin PR. Confirm it
+   exactly matches AL.13's recorded SHA/version before continuing.
+3. Build/select the pair, then run `atm doctor --json`. Stop for any unhealthy
+   daemon, version mismatch, or competing service.
+4. Run the local Windows ladder in order:
+
+   ```powershell
+   just smoke localhost
+   just smoke local-ip
+   ```
+
+   The Windows local-IP row is mandatory; it proves the runner uses the
+   Windows TCP adapter before a peer test is attempted.
+5. During the agreed M5 availability window, configure only the existing
+   recipient context and execute the same direct peer ladder from cwin:
+
+   ```powershell
+   $env:ATM_SMOKE_REMOTE_IDENTITY = '<configured-m5-agent>'
+   $env:ATM_SMOKE_REMOTE_TEAM = '<configured-m5-team>'
+   just smoke peer-preflight <m5-ssh-alias>
+   just smoke crosshost-send <m5-ssh-alias>
+   just smoke crosshost-ack <m5-ssh-alias>
+   ```
+
+   A pass requires the runner's forward and reverse exact-ID/body proof. The
+   acknowledgement stage additionally requires both acknowledgement replies
+   to arrive with correct source linkage. A peer-preflight failure blocks the
+   send and ack stages; do not replace it with a manual connection test.
+6. Retain the self-contained reports under
+   `site/reports/smoke/windows/<host>/<run>/`, confirm each is linked from
+   `site/reports/index.html`, and commit them on `feature/al-14-smoke`.
+7. Post a cwin PR status report with all command results, tested SHA/version,
+   master-index and per-run evidence links, failures/blocked stages, and any
+   narrow fix made before rerunning. Ask Rand for a decision if the only
+   apparent workaround changes endpoint selection, message serialization, or
+   direct-send semantics.
+
+## Acceptance criteria
+
+- cwin runs a healthy, version-matched single daemon and passes localhost plus
+  local-IP smoke before cross-host work.
+- The cwin-initiated direct ladder passes in order and the evidence proves the
+  same exact send/read and ack/reply behavior both directions with M5.
+- No Windows-only wire format, local daemon proxy, TLS/curl diagnostic, retry,
+  replay, message mutation, or second listener is used.
+- The master report index links every retained cwin run, each report includes
+  Windows platform and host identity, and the cwin PR describes the result.
+
+## Required validation
+
+- `just test` for any code change before the live run.
+- `atm doctor --json` on cwin and M5 before each cross-host ladder.
+- The complete ordered cwin sequence above, plus manual browser navigation
+  from `site/reports/index.html` to every generated evidence page.
+- Cross-check that the M5 and cwin reports name the same tested SHA/version
+  and report the same message IDs for the shared run window.
+
+## Non-closure
+
+AL.14 does not replace the M5-originating proof, test recovery after a network
+outage, or approve any resend/replay behavior. AL.15 evaluates only the
+retained evidence from the two direct lanes.

--- a/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
+++ b/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
@@ -1,0 +1,94 @@
+# AL.15 — Direct Cross-Host Evidence Closeout
+
+**branch:** `feature/al-15-smoke`
+**worktree:** `../atm-core-worktrees/feature/al-15-smoke`
+**recommended_agent:** coordinator with review access to the AL.13 M5 and
+AL.14 cwin PRs.
+**must_follow:** accepted AL.13 and AL.14 evidence PRs, both pinned to the
+same runtime commit/version.
+**unblocks:** a truthful statement of current direct M5↔cwin smoke status.
+It does not unblock replay, recovery, or Phase AM deletion by itself.
+**parallel_safe:** none; this is the evidence-consumption gate.
+
+## Purpose
+
+Review the two host-owned evidence bundles as one direct cross-host result.
+AL.15 prevents a local-only success, one-way send, generic CLI success line,
+or manually assembled HTML page from being misrepresented as physical
+cross-host proof. It makes the retained `just smoke` artifacts and the public
+CLI observations the sole evidence source.
+
+## Deliverables
+
+1. Verify both PRs identify the same tested commit, ATM version, and direct
+   endpoint selection. Verify that the testing ref includes `faf0c24b` (or a
+   reviewed equivalent merge-forward) so the retained smoke artifacts use the
+   master-report registration contract. A mixed build is a failed/blocked
+   proof, not an acceptable compatibility result.
+2. For each host, inspect its generated master reports index and navigate to
+   all local and cross-host run pages. Confirm the expected self-contained
+   layout and metadata:
+
+   ```text
+   site/reports/index.html
+     -> smoke/<platform>/<host>/<run>/index.html
+       -> per-host XHTML evidence panels
+   ```
+
+3. Confirm the exact ordered evidence matrix is complete:
+
+   | Row | M5-originating proof | cwin-originating proof |
+   |---|---|---|
+   | matched daemon/CLI doctor | required | required |
+   | localhost | required | required |
+   | local-IP | required | required |
+   | peer preflight | required | required |
+   | direct send/read exact ID and body, both directions | required | required |
+   | requires-ack/ack reply linkage, both directions | required | required |
+
+4. Confirm each direct row used the normal public CLI path and the configured
+   peer endpoint. Reject evidence that substitutes curl, raw sockets, a
+   changed message body, direct database inspection, a second daemon, TLS
+   setup, or a background recovery mechanism.
+5. Record one of two precise outcomes in the AL.15 PR:
+
+   - **PASS:** every matrix row passes from both origins and retained reports
+  are browsable from the master index.
+   - **BLOCKED/FAIL:** identify the first failing command, the host of origin,
+     exact runner output, affected matrix rows, report link, and the smallest
+     next owner. Do not claim partial cross-host closure.
+
+6. If a defect is found, leave the evidence untouched, open a focused fix on
+   the affected host's home sprint branch (or the smallest appropriate branch),
+   and rerun only from the earliest invalidated stage after review. Escalate to
+   Rand if the proposed fix changes endpoint selection, canonical request
+   types, storage semantics, notification semantics, or introduces retry/
+   replay.
+
+## Acceptance criteria
+
+- The two host PRs provide current, same-version, self-contained evidence for
+  every matrix row.
+- Evidence proves normal direct send/receive and acknowledgement semantics
+  without a peer-specific application protocol or altered payload.
+- Each result is browsable through `site/reports/index.html`; platform and
+  host identity are visible in the retained path and report metadata.
+- The closeout report is a binary PASS or a specifically bounded BLOCKED/FAIL;
+  no local-only, one-way, or TLS/curl diagnostic result is accepted as direct
+  cross-host success.
+- No replay/recovery work, legacy daemon work, TLS work, or transport-schema
+  changes enter AL.15.
+
+## Required validation
+
+- `just test` and CI-green status for every code-bearing fix cited by the two
+  evidence PRs.
+- Manual inspection of the report-index links and XHTML panels for each run.
+- Independent review by an operator who did not author the evidence under
+  review.
+
+## Non-closure
+
+AL.15 does not add a timer, heartbeat, resend cursor, `message[]` delivery,
+outage replay, TLS certification work, or legacy daemon compatibility work.
+Those are separate future decisions after direct cross-host behavior is proven.

--- a/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
+++ b/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
@@ -1,118 +1,47 @@
-# AL.15 — Direct Cross-Host Evidence Closeout
+# AL.15 — M5/cwin Smoke Closeout
 
 **branch:** `feature/al-15-smoke`
 **worktree:** `../atm-core-worktrees/feature/al-15-smoke`
-**recommended_agent:** coordinator with review access to the AL.13 M5 and
-AL.14 cwin PRs.
-**must_follow:** accepted AL.13 and AL.14 evidence PRs, both pinned to the
-same runtime commit/version.
-**unblocks:** a truthful statement of current direct M5↔cwin smoke status.
-It does not unblock replay, recovery, or Phase AM deletion by itself.
-**parallel_safe:** none; this is the evidence-consumption gate.
+**base:** current `origin/integrate/phase-al`
+**owner:** coordinator
+**must_follow:** AL.13 and AL.14 report PRs
 
-## Evidence manifest and exclusion verification
+## Goal
 
-AL.15 accepts exactly one shared manifest, copied verbatim from both host PRs:
-`tested_sha`, `runtime_candidate_sha`, and
-`report_index_sha=faf0c24b2743274590de4607bfc07654bff63709` (PR #788). It
-verifies the two ancestor checks recorded by AL.13/AL.14 and rejects a report
-that names a different branch or only a version string. The M5 evidence must
-come from `feature/al-13-smoke` and cwin evidence from
-`feature/al-14-smoke`; AL.15's own branch, `feature/al-15-smoke`, contains
-review/closeout material only.
+Create or refresh `feature/al-15-smoke` from current
+`origin/integrate/phase-al` with `/sc-git-worktree`. Review the M5 and cwin
+`/smoke-test` reports as one direct cross-host result. AL.15 does not add a
+new smoke runner or rerun a host lane.
 
-For each retained report, AL.15 verifies that its feature is one of the exact
-allowed set: `localhost`, `local-ip`, `peer-preflight`, `crosshost-send`, or
-`crosshost-ack`. It rejects an alias (`crosshost`), curl feature, raw socket
-probe, manually issued public CLI proof, transformed payload, direct database
-inspection, TLS/certificate configuration, a second daemon/listener, or a
-legacy-daemon change. For a code-bearing host PR, it also checks the recorded
-scope-gate result: no diff from `tested_sha` changed `crates/atm-daemon/**` or
-added TLS/certificate/peer-wire-security or
-resend/replay/retry/heartbeat/cursor/scheduler/batch behavior.
+## Required review
 
-## Purpose
+Confirm that both host PRs contain reports for:
 
-Review the two host-owned evidence bundles as one direct cross-host result.
-AL.15 prevents a local-only success, one-way send, generic CLI success line,
-or manually assembled HTML page from being misrepresented as physical
-cross-host proof. It makes the retained `just smoke` artifacts and the public
-CLI observations the sole evidence source.
+| Row | M5 | cwin |
+|---|---|---|
+| Runtime health | required | required |
+| Localhost | required | required |
+| Local IP | required | required |
+| Peer readiness | required | required |
+| Direct send, both directions | required | required |
+| Requires-ack/reply, both directions | required | required |
+| Benchmark | required | required |
 
-## Deliverables
+Use the master `site/reports/index.html` navigation to inspect each retained
+smoke and benchmark report. The two hosts must identify the same tested runtime
+version before a combined PASS is possible.
 
-1. Verify both PRs reproduce the same three-SHA manifest, ATM version, direct
-   endpoint selection, and successful ancestor checks. Verify that the tested
-   SHA contains the named HTTP-runtime candidate and
-   `faf0c24b2743274590de4607bfc07654bff63709` so the retained smoke artifacts
-   use the master-report registration contract. A mixed build is a
-   failed/blocked proof, not an acceptable compatibility result.
-2. For each host, inspect its generated master reports index and navigate to
-   all local and cross-host run pages. Confirm the expected self-contained
-   layout and metadata:
+## Report and PR
 
-   ```text
-   site/reports/index.html
-     -> smoke/<platform>/<host>/<run>/index.html
-       -> per-host XHTML evidence panels
-   ```
+Open a PR from `feature/al-15-smoke` to `integrate/phase-al` with one closeout
+report that links the M5 and cwin run reports and records one result:
 
-3. Confirm the exact ordered evidence matrix is complete:
+- **PASS:** all required rows pass on both origins.
+- **BLOCKED/FAIL:** name the first failing host and row, link its report, and
+  identify the next owner.
 
-   | Row | M5-originating proof | cwin-originating proof |
-   |---|---|---|
-   | matched daemon/CLI doctor | required | required |
-   | localhost | required | required |
-   | local-IP | required | required |
-   | peer preflight | required | required |
-   | direct send/read exact ID and body, both directions | required | required |
-   | requires-ack/ack reply linkage, both directions | required | required |
+## Acceptance
 
-4. Confirm each direct row used the normal public CLI path and the configured
-   peer endpoint. Reject evidence that substitutes curl, raw sockets, a
-   changed message body, direct database inspection, a second daemon, TLS
-   setup, or a background recovery mechanism.
-5. Record one of two precise outcomes in the AL.15 PR:
-
-   - **PASS:** every matrix row passes from both origins and retained reports
-  are browsable from the master index.
-   - **BLOCKED/FAIL:** identify the first failing command, the host of origin,
-     exact runner output, affected matrix rows, report link, and the smallest
-     next owner. Do not claim partial cross-host closure.
-
-6. If a defect is found, leave the evidence untouched, open a focused fix on
-   the affected host's home sprint branch (or the smallest appropriate branch),
-   and rerun only from the earliest invalidated stage after review. Escalate to
-   Rand if the proposed fix changes endpoint selection, canonical request
-   types, storage semantics, notification semantics, or introduces retry/
-   replay.
-
-## Acceptance criteria
-
-- The two host PRs provide current, same-version, self-contained evidence for
-  every matrix row, the same three-SHA manifest, and passing scope-gate
-  records.
-- Evidence proves normal direct send/receive and acknowledgement semantics
-  without a peer-specific application protocol or altered payload.
-- Each result is browsable through `site/reports/index.html`; platform and
-  host identity are visible in the retained path and report metadata.
-- The closeout report is a binary PASS or a specifically bounded BLOCKED/FAIL;
-  no local-only, one-way, or TLS/curl diagnostic result is accepted as direct
-  cross-host success.
-- No replay/recovery work, legacy daemon work, TLS work, or transport-schema
-  changes enter AL.15; the exclusion-verification gate above is recorded in
-  the closeout PR.
-
-## Required validation
-
-- `just test` and CI-green status for every code-bearing fix cited by the two
-  evidence PRs.
-- Manual inspection of the report-index links and XHTML panels for each run.
-- Independent review by an operator who did not author the evidence under
-  review.
-
-## Non-closure
-
-AL.15 does not add a timer, heartbeat, resend cursor, `message[]` delivery,
-outage replay, TLS certification work, or legacy daemon compatibility work.
-Those are separate future decisions after direct cross-host behavior is proven.
+- The closeout PR links report artifacts from both host lanes through the
+  master reports index.
+- It reports a complete two-host PASS or a specific BLOCKED/FAIL result.

--- a/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
+++ b/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
@@ -14,11 +14,12 @@ It does not unblock replay, recovery, or Phase AM deletion by itself.
 
 AL.15 accepts exactly one shared manifest, copied verbatim from both host PRs:
 `tested_sha`, `runtime_candidate_sha`, and
-`report_index_sha=faf0c24b2743274590de4607bfc07654bff63709`. It verifies the
-two ancestor checks recorded by AL.13/AL.14 and rejects a report that names a
-different branch or only a version string. The M5 evidence must come from
-`feature/al-13-smoke` and cwin evidence from `feature/al-14-smoke`; AL.15's
-own branch, `feature/al-15-smoke`, contains review/closeout material only.
+`report_index_sha=faf0c24b2743274590de4607bfc07654bff63709` (PR #788). It
+verifies the two ancestor checks recorded by AL.13/AL.14 and rejects a report
+that names a different branch or only a version string. The M5 evidence must
+come from `feature/al-13-smoke` and cwin evidence from
+`feature/al-14-smoke`; AL.15's own branch, `feature/al-15-smoke`, contains
+review/closeout material only.
 
 For each retained report, AL.15 verifies that its feature is one of the exact
 allowed set: `localhost`, `local-ip`, `peer-preflight`, `crosshost-send`, or

--- a/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
+++ b/docs/plans/phase-al/sprint-AL15-direct-crosshost-evidence-closeout.md
@@ -10,6 +10,26 @@ same runtime commit/version.
 It does not unblock replay, recovery, or Phase AM deletion by itself.
 **parallel_safe:** none; this is the evidence-consumption gate.
 
+## Evidence manifest and exclusion verification
+
+AL.15 accepts exactly one shared manifest, copied verbatim from both host PRs:
+`tested_sha`, `runtime_candidate_sha`, and
+`report_index_sha=faf0c24b2743274590de4607bfc07654bff63709`. It verifies the
+two ancestor checks recorded by AL.13/AL.14 and rejects a report that names a
+different branch or only a version string. The M5 evidence must come from
+`feature/al-13-smoke` and cwin evidence from `feature/al-14-smoke`; AL.15's
+own branch, `feature/al-15-smoke`, contains review/closeout material only.
+
+For each retained report, AL.15 verifies that its feature is one of the exact
+allowed set: `localhost`, `local-ip`, `peer-preflight`, `crosshost-send`, or
+`crosshost-ack`. It rejects an alias (`crosshost`), curl feature, raw socket
+probe, manually issued public CLI proof, transformed payload, direct database
+inspection, TLS/certificate configuration, a second daemon/listener, or a
+legacy-daemon change. For a code-bearing host PR, it also checks the recorded
+scope-gate result: no diff from `tested_sha` changed `crates/atm-daemon/**` or
+added TLS/certificate/peer-wire-security or
+resend/replay/retry/heartbeat/cursor/scheduler/batch behavior.
+
 ## Purpose
 
 Review the two host-owned evidence bundles as one direct cross-host result.
@@ -20,11 +40,12 @@ CLI observations the sole evidence source.
 
 ## Deliverables
 
-1. Verify both PRs identify the same tested commit, ATM version, and direct
-   endpoint selection. Verify that the testing ref includes `faf0c24b` (or a
-   reviewed equivalent merge-forward) so the retained smoke artifacts use the
-   master-report registration contract. A mixed build is a failed/blocked
-   proof, not an acceptable compatibility result.
+1. Verify both PRs reproduce the same three-SHA manifest, ATM version, direct
+   endpoint selection, and successful ancestor checks. Verify that the tested
+   SHA contains the named HTTP-runtime candidate and
+   `faf0c24b2743274590de4607bfc07654bff63709` so the retained smoke artifacts
+   use the master-report registration contract. A mixed build is a
+   failed/blocked proof, not an acceptable compatibility result.
 2. For each host, inspect its generated master reports index and navigate to
    all local and cross-host run pages. Confirm the expected self-contained
    layout and metadata:
@@ -68,7 +89,8 @@ CLI observations the sole evidence source.
 ## Acceptance criteria
 
 - The two host PRs provide current, same-version, self-contained evidence for
-  every matrix row.
+  every matrix row, the same three-SHA manifest, and passing scope-gate
+  records.
 - Evidence proves normal direct send/receive and acknowledgement semantics
   without a peer-specific application protocol or altered payload.
 - Each result is browsable through `site/reports/index.html`; platform and
@@ -77,7 +99,8 @@ CLI observations the sole evidence source.
   no local-only, one-way, or TLS/curl diagnostic result is accepted as direct
   cross-host success.
 - No replay/recovery work, legacy daemon work, TLS work, or transport-schema
-  changes enter AL.15.
+  changes enter AL.15; the exclusion-verification gate above is recorded in
+  the closeout PR.
 
 ## Required validation
 


### PR DESCRIPTION
## Summary
- add AL.13 M5 direct cross-host hardware smoke
- add AL.14 cwin symmetric direct cross-host hardware smoke
- add AL.15 combined evidence closeout
- make the canonical `/smoke-test` + `just smoke` local/preflight/send/ack ladder the only proof path

## Guardrails
- one immutable testing SHA on both hosts, including the merged smoke report index
- host-owned AL.13/AL.14 branches and PR status reports
- no TLS/curl diagnostics, retry/replay, payload mutation, second daemon, raw socket, or legacy-daemon work

## Validation
- `just lint all` (25/25)
