### PR TITLE
fix(AL): recover dead owner UDS after runtime crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "atm-storage",
  "axum",
  "base64",
+ "fs2",
  "hyper",
  "hyper-util",
  "reqwest",

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tower.workspace = true
 async-trait.workspace = true
+fs2 = "0.4"
 tracing.workspace = true
 ulid.workspace = true
 

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -67,7 +67,7 @@ use loopback_tcp::{
     publish_loopback_endpoint_record, validate_loopback_config,
 };
 #[cfg(unix)]
-use unix_socket::{UnixSocketPathGuard, bind_unix_listener};
+use unix_socket::{UnixSocketPathGuard, bind_unix_listener, reclaim_stale_unix_socket};
 
 /// An aborted Tokio task should stop at its next cancellation point. Keep this
 /// grace deliberately short and fixed so a pathological task cannot extend the
@@ -527,6 +527,10 @@ async fn bind_configured_unix_listener(
     let Some(socket) = config.unix_socket.clone() else {
         return Ok(None);
     };
+    if let Err(error) = reclaim_stale_unix_socket(&socket).await {
+        health.mark_not_ready(error.to_string());
+        return Err(error);
+    }
     match tokio::task::spawn_blocking(move || bind_unix_listener(&socket)).await {
         Ok(Ok(listener)) => Ok(Some(listener)),
         Ok(Err(error)) => {

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -67,7 +67,9 @@ use loopback_tcp::{
     publish_loopback_endpoint_record, validate_loopback_config,
 };
 #[cfg(unix)]
-use unix_socket::{UnixSocketPathGuard, bind_unix_listener, reclaim_stale_unix_socket};
+use unix_socket::{
+    UnixSocketPathGuard, UnixSocketStartupLock, bind_unix_listener, reclaim_stale_unix_socket,
+};
 
 /// An aborted Tokio task should stop at its next cancellation point. Keep this
 /// grace deliberately short and fixed so a pathological task cannot extend the
@@ -527,11 +529,30 @@ async fn bind_configured_unix_listener(
     let Some(socket) = config.unix_socket.clone() else {
         return Ok(None);
     };
+    let lock_socket = socket.clone();
+    let startup_lock =
+        match tokio::task::spawn_blocking(move || UnixSocketStartupLock::acquire(&lock_socket))
+            .await
+        {
+            Ok(Ok(lock)) => lock,
+            Ok(Err(error)) => {
+                health.mark_not_ready(error.to_string());
+                return Err(error);
+            }
+            Err(source) => {
+                let error = AtmError::daemon_unavailable(
+                    "replacement Unix HTTP socket lock task ended unexpectedly",
+                )
+                .with_cause(source);
+                health.mark_not_ready(error.to_string());
+                return Err(error);
+            }
+        };
     if let Err(error) = reclaim_stale_unix_socket(&socket).await {
         health.mark_not_ready(error.to_string());
         return Err(error);
     }
-    match tokio::task::spawn_blocking(move || bind_unix_listener(&socket)).await {
+    let result = match tokio::task::spawn_blocking(move || bind_unix_listener(&socket)).await {
         Ok(Ok(listener)) => Ok(Some(listener)),
         Ok(Err(error)) => {
             health.mark_not_ready(error.to_string());
@@ -545,7 +566,9 @@ async fn bind_configured_unix_listener(
             health.mark_not_ready(error.to_string());
             Err(error)
         }
-    }
+    };
+    drop(startup_lock);
+    result
 }
 
 async fn publish_loopback_endpoint(

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -18,6 +18,32 @@ const SOCKET_LIVENESS_PROBE_ATTEMPTS: usize = 5;
 #[cfg(unix)]
 const SOCKET_LIVENESS_PROBE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
 
+// `sockaddr_un::sun_path` includes the trailing NUL required by pathname UDS
+// addresses. Keep one byte in reserve and reject inputs before `bind` turns a
+// deterministic configuration error into a platform-specific failure.
+#[cfg(all(
+    unix,
+    any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )
+))]
+const UNIX_SOCKET_PATH_CAPACITY: usize = 104;
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))
+))]
+const UNIX_SOCKET_PATH_CAPACITY: usize = 108;
+
 /// A same-user process lock that makes UDS recovery and publication one
 /// critical section. The socket pathname alone cannot provide that guarantee:
 /// a second daemon could otherwise observe stale state between recovery and
@@ -89,6 +115,7 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
     use std::fs;
     use std::os::unix::fs::MetadataExt;
 
+    validate_unix_socket_path_length(&socket.path)?;
     let parent = socket
         .path
         .parent()
@@ -122,6 +149,24 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
         );
     }
     Ok(parent)
+}
+
+#[cfg(unix)]
+fn validate_unix_socket_path_length(path: &Path) -> Result<(), AtmError> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bytes = path.as_os_str().as_bytes().len();
+    if bytes >= UNIX_SOCKET_PATH_CAPACITY {
+        return Err(AtmError::config(
+            "Unix HTTP socket path exceeds the platform sockaddr_un path limit",
+        )
+        .with_cause(format!(
+            "path `{}` is {bytes} bytes; limit is {} bytes plus its terminating NUL",
+            path.display(),
+            UNIX_SOCKET_PATH_CAPACITY - 1
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -353,6 +398,7 @@ fn bind_prepared_unix_socket(
     // published, without changing the process-global umask.
     let staging = PrivateStagingDirectory::create(parent)?;
     let staged_path = staging.path().join("listener.sock");
+    validate_unix_socket_path_length(&staged_path)?;
     let listener = UnixListener::bind(&staged_path).map_err(|source| {
         AtmError::daemon_unavailable("failed to bind replacement Unix HTTP socket")
             .with_cause(source)
@@ -521,8 +567,9 @@ mod tests {
     use std::os::unix::fs::MetadataExt;
 
     use super::{
-        SocketLiveness, UnixSocketStartupLock, bind_unix_listener, inspect_recovery_target,
-        probe_unix_socket_liveness, reclaim_stale_unix_socket,
+        SocketLiveness, UNIX_SOCKET_PATH_CAPACITY, UnixSocketStartupLock, bind_unix_listener,
+        inspect_recovery_target, probe_unix_socket_liveness, reclaim_stale_unix_socket,
+        validate_unix_socket_path_length,
     };
     use crate::{UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid};
 
@@ -603,6 +650,17 @@ mod tests {
         let error = UnixSocketStartupLock::acquire(&socket)
             .expect_err("second same-user start must not enter the recovery critical section");
         assert_eq!(error.code().as_str(), "ATM_DAEMON_SERVING_STATE_REJECTED");
+    }
+
+    #[test]
+    fn socket_path_length_is_rejected_before_bind() {
+        let accepted = std::path::PathBuf::from("x".repeat(UNIX_SOCKET_PATH_CAPACITY - 1));
+        validate_unix_socket_path_length(&accepted).expect("last byte before NUL is accepted");
+
+        let rejected = std::path::PathBuf::from("x".repeat(UNIX_SOCKET_PATH_CAPACITY));
+        let error = validate_unix_socket_path_length(&rejected)
+            .expect_err("socket pathname must leave space for its terminating NUL");
+        assert_eq!(error.code().as_str(), "ATM_CONFIG_PARSE_FAILED");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -139,25 +139,30 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
         Ok(metadata) => metadata,
         Err(source) if source.kind() == ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            return Err(AtmError::config("cannot inspect Unix HTTP socket path").with_cause(source));
+            return Err(AtmError::daemon_stale_owner_recovery_failed(
+                "cannot inspect Unix HTTP socket path during stale-owner recovery",
+            )
+            .with_cause(source));
         }
     };
     if !original.file_type().is_socket() {
-        return Err(
-            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
-                "refusing to replace non-socket path `{}`",
-                path.display()
-            )),
-        );
+        return Err(AtmError::daemon_stale_owner_recovery_failed(
+            "Unix HTTP socket path cannot be recovered because it is not a socket",
+        )
+        .with_cause(format!(
+            "refusing to replace non-socket path `{}`",
+            path.display()
+        )));
     }
     if original.uid() != socket.owner_uid.get() {
-        return Err(
-            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
-                "refusing to replace socket `{}` owned by uid {}",
-                path.display(),
-                original.uid()
-            )),
-        );
+        return Err(AtmError::daemon_stale_owner_recovery_failed(
+            "Unix HTTP socket path cannot be recovered because its owner differs",
+        )
+        .with_cause(format!(
+            "refusing to replace socket `{}` owned by uid {}",
+            path.display(),
+            original.uid()
+        )));
     }
     match probe_unix_socket_liveness(path).await {
         Ok(SocketLiveness::Reachable) => Err(AtmError::config(
@@ -169,15 +174,18 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
         ))),
         Ok(SocketLiveness::Dead) => {
             let current = fs::symlink_metadata(path).map_err(|source| {
-                AtmError::config("cannot re-inspect stale Unix HTTP socket path").with_cause(source)
+                AtmError::daemon_stale_owner_recovery_failed(
+                    "cannot re-inspect Unix HTTP socket path during stale-owner recovery",
+                )
+                .with_cause(source)
             })?;
             if !current.file_type().is_socket()
                 || current.uid() != socket.owner_uid.get()
                 || current.dev() != original.dev()
                 || current.ino() != original.ino()
             {
-                return Err(AtmError::config(
-                    "Unix HTTP socket path changed during stale-path recovery",
+                return Err(AtmError::daemon_stale_owner_recovery_failed(
+                    "Unix HTTP socket path changed during stale-owner recovery",
                 )
                 .with_cause(format!(
                     "refusing to replace `{}` after identity changed",
@@ -185,16 +193,19 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
                 )));
             }
             fs::remove_file(path).map_err(|source| {
-                AtmError::daemon_unavailable("failed to remove stale Unix HTTP socket path")
-                    .with_cause(source)
+                AtmError::daemon_stale_owner_recovery_failed(
+                    "failed to remove stale Unix HTTP socket path",
+                )
+                .with_cause(source)
             })
         }
-        Err(source) => Err(
-            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
-                "refusing to replace socket `{}` after connection check failed: {source}",
-                path.display()
-            )),
-        ),
+        Err(source) => Err(AtmError::daemon_stale_owner_recovery_failed(
+            "cannot determine whether the Unix HTTP socket owner is stale",
+        )
+        .with_cause(format!(
+            "refusing to replace socket `{}` after connection check failed: {source}",
+            path.display()
+        ))),
     }
 }
 
@@ -493,5 +504,28 @@ mod tests {
         };
         assert!(error.message().contains("already occupied"));
         assert!(path.exists(), "the live socket pathname is retained");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn non_socket_recovery_rejection_uses_stale_owner_error_code() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let path = directory.path().join("atm-daemon.sock");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
+        std::fs::write(&path, "must not be unlinked as a socket")
+            .expect("create occupied non-socket path");
+
+        let error = reclaim_stale_unix_socket(&socket_config(path.clone(), uid))
+            .await
+            .expect_err("non-socket path cannot be reclaimed");
+        assert_eq!(
+            error.code().as_str(),
+            "ATM_DAEMON_STALE_OWNER_RECOVERY_FAILED"
+        );
+        assert!(
+            path.exists(),
+            "safety rejection preserves the occupied path"
+        );
     }
 }

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -12,11 +12,15 @@ use tokio::net::UnixListener;
 use super::UnixSocketConfig;
 
 #[cfg(unix)]
+const SOCKET_LIVENESS_PROBE_ATTEMPTS: usize = 3;
+#[cfg(unix)]
+const SOCKET_LIVENESS_PROBE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
+
+#[cfg(unix)]
 pub(super) fn bind_unix_listener(
     socket: &UnixSocketConfig,
 ) -> Result<(UnixListener, UnixSocketPathGuard), AtmError> {
     let parent = validate_unix_socket_parent(socket)?;
-    reclaim_stale_unix_socket(socket)?;
     let (listener, staging) = bind_prepared_unix_socket(socket, parent)?;
     publish_prepared_unix_socket(socket, staging)?;
     let cleanup = UnixSocketPathGuard::capture(&socket.path).inspect_err(|_| {
@@ -70,11 +74,11 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
 /// reachable endpoint. A supervisor can restart the replacement daemon after
 /// an ungraceful exit, which bypasses `UnixSocketPathGuard::drop`; without
 /// this narrowly checked recovery the new Tokio runtime cannot rebind.
-fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> {
+pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> {
+    validate_unix_socket_parent(socket)?;
     use std::fs;
     use std::io::ErrorKind;
     use std::os::unix::fs::{FileTypeExt, MetadataExt};
-    use std::os::unix::net::UnixStream;
 
     let path = &socket.path;
     let original = match fs::symlink_metadata(path) {
@@ -101,14 +105,15 @@ fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> 
             )),
         );
     }
-    match UnixStream::connect(path) {
-        Ok(_) => Err(
-            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
-                "refusing to replace reachable socket `{}`",
-                path.display()
-            )),
-        ),
-        Err(source) if source.kind() == ErrorKind::ConnectionRefused => {
+    match probe_unix_socket_liveness(path).await {
+        Ok(SocketLiveness::Reachable) => Err(AtmError::config(
+            "Unix HTTP socket path is already occupied",
+        )
+        .with_cause(format!(
+            "refusing to replace reachable socket `{}`",
+            path.display()
+        ))),
+        Ok(SocketLiveness::Dead) => {
             let current = fs::symlink_metadata(path).map_err(|source| {
                 AtmError::config("cannot re-inspect stale Unix HTTP socket path").with_cause(source)
             })?;
@@ -137,6 +142,32 @@ fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> 
             )),
         ),
     }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketLiveness {
+    Reachable,
+    Dead,
+}
+
+#[cfg(unix)]
+async fn probe_unix_socket_liveness(path: &Path) -> std::io::Result<SocketLiveness> {
+    // A refused AF_UNIX connection can be transient while a live listener's
+    // backlog drains, so one refusal is insufficient evidence for unlinking
+    // its pathname. This remains entirely on the Tokio runtime.
+    for attempt in 0..SOCKET_LIVENESS_PROBE_ATTEMPTS {
+        match tokio::net::UnixStream::connect(path).await {
+            Ok(_) => return Ok(SocketLiveness::Reachable),
+            Err(error) if error.kind() == std::io::ErrorKind::ConnectionRefused => {
+                if attempt + 1 < SOCKET_LIVENESS_PROBE_ATTEMPTS {
+                    tokio::time::sleep(SOCKET_LIVENESS_PROBE_BACKOFF).await;
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(SocketLiveness::Dead)
 }
 
 #[cfg(unix)]
@@ -319,7 +350,9 @@ mod tests {
     use std::num::NonZeroU32;
     use std::os::unix::fs::MetadataExt;
 
-    use super::bind_unix_listener;
+    use super::{
+        SocketLiveness, bind_unix_listener, probe_unix_socket_liveness, reclaim_stale_unix_socket,
+    };
     use crate::{UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid};
 
     fn socket_config(path: std::path::PathBuf, uid: u32) -> UnixSocketConfig {
@@ -328,6 +361,26 @@ mod tests {
             UnixSocketOwnerUid::new(NonZeroU32::new(uid).expect("test uid is non-zero")),
             UnixSocketMode::new(NonZeroU32::new(0o600).expect("owner-only socket mode")),
         )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refused_socket_is_retried_before_it_is_declared_dead() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let path = directory.path().join("atm-daemon.sock");
+        let stale = std::os::unix::net::UnixListener::bind(&path).expect("create stale socket");
+        drop(stale);
+
+        let probe = tokio::spawn(async move { probe_unix_socket_liveness(&path).await });
+        tokio::task::yield_now().await;
+        assert!(
+            !probe.is_finished(),
+            "one refusal cannot prove the socket is dead"
+        );
+        tokio::time::advance(std::time::Duration::from_millis(20)).await;
+        assert_eq!(
+            probe.await.expect("probe joins").expect("probe result"),
+            SocketLiveness::Dead
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -340,8 +393,11 @@ mod tests {
         let stale = std::os::unix::net::UnixListener::bind(&path).expect("create stale socket");
         drop(stale);
 
+        reclaim_stale_unix_socket(&socket_config(path.clone(), uid))
+            .await
+            .expect("reclaim stale socket");
         let (_listener, cleanup) =
-            bind_unix_listener(&socket_config(path.clone(), uid)).expect("reclaim and rebind");
+            bind_unix_listener(&socket_config(path.clone(), uid)).expect("rebind replacement");
         assert!(
             path.exists(),
             "the replacement listener owns the published path"
@@ -362,7 +418,7 @@ mod tests {
             .uid();
         let _live = std::os::unix::net::UnixListener::bind(&path).expect("create live socket");
 
-        let error = match bind_unix_listener(&socket_config(path.clone(), uid)) {
+        let error = match reclaim_stale_unix_socket(&socket_config(path.clone(), uid)).await {
             Ok(_) => panic!("a live socket must remain in place"),
             Err(error) => error,
         };

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -14,9 +14,9 @@ use tokio::net::UnixListener;
 use super::UnixSocketConfig;
 
 #[cfg(unix)]
-const SOCKET_LIVENESS_PROBE_ATTEMPTS: usize = 3;
+const SOCKET_LIVENESS_PROBE_ATTEMPTS: usize = 5;
 #[cfg(unix)]
-const SOCKET_LIVENESS_PROBE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
+const SOCKET_LIVENESS_PROBE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// A same-user process lock that makes UDS recovery and publication one
 /// critical section. The socket pathname alone cannot provide that guarantee:
@@ -44,6 +44,7 @@ impl UnixSocketStartupLock {
             .create(true)
             .read(true)
             .write(true)
+            .truncate(false)
             .open(&lock_path)
             .map_err(|source| {
                 AtmError::daemon_unavailable("failed to open Unix HTTP socket startup lock")
@@ -129,42 +130,12 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
 /// an ungraceful exit, which bypasses `UnixSocketPathGuard::drop`; without
 /// this narrowly checked recovery the new Tokio runtime cannot rebind.
 pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> {
-    validate_unix_socket_parent(socket)?;
-    use std::fs;
-    use std::io::ErrorKind;
-    use std::os::unix::fs::{FileTypeExt, MetadataExt};
-
-    let path = &socket.path;
-    let original = match fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(()),
-        Err(source) => {
-            return Err(AtmError::daemon_stale_owner_recovery_failed(
-                "cannot inspect Unix HTTP socket path during stale-owner recovery",
-            )
-            .with_cause(source));
-        }
+    let original = inspect_recovery_target(socket.clone()).await?;
+    let Some(original) = original else {
+        return Ok(());
     };
-    if !original.file_type().is_socket() {
-        return Err(AtmError::daemon_stale_owner_recovery_failed(
-            "Unix HTTP socket path cannot be recovered because it is not a socket",
-        )
-        .with_cause(format!(
-            "refusing to replace non-socket path `{}`",
-            path.display()
-        )));
-    }
-    if original.uid() != socket.owner_uid.get() {
-        return Err(AtmError::daemon_stale_owner_recovery_failed(
-            "Unix HTTP socket path cannot be recovered because its owner differs",
-        )
-        .with_cause(format!(
-            "refusing to replace socket `{}` owned by uid {}",
-            path.display(),
-            original.uid()
-        )));
-    }
-    match probe_unix_socket_liveness(path).await {
+    let path = socket.path.clone();
+    match probe_unix_socket_liveness(&path, original).await {
         Ok(SocketLiveness::Reachable) => Err(AtmError::config(
             "Unix HTTP socket path is already occupied",
         )
@@ -172,18 +143,15 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
             "refusing to replace reachable socket `{}`",
             path.display()
         ))),
+        Ok(SocketLiveness::Changed) => Err(AtmError::daemon_stale_owner_recovery_failed(
+            "Unix HTTP socket path changed while liveness was being observed",
+        )
+        .with_cause(format!(
+            "refusing to replace `{}` after its owner or file identity changed",
+            path.display()
+        ))),
         Ok(SocketLiveness::Dead) => {
-            let current = fs::symlink_metadata(path).map_err(|source| {
-                AtmError::daemon_stale_owner_recovery_failed(
-                    "cannot re-inspect Unix HTTP socket path during stale-owner recovery",
-                )
-                .with_cause(source)
-            })?;
-            if !current.file_type().is_socket()
-                || current.uid() != socket.owner_uid.get()
-                || current.dev() != original.dev()
-                || current.ino() != original.ino()
-            {
+            if !recovery_target_matches(path.clone(), original).await? {
                 return Err(AtmError::daemon_stale_owner_recovery_failed(
                     "Unix HTTP socket path changed during stale-owner recovery",
                 )
@@ -192,12 +160,7 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
                     path.display()
                 )));
             }
-            fs::remove_file(path).map_err(|source| {
-                AtmError::daemon_stale_owner_recovery_failed(
-                    "failed to remove stale Unix HTTP socket path",
-                )
-                .with_cause(source)
-            })
+            remove_stale_socket_path(path).await
         }
         Err(source) => Err(AtmError::daemon_stale_owner_recovery_failed(
             "cannot determine whether the Unix HTTP socket owner is stale",
@@ -211,25 +174,167 @@ pub(super) async fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Resu
 
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SocketLiveness {
-    Reachable,
-    Dead,
+struct SocketRecoverySnapshot {
+    device: u64,
+    inode: u64,
+    owner_uid: u32,
 }
 
 #[cfg(unix)]
-async fn probe_unix_socket_liveness(path: &Path) -> std::io::Result<SocketLiveness> {
+async fn inspect_recovery_target(
+    socket: UnixSocketConfig,
+) -> Result<Option<SocketRecoverySnapshot>, AtmError> {
+    tokio::task::spawn_blocking(move || inspect_recovery_target_blocking(&socket))
+        .await
+        .map_err(|source| {
+            AtmError::daemon_stale_owner_recovery_failed(
+                "Unix HTTP socket stale-owner inspection task ended unexpectedly",
+            )
+            .with_cause(source)
+        })?
+}
+
+#[cfg(unix)]
+fn inspect_recovery_target_blocking(
+    socket: &UnixSocketConfig,
+) -> Result<Option<SocketRecoverySnapshot>, AtmError> {
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    validate_unix_socket_parent(socket)?;
+    let metadata = match fs::symlink_metadata(&socket.path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(AtmError::daemon_stale_owner_recovery_failed(
+                "cannot inspect Unix HTTP socket path during stale-owner recovery",
+            )
+            .with_cause(source));
+        }
+    };
+    if !metadata.file_type().is_socket() {
+        return Err(AtmError::daemon_stale_owner_recovery_failed(
+            "Unix HTTP socket path cannot be recovered because it is not a socket",
+        )
+        .with_cause(format!(
+            "refusing to replace non-socket path `{}`",
+            socket.path.display()
+        )));
+    }
+    if metadata.uid() != socket.owner_uid.get() {
+        return Err(AtmError::daemon_stale_owner_recovery_failed(
+            "Unix HTTP socket path cannot be recovered because its owner differs",
+        )
+        .with_cause(format!(
+            "refusing to replace socket `{}` owned by uid {}",
+            socket.path.display(),
+            metadata.uid()
+        )));
+    }
+    Ok(Some(SocketRecoverySnapshot {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        owner_uid: metadata.uid(),
+    }))
+}
+
+#[cfg(unix)]
+async fn recovery_target_matches(
+    path: PathBuf,
+    original: SocketRecoverySnapshot,
+) -> Result<bool, AtmError> {
+    tokio::task::spawn_blocking(move || recovery_target_matches_blocking(&path, original))
+        .await
+        .map_err(|source| {
+            AtmError::daemon_stale_owner_recovery_failed(
+                "Unix HTTP socket stale-owner reinspection task ended unexpectedly",
+            )
+            .with_cause(source)
+        })?
+}
+
+#[cfg(unix)]
+fn recovery_target_matches_blocking(
+    path: &Path,
+    original: SocketRecoverySnapshot,
+) -> Result<bool, AtmError> {
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_socket()
+            && metadata.uid() == original.owner_uid
+            && metadata.dev() == original.device
+            && metadata.ino() == original.inode),
+        Err(source) if source.kind() == ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(AtmError::daemon_stale_owner_recovery_failed(
+            "cannot re-inspect Unix HTTP socket path during stale-owner recovery",
+        )
+        .with_cause(source)),
+    }
+}
+
+#[cfg(unix)]
+async fn remove_stale_socket_path(path: PathBuf) -> Result<(), AtmError> {
+    tokio::task::spawn_blocking(move || std::fs::remove_file(path))
+        .await
+        .map_err(|source| {
+            AtmError::daemon_stale_owner_recovery_failed(
+                "Unix HTTP socket stale-owner removal task ended unexpectedly",
+            )
+            .with_cause(source)
+        })?
+        .map_err(|source| {
+            AtmError::daemon_stale_owner_recovery_failed(
+                "failed to remove stale Unix HTTP socket path",
+            )
+            .with_cause(source)
+        })
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketLiveness {
+    Reachable,
+    Dead,
+    Changed,
+}
+
+#[cfg(unix)]
+async fn probe_unix_socket_liveness(
+    path: &Path,
+    original: SocketRecoverySnapshot,
+) -> std::io::Result<SocketLiveness> {
     // A refused AF_UNIX connection can be transient while a live listener's
-    // backlog drains, so one refusal is insufficient evidence for unlinking
-    // its pathname. This remains entirely on the Tokio runtime.
+    // backlog drains. Treat an endpoint as dead only after a bounded
+    // observation window has both repeatedly refused connections and retained
+    // its exact socket inode and owner throughout that window.
     for attempt in 0..SOCKET_LIVENESS_PROBE_ATTEMPTS {
         match tokio::net::UnixStream::connect(path).await {
             Ok(_) => return Ok(SocketLiveness::Reachable),
             Err(error) if error.kind() == std::io::ErrorKind::ConnectionRefused => {
+                if !recovery_target_matches(path.to_path_buf(), original)
+                    .await
+                    .map_err(std::io::Error::other)?
+                {
+                    return Ok(SocketLiveness::Changed);
+                }
                 if attempt + 1 < SOCKET_LIVENESS_PROBE_ATTEMPTS {
-                    tokio::time::sleep(SOCKET_LIVENESS_PROBE_BACKOFF).await;
+                    let multiplier = 1_u32 << attempt;
+                    tokio::time::sleep(SOCKET_LIVENESS_PROBE_BACKOFF * multiplier).await;
                 }
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                if !recovery_target_matches(path.to_path_buf(), original)
+                    .await
+                    .map_err(std::io::Error::other)?
+                {
+                    return Ok(SocketLiveness::Changed);
+                }
+                return Err(error);
+            }
         }
     }
     Ok(SocketLiveness::Dead)
@@ -416,8 +521,8 @@ mod tests {
     use std::os::unix::fs::MetadataExt;
 
     use super::{
-        SocketLiveness, UnixSocketStartupLock, bind_unix_listener, probe_unix_socket_liveness,
-        reclaim_stale_unix_socket,
+        SocketLiveness, UnixSocketStartupLock, bind_unix_listener, inspect_recovery_target,
+        probe_unix_socket_liveness, reclaim_stale_unix_socket,
     };
     use crate::{UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid};
 
@@ -433,19 +538,56 @@ mod tests {
     async fn refused_socket_is_retried_before_it_is_declared_dead() {
         let directory = tempfile::tempdir().expect("temporary UDS parent");
         let path = directory.path().join("atm-daemon.sock");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
         let stale = std::os::unix::net::UnixListener::bind(&path).expect("create stale socket");
         drop(stale);
+        let snapshot = inspect_recovery_target(socket_config(path.clone(), uid))
+            .await
+            .expect("inspect stale socket")
+            .expect("stale socket exists");
 
-        let probe = tokio::spawn(async move { probe_unix_socket_liveness(&path).await });
+        let probe_path = path.clone();
+        let probe =
+            tokio::spawn(async move { probe_unix_socket_liveness(&probe_path, snapshot).await });
         tokio::task::yield_now().await;
         assert!(
             !probe.is_finished(),
             "one refusal cannot prove the socket is dead"
         );
-        tokio::time::advance(std::time::Duration::from_millis(20)).await;
+        tokio::time::advance(std::time::Duration::from_millis(1_500)).await;
         assert_eq!(
             probe.await.expect("probe joins").expect("probe result"),
             SocketLiveness::Dead
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn changed_socket_is_never_classified_as_dead_after_a_refusal() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let path = directory.path().join("atm-daemon.sock");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
+        let stale = std::os::unix::net::UnixListener::bind(&path).expect("create stale socket");
+        drop(stale);
+        let snapshot = inspect_recovery_target(socket_config(path.clone(), uid))
+            .await
+            .expect("inspect stale socket")
+            .expect("stale socket exists");
+
+        let probe_path = path.clone();
+        let probe =
+            tokio::spawn(async move { probe_unix_socket_liveness(&probe_path, snapshot).await });
+        tokio::task::yield_now().await;
+        std::fs::remove_file(&path).expect("replace stale socket path");
+        std::fs::write(&path, "different owner must be left alone")
+            .expect("publish a different occupied path");
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            probe.await.expect("probe joins").expect("probe result"),
+            SocketLiveness::Changed
         );
     }
 

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -16,7 +16,7 @@ pub(super) fn bind_unix_listener(
     socket: &UnixSocketConfig,
 ) -> Result<(UnixListener, UnixSocketPathGuard), AtmError> {
     let parent = validate_unix_socket_parent(socket)?;
-    ensure_unix_socket_path_unoccupied(&socket.path)?;
+    reclaim_stale_unix_socket(socket)?;
     let (listener, staging) = bind_prepared_unix_socket(socket, parent)?;
     publish_prepared_unix_socket(socket, staging)?;
     let cleanup = UnixSocketPathGuard::capture(&socket.path).inspect_err(|_| {
@@ -66,21 +66,76 @@ fn validate_unix_socket_parent(socket: &UnixSocketConfig) -> Result<&Path, AtmEr
 }
 
 #[cfg(unix)]
-fn ensure_unix_socket_path_unoccupied(path: &Path) -> Result<(), AtmError> {
+/// Removes the prior runtime's dead socket pathname, but never replaces a
+/// reachable endpoint. A supervisor can restart the replacement daemon after
+/// an ungraceful exit, which bypasses `UnixSocketPathGuard::drop`; without
+/// this narrowly checked recovery the new Tokio runtime cannot rebind.
+fn reclaim_stale_unix_socket(socket: &UnixSocketConfig) -> Result<(), AtmError> {
     use std::fs;
     use std::io::ErrorKind;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+    use std::os::unix::net::UnixStream;
 
-    match fs::symlink_metadata(path) {
-        Ok(_) => Err(AtmError::config("Unix HTTP socket path is already occupied").with_cause(
-            format!(
-                "refusing to replace existing path `{}`; remove only the stale owner-owned socket before retrying",
-                path.display()
-            ),
-        )),
-        Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
+    let path = &socket.path;
+    let original = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            Err(AtmError::config("cannot inspect Unix HTTP socket path").with_cause(source))
+            return Err(AtmError::config("cannot inspect Unix HTTP socket path").with_cause(source));
         }
+    };
+    if !original.file_type().is_socket() {
+        return Err(
+            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
+                "refusing to replace non-socket path `{}`",
+                path.display()
+            )),
+        );
+    }
+    if original.uid() != socket.owner_uid.get() {
+        return Err(
+            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
+                "refusing to replace socket `{}` owned by uid {}",
+                path.display(),
+                original.uid()
+            )),
+        );
+    }
+    match UnixStream::connect(path) {
+        Ok(_) => Err(
+            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
+                "refusing to replace reachable socket `{}`",
+                path.display()
+            )),
+        ),
+        Err(source) if source.kind() == ErrorKind::ConnectionRefused => {
+            let current = fs::symlink_metadata(path).map_err(|source| {
+                AtmError::config("cannot re-inspect stale Unix HTTP socket path").with_cause(source)
+            })?;
+            if !current.file_type().is_socket()
+                || current.uid() != socket.owner_uid.get()
+                || current.dev() != original.dev()
+                || current.ino() != original.ino()
+            {
+                return Err(AtmError::config(
+                    "Unix HTTP socket path changed during stale-path recovery",
+                )
+                .with_cause(format!(
+                    "refusing to replace `{}` after identity changed",
+                    path.display()
+                )));
+            }
+            fs::remove_file(path).map_err(|source| {
+                AtmError::daemon_unavailable("failed to remove stale Unix HTTP socket path")
+                    .with_cause(source)
+            })
+        }
+        Err(source) => Err(
+            AtmError::config("Unix HTTP socket path is already occupied").with_cause(format!(
+                "refusing to replace socket `{}` after connection check failed: {source}",
+                path.display()
+            )),
+        ),
     }
 }
 
@@ -256,5 +311,62 @@ impl Drop for UnixSocketPathGuard {
         if is_our_socket {
             let _ = fs::remove_file(&self.path);
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::num::NonZeroU32;
+    use std::os::unix::fs::MetadataExt;
+
+    use super::bind_unix_listener;
+    use crate::{UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid};
+
+    fn socket_config(path: std::path::PathBuf, uid: u32) -> UnixSocketConfig {
+        UnixSocketConfig::new(
+            path,
+            UnixSocketOwnerUid::new(NonZeroU32::new(uid).expect("test uid is non-zero")),
+            UnixSocketMode::new(NonZeroU32::new(0o600).expect("owner-only socket mode")),
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dead_owner_socket_is_reclaimed_before_rebinding() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let path = directory.path().join("atm-daemon.sock");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
+        let stale = std::os::unix::net::UnixListener::bind(&path).expect("create stale socket");
+        drop(stale);
+
+        let (_listener, cleanup) =
+            bind_unix_listener(&socket_config(path.clone(), uid)).expect("reclaim and rebind");
+        assert!(
+            path.exists(),
+            "the replacement listener owns the published path"
+        );
+        drop(cleanup);
+        assert!(
+            !path.exists(),
+            "the replacement listener cleans up its own path"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reachable_socket_is_never_replaced() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let path = directory.path().join("atm-daemon.sock");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
+        let _live = std::os::unix::net::UnixListener::bind(&path).expect("create live socket");
+
+        let error = match bind_unix_listener(&socket_config(path.clone(), uid)) {
+            Ok(_) => panic!("a live socket must remain in place"),
+            Err(error) => error,
+        };
+        assert!(error.message().contains("already occupied"));
+        assert!(path.exists(), "the live socket pathname is retained");
     }
 }

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 
 use atm_core::error::AtmError;
 #[cfg(unix)]
+use fs2::FileExt;
+#[cfg(unix)]
 use tokio::net::UnixListener;
 
 use super::UnixSocketConfig;
@@ -15,6 +17,58 @@ use super::UnixSocketConfig;
 const SOCKET_LIVENESS_PROBE_ATTEMPTS: usize = 3;
 #[cfg(unix)]
 const SOCKET_LIVENESS_PROBE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
+
+/// A same-user process lock that makes UDS recovery and publication one
+/// critical section. The socket pathname alone cannot provide that guarantee:
+/// a second daemon could otherwise observe stale state between recovery and
+/// publication.
+#[cfg(unix)]
+#[derive(Debug)]
+pub(super) struct UnixSocketStartupLock {
+    file: std::fs::File,
+}
+
+#[cfg(unix)]
+impl UnixSocketStartupLock {
+    pub(super) fn acquire(socket: &UnixSocketConfig) -> Result<Self, AtmError> {
+        use std::fs::{self, OpenOptions};
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = validate_unix_socket_parent(socket)?;
+        let name = socket
+            .path
+            .file_name()
+            .ok_or_else(|| AtmError::config("Unix HTTP socket path must name a socket file"))?;
+        let lock_path = parent.join(format!(".{}.startup.lock", name.to_string_lossy()));
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|source| {
+                AtmError::daemon_unavailable("failed to open Unix HTTP socket startup lock")
+                    .with_cause(source)
+            })?;
+        fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600)).map_err(|source| {
+            AtmError::daemon_unavailable("failed to protect Unix HTTP socket startup lock")
+                .with_cause(source)
+        })?;
+        file.try_lock_exclusive().map_err(|source| {
+            AtmError::daemon_serving_state_rejected(format!(
+                "another daemon is starting the Unix HTTP socket `{}`: {source}",
+                socket.path.display()
+            ))
+        })?;
+        Ok(Self { file })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for UnixSocketStartupLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
 
 #[cfg(unix)]
 pub(super) fn bind_unix_listener(
@@ -351,7 +405,8 @@ mod tests {
     use std::os::unix::fs::MetadataExt;
 
     use super::{
-        SocketLiveness, bind_unix_listener, probe_unix_socket_liveness, reclaim_stale_unix_socket,
+        SocketLiveness, UnixSocketStartupLock, bind_unix_listener, probe_unix_socket_liveness,
+        reclaim_stale_unix_socket,
     };
     use crate::{UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid};
 
@@ -381,6 +436,20 @@ mod tests {
             probe.await.expect("probe joins").expect("probe result"),
             SocketLiveness::Dead
         );
+    }
+
+    #[test]
+    fn concurrent_socket_start_is_rejected_before_reclaim_or_publish() {
+        let directory = tempfile::tempdir().expect("temporary UDS parent");
+        let uid = std::fs::metadata(directory.path())
+            .expect("temporary UDS parent metadata")
+            .uid();
+        let socket = socket_config(directory.path().join("atm-daemon.sock"), uid);
+        let _first = UnixSocketStartupLock::acquire(&socket).expect("first startup lock");
+
+        let error = UnixSocketStartupLock::acquire(&socket)
+            .expect_err("second same-user start must not enter the recovery critical section");
+        assert_eq!(error.code().as_str(), "ATM_DAEMON_SERVING_STATE_REJECTED");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- atm-http-runtime (Tokio+Axum) can now reclaim a dead, same-owner UDS socket after a crash
- A live socket, or any non-socket/replaced path, still fails closed

## Test plan
- [ ] quality-mgr QA-1 (req-qa, arch-qa, ruthless-boundary-qa, rust-qa-agent, rust-best-practices-agent, rust-service-hardening-agent)
- [ ] CI green