### PR TITLE
AL.13 G7: partial benchmark fix (indexed lookup + bounded HTTP/1.1 batches) — throughput gate still open

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -511,6 +511,11 @@ def status(args: argparse.Namespace) -> None:
     }
     if args.doctor:
         result["doctor"] = doctor(cli)
+        try:
+            matched, detail = live_pair_matches(cli, daemon)
+        except SwitchError as error:
+            matched, detail = False, str(error)
+        result["live_pair"] = {"matched": matched, "detail": detail}
     print(json.dumps(result, indent=2, sort_keys=True))
 
 

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2096,8 +2096,8 @@ fn al5_uds_is_a_framework_adapter_over_the_one_client_and_router() {
         http1_server.contains("http1::Builder")
             && http1_server.contains("TokioTimer::new()")
             && http1_server.contains("header_read_timeout")
-            && http1_server.contains("keep_alive(false)"),
-        "the framework HTTP/1 adapter must enforce a Tokio timer-backed header deadline and close idle connections"
+            && http1_server.contains("keep_alive(true)"),
+        "the framework HTTP/1 adapter must enforce a Tokio timer-backed header deadline while allowing bounded HTTP/1 request batches"
     );
     assert!(
         staging.contains("pub(crate) fn allocate")

--- a/crates/atm-http-runtime/src/http1_server.rs
+++ b/crates/atm-http-runtime/src/http1_server.rs
@@ -140,7 +140,11 @@ where
     builder
         .timer(TokioTimer::new())
         .header_read_timeout(header_read_timeout)
-        .keep_alive(false);
+        // Keep a bounded admitted connection available for its HTTP/1.1
+        // request sequence. The connection semaphore still caps concurrent
+        // peers, the header timer bounds idle/header waits, and callers send
+        // `Connection: close` when their finite batch is complete.
+        .keep_alive(true);
     let connection = builder.serve_connection(io, service);
     tokio::pin!(connection);
 
@@ -158,4 +162,58 @@ async fn drain_connections(mut connections: JoinSet<()>) -> io::Result<()> {
         result.map_err(io::Error::other)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::routing::post;
+    use hyper_util::rt::TokioIo;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::watch;
+
+    use super::serve_connection;
+
+    #[tokio::test]
+    async fn http1_connection_serves_a_bounded_pipelined_request_batch() {
+        let router = Router::new().route("/messages", post(|| async { StatusCode::CREATED }));
+        let (mut client, server) = tokio::io::duplex(4096);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(());
+        let server = tokio::spawn(serve_connection(
+            TokioIo::new(server),
+            router,
+            Duration::from_secs(1),
+            shutdown_rx,
+        ));
+
+        client
+            .write_all(
+                b"POST /messages HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n\
+                  POST /messages HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .expect("write pipelined HTTP requests");
+        client.flush().await.expect("flush pipelined HTTP requests");
+
+        let mut responses = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), client.read_to_end(&mut responses))
+            .await
+            .expect("server closes after the bounded request batch")
+            .expect("read pipelined HTTP responses");
+        assert_eq!(
+            responses
+                .windows(b"HTTP/1.1 201 Created".len())
+                .filter(|window| *window == b"HTTP/1.1 201 Created")
+                .count(),
+            2,
+            "both pipelined requests must receive ordered responses on one connection"
+        );
+        server
+            .await
+            .expect("HTTP/1 task joins")
+            .expect("HTTP/1 connection completes cleanly");
+    }
 }

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -120,6 +120,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_messages_message_id
 CREATE INDEX IF NOT EXISTS idx_mail_messages_mailbox
     ON mail_messages(team, agent);
 
+-- Post-commit received-hook dispatch reloads an admitted record by its
+-- immutable message key.  The mailbox primary key begins with team and agent,
+-- so it cannot serve that global-key lookup without scanning a growing table.
+CREATE INDEX IF NOT EXISTS idx_mail_messages_message_key
+    ON mail_messages(message_key);
+
 CREATE INDEX IF NOT EXISTS idx_mail_message_states_mailbox
     ON mail_message_states(team, agent);
 
@@ -910,6 +916,38 @@ mod tests {
             !table_exists(&connection, &target, "peer_sync_policies")
                 .expect("inspect retired table"),
             "AK.2 must remove the obsolete worker policy from existing databases"
+        );
+    }
+
+    #[test]
+    fn ensure_schema_adds_the_message_key_lookup_index_for_post_commit_dispatch() {
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:atm-storage-rusqlite-message-key-index-{}?mode=memory&cache=shared",
+                NEXT_IN_MEMORY_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_connection_for_target(&target).expect("open connection");
+        ensure_schema(&mut connection, &target).expect("initialize schema");
+        connection
+            .execute_batch("DROP INDEX idx_mail_messages_message_key;")
+            .expect("simulate database created before the lookup index");
+
+        ensure_schema(&mut connection, &target).expect("upgrade existing schema");
+
+        let plan: String = connection
+            .query_row(
+                "EXPLAIN QUERY PLAN
+                 SELECT team, agent, envelope_json
+                 FROM mail_messages
+                 WHERE message_key = ?1;",
+                ["atm:01J00000000000000000000000"],
+                |row| row.get(3),
+            )
+            .expect("explain message-key lookup");
+        assert!(
+            plan.contains("idx_mail_messages_message_key"),
+            "post-commit message lookup must remain indexed instead of scanning a growing mailbox: {plan}"
         );
     }
     use std::sync::Barrier;

--- a/scripts/smoke/daemon_lifecycle.py
+++ b/scripts/smoke/daemon_lifecycle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import signal
 import subprocess
 import time
@@ -54,7 +53,7 @@ def count_atm_daemon_processes() -> list[int]:
     if completed.returncode != 0:
         return []
     pids: list[int] = []
-    pattern = re.compile(r"(^|[ /])atm-daemon($| )")
+    daemon_name = "atm-daemon.exe" if os.name == "nt" else "atm-daemon"
     for line in completed.stdout.splitlines():
         stripped = line.strip()
         if not stripped:
@@ -63,8 +62,8 @@ def count_atm_daemon_processes() -> list[int]:
         if len(parts) != 2 or not parts[0].isdigit():
             continue
         pid = int(parts[0])
-        command = parts[1]
-        if pattern.search(command):
+        executable = parts[1].split(None, 1)[0]
+        if os.path.basename(executable) == daemon_name:
             pids.append(pid)
     return pids
 

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -440,6 +440,13 @@ def runtime_environment(atm_home: Path) -> dict[str, str]:
     return environment
 
 
+def host_runtime_client_environment(environment: dict[str, str]) -> dict[str, str]:
+    """Use the OS-user runtime record, never the disposable config root, for doctor."""
+    result = dict(environment)
+    result.pop("ATM_HOME", None)
+    return result
+
+
 def await_daemon_ready(process: subprocess.Popen[str], output: DaemonOutputCapture) -> None:
     """Wait only for the daemon's explicit readiness signal."""
     deadline = time.monotonic() + READY_TIMEOUT_SECONDS
@@ -959,7 +966,11 @@ def run_capacity(
         home.mkdir(parents=True, exist_ok=False)
         prepare_capacity_roster(atm, env, home)
         process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
-        doctor = command_result([str(atm), "doctor", "--json"], timeout=10.0, env=env)
+        doctor = command_result(
+            [str(atm), "doctor", "--json"],
+            timeout=10.0,
+            env=host_runtime_client_environment(env),
+        )
         if doctor["exit_code"] != 0:
             raise SmokeError(f"capacity doctor failed: {doctor['stderr'].strip()}")
         evidence["daemon_pid"] = process.pid
@@ -1004,7 +1015,11 @@ def run_capacity(
         process = None
         daemon_output = None
         process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
-        restart_doctor = command_result([str(atm), "doctor", "--json"], timeout=10.0, env=env)
+        restart_doctor = command_result(
+            [str(atm), "doctor", "--json"],
+            timeout=10.0,
+            env=host_runtime_client_environment(env),
+        )
         if restart_doctor["exit_code"] != 0:
             raise SmokeError(f"capacity doctor after restart failed: {restart_doctor['stderr'].strip()}")
         # The full doctor payload is host-private diagnostics; publication only

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -447,6 +447,55 @@ def host_runtime_client_environment(environment: dict[str, str]) -> dict[str, st
     return result
 
 
+def benchmark_doctor_payload(result: dict[str, object]) -> dict[str, object]:
+    """Validate the benchmark daemon's ready state from its public doctor response.
+
+    The dedicated benchmark binary deliberately installs ``NullObservability``
+    so a throughput run cannot create external hook/logging work.  Doctor
+    consequently returns its one documented observability finding with a
+    non-zero exit status even though the Tokio runtime is live and ready.  Do
+    not turn that intentional harness configuration into a false capacity
+    failure, but reject every other unhealthy response.
+    """
+    stdout = result.get("stdout")
+    if not isinstance(stdout, str):
+        raise SmokeError("capacity doctor returned no JSON response")
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as error:
+        raise SmokeError("capacity doctor returned malformed JSON") from error
+    if not isinstance(payload, dict):
+        raise SmokeError("capacity doctor response must be an object")
+
+    runtime_status = payload.get("runtime_status")
+    if not isinstance(runtime_status, dict):
+        raise SmokeError("capacity doctor did not report runtime status")
+    if runtime_status.get("liveness") != "running" or runtime_status.get("readiness") != "ready":
+        raise SmokeError("capacity doctor did not report a running, ready runtime")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise SmokeError("capacity doctor did not report a summary")
+    if summary.get("status") == "healthy" and result.get("exit_code") == 0:
+        return payload
+
+    findings = payload.get("findings")
+    if (
+        result.get("exit_code") == 1
+        and summary.get("status") == "error"
+        and isinstance(findings, list)
+        and len(findings) == 1
+        and isinstance(findings[0], dict)
+        and findings[0].get("code") == "ATM_OBSERVABILITY_HEALTH_FAILED"
+    ):
+        return payload
+
+    detail = result.get("stderr")
+    if not isinstance(detail, str) or not detail.strip():
+        detail = f"summary status {summary.get('status')!r}"
+    raise SmokeError(f"capacity doctor failed: {detail.strip()}")
+
+
 def await_daemon_ready(process: subprocess.Popen[str], output: DaemonOutputCapture) -> None:
     """Wait only for the daemon's explicit readiness signal."""
     deadline = time.monotonic() + READY_TIMEOUT_SECONDS
@@ -971,10 +1020,9 @@ def run_capacity(
             timeout=10.0,
             env=host_runtime_client_environment(env),
         )
-        if doctor["exit_code"] != 0:
-            raise SmokeError(f"capacity doctor failed: {doctor['stderr'].strip()}")
+        doctor_payload = benchmark_doctor_payload(doctor)
         evidence["daemon_pid"] = process.pid
-        evidence["doctor"] = json.loads(doctor["stdout"])
+        evidence["doctor"] = doctor_payload
         evidence["doctor_status"] = "passed"
         endpoint = local_endpoint(transport)
         evidence["endpoint"] = {
@@ -1020,11 +1068,9 @@ def run_capacity(
             timeout=10.0,
             env=host_runtime_client_environment(env),
         )
-        if restart_doctor["exit_code"] != 0:
-            raise SmokeError(f"capacity doctor after restart failed: {restart_doctor['stderr'].strip()}")
+        benchmark_doctor_payload(restart_doctor)
         # The full doctor payload is host-private diagnostics; publication only
         # needs the asserted healthy result after the restart.
-        json.loads(restart_doctor["stdout"])
         evidence["doctor_after_restart"] = {"status": "passed"}
         evidence["durability_after_restart"] = verify_durable_admissions(
             os_account_home() / ".atm" / "db" / "mail.db", expected_accepted_count,

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -178,7 +178,7 @@ def daemon_switch_result(
 
 
 def require_ready_managed_doctor(status: dict[str, Any]) -> None:
-    """Accept only the healthy, ready, matched runtime doctor contract."""
+    """Accept only a healthy doctor paired to the selected daemon executable."""
     doctor_status = status.get("doctor")
     if not isinstance(doctor_status, dict) or "error" in doctor_status:
         detail = doctor_status.get("error") if isinstance(doctor_status, dict) else "missing doctor result"
@@ -187,14 +187,20 @@ def require_ready_managed_doctor(status: dict[str, Any]) -> None:
     if not isinstance(summary, dict) or summary.get("status") != "healthy":
         raise SmokeError("managed daemon doctor is not healthy")
     runtime = doctor_status.get("runtime_status")
-    if not isinstance(runtime, dict) or runtime.get("readiness") != "ready":
+    if isinstance(runtime, dict) and runtime.get("readiness") != "ready":
         raise SmokeError("managed daemon doctor is not ready")
+    live_pair = status.get("live_pair")
+    if not isinstance(live_pair, dict) or live_pair.get("matched") is not True:
+        detail = live_pair.get("detail") if isinstance(live_pair, dict) else "missing live-pair proof"
+        raise SmokeError(f"managed daemon does not match the selected release: {detail}")
     client_context = doctor_status.get("client_context")
     daemon_context = doctor_status.get("daemon_context")
     client_version = client_context.get("version") if isinstance(client_context, dict) else None
     daemon_version = daemon_context.get("version") if isinstance(daemon_context, dict) else None
-    if not isinstance(client_version, str) or not client_version or client_version != daemon_version:
-        raise SmokeError("managed daemon doctor does not report one matched client/daemon version")
+    if not isinstance(client_version, str) or not client_version:
+        raise SmokeError("managed daemon doctor omitted the client version")
+    if daemon_version is not None and client_version != daemon_version:
+        raise SmokeError("managed daemon doctor reports mismatched client/daemon versions")
     selected_cli = status.get("atm")
     selected_version = selected_cli.get("version") if isinstance(selected_cli, dict) else None
     if not isinstance(selected_version, str) or not selected_version:

--- a/scripts/smoke/test_daemon_lifecycle.py
+++ b/scripts/smoke/test_daemon_lifecycle.py
@@ -1,0 +1,25 @@
+"""Regression tests for exact local daemon process detection."""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+from scripts.smoke import daemon_lifecycle
+
+
+class DaemonLifecycleTests(unittest.TestCase):
+    def test_unix_detection_matches_only_the_executable_not_shell_arguments(self) -> None:
+        listing = "\n".join((
+            "42 /opt/homebrew/bin/atm-daemon",
+            "43 zsh -c python runner.py --daemon-link /opt/homebrew/bin/atm-daemon --yes",
+        ))
+        completed = subprocess.CompletedProcess(["ps"], 0, stdout=listing, stderr="")
+        with mock.patch.object(daemon_lifecycle.os, "name", "posix"), mock.patch.object(
+            daemon_lifecycle.subprocess, "run", return_value=completed
+        ):
+            self.assertEqual(daemon_lifecycle.count_atm_daemon_processes(), [42])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -88,6 +88,40 @@ class AdmissionCapacityTests(unittest.TestCase):
         )
         self.assertIn("ATM_HOME", environment)
 
+    def test_benchmark_doctor_accepts_ready_null_observability_runtime(self):
+        result = {
+            "exit_code": 1,
+            "stderr": "",
+            "stdout": json.dumps({
+                "summary": {"status": "error"},
+                "findings": [{"code": "ATM_OBSERVABILITY_HEALTH_FAILED"}],
+                "runtime_status": {"liveness": "running", "readiness": "ready"},
+            }),
+        }
+        self.assertEqual(
+            RUNNER.benchmark_doctor_payload(result)["runtime_status"],
+            {"liveness": "running", "readiness": "ready"},
+        )
+
+    def test_benchmark_doctor_rejects_other_or_not_ready_failure(self):
+        for payload in (
+            {
+                "summary": {"status": "error"},
+                "findings": [{"code": "ATM_MAIL_STORE_FAILED"}],
+                "runtime_status": {"liveness": "running", "readiness": "ready"},
+            },
+            {
+                "summary": {"status": "error"},
+                "findings": [{"code": "ATM_OBSERVABILITY_HEALTH_FAILED"}],
+                "runtime_status": {"liveness": "running", "readiness": "draining"},
+            },
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(RUNNER.SmokeError, "capacity doctor"):
+                    RUNNER.benchmark_doctor_payload(
+                        {"exit_code": 1, "stderr": "", "stdout": json.dumps(payload)},
+                    )
+
     def test_compaction_math_matches_hand_calculated_intervals(self):
         values = [10.0, 20.0, 30.0, 40.0]
         self.assertEqual(percentile(values, 0.95), 40.0)

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -65,6 +65,7 @@ def healthy_managed_status() -> dict[str, object]:
             "version": "atm 1.4.1-beta-ai-1",
         },
         "atm_daemon": {"selector": "/active/atm-daemon", "target": "/release/atm-daemon"},
+        "live_pair": {"matched": True, "detail": "selected executable is live"},
         "doctor": {
             "summary": {"status": "healthy"},
             "runtime_status": {"readiness": "ready"},
@@ -257,6 +258,24 @@ class AdmissionCapacityTests(unittest.TestCase):
             with mock.patch.object(RUNNER, "command_result", return_value=command):
                 with self.assertRaisesRegex(RUNNER.SmokeError, expected):
                     RUNNER.daemon_switch_result("status", options, doctor=True)
+
+    def test_daemon_switch_status_accepts_http_runtime_without_legacy_doctor_fields(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        status = healthy_managed_status()
+        status["doctor"].pop("runtime_status")
+        status["doctor"].pop("daemon_context")
+        command = {"exit_code": 0, "stdout": json.dumps(status), "stderr": ""}
+        with mock.patch.object(RUNNER, "command_result", return_value=command):
+            self.assertEqual(RUNNER.daemon_switch_result("status", options, doctor=True), status)
+
+    def test_daemon_switch_status_requires_live_pair_proof(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        status = healthy_managed_status()
+        status.pop("live_pair")
+        command = {"exit_code": 0, "stdout": json.dumps(status), "stderr": ""}
+        with mock.patch.object(RUNNER, "command_result", return_value=command):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "selected release"):
+                RUNNER.daemon_switch_result("status", options, doctor=True)
 
     def test_restore_surfaces_a_failed_doctor_after_state_is_put_back(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -76,6 +76,18 @@ def healthy_managed_status() -> dict[str, object]:
 
 
 class AdmissionCapacityTests(unittest.TestCase):
+    def test_host_runtime_doctor_environment_ignores_disposable_atm_home(self):
+        environment = {
+            "ATM_HOME": "/tmp/atm-capacity-1",
+            "ATM_IDENTITY": "capacity-agent",
+            "ATM_TEAM": "capacity-team",
+        }
+        self.assertEqual(
+            RUNNER.host_runtime_client_environment(environment),
+            {"ATM_IDENTITY": "capacity-agent", "ATM_TEAM": "capacity-team"},
+        )
+        self.assertIn("ATM_HOME", environment)
+
     def test_compaction_math_matches_hand_calculated_intervals(self):
         values = [10.0, 20.0, 30.0, 40.0]
         self.assertEqual(percentile(values, 0.95), 40.0)


### PR DESCRIPTION
Split out of PR #800 per scope correction — these are AL.13 G7 managed-benchmark repairs, unrelated to the daemon-switch owner-lock fix.

- Add index on `mail_messages(message_key)` for the post-commit reload hot path.
- Retain bounded HTTP/1.1 batches so F2/F4/F8/F16/F64 don't close after request one.

**Status: partial fix only.** An earlier commit on this branch raised `WriteAdmission` from `NonZeroUsize::new(1)` to a 128-concurrent-job constant; that change was undisclosed, judged unsafe against the single-SQLite-writer invariant, and has been reverted (removed at 9883347f). The 3888–4627 msg/s figures previously reported here were measured against that removed code and do not apply to this head.

**Exact-head M5 rerun at 9883347f**: F1 durable post-restart count correct (10,000), median 461.674 msg/s — below the 1,000 msg/s AL.13 G7 gate. M5 correctly stopped before F2+ and restored a healthy daemon. **The G7 throughput gate is NOT closed by this PR.**

QA-1 (quality-mgr): 0 Blocking + 0 Important + 0 Minor on the index/keepalive changes themselves; CI 9/9 green; scope confirmed narrow (8 files, no atm-daemon, no WriteAdmission change). Merging as a partial fix — index + bounded HTTP/1.1 batching are real, correct, and tested improvements, but do not by themselves meet the throughput target.

**Follow-on work required** (tracked separately, not in this PR): a purpose-built Tokio-owned bounded single-writer queue with explicit admission, ordering, cancellation, saturation, and durable-outcome tests. Do not reinstate unbounded/high-concurrency SQLite writers as a shortcut.

No atm-daemon (legacy) files touched.