### PR TITLE
AL.13 G7: capacity backup/restore lifecycle correction

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -54,6 +54,12 @@ python3 .claude/skills/daemon-switch/scripts/daemon-switch.py restore --yes \
 # Reload changed peer configuration without switching the selected pair.
 python3 .claude/skills/daemon-switch/scripts/daemon-switch.py restart --yes \
   --service <actual-label> --launch-agent-plist ~/Library/LaunchAgents/<actual-label>.plist
+
+# Temporarily stop exactly the managed daemon without altering either selected
+# binary.  This is for an explicitly authorized backup/restore workflow only;
+# follow it with `restart --yes` and `status --doctor` after restoration.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py quiesce --yes \
+  --service <actual-label> --launch-agent-plist ~/Library/LaunchAgents/<actual-label>.plist
 ```
 
 On systems without Homebrew, provide `--default-cli` and `--default-daemon` to

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -364,6 +364,15 @@ def restart(args: argparse.Namespace) -> None:
         raise SwitchError(f"refusing a split CLI/daemon pair after restart: {detail}")
 
 
+def quiesce(args: argparse.Namespace) -> None:
+    """Stop the one managed daemon without changing either selected binary."""
+    if not args.yes:
+        raise SwitchError("quiesce changes the singleton daemon; re-run with --yes")
+    cli, _daemon = selected_links(args)
+    run_service(args, "stop")
+    require_stopped_daemon(args, cli)
+
+
 def doctor(cli: Path) -> dict[str, object]:
     try:
         # The managed daemon must not be forced to traverse a caller's source
@@ -468,6 +477,8 @@ def parser() -> argparse.ArgumentParser:
     restore.add_argument("--dry-run", action="store_true")
     restart_parser = sub.add_parser("restart", parents=[selectors])
     restart_parser.add_argument("--yes", action="store_true")
+    quiesce_parser = sub.add_parser("quiesce", parents=[selectors])
+    quiesce_parser.add_argument("--yes", action="store_true")
     return result
 
 
@@ -481,8 +492,10 @@ def main() -> int:
         elif args.command == "restore":
             cli, daemon = restore_pair(args)
             switch_pair(args, cli, daemon)
-        else:
+        elif args.command == "restart":
             restart(args)
+        else:
+            quiesce(args)
     except SwitchError as error:
         print(f"daemon-switch: {error}", file=sys.stderr)
         return 2

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import socket
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "daemon-switch.py"
@@ -54,6 +55,27 @@ class StaleSocketCleanupTests(unittest.TestCase):
             DAEMON_SWITCH.remove_verified_stale_macos_socket(None)
 
         self.assertTrue(self.socket_path.is_file())
+
+
+class QuiesceTests(unittest.TestCase):
+    def test_requires_explicit_confirmation(self) -> None:
+        with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "--yes"):
+            DAEMON_SWITCH.quiesce(mock.Mock(yes=False))
+
+    def test_stops_managed_daemon_without_mutating_selectors(self) -> None:
+        args = mock.Mock(yes=True)
+        cli = Path("/selected/atm")
+        daemon = Path("/selected/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(cli, daemon)) as selected,
+            mock.patch.object(DAEMON_SWITCH, "run_service") as service,
+            mock.patch.object(DAEMON_SWITCH, "require_stopped_daemon") as stopped,
+        ):
+            DAEMON_SWITCH.quiesce(args)
+
+        selected.assert_called_once_with(args)
+        service.assert_called_once_with(args, "stop")
+        stopped.assert_called_once_with(args, cli)
 
 
 if __name__ == "__main__":

--- a/docs/plans/phase-al/AL9-benchmark-gate.md
+++ b/docs/plans/phase-al/AL9-benchmark-gate.md
@@ -71,6 +71,30 @@ The production daemon remains unable to select `disabled`. Current-runtime
 rows, including hook-active and Windows, are still **pending** until an
 authorized operator executes the isolated benchmark gate.
 
+### Explicit managed-host backup/restore mode
+
+The default remains fail-closed: a runner must use a dedicated clean OS user
+and refuses to attach to, stop, or replace an ambient daemon. An operator who
+is explicitly authorized to interrupt the sole managed daemon may instead set
+`ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1` and provide the normal
+`daemon-switch` service details to the runner:
+
+```sh
+ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1 \
+python3 scripts/smoke/run_admission_capacity.py \
+  --managed-service <actual-label> \
+  --managed-launch-agent-plist ~/Library/LaunchAgents/<actual-label>.plist
+```
+
+On Linux or Windows, supply the service name and any documented selector-link
+arguments appropriate to `daemon-switch`. This mode captures the selected
+pair and its healthy doctor state, calls only `daemon-switch quiesce` to stop
+the one managed daemon, atomically moves the complete host `.atm` state root,
+and runs the disposable benchmark. In a `finally` path it restores that root,
+restarts the same selected pair through `daemon-switch`, verifies `atm doctor`
+through the switch status, and rejects selector drift. It must be used only by
+an authorized operator; it does not weaken the clean-user default.
+
 ## Required artifacts before closure
 
 1. Retain raw runner output outside `site/`, then commit the compact schema

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -173,11 +173,34 @@ def daemon_switch_result(
     if not isinstance(status, dict):
         raise SmokeError("daemon-switch status returned a non-object response")
     if doctor:
-        doctor_status = status.get("doctor")
-        if not isinstance(doctor_status, dict) or "error" in doctor_status:
-            detail = doctor_status.get("error") if isinstance(doctor_status, dict) else "missing doctor result"
-            raise SmokeError(f"managed daemon doctor failed: {detail}")
+        require_ready_managed_doctor(status)
     return status
+
+
+def require_ready_managed_doctor(status: dict[str, Any]) -> None:
+    """Accept only the healthy, ready, matched runtime doctor contract."""
+    doctor_status = status.get("doctor")
+    if not isinstance(doctor_status, dict) or "error" in doctor_status:
+        detail = doctor_status.get("error") if isinstance(doctor_status, dict) else "missing doctor result"
+        raise SmokeError(f"managed daemon doctor failed: {detail}")
+    summary = doctor_status.get("summary")
+    if not isinstance(summary, dict) or summary.get("status") != "healthy":
+        raise SmokeError("managed daemon doctor is not healthy")
+    runtime = doctor_status.get("runtime_status")
+    if not isinstance(runtime, dict) or runtime.get("readiness") != "ready":
+        raise SmokeError("managed daemon doctor is not ready")
+    client_context = doctor_status.get("client_context")
+    daemon_context = doctor_status.get("daemon_context")
+    client_version = client_context.get("version") if isinstance(client_context, dict) else None
+    daemon_version = daemon_context.get("version") if isinstance(daemon_context, dict) else None
+    if not isinstance(client_version, str) or not client_version or client_version != daemon_version:
+        raise SmokeError("managed daemon doctor does not report one matched client/daemon version")
+    selected_cli = status.get("atm")
+    selected_version = selected_cli.get("version") if isinstance(selected_cli, dict) else None
+    if not isinstance(selected_version, str) or not selected_version:
+        raise SmokeError("daemon-switch status omitted the selected ATM CLI version")
+    if selected_version.rsplit(maxsplit=1)[-1] != client_version:
+        raise SmokeError("managed daemon doctor version differs from the selected ATM CLI")
 
 
 def selected_pair(status: dict[str, Any]) -> dict[str, str | None]:
@@ -229,17 +252,17 @@ class ManagedDaemonLifecycle:
     def restore(self) -> None:
         if not self.quiesced:
             return
-        restore_error: Exception | None = None
+        failures: list[str] = []
         if self.backup is not None:
             try:
                 self.backup.restore()
             except OSError as error:
-                restore_error = error
-        if restore_error is not None:
-            raise SmokeError(f"could not restore prior host ATM state: {restore_error}")
+                failures.append(f"could not restore prior host ATM state: {error}")
         recovery_error = self._restart_and_verify()
         if recovery_error is not None:
-            raise SmokeError(f"could not restore managed daemon pair: {recovery_error}")
+            failures.append(f"could not restore managed daemon pair: {recovery_error}")
+        if failures:
+            raise SmokeError("; ".join(failures))
 
     def _restart_and_verify(self) -> Exception | None:
         try:

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Prove the public local ATM admission boundary accepts 1,000 writes/second.
 
-This runner is deliberately a *clean-user* smoke gate.  ADR-026 makes the
-daemon and its SQLite store OS-user-owned, not ``ATM_HOME``-owned.  Therefore
-it refuses to run beside an ambient daemon and requires an explicit isolated
-OS-user acknowledgement; changing ``ATM_HOME`` alone would not isolate a
-developer's real mail database.
+This runner is deliberately a *clean-user* smoke gate. ADR-026 makes the
+daemon and its SQLite store OS-user-owned, not ``ATM_HOME``-owned. It therefore
+refuses to run beside an ambient daemon unless an authorized operator opts into
+the explicit daemon-switch backup/restore lifecycle; changing ``ATM_HOME``
+alone would not isolate a developer's real mail database.
 """
 from __future__ import annotations
 
@@ -70,6 +70,8 @@ SUSTAINED_MESSAGE_COUNTS = (10_000, 100_000)
 DAEMON_OUTPUT_TAIL_LINES = 200
 GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
 HOOK_MODES = ("active", "disabled")
+DAEMON_SWITCH = ROOT / ".claude" / "skills" / "daemon-switch" / "scripts" / "daemon-switch.py"
+MANAGED_DAEMON_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -119,6 +121,136 @@ class HostStateBackup:
             shutil.rmtree(self.state_root)
         if self.backup_root is not None:
             self.backup_root.rename(self.state_root)
+
+
+@dataclass(frozen=True)
+class ManagedDaemonOptions:
+    """The existing singleton daemon selected by the daemon-switch skill."""
+
+    service: str
+    launch_agent_plist: Path | None = None
+    cli_link: Path | None = None
+    daemon_link: Path | None = None
+    repair_orphan: bool = False
+
+    def command_arguments(self) -> list[str]:
+        if not self.service.strip():
+            raise SmokeError("backup/restore capacity mode requires a managed daemon --service")
+        arguments = ["--service", self.service]
+        if self.launch_agent_plist is not None:
+            arguments.extend(["--launch-agent-plist", str(self.launch_agent_plist)])
+        if self.cli_link is not None:
+            arguments.extend(["--cli-link", str(self.cli_link)])
+        if self.daemon_link is not None:
+            arguments.extend(["--daemon-link", str(self.daemon_link)])
+        if self.repair_orphan:
+            arguments.append("--repair-orphan")
+        return arguments
+
+
+def daemon_switch_result(
+    action: str,
+    options: ManagedDaemonOptions,
+    *,
+    doctor: bool = False,
+) -> dict[str, Any]:
+    """Run only the documented daemon-switch control plane for the singleton."""
+    command = [sys.executable, str(DAEMON_SWITCH), action, *options.command_arguments()]
+    if action in {"quiesce", "restart"}:
+        command.append("--yes")
+    if doctor:
+        command.append("--doctor")
+    result = command_result(command, timeout=MANAGED_DAEMON_TIMEOUT_SECONDS)
+    if result["exit_code"] != 0:
+        detail = result["stderr"].strip() or result["stdout"].strip()
+        raise SmokeError(f"daemon-switch {action} failed: {detail}")
+    if action != "status":
+        return {}
+    try:
+        status = json.loads(result["stdout"])
+    except json.JSONDecodeError as error:
+        raise SmokeError(f"daemon-switch status returned invalid JSON: {error}") from error
+    if not isinstance(status, dict):
+        raise SmokeError("daemon-switch status returned a non-object response")
+    if doctor:
+        doctor_status = status.get("doctor")
+        if not isinstance(doctor_status, dict) or "error" in doctor_status:
+            detail = doctor_status.get("error") if isinstance(doctor_status, dict) else "missing doctor result"
+            raise SmokeError(f"managed daemon doctor failed: {detail}")
+    return status
+
+
+def selected_pair(status: dict[str, Any]) -> dict[str, str | None]:
+    """Keep only the selected-pair identity needed to prove no selector drift."""
+    result: dict[str, str | None] = {}
+    for role in ("atm", "atm_daemon"):
+        value = status.get(role)
+        if not isinstance(value, dict):
+            raise SmokeError(f"daemon-switch status omitted {role}")
+        for field in ("selector", "target"):
+            item = value.get(field)
+            if not isinstance(item, str) or not item:
+                raise SmokeError(f"daemon-switch status omitted {role}.{field}")
+            result[f"{role}.{field}"] = item
+    return result
+
+
+@dataclass
+class ManagedDaemonLifecycle:
+    """Quiesce, isolate, and recover one explicitly authorized daemon pair.
+
+    The state root is moved only after daemon-switch has stopped the managed
+    daemon, so an open SQLite connection cannot race the snapshot. The selected
+    pair is captured before quiescence and compared after restart; this flow
+    never changes CLI/daemon selectors or their configuration.
+    """
+
+    options: ManagedDaemonOptions
+    backup: HostStateBackup | None = None
+    pre_pair: dict[str, str | None] | None = None
+    quiesced: bool = False
+
+    def begin(self) -> None:
+        before = daemon_switch_result("status", self.options, doctor=True)
+        self.pre_pair = selected_pair(before)
+        daemon_switch_result("quiesce", self.options)
+        self.quiesced = True
+        try:
+            require_clean_host_daemon_state(smoke_label="admission-capacity smoke")
+            self.backup = HostStateBackup.begin()
+        except Exception as error:
+            recovery_error = self._restart_and_verify()
+            if recovery_error is not None:
+                raise SmokeError(
+                    f"could not isolate managed daemon state: {error}; recovery also failed: {recovery_error}"
+                ) from error
+            raise
+
+    def restore(self) -> None:
+        if not self.quiesced:
+            return
+        restore_error: Exception | None = None
+        if self.backup is not None:
+            try:
+                self.backup.restore()
+            except OSError as error:
+                restore_error = error
+        if restore_error is not None:
+            raise SmokeError(f"could not restore prior host ATM state: {restore_error}")
+        recovery_error = self._restart_and_verify()
+        if recovery_error is not None:
+            raise SmokeError(f"could not restore managed daemon pair: {recovery_error}")
+
+    def _restart_and_verify(self) -> Exception | None:
+        try:
+            daemon_switch_result("restart", self.options)
+            after = daemon_switch_result("status", self.options, doctor=True)
+            if self.pre_pair is not None and selected_pair(after) != self.pre_pair:
+                raise SmokeError("managed daemon selectors changed during capacity backup/restore")
+            self.quiesced = False
+            return None
+        except Exception as error:  # pragma: no cover - covered through callers' recovery paths.
+            return error
 
 
 class DaemonOutputCapture:
@@ -729,6 +861,7 @@ def run_capacity(
     comparison_required: bool = True,
     raw_evidence_directory: Path = DEFAULT_RAW_EVIDENCE_DIR,
     hook_mode: str = "active",
+    managed_daemon: ManagedDaemonOptions | None = None,
 ) -> tuple[int, Path]:
     """Start one branch daemon, exercise public UDS API, retain evidence, then clean up."""
     transport = validate_transport(transport)
@@ -741,15 +874,20 @@ def run_capacity(
         raise SmokeError("capacity worker limit must be positive")
     isolation_mode = select_host_state_isolation()
     home = validate_capacity_home(atm_home)
-    require_clean_host_daemon_state(smoke_label="admission-capacity smoke")
-    before = count_atm_daemon_processes()
+    if isolation_mode == "isolated_os_user":
+        require_clean_host_daemon_state(smoke_label="admission-capacity smoke")
+    elif managed_daemon is None:
+        raise SmokeError(
+            "ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1 requires the managed daemon "
+            "service details; pass --managed-service and the platform-specific daemon-switch options"
+        )
     atm = release_binary("atm")
     daemon = release_binary("atm-daemon-benchmark")
-    home.mkdir(parents=True, exist_ok=False)
     env = runtime_environment(home)
     process: subprocess.Popen[str] | None = None
     daemon_output: DaemonOutputCapture | None = None
-    host_state_backup: HostStateBackup | None = None
+    managed_lifecycle: ManagedDaemonLifecycle | None = None
+    before: list[int] | None = None
     evidence: dict[str, Any] = {
         "schema_version": 2,
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -785,7 +923,11 @@ def run_capacity(
     }
     try:
         if isolation_mode == "backup_restore":
-            host_state_backup = HostStateBackup.begin()
+            assert managed_daemon is not None
+            managed_lifecycle = ManagedDaemonLifecycle(managed_daemon)
+            managed_lifecycle.begin()
+        before = count_atm_daemon_processes()
+        home.mkdir(parents=True, exist_ok=False)
         prepare_capacity_roster(atm, env, home)
         process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
         doctor = command_result([str(atm), "doctor", "--json"], timeout=10.0, env=env)
@@ -858,17 +1000,22 @@ def run_capacity(
         if daemon_output is not None:
             daemon_output.join()
             evidence["daemon_output"] = daemon_output.evidence()
-        try:
-            assert_no_process_leak(before, count_atm_daemon_processes(), smoke_label="admission-capacity smoke")
-        except RuntimeError as error:
-            evidence["passed"] = False
-            evidence["cleanup_failure"] = str(error)
-        if host_state_backup is not None:
+        if before is not None:
             try:
-                host_state_backup.restore()
-            except OSError as error:
+                assert_no_process_leak(
+                    before, count_atm_daemon_processes(), smoke_label="admission-capacity smoke",
+                )
+            except RuntimeError as error:
                 evidence["passed"] = False
-                evidence["cleanup_failure"] = f"could not restore prior host ATM state: {error}"
+                evidence["cleanup_failure"] = str(error)
+        if managed_lifecycle is not None:
+            try:
+                managed_lifecycle.restore()
+                evidence["managed_daemon_recovery"] = "doctor-verified"
+            except SmokeError as error:
+                evidence["passed"] = False
+                evidence["managed_daemon_recovery"] = "failed"
+                evidence["cleanup_failure"] = str(error)
         raw_evidence_path = write_raw_evidence(raw_evidence_directory, evidence)
         evidence_path = write_evidence(evidence_directory, evidence)
         print(f"local benchmark trace: {raw_evidence_path}")
@@ -925,12 +1072,50 @@ def main() -> int:
         choices=SUSTAINED_MESSAGE_COUNTS,
         help="add one 10K or 100K sustained profile after the sparse baseline",
     )
+    parser.add_argument(
+        "--managed-service",
+        help=(
+            "daemon-switch service label for explicit ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1 "
+            "mode; never needed for an isolated OS user"
+        ),
+    )
+    parser.add_argument(
+        "--managed-launch-agent-plist",
+        type=Path,
+        help="macOS LaunchAgent plist required by daemon-switch backup/restore mode",
+    )
+    parser.add_argument(
+        "--managed-cli-link",
+        type=Path,
+        help="optional selected atm CLI symlink passed through to daemon-switch",
+    )
+    parser.add_argument(
+        "--managed-daemon-link",
+        type=Path,
+        help="optional selected atm-daemon symlink passed through to daemon-switch",
+    )
+    parser.add_argument(
+        "--managed-repair-orphan",
+        action="store_true",
+        help="allow daemon-switch's narrow verified-orphan repair during controlled lifecycle recovery",
+    )
     args = parser.parse_args()
     transport = validate_transport(args.transport)
     hook_mode = validate_hook_mode(args.hook_mode)
     sparse_profiles = tuple(args.frames_per_connection or SPARSE_FRAMES_PER_CONNECTION)
     sustained_profiles = tuple(args.sustained or ())
     profiles = selected_profiles(sparse_profiles, sustained_profiles)
+    managed_daemon = (
+        ManagedDaemonOptions(
+            service=args.managed_service,
+            launch_agent_plist=args.managed_launch_agent_plist,
+            cli_link=args.managed_cli_link,
+            daemon_link=args.managed_daemon_link,
+            repair_orphan=args.managed_repair_orphan,
+        )
+        if args.managed_service
+        else None
+    )
     codes: list[int] = []
     current_revision = source_revision()
     host_label = os.environ.get("ATM_CAPACITY_HOST_LABEL", "local")
@@ -988,6 +1173,7 @@ def main() -> int:
                     comparison_required=comparison_required,
                     raw_evidence_directory=args.raw_evidence_dir,
                     hook_mode=hook_mode,
+                    managed_daemon=managed_daemon,
                 )
         else:
             home = args.atm_home / f"{CAPACITY_ROOT_PREFIX}{position}"
@@ -1003,6 +1189,7 @@ def main() -> int:
                     comparison_required=comparison_required,
                     raw_evidence_directory=args.raw_evidence_dir,
                     hook_mode=hook_mode,
+                    managed_daemon=managed_daemon,
                 )
         codes.append(code)
         if transport == "uds" and frames_per_connection == 1 and code == 0:

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -57,6 +57,23 @@ def complete_evidence(**overrides):
     return evidence
 
 
+def healthy_managed_status() -> dict[str, object]:
+    return {
+        "atm": {
+            "selector": "/active/atm",
+            "target": "/release/atm",
+            "version": "atm 1.4.1-beta-ai-1",
+        },
+        "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+        "doctor": {
+            "summary": {"status": "healthy"},
+            "runtime_status": {"readiness": "ready"},
+            "client_context": {"version": "1.4.1-beta-ai-1"},
+            "daemon_context": {"version": "1.4.1-beta-ai-1"},
+        },
+    }
+
+
 class AdmissionCapacityTests(unittest.TestCase):
     def test_compaction_math_matches_hand_calculated_intervals(self):
         values = [10.0, 20.0, 30.0, 40.0]
@@ -159,11 +176,7 @@ class AdmissionCapacityTests(unittest.TestCase):
 
     def test_managed_lifecycle_quiesces_then_restores_original_state_and_pair(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
-        before = {
-            "atm": {"selector": "/active/atm", "target": "/release/atm"},
-            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
-            "doctor": {"status": "healthy"},
-        }
+        before = healthy_managed_status()
         calls: list[tuple[str, bool]] = []
 
         def daemon_switch(action, _options, *, doctor=False):
@@ -195,11 +208,7 @@ class AdmissionCapacityTests(unittest.TestCase):
 
     def test_backup_snapshot_failure_restarts_the_managed_pair(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
-        status = {
-            "atm": {"selector": "/active/atm", "target": "/release/atm"},
-            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
-            "doctor": {"status": "healthy"},
-        }
+        status = healthy_managed_status()
         calls: list[str] = []
 
         def daemon_switch(action, _options, *, doctor=False):
@@ -216,13 +225,42 @@ class AdmissionCapacityTests(unittest.TestCase):
 
         self.assertEqual(calls, ["status", "quiesce", "restart", "status"])
 
+    def test_restore_attempts_restart_and_doctor_even_when_state_restore_fails(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        calls: list[str] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append(action)
+            return healthy_managed_status()
+
+        lifecycle = RUNNER.ManagedDaemonLifecycle(
+            options,
+            backup=mock.Mock(restore=mock.Mock(side_effect=OSError("rename failed"))),
+            pre_pair=RUNNER.selected_pair(healthy_managed_status()),
+            quiesced=True,
+        )
+        with mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "could not restore prior host ATM state"):
+                lifecycle.restore()
+
+        self.assertEqual(calls, ["restart", "status"])
+
+    def test_daemon_switch_status_rejects_non_healthy_or_non_ready_doctor(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        for field, value, expected in (
+            ("summary", {"status": "degraded"}, "not healthy"),
+            ("runtime_status", {"readiness": "draining"}, "not ready"),
+        ):
+            status = healthy_managed_status()
+            status["doctor"][field] = value
+            command = {"exit_code": 0, "stdout": json.dumps(status), "stderr": ""}
+            with mock.patch.object(RUNNER, "command_result", return_value=command):
+                with self.assertRaisesRegex(RUNNER.SmokeError, expected):
+                    RUNNER.daemon_switch_result("status", options, doctor=True)
+
     def test_restore_surfaces_a_failed_doctor_after_state_is_put_back(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
-        status = {
-            "atm": {"selector": "/active/atm", "target": "/release/atm"},
-            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
-            "doctor": {"status": "healthy"},
-        }
+        status = healthy_managed_status()
         calls: list[str] = []
 
         def daemon_switch(action, _options, *, doctor=False):
@@ -252,11 +290,7 @@ class AdmissionCapacityTests(unittest.TestCase):
 
     def test_benchmark_failure_restores_managed_state_and_verifies_doctor(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
-        status = {
-            "atm": {"selector": "/active/atm", "target": "/release/atm"},
-            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
-            "doctor": {"status": "healthy"},
-        }
+        status = healthy_managed_status()
         calls: list[str] = []
         captured: dict[str, object] = {}
 

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -141,6 +141,171 @@ class AdmissionCapacityTests(unittest.TestCase):
                 backup.restore()
             self.assertEqual((original / "mail.db").read_text(encoding="utf-8"), "prior state")
 
+    def test_undeclared_host_state_refuses_before_backup_or_daemon_quiesce(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"ATM_CAPACITY_ISOLATED_OS_USER": "", "ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE": ""},
+                clear=False,
+            ),
+            mock.patch.object(RUNNER.HostStateBackup, "begin") as backup,
+            mock.patch.object(RUNNER, "daemon_switch_result") as daemon_switch,
+        ):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "ATM_CAPACITY_ISOLATED_OS_USER"):
+                RUNNER.run_capacity(Path("/tmp/atm-capacity-unit"), Path("/tmp"), "tcp", 1)
+
+        backup.assert_not_called()
+        daemon_switch.assert_not_called()
+
+    def test_managed_lifecycle_quiesces_then_restores_original_state_and_pair(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        before = {
+            "atm": {"selector": "/active/atm", "target": "/release/atm"},
+            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+            "doctor": {"status": "healthy"},
+        }
+        calls: list[tuple[str, bool]] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append((action, doctor))
+            return before
+
+        with tempfile.TemporaryDirectory() as temp:
+            os_home = Path(temp)
+            state = os_home / ".atm"
+            state.mkdir()
+            (state / "mail.db").write_text("managed-state", encoding="utf-8")
+            with (
+                mock.patch.object(RUNNER, "os_account_home", return_value=os_home),
+                mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+                mock.patch.object(RUNNER, "require_clean_host_daemon_state") as clean,
+            ):
+                lifecycle = RUNNER.ManagedDaemonLifecycle(options)
+                lifecycle.begin()
+                self.assertFalse((state / "mail.db").exists())
+                lifecycle.restore()
+
+            self.assertEqual((state / "mail.db").read_text(encoding="utf-8"), "managed-state")
+
+        clean.assert_called_once_with(smoke_label="admission-capacity smoke")
+        self.assertEqual(
+            calls,
+            [("status", True), ("quiesce", False), ("restart", False), ("status", True)],
+        )
+
+    def test_backup_snapshot_failure_restarts_the_managed_pair(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        status = {
+            "atm": {"selector": "/active/atm", "target": "/release/atm"},
+            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+            "doctor": {"status": "healthy"},
+        }
+        calls: list[str] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append(action)
+            return status
+
+        with (
+            mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+            mock.patch.object(RUNNER, "require_clean_host_daemon_state"),
+            mock.patch.object(RUNNER.HostStateBackup, "begin", side_effect=OSError("disk error")),
+        ):
+            with self.assertRaisesRegex(OSError, "disk error"):
+                RUNNER.ManagedDaemonLifecycle(options).begin()
+
+        self.assertEqual(calls, ["status", "quiesce", "restart", "status"])
+
+    def test_restore_surfaces_a_failed_doctor_after_state_is_put_back(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        status = {
+            "atm": {"selector": "/active/atm", "target": "/release/atm"},
+            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+            "doctor": {"status": "healthy"},
+        }
+        calls: list[str] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append(action)
+            if action == "status" and len(calls) > 3:
+                raise RUNNER.SmokeError("managed daemon doctor failed: unavailable")
+            return status
+
+        with tempfile.TemporaryDirectory() as temp:
+            os_home = Path(temp)
+            state = os_home / ".atm"
+            state.mkdir()
+            (state / "mail.db").write_text("managed-state", encoding="utf-8")
+            with (
+                mock.patch.object(RUNNER, "os_account_home", return_value=os_home),
+                mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+                mock.patch.object(RUNNER, "require_clean_host_daemon_state"),
+            ):
+                lifecycle = RUNNER.ManagedDaemonLifecycle(options)
+                lifecycle.begin()
+                with self.assertRaisesRegex(RUNNER.SmokeError, "could not restore managed daemon pair"):
+                    lifecycle.restore()
+
+            self.assertEqual((state / "mail.db").read_text(encoding="utf-8"), "managed-state")
+
+        self.assertEqual(calls, ["status", "quiesce", "restart", "status"])
+
+    def test_benchmark_failure_restores_managed_state_and_verifies_doctor(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        status = {
+            "atm": {"selector": "/active/atm", "target": "/release/atm"},
+            "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+            "doctor": {"status": "healthy"},
+        }
+        calls: list[str] = []
+        captured: dict[str, object] = {}
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append(action)
+            return status
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            os_home = root / "os-home"
+            state = os_home / ".atm"
+            state.mkdir(parents=True)
+            (state / "mail.db").write_text("managed-state", encoding="utf-8")
+            home = root / "atm-capacity-benchmark"
+            atm = root / "atm"
+            daemon = root / "atm-daemon-benchmark"
+            atm.touch()
+            daemon.touch()
+            with (
+                mock.patch.object(RUNNER, "select_host_state_isolation", return_value="backup_restore"),
+                mock.patch.object(RUNNER, "os_account_home", return_value=os_home),
+                mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+                mock.patch.object(RUNNER, "require_clean_host_daemon_state"),
+                mock.patch.object(RUNNER, "count_atm_daemon_processes", return_value=[]),
+                mock.patch.object(RUNNER, "release_binary", side_effect=[atm, daemon]),
+                mock.patch.object(RUNNER, "runtime_environment", return_value={}),
+                mock.patch.object(RUNNER, "prepare_capacity_roster"),
+                mock.patch.object(
+                    RUNNER, "start_capacity_daemon", side_effect=RUNNER.SmokeError("benchmark failed"),
+                ),
+                mock.patch.object(RUNNER, "write_raw_evidence", return_value=root / "raw.json"),
+                mock.patch.object(
+                    RUNNER,
+                    "write_evidence",
+                    side_effect=lambda _path, value: (captured.update(value), root / "evidence.json")[1],
+                ),
+            ):
+                code, _evidence = RUNNER.run_capacity(
+                    home, root, "tcp", 1, sample_count=1,
+                    raw_evidence_directory=root, managed_daemon=options,
+                )
+
+            self.assertEqual((state / "mail.db").read_text(encoding="utf-8"), "managed-state")
+
+        self.assertEqual(code, 1)
+        self.assertEqual(captured["failure"], "benchmark failed")
+        self.assertEqual(captured["managed_daemon_recovery"], "doctor-verified")
+        self.assertEqual(calls, ["status", "quiesce", "restart", "status"])
+
     def test_transport_is_platform_explicit(self):
         self.assertEqual(RUNNER.validate_transport("tcp"), "tcp")
         with mock.patch.object(RUNNER.os, "name", "posix"):


### PR DESCRIPTION
## Summary
- Fixes the AL.13 G7 harness defect (task #1635): `ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1` was unreachable because `run_capacity` called `require_clean_host_daemon_state` before `HostStateBackup` was created, so M5 correctly failed closed instead of exercising the backup/restore path.
- Scope: explicit managed-daemon state backup/quiesce/benchmark/restore/doctor verification lifecycle, with default ambient-state refusal preserved.

## Verification (arch-ctm)
- `just test`
- `just fmt check`
- `just lint` (fixed-sleep / function-length / lines / boundaries)
- `git diff --check`

## Test plan
- [ ] quality-mgr QA-1 full review