### PR TITLE
AL.13 G7: fix benchmark harness build blocker

### DIFF
--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -85,6 +85,17 @@ class SignDaemonDevTests(unittest.TestCase):
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
         self.assertIn("build:\n    cargo build --workspace\n    {{python_cmd}} .just/sign_daemon_dev.py", justfile)
 
+    def test_benchmark_recipe_builds_its_feature_gated_daemon(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn(
+            "benchmark *args:\n"
+            "    cargo build --release -p agent-team-mail -p atm-daemon\n"
+            "    # The isolated capacity runner launches this feature-gated bootstrap binary.\n"
+            "    cargo build --release -p atm-daemon-bootstrap --features benchmark-harness --bin atm-daemon-benchmark\n"
+            "    {{python_cmd}} .just/sign_daemon_dev.py",
+            justfile,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Justfile
+++ b/Justfile
@@ -191,6 +191,8 @@ smoke feature='normal' *args:
 # daemon/database state and writes one report-compatible JSON artifact per run.
 benchmark *args:
     cargo build --release -p agent-team-mail -p atm-daemon
+    # The isolated capacity runner launches this feature-gated bootstrap binary.
+    cargo build --release -p atm-daemon-bootstrap --features benchmark-harness --bin atm-daemon-benchmark
     {{python_cmd}} .just/sign_daemon_dev.py
     {{python_cmd}} scripts/smoke/run_admission_capacity.py {{args}}
 


### PR DESCRIPTION
## Summary
- Justfile now builds the documented feature-gated `atm-daemon-benchmark` binary before the runner, fixing a build blocker in the AL.13 G7 lifecycle harness.
- Regression test added to `.just/tests/test_sign_daemon_dev.py`.

## Verification (arch-ctm self-report)
- Release build creates `target/release/atm-daemon-benchmark`
- Focused test passes
- `just fmt` check passes
- daemon-signing lint passes
- `just test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)