### PR TITLE
perf(AL13): async storage ingress via sealed AsyncMessageStore admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
 name = "atm-storage"
 version = "1.4.1-beta-ai-1"
 dependencies = [
+ "async-trait",
  "atm-error",
  "chrono",
  "rustls",
@@ -292,11 +293,13 @@ dependencies = [
 name = "atm-storage-rusqlite"
 version = "1.4.1-beta-ai-1"
 dependencies = [
+ "async-trait",
  "atm-storage",
  "chrono",
  "rusqlite",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/boundaries/atm-storage-rusqlite/async-message-store-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/async-message-store-sqlite.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-AsyncMessageStore-Sqlite"
+owner_package = "atm-storage-rusqlite"
+owner_crate_path = "atm_storage_rusqlite"
+name = "SqliteAsyncMessageStoreAdapter"
+
+[public]
+trait = "AsyncMessageStore"
+
+[implementation]
+type = "SqliteMessageStore"
+module = "atm_storage_rusqlite"
+visibility = "private"
+constructor = "private"
+
+[composition]
+roots = ["atm_storage_rusqlite::SqliteStorageBackend::new"]
+
+[ownership]
+io_owns = ["sqlite", "bounded_durable_admission", "mailbox_state_persistence"]
+io_forbidden = ["socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime-test-support"]
+allowed_dependencies = ["atm-storage", "rusqlite"]
+forbidden_edges = ["atm -> atm-storage-rusqlite", "atm-daemon -> atm-storage-rusqlite", "atm-graft -> atm-storage-rusqlite", "atm-runtime -> atm-storage-rusqlite", "atm-storage-rusqlite -> atm-runtime"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["SqliteMessageStore"]
+
+[contracts]
+request_types = ["Message", "AcknowledgementSource"]
+response_types = ["Message", "AcknowledgementCommit"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["rusqlite::Connection"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-MAILSTORE-SQLITE-EDGES"]
+review_gates = ["no_public_impl", "no_public_constructor", "no_public_reexport"]
+
+[status]
+state = "active"
+notes = ["One dedicated synchronous writer owns SQLite transactions; Tokio callers asynchronously await bounded admission and durable replies."]

--- a/boundaries/atm-storage-rusqlite/mail-store-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/mail-store-sqlite.toml
@@ -71,5 +71,6 @@ review_gates = [
 state = "active"
 notes = [
   "SQLite message persistence is a backend-only implementation of the shared atm-storage MessageStore trait",
+  "AsyncMessageStore admission awaits a bounded Tokio channel; one dedicated synchronous SQLite writer owns ordered transaction batching",
   "notification semantics remain post-commit only",
 ]

--- a/boundaries/atm-storage/async-message-store.toml
+++ b/boundaries/atm-storage/async-message-store.toml
@@ -1,0 +1,45 @@
+boundary_id = "BOUNDARY-AsyncMessageStore"
+owner_package = "atm-storage"
+owner_crate_path = "atm_storage"
+name = "AsyncMessageStore"
+
+[public]
+trait = "AsyncMessageStore"
+notes = "Tokio-facing bounded durable-admission contract; it does not expose a backend queue or a database connection."
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = ["atm_runtime::composition::assemble_runtime"]
+
+[ownership]
+io_owns = ["bounded_durable_admission", "durable_message_result"]
+io_forbidden = ["socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-core", "atm-daemon-bootstrap", "atm-runtime", "atm-storage-rusqlite"]
+allowed_dependencies = []
+forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["Message", "AcknowledgementSource"]
+response_types = ["Message", "AcknowledgementCommit"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = []
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-MESSAGESTORE-REFERENCES"]
+review_gates = ["no_backend_specific_async_contract", "no_tokio_write_spawn_blocking"]
+
+[status]
+state = "concrete_landed"
+notes = ["The SQLite adapter implements this trait with one synchronous transaction thread and a bounded Tokio submission channel."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2513,13 +2513,14 @@ fn al3_replacement_runtime_cannot_restore_legacy_or_blocking_runtime_constructs(
     }
     let storage_router = read_source(&runtime_root.join("storage_and_nudge_router.rs"));
     assert!(
-        storage_router.contains("spawn_blocking"),
-        "the synchronous core storage boundary must be isolated without blocking a Tokio worker"
+        storage_router.contains("async fn commit_write")
+            && storage_router.contains("prepare_write_with_async_runtime("),
+        "the replacement write path must await the core async storage admission boundary"
     );
     assert!(
-        storage_router.contains("StorageWriterIngress")
-            && storage_router.contains("MAX_CONCURRENT_WRITER_SUBMISSIONS"),
-        "the replacement write path must use bounded Tokio ingress to feed the core-owned writer queue"
+        !storage_router.contains("StorageWriterIngress")
+            && !storage_router.contains("MAX_CONCURRENT_WRITER_SUBMISSIONS"),
+        "the replacement write path must not restore the redundant spawn_blocking writer ingress"
     );
     for prohibited in ["rusqlite::", ".with_transaction(", "Connection::open"] {
         assert!(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -391,6 +391,75 @@ pub(crate) fn admit_acknowledgement_write<
     builder.take()
 }
 
+/// Async counterpart of [`admit_acknowledgement_write`] for the replacement
+/// Tokio daemon. The roster check remains synchronous core validation; the
+/// source lookup, reply creation, and atomic source transition are one await
+/// on the storage-owned durable-admission lane.
+pub(crate) async fn admit_acknowledgement_write_async(
+    request: SendRequest,
+    runtime: &LocalServiceRuntime,
+) -> Result<AtomicAcknowledgementWrite, AtmError> {
+    let provenance = validate_write_provenance(
+        if request.to.is_some() {
+            WriteIngress::Peer
+        } else {
+            WriteIngress::Canonical
+        },
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
+    let (source, builder) = if let Some(target) = request.to.as_ref() {
+        if !provenance.is_authenticated_peer() {
+            return Err(AtmError::validation(
+                "acknowledgement write must not include a client-supplied destination",
+            ));
+        }
+        let message_id = request.acknowledges_message_id.ok_or_else(|| {
+            AtmError::validation("acknowledgement write is missing acknowledges_message_id")
+        })?;
+        let team = target
+            .team()
+            .cloned()
+            .unwrap_or_else(|| request.caller_team.clone());
+        (
+            AcknowledgementSource {
+                team,
+                agent: target.agent().clone(),
+                message_id,
+            },
+            Arc::new(AtomicAcknowledgementBuilder::new(
+                AtomicAcknowledgementKind::Received(Box::new(request)),
+            )),
+        )
+    } else {
+        let request = AckRequest::from_unresolved_write(request)?;
+        ensure_roster_member_exists(
+            runtime,
+            &request.caller_team,
+            &request.caller_identity,
+            "Repair or reload the ATM roster before retrying `atm ack`.",
+        )?;
+        (
+            AcknowledgementSource {
+                team: request.caller_team.clone(),
+                agent: request.caller_identity.clone(),
+                message_id: request.message_id,
+            },
+            Arc::new(AtomicAcknowledgementBuilder::new(
+                AtomicAcknowledgementKind::Local(Box::new(request)),
+            )),
+        )
+    };
+    let _commit = runtime
+        .acknowledge_message_atomically_async(source, builder.clone())
+        .await?;
+    builder.take()
+}
+
 fn build_atomic_acknowledgement(
     canonical_request: SendRequest,
     actor: AgentName,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -553,6 +553,41 @@ pub fn prepare_write_with_runtime(
     )
 }
 
+/// Prepares one canonical write through the Tokio durable-admission boundary.
+///
+/// Core validation and response construction remain shared with the legacy
+/// path. The immutable storage transition is the only await: it enqueues work
+/// to the backend's bounded writer lane and receives that lane's durable
+/// result without a blocking task in the HTTP runtime.
+pub async fn prepare_write_with_async_runtime(
+    request: WriteRequest,
+    observability: &(dyn ObservabilityPort + Send + Sync),
+    runtime: &LocalServiceRuntime,
+) -> Result<PreparedWrite, AtmError> {
+    validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
+    if request.acknowledges_message_id.is_none() {
+        if request.to.is_none() {
+            return Err(AtmError::validation(
+                "message write is missing a destination",
+            ));
+        }
+        return prepare_persisted_write_async(request, observability, runtime, None).await;
+    }
+    if has_authenticated_peer_provenance(&request) {
+        return prepare_persisted_write_async(request, observability, runtime, None).await;
+    }
+    let acknowledgement = crate::ack::admit_acknowledgement_write_async(request, runtime).await?;
+    prepare_atomic_acknowledgement_write(acknowledgement, observability, runtime)
+}
+
 /// The sole write pipeline. `acknowledges_message_id` selects only an
 /// acknowledgement-source normalization step; both variants persist through
 /// the same canonical writer exactly once.
@@ -753,6 +788,76 @@ fn prepare_persisted_write<
     })
 }
 
+async fn prepare_persisted_write_async(
+    request: SendRequest,
+    observability: &(dyn ObservabilityPort + Send + Sync),
+    runtime: &LocalServiceRuntime,
+    acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
+) -> Result<PreparedWrite, AtmError> {
+    let context = prepare_send_context(runtime, &request)?;
+    let task_id = request.task_id.clone();
+    let requires_ack = request.requires_ack
+        || task_id.is_some()
+        || matches!(
+            &request.message_source,
+            SendMessageSource::File { path, .. } if file_policy::is_task_envelope(path)
+        );
+    let body = resolve_message_body(
+        &request.message_source,
+        &request.current_dir,
+        &request.home_dir,
+        &context.recipient.team,
+    )?;
+    let summary = summary::build_summary(&body, request.summary_override.clone());
+    let message_id = request.origin_message_id.unwrap_or_default();
+    let timestamp = request.origin_timestamp.unwrap_or_else(IsoTimestamp::now);
+    let persistence = persist_send_message_async(
+        runtime,
+        &request,
+        &context,
+        &body,
+        &summary,
+        message_id,
+        timestamp,
+        requires_ack,
+        task_id.clone(),
+    )
+    .await?;
+    let outcome = finalize_send_outcome(
+        runtime,
+        observability,
+        &request,
+        &context,
+        &body,
+        &summary,
+        message_id,
+        requires_ack,
+        task_id,
+        &persistence,
+        DeliveryExecutionMode::Deferred,
+    )?;
+    Ok(PreparedWrite {
+        outcome,
+        outbound_request: request,
+        persisted_timestamp: timestamp,
+        post_write_needed: persistence.requires_post_write(),
+        same_store_peer_receipt: persistence.duplicate_disposition
+            == DuplicateWriteDisposition::SameStorePeerReceipt,
+        #[cfg(test)]
+        post_write: LocalPostWrite {
+            post_send_config: context.post_send_config,
+            recipient: context.recipient,
+            delivery_snapshot: context.delivery_snapshot,
+            messages: post_send_messages_from_persistence(
+                &persistence,
+                requires_ack,
+                acknowledgement.is_some(),
+            )?,
+        },
+        acknowledgement,
+    })
+}
+
 fn has_authenticated_peer_provenance(request: &WriteRequest) -> bool {
     validate_write_provenance(
         WriteIngress::Canonical,
@@ -912,6 +1017,55 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
             }),
         acknowledgement_source_update,
     )
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Send persistence keeps the canonical request/body/message envelope fields explicit at the async seam."
+)]
+async fn persist_send_message_async(
+    runtime: &LocalServiceRuntime,
+    request: &SendRequest,
+    context: &SendExecutionContext,
+    body: &str,
+    summary: &str,
+    message_id: AtmMessageId,
+    timestamp: IsoTimestamp,
+    requires_ack: bool,
+    task_id: Option<TaskId>,
+) -> Result<DeliveryPersistenceResult, AtmError> {
+    let mut envelope = build_send_envelope(
+        request,
+        context,
+        body,
+        summary,
+        message_id,
+        timestamp,
+        requires_ack,
+        task_id,
+    );
+    if request.dry_run {
+        return Ok(DeliveryPersistenceResult::persisted(envelope));
+    }
+    if let Some(destination) = request.to.as_ref()
+        && let Some((host, request_json)) =
+            build_peer_outbound_replay(request, destination, message_id, timestamp)?
+    {
+        set_peer_outbound_write(&mut envelope, &host, request_json);
+    }
+    persistence::persist_message_with_async_admission(
+        runtime,
+        &request.home_dir,
+        &context.delivery_snapshot,
+        &context.inbox_path,
+        &envelope,
+        false,
+        request
+            .authenticated_source_host
+            .as_ref()
+            .zip(request.to.as_ref().and_then(|recipient| recipient.host())),
+    )
+    .await
 }
 
 #[expect(

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -86,6 +86,29 @@ pub(crate) fn persist_message_with_ack_update(
     }
 }
 
+async fn load_store_backed_mailbox_projection_async(
+    runtime: &LocalServiceRuntime,
+    team: &TeamName,
+    agent: &AgentName,
+) -> Result<Vec<InboxMessage>, AtmError> {
+    let mut records = runtime
+        .list_messages_async(atm_storage::MessageQuery {
+            team: team.clone(),
+            agent: agent.clone(),
+            sender: None,
+            task_id: None,
+            limit: None,
+        })
+        .await?;
+    records.sort_by(|left, right| {
+        left.envelope
+            .timestamp
+            .cmp(&right.envelope.timestamp)
+            .then_with(|| left.message_key.as_ref().cmp(right.message_key.as_ref()))
+    });
+    Ok(records.into_iter().map(|record| record.envelope).collect())
+}
+
 /// Tokio-owned durable admission for ordinary immutable messages.
 ///
 /// Validation and message construction remain in the canonical core path;
@@ -94,7 +117,7 @@ pub(crate) fn persist_message_with_ack_update(
 /// reply, so no Tokio worker waits on SQLite or a blocking bridge.
 pub(crate) async fn persist_message_with_async_admission(
     runtime: &LocalServiceRuntime,
-    home_dir: &Path,
+    _home_dir: &Path,
     recipient: &DeliveryRecipientSnapshot,
     inbox_path: &Path,
     envelope: &InboxMessage,
@@ -107,7 +130,8 @@ pub(crate) async fn persist_message_with_async_admission(
 
     let mut prepared = envelope.clone();
     let inbox_messages = if prepared.parent_message_id.is_some() && prepared.thread_mode.is_some() {
-        load_store_backed_mailbox_projection(runtime, home_dir, &recipient.team, &recipient.agent)?
+        load_store_backed_mailbox_projection_async(runtime, &recipient.team, &recipient.agent)
+            .await?
     } else {
         Vec::new()
     };

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -6,6 +6,7 @@ use crate::boundary;
 use crate::delivery_policy::DeliveryRecipientSnapshot;
 use crate::error::AtmError;
 use crate::schema::{InboxMessage, clear_transport_delivery_metadata, peer_outbound_host};
+use crate::service_runtime::LocalServiceRuntime;
 use crate::service_runtime::RetainedServiceRuntime;
 use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::types::{AgentName, HostName, TeamName};
@@ -72,6 +73,55 @@ pub(crate) fn persist_message_with_ack_update(
         same_store_peer_receipt,
         acknowledgement_source_update,
     ) {
+        Ok(DuplicateWriteDisposition::NotDuplicate) => {
+            Ok(DeliveryPersistenceResult::persisted(prepared))
+        }
+        Ok(DuplicateWriteDisposition::AlreadyDeliveredRemote) => {
+            Ok(DeliveryPersistenceResult::already_persisted(prepared))
+        }
+        Ok(DuplicateWriteDisposition::SameStorePeerReceipt) => {
+            Ok(DeliveryPersistenceResult::same_store_peer_receipt(prepared))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Tokio-owned durable admission for ordinary immutable messages.
+///
+/// Validation and message construction remain in the canonical core path;
+/// only the storage transition is asynchronous. The future enqueues exactly
+/// one ordered record in the backend-owned write lane and awaits its durable
+/// reply, so no Tokio worker waits on SQLite or a blocking bridge.
+pub(crate) async fn persist_message_with_async_admission(
+    runtime: &LocalServiceRuntime,
+    home_dir: &Path,
+    recipient: &DeliveryRecipientSnapshot,
+    inbox_path: &Path,
+    envelope: &InboxMessage,
+    require_existing_inbox: bool,
+    same_store_peer_receipt: Option<(&HostName, &HostName)>,
+) -> Result<DeliveryPersistenceResult, AtmError> {
+    if require_existing_inbox && !inbox_path.exists() {
+        return Ok(DeliveryPersistenceResult::persisted(envelope.clone()));
+    }
+
+    let mut prepared = envelope.clone();
+    let inbox_messages = if prepared.parent_message_id.is_some() && prepared.thread_mode.is_some() {
+        load_store_backed_mailbox_projection(runtime, home_dir, &recipient.team, &recipient.agent)?
+    } else {
+        Vec::new()
+    };
+    prepare_threaded_message(&mut prepared, &inbox_messages)?;
+
+    match mirror_message_to_store_async(
+        runtime,
+        &recipient.team,
+        &recipient.agent,
+        &prepared,
+        same_store_peer_receipt,
+    )
+    .await
+    {
         Ok(DuplicateWriteDisposition::NotDuplicate) => {
             Ok(DeliveryPersistenceResult::persisted(prepared))
         }
@@ -155,6 +205,36 @@ fn mirror_message_to_store(
                 same_store_peer_receipt,
             );
         }
+    }
+    Ok(DuplicateWriteDisposition::NotDuplicate)
+}
+
+async fn mirror_message_to_store_async(
+    runtime: &LocalServiceRuntime,
+    team: &TeamName,
+    agent: &AgentName,
+    envelope: &InboxMessage,
+    same_store_peer_receipt: Option<(&HostName, &HostName)>,
+) -> Result<DuplicateWriteDisposition, AtmError> {
+    let Some(message_id) = envelope.message_id else {
+        return Ok(DuplicateWriteDisposition::NotDuplicate);
+    };
+    let message_key = boundary::MessageKey::from(message_id);
+    let record = boundary::Message {
+        team: team.clone(),
+        agent: agent.clone(),
+        message_key,
+        envelope: envelope.clone(),
+    };
+    if let Some(existing) = runtime.save_message_if_absent_async(record).await? {
+        return classify_existing_message(
+            existing,
+            envelope,
+            message_id,
+            team,
+            agent,
+            same_store_peer_receipt,
+        );
     }
     Ok(DuplicateWriteDisposition::NotDuplicate)
 }

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -193,6 +193,21 @@ impl LocalServiceRuntime {
         store.save_message_if_absent_async(message).await
     }
 
+    /// Loads a threaded-message validation projection through the Tokio-safe
+    /// storage lane. Unlike the retained compatibility runtime, this never
+    /// opens a synchronous SQLite reader on an HTTP request worker.
+    pub async fn list_messages_async(
+        &self,
+        query: atm_storage::MessageQuery,
+    ) -> Result<Vec<crate::boundary::Message>, AtmError> {
+        let store = self.async_message_store.as_ref().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "Tokio async mailbox projection was not installed in this runtime",
+            )
+        })?;
+        store.list_messages_async(query).await
+    }
+
     /// Performs the acknowledgement source transition and reply insertion on
     /// the same async durable-admission lane as ordinary writes.
     pub async fn acknowledge_message_atomically_async(

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -8,7 +8,10 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use atm_storage::{MessageStore as SharedMessageStore, RosterStore as SharedRosterStore};
+use atm_storage::{
+    AsyncMessageStore as SharedAsyncMessageStore, MessageStore as SharedMessageStore,
+    RosterStore as SharedRosterStore,
+};
 
 use crate::config::{self, AtmConfig};
 use crate::delivery_policy::DeliveryRecipientSnapshot;
@@ -128,6 +131,7 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
 #[derive(Clone)]
 pub struct LocalServiceRuntime {
     pub(crate) message_store: std::sync::Arc<dyn SharedMessageStore + Send + Sync>,
+    async_message_store: Option<std::sync::Arc<dyn SharedAsyncMessageStore + Send + Sync>>,
     pub(crate) roster_store: std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
     pub(crate) nudge_template_override_store:
         std::sync::Arc<dyn crate::boundary::NudgeTemplateOverrideStore + Send + Sync>,
@@ -154,12 +158,56 @@ impl LocalServiceRuntime {
     ) -> Self {
         Self {
             message_store,
+            async_message_store: None,
             roster_store,
             nudge_template_override_store,
             non_claude_outbound,
             roster_cache: Arc::new(RosterSnapshotCache::default()),
             workspace_config_access: WorkspaceConfigAccess::Client,
         }
+    }
+
+    /// Attaches the Tokio-safe durable-admission boundary selected by the
+    /// composition root. The legacy synchronous store remains available only
+    /// to transitional non-Tokio callers.
+    #[must_use]
+    pub fn with_async_message_store(
+        mut self,
+        async_message_store: std::sync::Arc<dyn SharedAsyncMessageStore + Send + Sync>,
+    ) -> Self {
+        self.async_message_store = Some(async_message_store);
+        self
+    }
+
+    /// Awaits bounded admission and the durable outcome without blocking a
+    /// Tokio request executor. This is the replacement daemon's write seam.
+    pub async fn save_message_if_absent_async(
+        &self,
+        message: crate::boundary::Message,
+    ) -> Result<Option<crate::boundary::Message>, AtmError> {
+        let store = self.async_message_store.as_ref().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "Tokio durable message admission was not installed in this runtime",
+            )
+        })?;
+        store.save_message_if_absent_async(message).await
+    }
+
+    /// Performs the acknowledgement source transition and reply insertion on
+    /// the same async durable-admission lane as ordinary writes.
+    pub async fn acknowledge_message_atomically_async(
+        &self,
+        source: atm_storage::AcknowledgementSource,
+        builder: std::sync::Arc<dyn atm_storage::AcknowledgementReplyBuilder>,
+    ) -> Result<atm_storage::AcknowledgementCommit, AtmError> {
+        let store = self.async_message_store.as_ref().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "Tokio acknowledgement admission was not installed in this runtime",
+            )
+        })?;
+        store
+            .acknowledge_message_atomically_async(source, builder)
+            .await
     }
 
     /// Returns the daemon-owned runtime view. A system daemon must not read a
@@ -219,6 +267,7 @@ impl fmt::Debug for LocalServiceRuntime {
                 "message_store",
                 &std::sync::Arc::as_ptr(&self.message_store),
             )
+            .field("async_message_store", &self.async_message_store.is_some())
             .field("roster_store", &std::sync::Arc::as_ptr(&self.roster_store))
             .field(
                 "nudge_template_override_store",

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -25,29 +25,17 @@ use atm_core::protocol::{
 use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::send::{
     WarningEntry, WriteOutcome, build_received_message_hook_dispatches_after_commit,
-    prepare_write_with_runtime,
+    prepare_write_with_async_runtime,
 };
 
 use crate::CanonicalWriteHandler;
 use crate::RuntimeHealth;
 
-/// Bound the number of async request futures that may be submitting work to
-/// the core storage writer at once.
-///
-/// `LocalServiceRuntime` owns the storage boundary.  For SQLite that boundary
-/// owns exactly one `Arc<SqliteWriter>` and its bounded transaction channel;
-/// it drains a burst of ordered write operations into one transaction before
-/// resolving the individual replies.  This ingress must therefore admit a
-/// bounded burst instead of serializing every HTTP future before it reaches
-/// that channel.  It never opens a SQLite connection or transaction itself.
-const MAX_CONCURRENT_WRITER_SUBMISSIONS: usize = 128;
-
 /// Bounded bridge for a synchronous core operation that is not a storage-writer
 /// submission.
 ///
-/// Keeping this separate from [`StorageWriterIngress`] makes it impossible for
-/// read, doctor, and heartbeat bridging to accidentally redefine the storage
-/// writer's batching capacity.
+/// This is reserved for read, doctor, and heartbeat work. Durable writes use
+/// the async storage boundary directly and must not enter this bridge.
 #[derive(Clone)]
 struct BlockingCoreBridge {
     permits: Arc<tokio::sync::Semaphore>,
@@ -97,35 +85,6 @@ impl BlockingCoreBridge {
     }
 }
 
-/// Replacement-owned async ingress for core storage-writer submissions.
-///
-/// A caller waits as a Tokio future for bounded submission capacity before
-/// creating the narrow blocking bridge to the sealed storage boundary.
-/// Dropping that future while it waits cancels only its ingress admission.
-/// Once submitted, the caller awaits the core writer's real durable outcome;
-/// the request deadline is not reused to falsely reclassify a committed
-/// transaction as a timeout.
-#[derive(Clone)]
-struct StorageWriterIngress {
-    submission_bridge: BlockingCoreBridge,
-}
-
-impl StorageWriterIngress {
-    fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            submission_bridge: BlockingCoreBridge::new(capacity),
-        }
-    }
-
-    async fn submit<T, F>(&self, deadline: RequestDeadline, job: F) -> Result<T, AtmError>
-    where
-        T: Send + 'static,
-        F: FnOnce() -> Result<T, AtmError> + Send + 'static,
-    {
-        self.submission_bridge.run(deadline, job).await
-    }
-}
-
 /// The replacement implementation of the canonical write operation.
 ///
 /// Storage stays behind `LocalServiceRuntime`'s core interfaces and
@@ -136,7 +95,6 @@ pub struct StorageAndNudgeRouter {
     service_runtime: LocalServiceRuntime,
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
     received_hook_selector: Arc<dyn MessageReceivedHookSelector>,
-    storage_writer_ingress: StorageWriterIngress,
     blocking_core_bridge: BlockingCoreBridge,
     daemon_home: PathBuf,
     runtime_health: RuntimeHealth,
@@ -157,10 +115,6 @@ impl StorageAndNudgeRouter {
             service_runtime,
             observability,
             received_hook_selector,
-            storage_writer_ingress: StorageWriterIngress::new(
-                NonZeroUsize::new(MAX_CONCURRENT_WRITER_SUBMISSIONS)
-                    .expect("writer submission limit is non-zero"),
-            ),
             blocking_core_bridge: BlockingCoreBridge::new(
                 NonZeroUsize::new(1).expect("one non-storage core bridge operation"),
             ),
@@ -204,15 +158,16 @@ impl StorageAndNudgeRouter {
         self
     }
 
-    fn commit_write(
+    async fn commit_write(
         &self,
         request: atm_core::send::WriteRequest,
     ) -> Result<CommittedWrite, AtmError> {
-        let mut prepared = prepare_write_with_runtime(
+        let mut prepared = prepare_write_with_async_runtime(
             request,
             self.observability.as_ref(),
             &self.service_runtime,
-        )?;
+        )
+        .await?;
         let newly_persisted = prepared.is_newly_persisted();
         let canonical_request = prepared.outbound_request();
         let message_id = prepared.persisted_message_id();
@@ -539,11 +494,7 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             // shared writer uses them for its state and file-policy paths.
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
-            let storage = self.clone();
-            let mut committed = self
-                .storage_writer_ingress
-                .submit(deadline, move || storage.commit_write(request))
-                .await?;
+            let mut committed = self.commit_write(request).await?;
             if ingress == AuthenticatedIngress::Local
                 && matches!(committed.outcome, WriteOutcome::Acknowledged(_))
             {
@@ -658,8 +609,8 @@ mod tests {
     use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Barrier, Mutex};
     use std::time::Duration;
 
     use atm_core::boundary::{
@@ -684,7 +635,7 @@ mod tests {
     use tempfile::TempDir;
     use tower::ServiceExt;
 
-    use super::{BlockingCoreBridge, StorageAndNudgeRouter, StorageWriterIngress};
+    use super::{BlockingCoreBridge, StorageAndNudgeRouter};
     use crate::{
         AuthenticatedConnector, CanonicalWriteHandler, NonZeroDuration, RuntimeHealth,
         RuntimeLimits, RuntimeTimeouts, canonical_message_router,
@@ -1007,107 +958,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn storage_writer_ingress_admits_a_burst_of_request_futures() {
-        let ingress = StorageWriterIngress::new(NonZeroUsize::new(4).expect("non-zero capacity"));
-        let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
-        let release = Arc::new(Barrier::new(5));
-        let mut submissions = Vec::new();
-
-        for submission_id in 0..4_u8 {
-            let ingress = ingress.clone();
-            let started_tx = started_tx.clone();
-            let release = Arc::clone(&release);
-            submissions.push(tokio::spawn(async move {
-                ingress
-                    .submit(RequestDeadline::after(Duration::from_secs(1)), move || {
-                        started_tx
-                            .send(submission_id)
-                            .expect("report admitted future");
-                        release.wait();
-                        Ok(submission_id)
-                    })
-                    .await
-            }));
-        }
-        drop(started_tx);
-
-        let mut admitted = Vec::new();
-        for _ in 0..4 {
-            admitted.push(
-                tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
-                    .await
-                    .expect("every bounded request future enters the storage-writer ingress")
-                    .expect("submission sender remains live"),
-            );
-        }
-        admitted.sort_unstable();
-        assert_eq!(admitted, vec![0, 1, 2, 3]);
-
-        // All four jobs are admitted before release.  In production each then
-        // submits its ordered WriteOp to the single core SqliteWriter queue.
-        release.wait();
-        let mut outcomes = Vec::new();
-        for submission in submissions {
-            outcomes.push(
-                submission
-                    .await
-                    .expect("submission task joins")
-                    .expect("submission result"),
-            );
-        }
-        assert_eq!(outcomes, vec![0, 1, 2, 3]);
-    }
-
-    #[tokio::test]
-    async fn storage_writer_ingress_rejects_saturation_without_starting_an_extra_submission() {
-        let ingress = StorageWriterIngress::new(NonZeroUsize::new(1).expect("non-zero capacity"));
-        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let first_ingress = ingress.clone();
-        let first = tokio::spawn(async move {
-            first_ingress
-                .submit(RequestDeadline::after(Duration::from_secs(1)), move || {
-                    first_started_tx
-                        .send(())
-                        .expect("signal started submission");
-                    release_first_rx
-                        .blocking_recv()
-                        .expect("release first submission");
-                    Ok(())
-                })
-                .await
-        });
-        first_started_rx.await.expect("first submission starts");
-
-        let second_started = Arc::new(AtomicBool::new(false));
-        let second_started_in_job = Arc::clone(&second_started);
-        let second = ingress
-            .submit(
-                RequestDeadline::after(Duration::from_millis(20)),
-                move || {
-                    second_started_in_job.store(true, Ordering::SeqCst);
-                    Ok(())
-                },
-            )
-            .await
-            .expect_err("saturated ingress is bounded by the caller deadline");
-
-        assert_eq!(
-            second.code(),
-            atm_core::error::AtmErrorCode::DaemonUnavailable
-        );
-        assert!(
-            !second_started.load(Ordering::SeqCst),
-            "a rejected submission must never reach the core storage writer"
-        );
-        release_first_tx.send(()).expect("release first submission");
-        first
-            .await
-            .expect("first task joins")
-            .expect("first submission succeeds");
-    }
-
-    #[tokio::test]
     async fn expired_blocking_core_bridge_never_starts_a_blocking_job() {
         let admission = BlockingCoreBridge::new(NonZeroUsize::new(1).expect("non-zero capacity"));
         let started = Arc::new(AtomicBool::new(false));
@@ -1197,56 +1047,6 @@ mod tests {
             selected_graft,
             graft.as_ref() as &dyn AsyncMessageReceivedHookEmitter
         ));
-    }
-
-    #[tokio::test]
-    async fn cancelled_storage_writer_ingress_future_never_starts_after_capacity_returns() {
-        let admission = StorageWriterIngress::new(NonZeroUsize::new(1).expect("non-zero capacity"));
-        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let first_admission = admission.clone();
-        let first = tokio::spawn(async move {
-            first_admission
-                .submit(RequestDeadline::after(Duration::from_secs(1)), move || {
-                    first_started_tx.send(()).expect("signal started job");
-                    release_first_rx
-                        .blocking_recv()
-                        .expect("release started job");
-                    Ok(())
-                })
-                .await
-        });
-        first_started_rx.await.expect("first job starts");
-
-        let cancelled_job_started = Arc::new(AtomicBool::new(false));
-        let cancelled_job_flag = Arc::clone(&cancelled_job_started);
-        let waiting_admission = admission.clone();
-        let waiting = tokio::spawn(async move {
-            waiting_admission
-                .submit(RequestDeadline::after(Duration::from_secs(1)), move || {
-                    cancelled_job_flag.store(true, Ordering::SeqCst);
-                    Ok(())
-                })
-                .await
-        });
-        tokio::task::yield_now().await;
-        waiting.abort();
-        assert!(
-            waiting
-                .await
-                .expect_err("waiter is cancelled")
-                .is_cancelled()
-        );
-
-        release_first_tx.send(()).expect("release first job");
-        first
-            .await
-            .expect("first task joins")
-            .expect("first durable result");
-        assert!(
-            !cancelled_job_started.load(Ordering::SeqCst),
-            "cancelling while queued removes the job before it can start"
-        );
     }
 
     #[tokio::test]

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -94,6 +94,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         messages: storage.message_store(),
         rosters: storage.roster_store(),
     };
+    let async_message_store = storage.async_message_store();
     let nudge_template_override_store = storage.nudge_template_override_store();
     let peer_config_store = storage.peer_config_store();
     let outbound_message_query = storage.outbound_message_query();
@@ -102,7 +103,8 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         storage_backends.rosters.clone(),
         Arc::clone(&nudge_template_override_store),
         inputs.non_claude_outbound,
-    );
+    )
+    .with_async_message_store(async_message_store);
     let doctor_ports = runtime_doctor_ports(Arc::new(RuntimeConfigDoctor {
         config_current_dir: Some(inputs.config_current_dir),
     }));

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -21,6 +21,8 @@ serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
+tokio.workspace = true
+async-trait.workspace = true
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 rusqlite = { version = "0.33.0", features = ["bundled", "hooks"] }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -541,6 +541,10 @@ impl MessageStore for SqliteMessageStore {
 
 #[async_trait::async_trait]
 impl AsyncMessageStore for SqliteMessageStore {
+    async fn list_messages_async(&self, query: MessageQuery) -> Result<Vec<Message>, AtmError> {
+        self.db.submit_list_messages_async(query).await
+    }
+
     async fn save_message_if_absent_async(
         &self,
         message: Message,
@@ -1057,6 +1061,33 @@ mod tests {
             Some(original),
             "duplicate admission receives the existing immutable record"
         );
+    }
+
+    #[tokio::test]
+    async fn sqlite_backend_async_mailbox_projection_uses_the_writer_lane() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.async_message_store();
+        let first = message("atm:async-projection-first", "first");
+        let second = message("atm:async-projection-second", "second");
+        backend
+            .message_store()
+            .save_messages_atomically(&[first.clone(), second.clone()])
+            .expect("seed mailbox");
+
+        let projection = store
+            .list_messages_async(MessageQuery {
+                team: team(),
+                agent: agent(),
+                sender: None,
+                task_id: None,
+                limit: None,
+            })
+            .await
+            .expect("async writer-owned mailbox projection");
+
+        assert_eq!(projection.len(), 2);
+        assert!(projection.contains(&first));
+        assert!(projection.contains(&second));
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -23,8 +23,9 @@ pub use crate::observability::{
     SqliteObservabilityOutcome,
 };
 use atm_storage::contract::{
-    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, MailboxBucketCounts,
-    Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, AsyncMessageStore,
+    MailboxBucketCounts, Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore,
+    RosterStore,
 };
 #[cfg(test)]
 use atm_storage::schema::ThreadMode;
@@ -538,6 +539,24 @@ impl MessageStore for SqliteMessageStore {
     }
 }
 
+#[async_trait::async_trait]
+impl AsyncMessageStore for SqliteMessageStore {
+    async fn save_message_if_absent_async(
+        &self,
+        message: Message,
+    ) -> Result<Option<Message>, AtmError> {
+        self.db.submit_upsert_message_async(message).await
+    }
+
+    async fn acknowledge_message_atomically_async(
+        &self,
+        source: AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        self.db.submit_acknowledgement_async(source, builder).await
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SqliteStorageBackend {
     message_store: Arc<SqliteMessageStore>,
@@ -578,6 +597,7 @@ impl StorageFactory for SqliteStorageFactory {
         let backend = SqliteStorageBackend::new(self.database_path(durable_state_root))?;
         Ok(StorageHandles::new(
             backend.message_store(),
+            backend.async_message_store(),
             backend.roster_store(),
             backend.nudge_template_override_store(),
             backend.peer_config_store(),
@@ -622,6 +642,10 @@ impl SqliteStorageBackend {
     }
 
     pub fn message_store(&self) -> Arc<dyn MessageStore + Send + Sync> {
+        self.message_store.clone()
+    }
+
+    pub fn async_message_store(&self) -> Arc<dyn AsyncMessageStore + Send + Sync> {
         self.message_store.clone()
     }
 
@@ -1008,6 +1032,30 @@ mod tests {
                 .expect("load stored message"),
             Some(original),
             "a duplicate admission does not replace the original immutable record"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_backend_async_admission_is_idempotent_and_uses_the_writer_lane() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.async_message_store();
+        let original = message("atm:async-admit-once", "immutable payload");
+
+        assert_eq!(
+            store
+                .save_message_if_absent_async(original.clone())
+                .await
+                .expect("first async admission"),
+            None,
+            "first admission is durable through the writer lane"
+        );
+        assert_eq!(
+            store
+                .save_message_if_absent_async(original.clone())
+                .await
+                .expect("duplicate async admission"),
+            Some(original),
+            "duplicate admission receives the existing immutable record"
         );
     }
 

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -323,10 +323,39 @@ impl SharedDb {
             .writer
             .submit(WriteOp::UpsertMessage(Box::new(record)))?;
         match result {
-            WriteOpResult::UpsertMessage { inserted } => Ok(inserted),
+            WriteOpResult::UpsertMessage { inserted, .. } => Ok(inserted),
             WriteOpResult::UpsertMessages | WriteOpResult::Acknowledged(_) => {
                 Err(AtmError::daemon_unavailable(
                     "sqlite writer returned the wrong result for message upsert",
+                ))
+            }
+        }
+    }
+
+    pub(crate) async fn submit_upsert_message_async(
+        &self,
+        record: Message,
+    ) -> Result<Option<Message>, AtmError> {
+        validate_upsert_message_request(&record)?;
+        match self
+            .writer
+            .submit_async(WriteOp::UpsertMessage(Box::new(record)))
+            .await?
+        {
+            WriteOpResult::UpsertMessage { inserted: true, .. } => Ok(None),
+            WriteOpResult::UpsertMessage {
+                inserted: false,
+                existing: Some(existing),
+            } => Ok(Some(*existing)),
+            WriteOpResult::UpsertMessage {
+                inserted: false,
+                existing: None,
+            } => Err(AtmError::daemon_unavailable(
+                "sqlite writer reported a duplicate without its retained record",
+            )),
+            WriteOpResult::UpsertMessages | WriteOpResult::Acknowledged(_) => {
+                Err(AtmError::daemon_unavailable(
+                    "sqlite writer returned the wrong result for async message upsert",
                 ))
             }
         }
@@ -366,6 +395,25 @@ impl SharedDb {
             WriteOpResult::UpsertMessage { .. } | WriteOpResult::UpsertMessages => {
                 Err(AtmError::daemon_unavailable(
                     "sqlite writer returned the wrong result for acknowledgement admission",
+                ))
+            }
+        }
+    }
+
+    pub(crate) async fn submit_acknowledgement_async(
+        &self,
+        source: AcknowledgementSource,
+        builder: std::sync::Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        match self
+            .writer
+            .submit_async(WriteOp::Acknowledge { source, builder })
+            .await?
+        {
+            WriteOpResult::Acknowledged(commit) => Ok(*commit),
+            WriteOpResult::UpsertMessage { .. } | WriteOpResult::UpsertMessages => {
+                Err(AtmError::daemon_unavailable(
+                    "sqlite writer returned the wrong result for async acknowledgement admission",
                 ))
             }
         }

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -6,6 +6,7 @@ use crate::observability::{
 use crate::writer::{SqliteWriter, WriteOp, WriteOpResult, validate_upsert_message_request};
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message,
+    MessageQuery,
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::ThreadMode;
@@ -324,11 +325,11 @@ impl SharedDb {
             .submit(WriteOp::UpsertMessage(Box::new(record)))?;
         match result {
             WriteOpResult::UpsertMessage { inserted, .. } => Ok(inserted),
-            WriteOpResult::UpsertMessages | WriteOpResult::Acknowledged(_) => {
-                Err(AtmError::daemon_unavailable(
-                    "sqlite writer returned the wrong result for message upsert",
-                ))
-            }
+            WriteOpResult::Messages(_)
+            | WriteOpResult::UpsertMessages
+            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for message upsert",
+            )),
         }
     }
 
@@ -353,11 +354,11 @@ impl SharedDb {
             } => Err(AtmError::daemon_unavailable(
                 "sqlite writer reported a duplicate without its retained record",
             )),
-            WriteOpResult::UpsertMessages | WriteOpResult::Acknowledged(_) => {
-                Err(AtmError::daemon_unavailable(
-                    "sqlite writer returned the wrong result for async message upsert",
-                ))
-            }
+            WriteOpResult::Messages(_)
+            | WriteOpResult::UpsertMessages
+            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for async message upsert",
+            )),
         }
     }
 
@@ -374,11 +375,11 @@ impl SharedDb {
         let result = self.writer.submit(WriteOp::UpsertMessages(records))?;
         match result {
             WriteOpResult::UpsertMessages => Ok(()),
-            WriteOpResult::UpsertMessage { .. } | WriteOpResult::Acknowledged(_) => {
-                Err(AtmError::daemon_unavailable(
-                    "sqlite writer returned the wrong result for atomic message commit",
-                ))
-            }
+            WriteOpResult::Messages(_)
+            | WriteOpResult::UpsertMessage { .. }
+            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for atomic message commit",
+            )),
         }
     }
 
@@ -392,11 +393,11 @@ impl SharedDb {
             .submit(WriteOp::Acknowledge { source, builder })?
         {
             WriteOpResult::Acknowledged(commit) => Ok(*commit),
-            WriteOpResult::UpsertMessage { .. } | WriteOpResult::UpsertMessages => {
-                Err(AtmError::daemon_unavailable(
-                    "sqlite writer returned the wrong result for acknowledgement admission",
-                ))
-            }
+            WriteOpResult::Messages(_)
+            | WriteOpResult::UpsertMessage { .. }
+            | WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for acknowledgement admission",
+            )),
         }
     }
 
@@ -411,11 +412,29 @@ impl SharedDb {
             .await?
         {
             WriteOpResult::Acknowledged(commit) => Ok(*commit),
-            WriteOpResult::UpsertMessage { .. } | WriteOpResult::UpsertMessages => {
-                Err(AtmError::daemon_unavailable(
-                    "sqlite writer returned the wrong result for async acknowledgement admission",
-                ))
-            }
+            WriteOpResult::Messages(_)
+            | WriteOpResult::UpsertMessage { .. }
+            | WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for async acknowledgement admission",
+            )),
+        }
+    }
+
+    pub(crate) async fn submit_list_messages_async(
+        &self,
+        query: MessageQuery,
+    ) -> Result<Vec<Message>, AtmError> {
+        match self
+            .writer
+            .submit_async(WriteOp::ListMessages(query))
+            .await?
+        {
+            WriteOpResult::Messages(messages) => Ok(messages),
+            WriteOpResult::UpsertMessage { .. }
+            | WriteOpResult::UpsertMessages
+            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for async mailbox projection",
+            )),
         }
     }
 

--- a/crates/atm-storage-rusqlite/src/writer/mod.rs
+++ b/crates/atm-storage-rusqlite/src/writer/mod.rs
@@ -14,17 +14,11 @@ use atm_storage::{AtmError, AtmErrorCode};
 use rusqlite::TransactionBehavior;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 pub(crate) const CHANNEL_CAPACITY: usize = 256;
-// Local admission must sustain at least 1,000 request/response writes per
-// second even when a connection serializes frames.  A 2 ms collection window
-// alone capped that path at 500 writes/s.  This short window still coalesces
-// concurrently-arriving work without making a lone durable write wait longer
-// than the admission latency budget permits.
-pub(crate) const BATCH_TIME_BUDGET: Duration = Duration::from_millis(1);
 // Bound one write request long enough for a short lock wait + flush cycle while
 // still surfacing wedged durable-state work as an actionable timeout.
 const WRITE_OP_DEADLINE: Duration = Duration::from_secs(10);
@@ -33,7 +27,23 @@ const WRITE_OP_DEADLINE: Duration = Duration::from_secs(10);
 const WRITER_SHUTDOWN_JOIN_DEADLINE: Duration = Duration::from_secs(5);
 const SUBMIT_RETRY_INTERVAL: Duration = Duration::from_millis(5);
 
-type ReplyTx = SyncSender<Result<WriteOpResult, AtmError>>;
+enum ReplyTx {
+    Sync(SyncSender<Result<WriteOpResult, AtmError>>),
+    Async(tokio::sync::oneshot::Sender<Result<WriteOpResult, AtmError>>),
+}
+
+impl ReplyTx {
+    fn send(self, result: Result<WriteOpResult, AtmError>) {
+        match self {
+            Self::Sync(sender) => {
+                let _ = sender.send(result);
+            }
+            Self::Async(sender) => {
+                let _ = sender.send(result);
+            }
+        }
+    }
+}
 
 enum WriterMessage {
     Submit { op: Box<WriteOp>, reply: ReplyTx },
@@ -46,7 +56,7 @@ struct QueuedWrite {
 }
 
 pub(crate) struct SqliteWriter {
-    sender: Option<SyncSender<WriterMessage>>,
+    sender: Option<tokio::sync::mpsc::Sender<WriterMessage>>,
     worker: Option<JoinHandle<()>>,
     observability: Arc<dyn SqliteObservability>,
     write_op_deadline: Duration,
@@ -88,7 +98,7 @@ impl SqliteWriter {
         let mut connection = open_writer_connection_for_target(target.as_ref())?;
         ensure_schema(&mut connection, target.as_ref())?;
 
-        let (sender, receiver) = mpsc::sync_channel(channel_capacity);
+        let (sender, receiver) = tokio::sync::mpsc::channel(channel_capacity);
         let worker_observability = Arc::clone(&observability);
         let worker = thread::Builder::new()
             .name("atm-sqlite-writer".to_string())
@@ -130,12 +140,12 @@ impl SqliteWriter {
         let deadline = Instant::now() + self.write_op_deadline;
         let mut message = WriterMessage::Submit {
             op: Box::new(op),
-            reply: reply_tx,
+            reply: ReplyTx::Sync(reply_tx),
         };
         loop {
             match sender.try_send(message) {
                 Ok(()) => break,
-                Err(TrySendError::Full(returned)) => {
+                Err(tokio::sync::mpsc::error::TrySendError::Full(returned)) => {
                     if Instant::now() >= deadline {
                         let error = writer_queue_timeout_error(self.write_op_deadline);
                         self.observability
@@ -150,7 +160,7 @@ impl SqliteWriter {
                     message = returned;
                     thread::park_timeout(SUBMIT_RETRY_INTERVAL);
                 }
-                Err(TrySendError::Disconnected(_)) => {
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                     let error = writer_channel_closed_error();
                     self.observability
                         .emit_or_warn(SqliteObservabilityEvent::new(
@@ -190,6 +200,75 @@ impl SqliteWriter {
                 }
             })?
     }
+
+    /// Enqueues one operation without blocking the Tokio executor, then awaits
+    /// the reply from the single synchronous SQLite writer thread.
+    pub(crate) async fn submit_async(&self, op: WriteOp) -> Result<WriteOpResult, AtmError> {
+        let sender = self.sender.as_ref().ok_or_else(|| {
+            let error = writer_channel_closed_error();
+            self.observability
+                .emit_or_warn(SqliteObservabilityEvent::new(
+                    "writer_submit",
+                    SqliteObservabilityOutcome::Failed,
+                    error.message().to_owned(),
+                    Some(error.code()),
+                ));
+            error
+        })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        let message = WriterMessage::Submit {
+            op: Box::new(op),
+            reply: ReplyTx::Async(reply_tx),
+        };
+        tokio::time::timeout(self.write_op_deadline, sender.send(message))
+            .await
+            .map_err(|_| {
+                let error = writer_queue_timeout_error(self.write_op_deadline);
+                self.observability
+                    .emit_or_warn(SqliteObservabilityEvent::new(
+                        "writer_submit",
+                        SqliteObservabilityOutcome::Timeout,
+                        error.message().to_owned(),
+                        Some(error.code()),
+                    ));
+                error
+            })?
+            .map_err(|_| {
+                let error = writer_channel_closed_error();
+                self.observability
+                    .emit_or_warn(SqliteObservabilityEvent::new(
+                        "writer_submit",
+                        SqliteObservabilityOutcome::Failed,
+                        error.message().to_owned(),
+                        Some(error.code()),
+                    ));
+                error
+            })?;
+        tokio::time::timeout(self.write_op_deadline, reply_rx)
+            .await
+            .map_err(|_| {
+                let error = writer_reply_timeout_error(self.write_op_deadline);
+                self.observability
+                    .emit_or_warn(SqliteObservabilityEvent::new(
+                        "writer_reply",
+                        SqliteObservabilityOutcome::Timeout,
+                        error.message().to_owned(),
+                        Some(error.code()),
+                    ));
+                error
+            })?
+            .map_err(|_| {
+                let error = writer_reply_channel_closed_error();
+                self.observability
+                    .emit_or_warn(SqliteObservabilityEvent::new(
+                        "writer_reply",
+                        SqliteObservabilityOutcome::Failed,
+                        error.message().to_owned(),
+                        Some(error.code()),
+                    ));
+                error
+            })?
+    }
 }
 
 impl Drop for SqliteWriter {
@@ -199,11 +278,11 @@ impl Drop for SqliteWriter {
 
         if let Some(sender) = sender {
             match sender.try_send(WriterMessage::Shutdown) {
-                Ok(()) | Err(TrySendError::Disconnected(_)) => {}
+                Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
                 // Accepted risk: std::sync::mpsc::SyncSender does not expose a
                 // queue-depth probe here, so shutdown logging cannot report an
                 // exact depth without replacing the channel primitive.
-                Err(TrySendError::Full(_)) => {
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                     let detail = "sqlite writer shutdown signal skipped because the bounded queue was full; relying on channel disconnect to let the writer exit once in-flight work drains";
                     tracing::warn!("{detail}");
                     self.observability
@@ -300,14 +379,17 @@ fn writer_unavailable_reply_error() -> AtmError {
     AtmError::daemon_unavailable("sqlite writer is unavailable during shutdown")
 }
 
-fn drain_submit_replies(receiver: &Receiver<WriterMessage>) {
+fn drain_submit_replies(receiver: &mut tokio::sync::mpsc::Receiver<WriterMessage>) {
     loop {
         match receiver.try_recv() {
             Ok(WriterMessage::Submit { reply, .. }) => {
-                let _ = reply.send(Err(writer_unavailable_reply_error()));
+                reply.send(Err(writer_unavailable_reply_error()));
             }
             Ok(WriterMessage::Shutdown) => continue,
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            Err(
+                tokio::sync::mpsc::error::TryRecvError::Empty
+                | tokio::sync::mpsc::error::TryRecvError::Disconnected,
+            ) => break,
         }
     }
 }
@@ -345,17 +427,17 @@ fn checkpoint_writer_connection(
 fn writer_loop(
     target: Arc<SharedDbTarget>,
     mut connection: SqliteConnection,
-    receiver: Receiver<WriterMessage>,
+    mut receiver: tokio::sync::mpsc::Receiver<WriterMessage>,
     observability: Arc<dyn SqliteObservability>,
 ) {
     let mut cache = stmt_cache::WriterStatementCache;
     let mut shutting_down = false;
     loop {
-        let Some(first) = receive_first_message(&receiver, shutting_down) else {
+        let Some(first) = receive_first_message(&mut receiver, shutting_down) else {
             break;
         };
         let mut batch = vec![first];
-        if collect_batch(&receiver, &mut batch, &mut shutting_down).is_none() {
+        if collect_batch(&mut receiver, &mut batch, &mut shutting_down).is_none() {
             break;
         }
         process_batch(&target, &mut connection, &mut cache, batch);
@@ -364,7 +446,7 @@ fn writer_loop(
 }
 
 fn receive_first_message(
-    receiver: &Receiver<WriterMessage>,
+    receiver: &mut tokio::sync::mpsc::Receiver<WriterMessage>,
     shutting_down: bool,
 ) -> Option<QueuedWrite> {
     if shutting_down {
@@ -374,26 +456,28 @@ fn receive_first_message(
                 drain_submit_replies(receiver);
                 None
             }
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => None,
+            Err(
+                tokio::sync::mpsc::error::TryRecvError::Empty
+                | tokio::sync::mpsc::error::TryRecvError::Disconnected,
+            ) => None,
         }
     } else {
-        match receiver.recv() {
-            Ok(WriterMessage::Submit { op, reply }) => Some(QueuedWrite { op, reply }),
-            Ok(WriterMessage::Shutdown) => {
+        match receiver.blocking_recv() {
+            Some(WriterMessage::Submit { op, reply }) => Some(QueuedWrite { op, reply }),
+            Some(WriterMessage::Shutdown) => {
                 drain_submit_replies(receiver);
                 None
             }
-            Err(_) => None,
+            None => None,
         }
     }
 }
 
 fn collect_batch(
-    receiver: &Receiver<WriterMessage>,
+    receiver: &mut tokio::sync::mpsc::Receiver<WriterMessage>,
     batch: &mut Vec<QueuedWrite>,
     shutting_down: &mut bool,
 ) -> Option<()> {
-    let deadline = Instant::now() + BATCH_TIME_BUDGET;
     // The admission channel is already bounded. Drain every write that has
     // arrived during the fixed coalescing window into one durable commit;
     // an arbitrary operation-count ceiling would turn a burst into repeated
@@ -408,30 +492,17 @@ fn collect_batch(
                 *shutting_down = true;
                 continue;
             }
-            Err(TryRecvError::Disconnected) => {
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
                 *shutting_down = true;
                 return Some(());
             }
-            Err(TryRecvError::Empty) => {
-                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                    break;
-                };
-                if remaining.is_zero() {
-                    break;
-                }
-                match receiver.recv_timeout(remaining) {
-                    Ok(WriterMessage::Submit { op, reply }) => {
-                        batch.push(QueuedWrite { op, reply });
-                    }
-                    Ok(WriterMessage::Shutdown) => {
-                        *shutting_down = true;
-                    }
-                    Err(RecvTimeoutError::Timeout) => break,
-                    Err(RecvTimeoutError::Disconnected) => {
-                        *shutting_down = true;
-                        return Some(());
-                    }
-                }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                // Tokio's bounded channel keeps the async side cancellable;
+                // drain every operation already admitted to preserve one
+                // ordered SQLite transaction for a concurrent burst. Waiting
+                // for a later arrival would block this dedicated writer thread
+                // and merely add latency to a lone durable write.
+                break;
             }
         }
     }
@@ -481,7 +552,7 @@ fn process_batch(
         } else {
             result
         };
-        let _ = reply.send(final_result);
+        reply.send(final_result);
     }
 }
 
@@ -496,7 +567,7 @@ fn send_batch_transaction_open_error(
         error,
     );
     for queued in batch {
-        let _ = queued.reply.send(Err(copy_error(target, &error)));
+        queued.reply.send(Err(copy_error(target, &error)));
     }
 }
 
@@ -571,24 +642,24 @@ mod tests {
         let (reply, _receiver) = mpsc::sync_channel(1);
         WriterMessage::Submit {
             op: Box::new(WriteOp::UpsertMessages(Vec::new())),
-            reply,
+            reply: ReplyTx::Sync(reply),
         }
     }
 
     #[test]
-    fn batch_collection_drains_all_currently_queued_writes_within_its_window() {
-        let (sender, receiver) = mpsc::sync_channel(128);
-        sender.send(queued_write()).expect("first queued write");
+    fn batch_collection_drains_all_currently_queued_writes() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(128);
+        sender.try_send(queued_write()).expect("first queued write");
         for _ in 0..96 {
-            sender.send(queued_write()).expect("queued write");
+            sender.try_send(queued_write()).expect("queued write");
         }
-        let WriterMessage::Submit { op, reply } = receiver.recv().expect("first write") else {
+        let WriterMessage::Submit { op, reply } = receiver.try_recv().expect("first write") else {
             panic!("test queue contains only submit messages");
         };
         let mut batch = vec![QueuedWrite { op, reply }];
         let mut shutting_down = false;
 
-        collect_batch(&receiver, &mut batch, &mut shutting_down).expect("batch collection");
+        collect_batch(&mut receiver, &mut batch, &mut shutting_down).expect("batch collection");
 
         assert_eq!(batch.len(), 97);
         assert!(!shutting_down);

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -139,28 +139,42 @@ fn execute_list_messages(
             sqlite_error(target, "failed to execute writer mailbox projection", error)
         })?;
 
-    let mut messages = Vec::new();
-    for row in rows {
-        let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row
-            .map_err(
-            |error| sqlite_error(target, "failed to decode writer mailbox projection", error),
-        )?;
-        let mut envelope =
-            serde_json::from_str::<MessageEnvelope>(&envelope_json).map_err(|_| {
-                AtmError::mailbox_read("failed to decode writer mailbox projection envelope")
-            })?;
-        envelope.read = read != 0;
-        envelope.pending_ack_at = parse_timestamp(pending_ack_at, "pending_ack_at")?;
-        envelope.acknowledged_at = parse_timestamp(acknowledged_at, "acknowledged_at")?;
-        envelope.expires_at = parse_timestamp(expires_at, "expires_at")?;
-        messages.push(Message {
-            team: query.team.clone(),
-            agent: query.agent.clone(),
-            message_key: MessageKey::new(message_key)?,
-            envelope,
-        });
-    }
-    Ok(WriteOpResult::Messages(messages))
+    rows.map(|row| decode_mailbox_projection_row(row, query, target))
+        .collect::<Result<Vec<_>, _>>()
+        .map(WriteOpResult::Messages)
+}
+
+type MailboxProjectionRow = (
+    String,
+    String,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn decode_mailbox_projection_row(
+    row: rusqlite::Result<MailboxProjectionRow>,
+    query: &MessageQuery,
+    target: &SharedDbTarget,
+) -> Result<Message, AtmError> {
+    let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row
+        .map_err(|error| {
+            sqlite_error(target, "failed to decode writer mailbox projection", error)
+        })?;
+    let mut envelope = serde_json::from_str::<MessageEnvelope>(&envelope_json).map_err(|_| {
+        AtmError::mailbox_read("failed to decode writer mailbox projection envelope")
+    })?;
+    envelope.read = read != 0;
+    envelope.pending_ack_at = parse_timestamp(pending_ack_at, "pending_ack_at")?;
+    envelope.acknowledged_at = parse_timestamp(acknowledged_at, "acknowledged_at")?;
+    envelope.expires_at = parse_timestamp(expires_at, "expires_at")?;
+    Ok(Message {
+        team: query.team.clone(),
+        agent: query.agent.clone(),
+        message_key: MessageKey::new(message_key)?,
+        envelope,
+    })
 }
 
 fn execute_acknowledgement(

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -2,6 +2,7 @@ use super::stmt_cache::WriterStatementCache;
 use crate::shared_db::{SharedDbTarget, serialize_json, sqlite_error, sqlite_thread_mode};
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message, MessageKey,
+    MessageQuery,
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::MessageEnvelope;
@@ -14,6 +15,10 @@ pub(crate) const MAX_ENVELOPE_JSON_BYTES: usize = 1_048_576;
 
 #[derive(Clone)]
 pub(crate) enum WriteOp {
+    /// A read projection executed by the single SQLite owner so a Tokio
+    /// request never opens a synchronous reader connection for thread
+    /// validation.
+    ListMessages(MessageQuery),
     UpsertMessage(Box<Message>),
     /// A related group of immutable records that must either all become
     /// visible or none do.  AI.31 uses this for the ACK reply and the
@@ -28,6 +33,7 @@ pub(crate) enum WriteOp {
 impl std::fmt::Debug for WriteOp {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::ListMessages(_) => formatter.write_str("ListMessages(..)"),
             Self::UpsertMessage(_) => formatter.write_str("UpsertMessage(..)"),
             Self::UpsertMessages(_) => formatter.write_str("UpsertMessages(..)"),
             Self::Acknowledge { source, .. } => formatter
@@ -40,6 +46,7 @@ impl std::fmt::Debug for WriteOp {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum WriteOpResult {
+    Messages(Vec<Message>),
     UpsertMessage {
         inserted: bool,
         /// Populated only when an immutable-key duplicate won the admission
@@ -58,6 +65,7 @@ pub(crate) fn execute(
     target: &SharedDbTarget,
 ) -> Result<WriteOpResult, AtmError> {
     match op {
+        WriteOp::ListMessages(query) => execute_list_messages(query, connection, target),
         WriteOp::UpsertMessage(request) => {
             execute_upsert_message(request, connection, cache, target)
         }
@@ -71,6 +79,88 @@ pub(crate) fn execute(
             execute_acknowledgement(source, builder, connection, cache, target)
         }
     }
+}
+
+fn execute_list_messages(
+    query: &MessageQuery,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<WriteOpResult, AtmError> {
+    let limit = query
+        .limit
+        .map(|value| i64::try_from(value).unwrap_or(i64::MAX))
+        .unwrap_or(-1);
+    let mut statement = connection
+        .prepare(
+            "SELECT mail_messages.message_key, mail_messages.envelope_json,
+                    mail_message_states.read, mail_message_states.pending_ack_at,
+                    mail_message_states.acknowledged_at, mail_message_states.expires_at
+             FROM mail_messages
+             JOIN mail_message_states
+               ON mail_message_states.team = mail_messages.team
+              AND mail_message_states.agent = mail_messages.agent
+              AND mail_message_states.message_key = mail_messages.message_key
+             WHERE mail_messages.team = ?1
+               AND mail_messages.agent = ?2
+               AND (?3 IS NULL OR mail_messages.from_agent = ?3)
+               AND (?4 IS NULL OR json_extract(mail_messages.envelope_json, '$.taskId') = ?4)
+               AND mail_message_states.deleted_at IS NULL
+               AND (
+                    mail_message_states.expires_at IS NULL
+                    OR mail_message_states.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+               )
+             ORDER BY mail_messages.message_at DESC, mail_messages.message_key DESC
+             LIMIT ?5",
+        )
+        .map_err(|error| {
+            sqlite_error(target, "failed to prepare writer mailbox projection", error)
+        })?;
+    let rows = statement
+        .query_map(
+            params![
+                query.team.as_str(),
+                query.agent.as_str(),
+                query.sender.as_ref().map(|value| value.as_str()),
+                query.task_id.as_ref().map(|value| value.as_str()),
+                limit,
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .map_err(|error| {
+            sqlite_error(target, "failed to execute writer mailbox projection", error)
+        })?;
+
+    let mut messages = Vec::new();
+    for row in rows {
+        let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row
+            .map_err(
+            |error| sqlite_error(target, "failed to decode writer mailbox projection", error),
+        )?;
+        let mut envelope =
+            serde_json::from_str::<MessageEnvelope>(&envelope_json).map_err(|_| {
+                AtmError::mailbox_read("failed to decode writer mailbox projection envelope")
+            })?;
+        envelope.read = read != 0;
+        envelope.pending_ack_at = parse_timestamp(pending_ack_at, "pending_ack_at")?;
+        envelope.acknowledged_at = parse_timestamp(acknowledged_at, "acknowledged_at")?;
+        envelope.expires_at = parse_timestamp(expires_at, "expires_at")?;
+        messages.push(Message {
+            team: query.team.clone(),
+            agent: query.agent.clone(),
+            message_key: MessageKey::new(message_key)?,
+            envelope,
+        });
+    }
+    Ok(WriteOpResult::Messages(messages))
 }
 
 fn execute_acknowledgement(

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -1,11 +1,11 @@
 use super::stmt_cache::WriterStatementCache;
-use crate::shared_db::{SharedDbTarget, serialize_json, sqlite_thread_mode};
+use crate::shared_db::{SharedDbTarget, serialize_json, sqlite_error, sqlite_thread_mode};
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message, MessageKey,
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::MessageEnvelope;
-use atm_storage::types::IsoTimestamp;
+use atm_storage::types::{AgentName, IsoTimestamp, TeamName};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use std::sync::Arc;
@@ -40,7 +40,13 @@ impl std::fmt::Debug for WriteOp {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum WriteOpResult {
-    UpsertMessage { inserted: bool },
+    UpsertMessage {
+        inserted: bool,
+        /// Populated only when an immutable-key duplicate won the admission
+        /// race. Loading it on the writer connection keeps async callers from
+        /// opening a synchronous reader connection after awaiting the queue.
+        existing: Option<Box<Message>>,
+    },
     UpsertMessages,
     Acknowledged(Box<AcknowledgementCommit>),
 }
@@ -313,7 +319,91 @@ fn execute_upsert_message(
         initial_state_timestamps(pending_ack_at, acknowledged_at, expires_at, recorded_at);
     insert_initial_message_state(connection, cache, target, record, timestamps)?;
 
-    Ok(WriteOpResult::UpsertMessage { inserted })
+    let existing = if inserted {
+        None
+    } else {
+        Some(Box::new(load_existing_message(record, connection, target)?))
+    };
+    Ok(WriteOpResult::UpsertMessage { inserted, existing })
+}
+
+fn load_existing_message(
+    requested: &Message,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<Message, AtmError> {
+    let row = connection
+        .query_row(
+            "SELECT mail_messages.team, mail_messages.agent, mail_messages.envelope_json,
+                    mail_message_states.read, mail_message_states.pending_ack_at,
+                    mail_message_states.acknowledged_at, mail_message_states.expires_at
+             FROM mail_messages
+             LEFT JOIN mail_message_states
+               ON mail_message_states.team = mail_messages.team
+              AND mail_message_states.agent = mail_messages.agent
+              AND mail_message_states.message_key = mail_messages.message_key
+             WHERE mail_messages.team = ?1
+               AND mail_messages.agent = ?2
+               AND mail_messages.message_key = ?3",
+            params![
+                requested.team.as_str(),
+                requested.agent.as_str(),
+                requested.message_key.as_ref(),
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<i64>>(3)?.unwrap_or_default(),
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|error| sqlite_error(target, "failed to load duplicate message", error))?
+        .ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "sqlite writer reported an existing message key but the retained record could not be loaded",
+            )
+        })?;
+    let (team, agent, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row;
+    let team = team.parse::<TeamName>().map_err(|error: AtmError| {
+        AtmError::validation(format!(
+            "failed to parse sqlite team for duplicate message {}: {error}",
+            requested.message_key
+        ))
+    })?;
+    let agent = agent.parse::<AgentName>().map_err(|error: AtmError| {
+        AtmError::validation(format!(
+            "failed to parse sqlite agent for duplicate message {}: {error}",
+            requested.message_key
+        ))
+    })?;
+    let mut envelope = serde_json::from_str::<MessageEnvelope>(&envelope_json)
+        .map_err(|_| AtmError::mailbox_read("failed to decode duplicate message envelope"))?;
+    envelope.read = read != 0;
+    envelope.pending_ack_at = parse_optional_timestamp(pending_ack_at, "pending_ack_at")?;
+    envelope.acknowledged_at = parse_optional_timestamp(acknowledged_at, "acknowledged_at")?;
+    envelope.expires_at = parse_optional_timestamp(expires_at, "expires_at")?;
+    Ok(Message {
+        team,
+        agent,
+        message_key: requested.message_key.clone(),
+        envelope,
+    })
+}
+
+fn parse_optional_timestamp(
+    value: Option<String>,
+    field: &str,
+) -> Result<Option<IsoTimestamp>, AtmError> {
+    value
+        .map(|value| value.parse::<IsoTimestamp>())
+        .transpose()
+        .map_err(|_| AtmError::mailbox_read(format!("duplicate message {field} is invalid")))
 }
 
 struct InitialStateTimestamps {

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -18,3 +18,4 @@ sha2.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
 ulid.workspace = true
+async-trait.workspace = true

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -566,6 +566,18 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
 /// async backpressure without exposing its transaction queue or database.
 #[async_trait::async_trait]
 pub trait AsyncMessageStore: MessageStore {
+    /// Materializes a mailbox projection through the backend-owned async lane.
+    ///
+    /// Threaded-message validation needs this snapshot before it can submit
+    /// its immutable successor. The Tokio daemon must therefore not fall back
+    /// to [`MessageStore::list_messages`], which can synchronously open a
+    /// database reader on a request worker.
+    async fn list_messages_async(&self, _query: MessageQuery) -> Result<Vec<Message>, AtmError> {
+        Err(AtmError::daemon_unavailable(
+            "message store does not implement async mailbox projection admission",
+        ))
+    }
+
     /// Makes one immutable message durable, or returns the record that already
     /// owns its key, without blocking the Tokio request executor.
     async fn save_message_if_absent_async(

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -554,6 +554,38 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError>;
 }
 
+/// Async durable-admission boundary used by the Tokio HTTP runtime.
+///
+/// The future represents bounded admission to the backend's one ordered write
+/// lane and the durable result from that lane. Implementations may keep the
+/// actual database connection synchronous; callers must never create a
+/// blocking task merely to submit or await a message write.
+///
+/// `MessageStore` remains the compatibility surface for non-Tokio callers.
+/// New daemon write paths use this trait so an implementation can provide
+/// async backpressure without exposing its transaction queue or database.
+#[async_trait::async_trait]
+pub trait AsyncMessageStore: MessageStore {
+    /// Makes one immutable message durable, or returns the record that already
+    /// owns its key, without blocking the Tokio request executor.
+    async fn save_message_if_absent_async(
+        &self,
+        message: Message,
+    ) -> Result<Option<Message>, AtmError> {
+        self.save_message_if_absent(&message)
+    }
+
+    /// Resolves a pending acknowledgement source, persists its reply, and
+    /// transitions that source as one async durable admission.
+    async fn acknowledge_message_atomically_async(
+        &self,
+        source: AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        self.acknowledge_message_atomically(&source, builder)
+    }
+}
+
 pub trait RosterStore: sealed::Sealed + Send + Sync {
     fn load_roster(&self, team: &TeamName) -> Result<RosterSnapshot, AtmError>;
     fn save_roster(&self, roster: &RosterSnapshot) -> Result<(), AtmError>;

--- a/crates/atm-storage/src/factory.rs
+++ b/crates/atm-storage/src/factory.rs
@@ -3,14 +3,15 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::{
-    AtmError, MessageStore, NudgeTemplateOverrideStore, OutboundMessageQuery, PeerConfigStore,
-    RosterStore,
+    AsyncMessageStore, AtmError, MessageStore, NudgeTemplateOverrideStore, OutboundMessageQuery,
+    PeerConfigStore, RosterStore,
 };
 
 /// Backend-neutral handles returned by the selected durable storage backend.
 #[derive(Clone)]
 pub struct StorageHandles {
     message_store: Arc<dyn MessageStore + Send + Sync>,
+    async_message_store: Arc<dyn AsyncMessageStore + Send + Sync>,
     roster_store: Arc<dyn RosterStore + Send + Sync>,
     nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
@@ -21,6 +22,7 @@ impl fmt::Debug for StorageHandles {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StorageHandles")
             .field("message_store", &"dyn MessageStore")
+            .field("async_message_store", &"dyn AsyncMessageStore")
             .field("roster_store", &"dyn RosterStore")
             .field(
                 "nudge_template_override_store",
@@ -35,6 +37,7 @@ impl fmt::Debug for StorageHandles {
 impl StorageHandles {
     pub fn new(
         message_store: Arc<dyn MessageStore + Send + Sync>,
+        async_message_store: Arc<dyn AsyncMessageStore + Send + Sync>,
         roster_store: Arc<dyn RosterStore + Send + Sync>,
         nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
         peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
@@ -42,6 +45,7 @@ impl StorageHandles {
     ) -> Self {
         Self {
             message_store,
+            async_message_store,
             roster_store,
             nudge_template_override_store,
             peer_config_store,
@@ -51,6 +55,11 @@ impl StorageHandles {
 
     pub fn message_store(&self) -> Arc<dyn MessageStore + Send + Sync> {
         Arc::clone(&self.message_store)
+    }
+
+    /// Returns the Tokio-safe durable message-admission boundary.
+    pub fn async_message_store(&self) -> Arc<dyn AsyncMessageStore + Send + Sync> {
+        Arc::clone(&self.async_message_store)
     }
 
     pub fn roster_store(&self) -> Arc<dyn RosterStore + Send + Sync> {

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -14,7 +14,8 @@ mod validation;
 // Protocol role identity for worker agents used in shared storage fixtures.
 pub const ROLE_WORKER: &str = "worker";
 pub use contract::{
-    AckRequirementState, AckTransition, AgentType, BuiltInNudgeTemplateKind,
+    AckRequirementState, AckTransition, AcknowledgementCommit, AcknowledgementReplyBuilder,
+    AcknowledgementSource, AgentType, AsyncMessageStore, BuiltInNudgeTemplateKind,
     CertificateFingerprint, HttpsInterface, LocalCertificate, MailMessageState,
     MailboxBucketCounts, Message, MessageFingerprint, MessageKey, MessageQuery,
     MessageReceivedEvent, MessageStore, NudgeTemplateOverrideStore, OutboundMessageQuery,

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -2,6 +2,19 @@
 
 This document records shared storage-neutral contracts owned by `atm-storage`.
 
+## AsyncMessageStore
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-storage/async-message-store.toml](../../boundaries/atm-storage/async-message-store.toml)
+
+`AsyncMessageStore` is the Tokio daemon's narrow durable-admission contract.
+It awaits bounded submission and a durable result without exposing SQLite,
+transactions, writer threads, or queue implementation. The concrete SQLite
+adapter owns one synchronous transaction thread; `atm-http-runtime` must use
+this contract for writes and must not introduce `spawn_blocking` for admission.
+`MessageStore` remains the temporary synchronous compatibility surface for
+non-Tokio callers until the migration is performance-proven.
+
 ## TlsHelpers
 
 Canonical machine-readable boundary source:


### PR DESCRIPTION
## Summary
- Replaces the HTTP write spawn_blocking bridge with sealed `AsyncMessageStore` admission: Tokio awaits bounded writer-queue admission and an async reply.
- One synchronous SQLite owner drains ordered queued writes into SQLite transactions.
- Normal writes and ACK writes both use this path. Legacy `atm-daemon` was not touched.

## Validation (arch-ctm, pre-PR)
- `just test`
- `cargo clippy -p atm-storage-rusqlite -p agent-team-mail-core -p atm-http-runtime --all-targets -D warnings`
- boundary lint
- `git diff --check`

## Test plan
- [ ] quality-mgr QA-1
- [ ] CI green
- [ ] After merge: M5 benchmark on the merged integration SHA

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>