### PR TITLE
AL.13 G7: allow absent macOS quiesce label in daemon-switch

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -397,7 +397,12 @@ def quiesce(args: argparse.Namespace) -> None:
     if not args.yes:
         raise SwitchError("quiesce changes the singleton daemon; re-run with --yes")
     cli, _daemon = selected_links(args)
-    run_service(args, "stop")
+    # Benchmark recovery may find that the verified LaunchAgent label is
+    # already unloaded (launchctl reports "No such process").  Treat that as
+    # an absent service, then let require_stopped_daemon perform the actual
+    # ownership check and the explicitly authorized orphan repair if needed.
+    # Failing before that check makes a safe no-op quiesce impossible.
+    run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
 
 

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -78,8 +78,23 @@ class QuiesceTests(unittest.TestCase):
             DAEMON_SWITCH.quiesce(args)
 
         selected.assert_called_once_with(args)
-        service.assert_called_once_with(args, "stop")
+        service.assert_called_once_with(args, "stop", allow_absent=True)
         stopped.assert_called_once_with(args, cli)
+
+    def test_macos_absent_launch_agent_is_safe_before_owner_verification(self) -> None:
+        args = mock.Mock(service="com.atm.daemon.crosshost-smoke", launch_agent_plist="/tmp/atm.plist")
+        bootout_missing = subprocess.CompletedProcess(
+            ["launchctl", "bootout"], 3, stdout="", stderr="Boot-out failed: 3: No such process"
+        )
+        print_absent = subprocess.CompletedProcess(
+            ["launchctl", "print"], 3, stdout="", stderr="Could not find service"
+        )
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH.os, "getuid", return_value=501),
+            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[bootout_missing, print_absent]),
+        ):
+            DAEMON_SWITCH.run_service(args, "stop", allow_absent=True)
 
 
 class HttpRuntimeOwnerLockTests(unittest.TestCase):


### PR DESCRIPTION
Fixes a managed-lifecycle harness defect blocking the G7 M5 benchmark: macOS launchctl bootout's verified-absent-label ('No such process') was being treated as fatal in quiesce, ahead of the existing owner/orphan verification. This fix permits that absent state while retaining require_stopped_daemon and the explicit repair guard.

Added macOS regression coverage for the absent-label case.

Validated by arch-ctm: daemon-switch unit tests (9), admission harness tests (63), `just test` all pass.