### PR TITLE
Reject non-durable --host on peer trust add/replace (NUDGE-HOST-DURABLE-001)

### DIFF
--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -652,6 +652,7 @@ mod tests {
     struct RecordingReceivedHook {
         message_store: Arc<dyn MessageStore + Send + Sync>,
         emitted_ids: Mutex<Vec<AtmMessageId>>,
+        dispatches: Mutex<Vec<BuiltInPostSendDispatch>>,
         saw_durable_record: AtomicBool,
         failure: Option<AtmError>,
         cancelled_on_drop: Option<Arc<AtomicBool>>,
@@ -686,6 +687,10 @@ mod tests {
                 .lock()
                 .expect("record received hook emission")
                 .push(dispatch.event.message_id);
+            self.dispatches
+                .lock()
+                .expect("record received hook dispatch")
+                .push(dispatch.clone());
             let failure = self.failure.clone();
             if let Some(cancelled) = self.cancelled_on_drop.clone() {
                 return Box::pin(async move {
@@ -810,6 +815,7 @@ mod tests {
         let received_hook = Arc::new(RecordingReceivedHook {
             message_store: Arc::clone(&message_store),
             emitted_ids: Mutex::new(Vec::new()),
+            dispatches: Mutex::new(Vec::new()),
             saw_durable_record: AtomicBool::new(false),
             failure: hook_failure,
             cancelled_on_drop,
@@ -997,6 +1003,7 @@ mod tests {
         let tmux = Arc::new(RecordingReceivedHook {
             message_store: Arc::clone(&fixture.message_store),
             emitted_ids: Mutex::new(Vec::new()),
+            dispatches: Mutex::new(Vec::new()),
             saw_durable_record: AtomicBool::new(false),
             failure: None,
             cancelled_on_drop: None,
@@ -1004,6 +1011,7 @@ mod tests {
         let graft = Arc::new(RecordingReceivedHook {
             message_store: Arc::clone(&fixture.message_store),
             emitted_ids: Mutex::new(Vec::new()),
+            dispatches: Mutex::new(Vec::new()),
             saw_durable_record: AtomicBool::new(false),
             failure: None,
             cancelled_on_drop: None,
@@ -1439,6 +1447,32 @@ mod tests {
                 .is_some(),
             "the direct peer write reaches the shared storage boundary"
         );
+        {
+            let dispatches = fixture
+                .received_hook
+                .dispatches
+                .lock()
+                .expect("inspect direct peer nudge dispatches");
+            assert_eq!(dispatches.len(), 1, "one durable write emits one nudge");
+            assert_eq!(
+                dispatches[0]
+                    .event
+                    .sender_host
+                    .as_ref()
+                    .map(|host| host.as_str()),
+                Some("127.0.0.1"),
+                "direct ingress provenance comes from the accepted peer socket"
+            );
+            assert_eq!(
+                dispatches[0].event.source_address().to_string(),
+                "sender@test-team.127.0.0.1",
+                "the nudge source preserves the authenticated socket host"
+            );
+            assert!(
+                matches!(&dispatches[0].target, PostSendBuiltInTarget::Graft(_)),
+                "the roster harness routes the received nudge through graft"
+            );
+        }
         running
             .begin_shutdown()
             .finish()
@@ -1494,6 +1528,32 @@ mod tests {
                 .into_inner(),
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
         ));
+        {
+            let local_dispatches = local
+                .received_hook
+                .dispatches
+                .lock()
+                .expect("inspect two-runtime nudge dispatches");
+            assert_eq!(local_dispatches.len(), 1, "direct ingress emits one nudge");
+            assert_eq!(
+                local_dispatches[0]
+                    .event
+                    .sender_host
+                    .as_ref()
+                    .map(|host| host.as_str()),
+                Some("127.0.0.1"),
+                "the receiver records the accepted socket as the sender host"
+            );
+            assert_eq!(
+                local_dispatches[0].event.source_address().to_string(),
+                "sender@test-team.127.0.0.1",
+                "the cross-runtime nudge retains direct-peer provenance"
+            );
+            assert!(matches!(
+                &local_dispatches[0].target,
+                PostSendBuiltInTarget::Graft(_)
+            ));
+        }
 
         let acknowledgement = atm_core::ack::AckRequest {
             home_dir: local.home_dir.clone(),

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -169,6 +169,21 @@ impl HostName {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Reports whether this host is suitable as a durable peer identity.
+    ///
+    /// `HostName` remains permissive because ATM addresses and transport
+    /// provenance must continue to represent historical IP and mDNS values.
+    /// Peer configuration uses this explicit semantic check before accepting a
+    /// host that will later be used as the source qualifier in a nudge.
+    pub fn is_durable_hostname(&self) -> bool {
+        let ipv4_shaped = self.0.split('.').count() == 4
+            && self
+                .0
+                .split('.')
+                .all(|label| !label.is_empty() && label.bytes().all(|byte| byte.is_ascii_digit()));
+        !ipv4_shaped && !self.0.to_ascii_lowercase().ends_with(".local")
+    }
 }
 
 impl FromStr for HostName {
@@ -386,7 +401,7 @@ impl fmt::Display for TeamName {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentId, AgentIdentity, AgentName, ChatId, IsoTimestamp};
+    use super::{AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp};
     use std::str::FromStr;
 
     #[test]
@@ -462,6 +477,31 @@ mod tests {
         let timestamp: IsoTimestamp = "2026-07-11T01:20:17Z".parse().expect("timestamp");
 
         assert_eq!(timestamp.to_string(), "2026-07-11T01:20:17+00:00");
+    }
+
+    #[test]
+    fn host_name_distinguishes_durable_peer_names_from_attachment_names() {
+        for attachment_name in [
+            "192.168.128.29",
+            "192.168.128.029",
+            "999.1.1.1",
+            "peer.local",
+            "PEER.LOCAL",
+        ] {
+            let host: HostName = attachment_name.parse().expect("generic host syntax");
+            assert!(
+                !host.is_durable_hostname(),
+                "{attachment_name} must not be treated as a durable peer identity"
+            );
+        }
+
+        for durable_name in ["peer.example", "peer.localhost"] {
+            let host: HostName = durable_name.parse().expect("host");
+            assert!(
+                host.is_durable_hostname(),
+                "{durable_name} should be accepted as a durable peer identity"
+            );
+        }
     }
 }
 

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -285,9 +285,7 @@ fn peer(
     https_port: u16,
 ) -> std::result::Result<TrustedPeer, AtmError> {
     Ok(TrustedPeer {
-        host: host
-            .parse()
-            .map_err(|_source| AtmError::peer_config_validation("invalid --host"))?,
+        host: trusted_peer_host(&host)?,
         fingerprint: fingerprint
             .parse::<CertificateFingerprint>()
             .map_err(|_source| AtmError::peer_config_validation("invalid --fingerprint"))?,
@@ -295,6 +293,18 @@ fn peer(
         https_port: NonZeroU16::new(https_port)
             .ok_or_else(|| AtmError::peer_config_validation("--https-port must be non-zero"))?,
     })
+}
+
+fn trusted_peer_host(value: &str) -> std::result::Result<HostName, AtmError> {
+    let host: HostName = value
+        .parse()
+        .map_err(|_source| AtmError::peer_config_validation("invalid --host"))?;
+    if !host.is_durable_hostname() {
+        return Err(AtmError::peer_config_validation(
+            "--host must be a durable DNS hostname (IP addresses and .local names are not stable peer identities)",
+        ));
+    }
+    Ok(host)
 }
 
 fn certificate(
@@ -626,6 +636,57 @@ mod tests {
                 .expect("list peers after revoke")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn trust_add_and_replace_require_durable_peer_hostnames() {
+        let store = InMemoryPeerConfigStore::default();
+        for (command, host) in [("add", "192.168.128.29"), ("replace", "peer.local")] {
+            let error = run_peer(
+                &store,
+                &[
+                    "atm",
+                    "trust",
+                    command,
+                    "--host",
+                    host,
+                    "--fingerprint",
+                    "sha256:peer",
+                    "--yes",
+                ],
+            )
+            .expect_err("attachment-specific host must be rejected");
+            assert!(error.message().contains("durable DNS hostname"));
+        }
+        assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    #[test]
+    fn trust_revoke_keeps_legacy_host_lookup_available() {
+        let store = InMemoryPeerConfigStore::default();
+        let legacy_host: HostName = "192.168.128.29".parse().expect("legacy host syntax");
+        store
+            .save_trusted_peer(&TrustedPeer {
+                host: legacy_host,
+                fingerprint: "sha256:legacy".parse().expect("fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(443).expect("non-zero port"),
+            })
+            .expect("seed legacy peer");
+
+        run_peer(
+            &store,
+            &[
+                "atm",
+                "trust",
+                "revoke",
+                "--host",
+                "192.168.128.29",
+                "--yes",
+            ],
+        )
+        .expect("legacy peer should remain revocable");
+        assert!(store.list_trusted_peers().expect("list peers").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `HostName::is_durable_hostname` classification rejecting IPv4-shaped and `.local` identities while preserving generic address/provenance parsing
- `atm peer trust add`/`replace` now reject non-durable `--host` values
- `atm peer trust revoke` remains a lax lookup so legacy (already-trusted, non-durable) peers can still be removed
- Adds storage + CLI regression tests

## Finding
NUDGE-HOST-DURABLE-001 (integrate/phase-al, redesign-scope fix — not a port of the superseded PR #795 develop-based approach)

## Test plan
- [x] `just lint` 25/25 PASS
- [x] `just test` full workspace PASS (440 Python + Rust)