### PR TITLE
fix(daemon-switch): recover unowned stale UDS

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import platform
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -194,16 +195,32 @@ def require_stopped_daemon(args: argparse.Namespace, _cli: Path) -> None:
     if platform.system() != "Darwin":
         return
     pids = macos_socket_owner_pids()
-    if not pids:
-        return
-    if not args.repair_orphan:
+    if pids and not args.repair_orphan:
         raise SwitchError(
             "controlled service stop left an ATM socket owner; refuse a split pair. "
             "On macOS, rerun with --repair-orphan only after verifying the service label/plist."
         )
-    repair_macos_orphan(pids)
+    if pids:
+        repair_macos_orphan(pids)
     if macos_socket_owner_pids():
         raise SwitchError("ATM daemon socket remains owned after explicit orphan repair")
+    remove_stale_macos_socket()
+
+
+def remove_stale_macos_socket() -> None:
+    """Remove only an unowned Unix-domain socket left by a stopped daemon."""
+    socket_path = Path.home() / ".atm" / "daemon" / "atm-daemon.sock"
+    try:
+        metadata = socket_path.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISSOCK(metadata.st_mode):
+        raise SwitchError(f"refusing to remove non-socket daemon path: {socket_path}")
+    if metadata.st_uid != os.getuid():
+        raise SwitchError(f"refusing to remove daemon socket not owned by this user: {socket_path}")
+    if macos_socket_owner_pids():
+        raise SwitchError("refusing to remove a daemon socket that still has an owner")
+    socket_path.unlink()
 
 
 def replace_link(link: Path, target: Path) -> None:

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1,0 +1,60 @@
+"""Regression tests for the daemon-switch singleton cleanup rules."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import socket
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "daemon-switch.py"
+SPEC = importlib.util.spec_from_file_location("daemon_switch", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+DAEMON_SWITCH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(DAEMON_SWITCH)
+
+
+class StaleSocketCleanupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.home = Path(self.temporary.name)
+        self.socket_path = self.home / ".atm" / "daemon" / "atm-daemon.sock"
+        self.socket_path.parent.mkdir(parents=True)
+        self.original_path = DAEMON_SWITCH.Path
+        self.original_owners = DAEMON_SWITCH.macos_socket_owner_pids
+
+        class TestPath:
+            @staticmethod
+            def home() -> Path:
+                return self.home
+
+        DAEMON_SWITCH.Path = TestPath
+        DAEMON_SWITCH.macos_socket_owner_pids = lambda: []
+
+    def tearDown(self) -> None:
+        DAEMON_SWITCH.Path = self.original_path
+        DAEMON_SWITCH.macos_socket_owner_pids = self.original_owners
+        self.temporary.cleanup()
+
+    def test_removes_unowned_unix_socket(self) -> None:
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(self.socket_path))
+        listener.close()
+
+        DAEMON_SWITCH.remove_stale_macos_socket()
+
+        self.assertFalse(self.socket_path.exists())
+
+    def test_refuses_regular_file_at_daemon_socket_path(self) -> None:
+        self.socket_path.write_text("not a socket", encoding="utf-8")
+
+        with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "non-socket"):
+            DAEMON_SWITCH.remove_stale_macos_socket()
+
+        self.assertTrue(self.socket_path.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove only a user-owned, unowned Unix-domain socket after controlled macOS daemon shutdown
- retain fail-closed behavior for live owners and non-socket paths
- add focused stale-socket regression tests

## Verification
- `python3 .claude/skills/daemon-switch/tests/test_daemon_switch.py`
- `python3 -m py_compile .claude/skills/daemon-switch/scripts/daemon-switch.py`
- controlled `daemon-switch restart` + `status --doctor` on the AL.15 beta-ai-15 matched pair