### PR TITLE
AL.13 G7: daemon-switch HTTP-runtime owner detection

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -146,9 +146,10 @@ def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = F
         if args.repair_orphan:
             # `bootout` has already prevented a replacement process. A
             # blocked daemon can still keep the job loaded long enough to
-            # defeat the normal polling window, so repair the one verified
-            # socket owner before declaring the singleton unrecoverable.
-            repair_macos_orphan(macos_socket_owner_pids())
+            # defeat the normal polling window. The HTTP runtime may not own
+            # the legacy UDS pathname, so identify the singleton through its
+            # lock as well as through the UDS before a verified repair.
+            repair_macos_orphan(macos_daemon_owner_pids())
             for _ in range(20):
                 if run(["launchctl", "print", service], timeout=2.0).returncode != 0:
                     return
@@ -165,10 +166,37 @@ def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = F
     raise SwitchError(f"service start failed: {' '.join(command)}: {last_detail}")
 
 
-def macos_socket_owner_pids() -> list[int]:
-    socket_path = macos_socket_path()
-    result = run(["lsof", "-t", str(socket_path)], timeout=5.0)
+def macos_path_owner_pids(path: Path) -> list[int]:
+    """Return PIDs that hold one existing, user-owned daemon-state path."""
+    if not path.exists():
+        return []
+    lsof = shutil.which("lsof") or "/usr/sbin/lsof"
+    try:
+        result = run([lsof, "-t", str(path)], timeout=5.0)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SwitchError(f"cannot inspect ATM daemon owner at {path}: {error}") from error
     return [int(line) for line in result.stdout.splitlines() if line.strip().isdigit()]
+
+
+def macos_socket_owner_pids() -> list[int]:
+    return macos_path_owner_pids(macos_socket_path())
+
+
+def macos_owner_lock_path() -> Path:
+    return Path.home() / ".atm" / "daemon" / "owner.lock"
+
+
+def macos_daemon_owner_pids() -> list[int]:
+    """Find one live daemon through either its legacy socket or singleton lock.
+
+    The Tokio HTTP runtime does not publish the former local UDS socket, but
+    it always holds the same OS-user-owned singleton lock.  Both paths are
+    required so controlled replacement cannot start beside a live runtime.
+    """
+    return sorted({
+        *macos_socket_owner_pids(),
+        *macos_path_owner_pids(macos_owner_lock_path()),
+    })
 
 
 def macos_socket_path() -> Path:
@@ -204,7 +232,7 @@ def remove_verified_stale_macos_socket(expected_socket: tuple[int, int] | None) 
 
 
 def wait_for_macos_socket_release(pid: int, expected_socket: tuple[int, int] | None) -> None:
-    """Wait for a SIGTERM'd daemon to release its UDS, then remove only its stale inode."""
+    """Wait for a SIGTERM'd daemon to release its singleton resources."""
     socket_path = macos_socket_path()
     for _ in range(50):
         try:
@@ -212,7 +240,7 @@ def wait_for_macos_socket_release(pid: int, expected_socket: tuple[int, int] | N
             process_exists = True
         except ProcessLookupError:
             process_exists = False
-        if not process_exists and not macos_socket_owner_pids() and not socket_path.exists():
+        if not process_exists and not macos_daemon_owner_pids() and not socket_path.exists():
             return
         time.sleep(0.1)
 
@@ -220,7 +248,7 @@ def wait_for_macos_socket_release(pid: int, expected_socket: tuple[int, int] | N
     # listener.  The earlier owner proof authorizes cleanup only when the path
     # is still the exact socket inode that owner held before SIGTERM.  A path
     # replacement (or any non-socket) fails closed instead of being deleted.
-    if not macos_socket_owner_pids() and remove_verified_stale_macos_socket(expected_socket):
+    if not macos_daemon_owner_pids() and remove_verified_stale_macos_socket(expected_socket):
         return
     raise SwitchError(
         f"verified stale ATM daemon pid {pid} did not fully release {socket_path} after SIGTERM"
@@ -231,12 +259,12 @@ def repair_macos_orphan(pids: list[int]) -> None:
     """Terminate only a verified stale daemon after its LaunchAgent is unloaded."""
     if len(pids) != 1:
         raise SwitchError(
-            "managed stop left an ATM socket owner, but it is not exactly one repairable daemon PID"
+            "managed stop left an ATM daemon owner, but it is not exactly one repairable daemon PID"
         )
     pid = pids[0]
     command = run(["ps", "-p", str(pid), "-o", "command="], timeout=5.0).stdout.strip()
     if "atm-daemon" not in command:
-        raise SwitchError(f"refusing to terminate non-ATM socket owner pid {pid}: {command}")
+        raise SwitchError(f"refusing to terminate non-ATM daemon owner pid {pid}: {command}")
     expected_socket = socket_identity(macos_socket_path())
     os.kill(pid, signal.SIGTERM)
     wait_for_macos_socket_release(pid, expected_socket)
@@ -245,7 +273,7 @@ def repair_macos_orphan(pids: list[int]) -> None:
 def require_stopped_daemon(args: argparse.Namespace, _cli: Path) -> None:
     if platform.system() != "Darwin":
         return
-    pids = macos_socket_owner_pids()
+    pids = macos_daemon_owner_pids()
     if not pids:
         # A controlled stop can complete while an older daemon implementation
         # leaves its now-unowned UDS pathname behind. The next process must not
@@ -254,13 +282,13 @@ def require_stopped_daemon(args: argparse.Namespace, _cli: Path) -> None:
         return
     if not args.repair_orphan:
         raise SwitchError(
-            "controlled service stop left an ATM socket owner; refuse a split pair. "
+            "controlled service stop left an ATM daemon owner; refuse a split pair. "
             "On macOS, rerun with --repair-orphan only after verifying the service label/plist."
         )
     if pids:
         repair_macos_orphan(pids)
-    if macos_socket_owner_pids():
-        raise SwitchError("ATM daemon socket remains owned after explicit orphan repair")
+    if macos_daemon_owner_pids():
+        raise SwitchError("ATM daemon remains owned after explicit orphan repair")
     remove_verified_stale_macos_socket(None)
 
 
@@ -326,7 +354,7 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         replace_link(cli_link, cli_target)
         replace_link(daemon_link, daemon_target)
         run_service(args, "start")
-        matched, detail = wait_for_live_pair(cli_target)
+        matched, detail = wait_for_live_pair(cli_target, daemon_target)
         if not matched:
             raise SwitchError(f"refusing a split CLI/daemon pair: {detail}")
     except Exception:
@@ -355,11 +383,11 @@ def restore_pair(args: argparse.Namespace) -> tuple[Path, Path]:
 def restart(args: argparse.Namespace) -> None:
     if not args.yes:
         raise SwitchError("restart changes the singleton daemon; re-run with --yes")
-    cli, _daemon = selected_links(args)
+    cli, daemon = selected_links(args)
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
     run_service(args, "start")
-    matched, detail = wait_for_live_pair(cli)
+    matched, detail = wait_for_live_pair(cli, daemon)
     if not matched:
         raise SwitchError(f"refusing a split CLI/daemon pair after restart: {detail}")
 
@@ -407,27 +435,63 @@ def selected_release_version(cli: Path) -> str:
     return value.rsplit(maxsplit=1)[-1]
 
 
-def live_pair_matches(cli: Path) -> tuple[bool, str]:
+def macos_daemon_executable(pid: int) -> Path | None:
+    """Return the executable image held by one verified live daemon process."""
+    lsof = shutil.which("lsof") or "/usr/sbin/lsof"
+    try:
+        result = run([lsof, "-p", str(pid)], timeout=5.0)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SwitchError(f"cannot inspect ATM daemon executable for pid {pid}: {error}") from error
+    for line in result.stdout.splitlines():
+        fields = line.split(maxsplit=8)
+        if len(fields) == 9 and fields[3] == "txt":
+            candidate = Path(fields[8])
+            if candidate.name == executable_name("atm-daemon"):
+                return candidate.resolve()
+    return None
+
+
+def macos_live_daemon_matches(daemon: Path) -> tuple[bool, str]:
+    """Prove the singleton lock holder is the selected daemon executable."""
+    pids = macos_daemon_owner_pids()
+    if len(pids) != 1:
+        return False, f"expected one ATM daemon owner, found {len(pids)}"
+    actual = macos_daemon_executable(pids[0])
+    expected = daemon.resolve()
+    if actual != expected:
+        return False, f"selected daemon {expected}, live daemon {actual or '<unresolved>'}"
+    return True, f"live daemon pid {pids[0]} matches {expected}"
+
+
+def live_pair_matches(cli: Path, daemon: Path | None = None) -> tuple[bool, str]:
     """Prove the running daemon changed together with both selectors."""
     expected = selected_release_version(cli)
     payload = doctor(cli)
     if "error" in payload:
         return False, f"live daemon is unavailable after switch: {payload['error']}"
     client = context_version(payload, "client_context")
-    daemon = context_version(payload, "daemon_context")
-    if client != expected or daemon != expected:
+    daemon_context = context_version(payload, "daemon_context")
+    if client != expected:
         return False, (
-            f"selected {expected}, but doctor reports client={client or '<missing>'} "
-            f"daemon={daemon or '<missing>'}"
+            f"selected {expected}, but doctor reports client={client or '<missing>'}"
         )
-    return True, f"CLI and daemon both report {expected}"
+    if daemon_context == expected:
+        return True, f"CLI and daemon both report {expected}"
+    if daemon_context is not None:
+        return False, f"selected {expected}, but doctor reports daemon={daemon_context}"
+    if platform.system() != "Darwin" or daemon is None:
+        return False, f"selected {expected}, but doctor reports daemon=<missing>"
+    summary = payload.get("summary")
+    if not isinstance(summary, dict) or summary.get("status") != "healthy":
+        return False, "daemon doctor is not healthy enough for executable identity fallback"
+    return macos_live_daemon_matches(daemon)
 
 
-def wait_for_live_pair(cli: Path) -> tuple[bool, str]:
+def wait_for_live_pair(cli: Path, daemon: Path | None = None) -> tuple[bool, str]:
     """Allow the one managed daemon a bounded interval to become doctor-ready."""
     detail = "daemon did not report ready"
     for _ in range(50):
-        matched, detail = live_pair_matches(cli)
+        matched, detail = live_pair_matches(cli, daemon)
         if matched:
             return True, detail
         time.sleep(0.1)
@@ -460,7 +524,7 @@ def parser() -> argparse.ArgumentParser:
     selectors.add_argument(
         "--repair-orphan",
         action="store_true",
-        help="macOS only: SIGTERM one verified stale ATM socket owner after controlled service stop",
+        help="macOS only: SIGTERM one verified stale ATM daemon owner after controlled service stop",
     )
     sub = result.add_subparsers(dest="command", required=True)
     status_parser = sub.add_parser("status", parents=[selectors])

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import socket
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -25,6 +26,7 @@ class StaleSocketCleanupTests(unittest.TestCase):
         self.socket_path.parent.mkdir(parents=True)
         self.original_path = DAEMON_SWITCH.Path
         self.original_owners = DAEMON_SWITCH.macos_socket_owner_pids
+        self.original_daemon_owners = DAEMON_SWITCH.macos_daemon_owner_pids
 
         class TestPath:
             @staticmethod
@@ -33,10 +35,12 @@ class StaleSocketCleanupTests(unittest.TestCase):
 
         DAEMON_SWITCH.Path = TestPath
         DAEMON_SWITCH.macos_socket_owner_pids = lambda: []
+        DAEMON_SWITCH.macos_daemon_owner_pids = lambda: []
 
     def tearDown(self) -> None:
         DAEMON_SWITCH.Path = self.original_path
         DAEMON_SWITCH.macos_socket_owner_pids = self.original_owners
+        DAEMON_SWITCH.macos_daemon_owner_pids = self.original_daemon_owners
         self.temporary.cleanup()
 
     def test_removes_unowned_unix_socket(self) -> None:
@@ -76,6 +80,75 @@ class QuiesceTests(unittest.TestCase):
         selected.assert_called_once_with(args)
         service.assert_called_once_with(args, "stop")
         stopped.assert_called_once_with(args, cli)
+
+
+class HttpRuntimeOwnerLockTests(unittest.TestCase):
+    def test_owner_lock_identifies_http_runtime_without_legacy_socket(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary)
+            owner_lock = home / ".atm" / "daemon" / "owner.lock"
+            owner_lock.parent.mkdir(parents=True)
+            owner_lock.touch()
+            original_path = DAEMON_SWITCH.Path
+
+            class TestPath:
+                @staticmethod
+                def home() -> Path:
+                    return home
+
+            DAEMON_SWITCH.Path = TestPath
+            try:
+                completed = subprocess.CompletedProcess(["lsof"], 0, stdout="42\n", stderr="")
+                with (
+                    mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value=None),
+                    mock.patch.object(DAEMON_SWITCH, "run", return_value=completed) as run,
+                ):
+                    self.assertEqual(DAEMON_SWITCH.macos_daemon_owner_pids(), [42])
+                run.assert_called_once_with(["/usr/sbin/lsof", "-t", str(owner_lock)], timeout=5.0)
+            finally:
+                DAEMON_SWITCH.Path = original_path
+
+    def test_rejects_http_runtime_owner_without_explicit_repair(self) -> None:
+        args = mock.Mock(repair_orphan=False)
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "macos_daemon_owner_pids", return_value=[42]),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "daemon owner"):
+                DAEMON_SWITCH.require_stopped_daemon(args, Path("/selected/atm"))
+
+    def test_live_http_runtime_uses_executable_identity_when_doctor_has_no_daemon_context(self) -> None:
+        cli = Path("/selected/atm")
+        daemon = Path("/selected/atm-daemon")
+        doctor = {
+            "summary": {"status": "healthy"},
+            "client_context": {"version": "1.4.1-beta-ai-1"},
+        }
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "selected_release_version", return_value="1.4.1-beta-ai-1"),
+            mock.patch.object(DAEMON_SWITCH, "doctor", return_value=doctor),
+            mock.patch.object(DAEMON_SWITCH, "macos_live_daemon_matches", return_value=(True, "exact executable")) as matches,
+        ):
+            self.assertEqual(
+                DAEMON_SWITCH.live_pair_matches(cli, daemon),
+                (True, "exact executable"),
+            )
+        matches.assert_called_once_with(daemon)
+
+    def test_live_http_runtime_rejects_unhealthy_doctor_without_daemon_context(self) -> None:
+        doctor = {
+            "summary": {"status": "degraded"},
+            "client_context": {"version": "1.4.1-beta-ai-1"},
+        }
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "selected_release_version", return_value="1.4.1-beta-ai-1"),
+            mock.patch.object(DAEMON_SWITCH, "doctor", return_value=doctor),
+        ):
+            matched, detail = DAEMON_SWITCH.live_pair_matches(Path("/selected/atm"), Path("/selected/atm-daemon"))
+        self.assertFalse(matched)
+        self.assertIn("not healthy", detail)
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -176,7 +176,7 @@ class DaemonSwitchTests(unittest.TestCase):
     def test_reachable_daemon_requires_explicit_orphan_repair(self) -> None:
         args = argparse.Namespace(repair_orphan=False)
         with (
-            mock.patch.object(self.module, "macos_socket_owner_pids", return_value=[42]),
+            mock.patch.object(self.module, "macos_daemon_owner_pids", return_value=[42]),
             mock.patch.object(self.module.platform, "system", return_value="Darwin"),
         ):
             with self.assertRaisesRegex(self.module.SwitchError, "refuse a split pair"):
@@ -260,7 +260,7 @@ class DaemonSwitchTests(unittest.TestCase):
                 "run",
                 side_effect=[subprocess.CompletedProcess([], 0, "", ""), *([loaded] * 20), unloaded],
             ),
-            mock.patch.object(self.module, "macos_socket_owner_pids", return_value=[42]),
+            mock.patch.object(self.module, "macos_daemon_owner_pids", return_value=[42]),
             mock.patch.object(self.module, "repair_macos_orphan") as repair,
             mock.patch.object(self.module.time, "sleep"),
         ):


### PR DESCRIPTION
## Summary
- daemon-switch.py only detected legacy UDS ownership; the Tokio HTTP runtime owns a singleton `owner.lock` and has no legacy UDS, so a live atm-http-runtime daemon was missed and the switcher collided during replacement.
- Fix validates both ownership paths and, where the current doctor schema lacks `daemon_context`, proves the selected daemon via the lock-owner executable plus a healthy doctor check.

## Verification (arch-ctm self-report)
- Verified live on M5: repaired/restarted the selected pair; owner PID 72517, doctor healthy 1.4.1-beta-ai-1
- `just test` (448) passes
- function-length lint passes
- fixed-sleep lint passes
- diff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)