### PR TITLE
fix(runtime): decompose HTTP admission path and close M5 throughput regression

### DIFF
--- a/.just/tests/test_benchmark_report.py
+++ b/.just/tests/test_benchmark_report.py
@@ -34,6 +34,29 @@ class BenchmarkReportTests(unittest.TestCase):
         self.assertEqual((uds["transport"], uds["frames_per_connection"]), ("uds", 1))
         self.assertEqual((tcp["transport"], tcp["frames_per_connection"]), ("tcp", 8))
 
+    def test_direct_sqlite_measurement_is_retained_and_rendered(self) -> None:
+        payload = json.loads(self.fixture("success-uds-f1.json").read_text(encoding="utf-8"))
+        payload["direct_sqlite_message_write"] = {
+            "kind": "async_storage_admission",
+            "requested_count": 10_000,
+            "accepted_count": 10_000,
+            "worker_count": 64,
+            "elapsed_seconds": 0.2,
+            "admissions_per_second": 50_000.0,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "result.json"
+            source.write_text(json.dumps(payload), encoding="utf-8")
+            result = REPORT.load_result(source)
+            with mock.patch.object(REPORT, "ROOT", ROOT):
+                panel = REPORT.render_run(result, "sqlite-probe", Path(directory))
+                aggregate = REPORT.render_aggregate([result], Path(directory))
+            panel_text = panel.read_text(encoding="utf-8")
+            aggregate_text = aggregate.read_text(encoding="utf-8")
+        self.assertEqual(result["direct_sqlite_message_write"]["accepted_count"], 10_000)
+        self.assertIn("50000.00", panel_text)
+        self.assertIn("Direct SQLite msg/s", aggregate_text)
+
     def test_source_revision_is_retained_only_when_it_is_a_git_revision(self) -> None:
         payload = json.loads(self.fixture("success-uds-f1.json").read_text(encoding="utf-8"))
         payload["source_revision"] = "a" * 40

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -96,6 +96,15 @@ class SignDaemonDevTests(unittest.TestCase):
             justfile,
         )
 
+    def test_benchmark_recipe_publishes_the_canonical_report(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn(
+            "    {{python_cmd}} scripts/smoke/run_admission_capacity.py {{args}}\n"
+            "    # Publish all captured variants into the canonical report site.\n"
+            "    {{python_cmd}} scripts/smoke/benchmark_report.py --rebuild",
+            justfile,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
  "fs2",
+ "serde_json",
  "tempfile",
  "tokio",
  "ulid",

--- a/Justfile
+++ b/Justfile
@@ -195,6 +195,8 @@ benchmark *args:
     cargo build --release -p atm-daemon-bootstrap --features benchmark-harness --bin atm-daemon-benchmark
     {{python_cmd}} .just/sign_daemon_dev.py
     {{python_cmd}} scripts/smoke/run_admission_capacity.py {{args}}
+    # Publish all captured variants into the canonical report site.
+    {{python_cmd}} scripts/smoke/benchmark_report.py --rebuild
 
 # Persist AI.40 benchmark JSON and render the aggregate public report.
 benchmark-report *args:

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -18,7 +18,9 @@ use crate::config;
 use crate::delivery_execution::{
     DeliveryTransitionContext, emit_delivery_plan_transitions, execute_delivery_plan,
 };
-use crate::delivery_policy::{DeliveryPolicyCoordinator, DeliveryRecipientSnapshot};
+use crate::delivery_policy::DeliveryPolicyCoordinator;
+#[cfg(test)]
+use crate::delivery_policy::DeliveryRecipientSnapshot;
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
@@ -41,6 +43,7 @@ pub mod input;
 pub(crate) mod nudge_template;
 mod persistence;
 mod post_write;
+mod received_hook;
 mod recipient;
 mod request;
 pub(crate) mod summary;
@@ -59,6 +62,7 @@ pub(crate) use persistence::persist_message;
 pub use post_write::{
     build_received_message_hook_dispatches_after_commit, emit_persisted_local_post_write,
 };
+use received_hook::{PreparedReceivedHook, prepare_received_hook};
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 use request::{prepare_threaded_message, resolve_message_body};
 #[cfg(test)]
@@ -262,17 +266,6 @@ pub struct PreparedWrite {
     #[cfg(test)]
     post_write: LocalPostWrite,
     acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
-}
-
-/// In-memory post-commit data retained by the replacement runtime.
-///
-/// The durable write has already completed when this is constructed. Keeping
-/// its resolved recipient and logical message avoids reopening a synchronous
-/// SQLite reader merely to reconstruct the hook dispatch after commit.
-struct PreparedReceivedHook {
-    recipient: ResolvedRecipient,
-    delivery_snapshot: DeliveryRecipientSnapshot,
-    messages: Vec<crate::delivery_plan::LogicalMessage>,
 }
 
 /// Selects the owner of non-durable delivery work after a write commits.
@@ -755,46 +748,13 @@ fn prepare_atomic_acknowledgement_write<
     })
 }
 
-fn prepared_received_hook<R: RetainedServiceRuntime + ?Sized>(
-    runtime: &R,
-    context: &SendExecutionContext,
-    persistence: &DeliveryPersistenceResult,
-    requires_ack: bool,
-    is_ack: bool,
-) -> Result<Option<PreparedReceivedHook>, AtmError> {
-    if !persistence.requires_post_write() {
-        return Ok(None);
-    }
-    // An origin write to a host-qualified address keeps a remote snapshot for
-    // admission, because its actual delivery belongs to the peer client. The
-    // historical post-commit hook still resolves this local recipient if the
-    // record was admitted here (notably the localhost compatibility path).
-    // Preserve that behavior without reloading the committed message record.
-    let delivery_snapshot = if context.delivery_snapshot.roster_backed {
-        context.delivery_snapshot.clone()
-    } else {
-        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
-            runtime,
-            &context.recipient.team,
-            &context.recipient.agent,
-        )?
-    };
-    let hook_context = SendExecutionContext {
-        #[cfg(test)]
-        post_send_config: None,
-        recipient: context.recipient.clone(),
-        canonical_sender: context.canonical_sender.clone(),
-        inbox_path: context.inbox_path.clone(),
-        delivery_snapshot: delivery_snapshot.clone(),
-        delivery_family: context.delivery_family,
-        warnings: Vec::new(),
-    };
-    let plan = build_send_delivery_plan(&hook_context, requires_ack, is_ack, persistence)?;
-    Ok(Some(PreparedReceivedHook {
-        recipient: context.recipient.clone(),
-        delivery_snapshot,
-        messages: plan.messages,
-    }))
+fn request_requires_ack(request: &SendRequest, task_id: &Option<TaskId>) -> bool {
+    request.requires_ack
+        || task_id.is_some()
+        || matches!(
+            &request.message_source,
+            SendMessageSource::File { path, .. } if file_policy::is_task_envelope(path)
+        )
 }
 
 fn prepare_persisted_write<
@@ -808,15 +768,7 @@ fn prepare_persisted_write<
 ) -> Result<PreparedWrite, AtmError> {
     let context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
-    // Team-lead dispatches XML task envelopes through `atm send --file`.
-    // Those messages render an immediate-ack instruction, so admission must
-    // create the matching durable pending-ack state even without --task-id.
-    let requires_ack = request.requires_ack
-        || task_id.is_some()
-        || matches!(
-            &request.message_source,
-            SendMessageSource::File { path, .. } if file_policy::is_task_envelope(path)
-        );
+    let requires_ack = request_requires_ack(&request, &task_id);
     let body = resolve_message_body(
         &request.message_source,
         &request.current_dir,
@@ -839,7 +791,7 @@ fn prepare_persisted_write<
         task_id.clone(),
         acknowledgement_source_update,
     )?;
-    let received_hook = prepared_received_hook(
+    let received_hook = prepare_received_hook(
         runtime,
         &context,
         &persistence,
@@ -891,12 +843,7 @@ async fn prepare_persisted_write_async(
 ) -> Result<PreparedWrite, AtmError> {
     let context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
-    let requires_ack = request.requires_ack
-        || task_id.is_some()
-        || matches!(
-            &request.message_source,
-            SendMessageSource::File { path, .. } if file_policy::is_task_envelope(path)
-        );
+    let requires_ack = request_requires_ack(&request, &task_id);
     let body = resolve_message_body(
         &request.message_source,
         &request.current_dir,
@@ -918,7 +865,7 @@ async fn prepare_persisted_write_async(
         task_id.clone(),
     )
     .await?;
-    let received_hook = prepared_received_hook(
+    let received_hook = prepare_received_hook(
         runtime,
         &context,
         &persistence,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -9,16 +9,15 @@ use tracing::warn;
 
 use crate::ack::AckOutcome;
 use crate::address::AgentAddress;
-use crate::boundary;
 #[cfg(test)]
 use crate::boundary::MessageReceivedHookEmitter;
+use crate::boundary::{self, BuiltInPostSendDispatch};
 use crate::caller_context::ActivityObservation;
 #[cfg(test)]
 use crate::config;
 use crate::delivery_execution::{
     DeliveryTransitionContext, emit_delivery_plan_transitions, execute_delivery_plan,
 };
-#[cfg(test)]
 use crate::delivery_policy::{DeliveryPolicyCoordinator, DeliveryRecipientSnapshot};
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
@@ -259,16 +258,29 @@ pub struct PreparedWrite {
     persisted_timestamp: IsoTimestamp,
     post_write_needed: bool,
     same_store_peer_receipt: bool,
+    received_hook: Result<Option<PreparedReceivedHook>, AtmError>,
     #[cfg(test)]
     post_write: LocalPostWrite,
     acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
 }
 
+/// In-memory post-commit data retained by the replacement runtime.
+///
+/// The durable write has already completed when this is constructed. Keeping
+/// its resolved recipient and logical message avoids reopening a synchronous
+/// SQLite reader merely to reconstruct the hook dispatch after commit.
+struct PreparedReceivedHook {
+    recipient: ResolvedRecipient,
+    delivery_snapshot: DeliveryRecipientSnapshot,
+    messages: Vec<crate::delivery_plan::LogicalMessage>,
+}
+
 /// Selects the owner of non-durable delivery work after a write commits.
 ///
-/// Direct/core callers retain the historical synchronous contract. The daemon
-/// selects `Deferred` only after its public response has a dedicated
-/// post-commit worker to reload the immutable record.
+/// Direct/core callers retain the historical synchronous contract. The
+/// replacement runtime selects `Deferred`: it retains all hook-planning data
+/// during the async durable write, so its post-commit path never has to reopen
+/// the just-written record through a synchronous storage reader.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeliveryExecutionMode {
     Inline,
@@ -378,6 +390,34 @@ impl PreparedWrite {
     #[must_use]
     pub fn is_peer_receipt(&self) -> bool {
         has_authenticated_peer_provenance(&self.outbound_request)
+    }
+
+    /// Builds receiver-hook dispatches from the write's retained in-memory
+    /// planning data. This is valid only after durable admission has returned
+    /// successfully; it deliberately never reloads the committed record.
+    pub fn build_received_hook_dispatches(
+        &self,
+        runtime: &LocalServiceRuntime,
+    ) -> Result<Vec<BuiltInPostSendDispatch>, AtmError> {
+        let post_write = match &self.received_hook {
+            Ok(Some(post_write)) => post_write,
+            Ok(None) => return Ok(Vec::new()),
+            Err(error) => return Err(error.clone()),
+        };
+        let mut dispatches = Vec::new();
+        for message in &post_write.messages {
+            let event = hook::post_send_event_from_message(
+                &post_write.recipient,
+                message,
+                post_write.delivery_snapshot.recipient_pane_id.as_ref(),
+            )?;
+            if let Some(dispatch) =
+                hook::build_built_in_dispatch(runtime, &post_write.delivery_snapshot, &event)
+            {
+                dispatches.push(dispatch);
+            }
+        }
+        Ok(dispatches)
     }
 }
 
@@ -681,16 +721,20 @@ fn prepare_atomic_acknowledgement_write<
         source_task_id,
         &reply.envelope.from,
     );
+    let delivery_snapshot = DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
+        _runtime,
+        &recipient.team,
+        &recipient.agent,
+    )?;
+    let logical = crate::delivery_plan::LogicalMessage::new(reply.envelope.clone(), false, true)
+        .map_err(|error| AtmError::mailbox_read(error.to_string()))?;
+    let received_hook = Ok(Some(PreparedReceivedHook {
+        recipient: recipient.clone(),
+        delivery_snapshot: delivery_snapshot.clone(),
+        messages: vec![logical.clone()],
+    }));
     #[cfg(test)]
     let post_write = {
-        let delivery_snapshot = DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
-            _runtime,
-            &recipient.team,
-            &recipient.agent,
-        )?;
-        let logical =
-            crate::delivery_plan::LogicalMessage::new(reply.envelope.clone(), false, true)
-                .map_err(|error| AtmError::mailbox_read(error.to_string()))?;
         LocalPostWrite {
             post_send_config: None,
             recipient,
@@ -704,10 +748,53 @@ fn prepare_atomic_acknowledgement_write<
         persisted_timestamp: reply.envelope.timestamp,
         post_write_needed: true,
         same_store_peer_receipt: false,
+        received_hook,
         #[cfg(test)]
         post_write,
         acknowledgement: Some(acknowledgement.acknowledgement),
     })
+}
+
+fn prepared_received_hook<R: RetainedServiceRuntime + ?Sized>(
+    runtime: &R,
+    context: &SendExecutionContext,
+    persistence: &DeliveryPersistenceResult,
+    requires_ack: bool,
+    is_ack: bool,
+) -> Result<Option<PreparedReceivedHook>, AtmError> {
+    if !persistence.requires_post_write() {
+        return Ok(None);
+    }
+    // An origin write to a host-qualified address keeps a remote snapshot for
+    // admission, because its actual delivery belongs to the peer client. The
+    // historical post-commit hook still resolves this local recipient if the
+    // record was admitted here (notably the localhost compatibility path).
+    // Preserve that behavior without reloading the committed message record.
+    let delivery_snapshot = if context.delivery_snapshot.roster_backed {
+        context.delivery_snapshot.clone()
+    } else {
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
+            runtime,
+            &context.recipient.team,
+            &context.recipient.agent,
+        )?
+    };
+    let hook_context = SendExecutionContext {
+        #[cfg(test)]
+        post_send_config: None,
+        recipient: context.recipient.clone(),
+        canonical_sender: context.canonical_sender.clone(),
+        inbox_path: context.inbox_path.clone(),
+        delivery_snapshot: delivery_snapshot.clone(),
+        delivery_family: context.delivery_family,
+        warnings: Vec::new(),
+    };
+    let plan = build_send_delivery_plan(&hook_context, requires_ack, is_ack, persistence)?;
+    Ok(Some(PreparedReceivedHook {
+        recipient: context.recipient.clone(),
+        delivery_snapshot,
+        messages: plan.messages,
+    }))
 }
 
 fn prepare_persisted_write<
@@ -752,6 +839,13 @@ fn prepare_persisted_write<
         task_id.clone(),
         acknowledgement_source_update,
     )?;
+    let received_hook = prepared_received_hook(
+        runtime,
+        &context,
+        &persistence,
+        requires_ack,
+        acknowledgement.is_some(),
+    );
     // A same-host HTTPS receipt deliberately reuses the origin ULID. Storage
     // skips its duplicate row and the receiver-only hook is likewise skipped.
     #[cfg(test)]
@@ -777,6 +871,7 @@ fn prepare_persisted_write<
         post_write_needed: persistence.requires_post_write(),
         same_store_peer_receipt: persistence.duplicate_disposition
             == DuplicateWriteDisposition::SameStorePeerReceipt,
+        received_hook,
         #[cfg(test)]
         post_write: LocalPostWrite {
             post_send_config: context.post_send_config,
@@ -823,6 +918,13 @@ async fn prepare_persisted_write_async(
         task_id.clone(),
     )
     .await?;
+    let received_hook = prepared_received_hook(
+        runtime,
+        &context,
+        &persistence,
+        requires_ack,
+        acknowledgement.is_some(),
+    );
     let outcome = finalize_send_outcome(
         runtime,
         observability,
@@ -843,6 +945,7 @@ async fn prepare_persisted_write_async(
         post_write_needed: persistence.requires_post_write(),
         same_store_peer_receipt: persistence.duplicate_disposition
             == DuplicateWriteDisposition::SameStorePeerReceipt,
+        received_hook,
         #[cfg(test)]
         post_write: LocalPostWrite {
             post_send_config: context.post_send_config,

--- a/crates/atm-core/src/send/received_hook.rs
+++ b/crates/atm-core/src/send/received_hook.rs
@@ -1,0 +1,59 @@
+//! In-memory received-hook planning retained across durable admission.
+
+use crate::delivery_plan::LogicalMessage;
+use crate::delivery_policy::{DeliveryPolicyCoordinator, DeliveryRecipientSnapshot};
+use crate::error::AtmError;
+use crate::service_runtime::RetainedServiceRuntime;
+
+use super::{
+    DeliveryPersistenceResult, ResolvedRecipient, SendExecutionContext, build_send_delivery_plan,
+};
+
+/// Post-commit data retained by the replacement runtime without reloading the
+/// just-persisted SQLite record.
+pub(super) struct PreparedReceivedHook {
+    pub(super) recipient: ResolvedRecipient,
+    pub(super) delivery_snapshot: DeliveryRecipientSnapshot,
+    pub(super) messages: Vec<LogicalMessage>,
+}
+
+pub(super) fn prepare_received_hook<R: RetainedServiceRuntime + ?Sized>(
+    runtime: &R,
+    context: &SendExecutionContext,
+    persistence: &DeliveryPersistenceResult,
+    requires_ack: bool,
+    is_ack: bool,
+) -> Result<Option<PreparedReceivedHook>, AtmError> {
+    if !persistence.requires_post_write() {
+        return Ok(None);
+    }
+    // An origin write to a host-qualified address keeps a remote snapshot for
+    // admission, because its actual delivery belongs to the peer client. The
+    // historical post-commit hook still resolves this local recipient if the
+    // record was admitted here (notably the localhost compatibility path).
+    let delivery_snapshot = if context.delivery_snapshot.roster_backed {
+        context.delivery_snapshot.clone()
+    } else {
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
+            runtime,
+            &context.recipient.team,
+            &context.recipient.agent,
+        )?
+    };
+    let hook_context = SendExecutionContext {
+        #[cfg(test)]
+        post_send_config: None,
+        recipient: context.recipient.clone(),
+        canonical_sender: context.canonical_sender.clone(),
+        inbox_path: context.inbox_path.clone(),
+        delivery_snapshot: delivery_snapshot.clone(),
+        delivery_family: context.delivery_family,
+        warnings: Vec::new(),
+    };
+    let plan = build_send_delivery_plan(&hook_context, requires_ack, is_ack, persistence)?;
+    Ok(Some(PreparedReceivedHook {
+        recipient: context.recipient.clone(),
+        delivery_snapshot,
+        messages: plan.messages,
+    }))
+}

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -25,6 +25,7 @@ atm-storage = { path = "../atm-storage", version = "1.4.1-beta-ai-1" }
 atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.1-beta-ai-1" }
 tokio.workspace = true
 fs2 = "0.4"
+serde_json.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -2,15 +2,41 @@
 //!
 //! The shipped `atm-daemon` binary cannot select a disabled received hook.
 //! Capacity tooling must build this target with `benchmark-harness` and pass
-//! the mode explicitly on its command line.
+//! an explicit subcommand on its command line.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 
 use atm_core::error::AtmError;
+use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_daemon_bootstrap::BenchmarkHookMode;
+use atm_storage::{Message, MessageEnvelope, MessageKey};
+use tokio::task::JoinSet;
+
+const DIRECT_STORAGE_TEAM: &str = "capacity-direct-team";
+const DIRECT_STORAGE_RECIPIENT: &str = "capacity-direct-recipient";
+const DIRECT_STORAGE_SENDER: &str = "capacity-direct-agent";
+
+#[derive(Debug)]
+enum BenchmarkInvocation {
+    Daemon(BenchmarkHookMode),
+    DirectStorageAdmission {
+        messages: NonZeroUsize,
+        workers: NonZeroUsize,
+    },
+}
 
 #[tokio::main]
 async fn main() {
-    let result = match hook_mode_from_args() {
-        Ok(mode) => atm_daemon_bootstrap::run_benchmark_daemon(mode).await,
+    let result = match benchmark_invocation_from_args() {
+        Ok(BenchmarkInvocation::Daemon(mode)) => {
+            atm_daemon_bootstrap::run_benchmark_daemon(mode).await
+        }
+        Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers }) => {
+            run_direct_storage_admission(messages, workers).await
+        }
         Err(error) => Err(error),
     };
     let exit_code = match result {
@@ -23,13 +49,153 @@ async fn main() {
     std::process::exit(exit_code);
 }
 
-fn hook_mode_from_args() -> Result<BenchmarkHookMode, AtmError> {
-    let mut args = std::env::args().skip(1);
-    match (args.next().as_deref(), args.next()) {
-        (Some("--hook-mode"), Some(value)) => BenchmarkHookMode::parse(&value),
+fn benchmark_invocation_from_args() -> Result<BenchmarkInvocation, AtmError> {
+    parse_benchmark_invocation(std::env::args().skip(1))
+}
+
+fn parse_benchmark_invocation(
+    args: impl IntoIterator<Item = String>,
+) -> Result<BenchmarkInvocation, AtmError> {
+    let mut args = args.into_iter();
+    match args.next().as_deref() {
+        Some("--hook-mode") => {
+            let mode = args.next().ok_or_else(|| {
+                AtmError::config("usage: atm-daemon-benchmark --hook-mode <active|disabled>")
+            })?;
+            if args.next().is_some() {
+                return Err(AtmError::config(
+                    "usage: atm-daemon-benchmark --hook-mode <active|disabled>",
+                ));
+            }
+            BenchmarkHookMode::parse(&mode).map(BenchmarkInvocation::Daemon)
+        }
+        Some("--direct-storage-admission") => {
+            let messages = parse_nonzero_argument(args.next(), "direct-storage message count")?;
+            if args.next().as_deref() != Some("--workers") {
+                return Err(AtmError::config(
+                    "usage: atm-daemon-benchmark --direct-storage-admission <count> --workers <count>",
+                ));
+            }
+            let workers = parse_nonzero_argument(args.next(), "direct-storage worker count")?;
+            if args.next().is_some() {
+                return Err(AtmError::config(
+                    "usage: atm-daemon-benchmark --direct-storage-admission <count> --workers <count>",
+                ));
+            }
+            Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers })
+        }
         _ => Err(AtmError::config(
-            "usage: atm-daemon-benchmark --hook-mode <active|disabled>",
+            "usage: atm-daemon-benchmark --hook-mode <active|disabled> | --direct-storage-admission <count> --workers <count>",
         )),
+    }
+}
+
+fn parse_nonzero_argument(value: Option<String>, name: &str) -> Result<NonZeroUsize, AtmError> {
+    value
+        .ok_or_else(|| AtmError::config(format!("{name} is required")))?
+        .parse::<usize>()
+        .map_err(|_| AtmError::config(format!("{name} must be a positive integer")))
+        .and_then(|value| {
+            NonZeroUsize::new(value)
+                .ok_or_else(|| AtmError::config(format!("{name} must be a positive integer")))
+        })
+}
+
+/// Measures only the replacement daemon's async durable-admission seam.
+///
+/// This command is feature-gated with the daemon benchmark harness and is
+/// invoked only after the Python harness has isolated the OS-user store. It
+/// deliberately bypasses HTTP, JSON, capability validation, and core send
+/// preparation so the resulting rate is the queue-plus-single-SQLite-writer
+/// ceiling for the same `AsyncMessageStore` used by the Tokio daemon.
+async fn run_direct_storage_admission(
+    messages: NonZeroUsize,
+    workers: NonZeroUsize,
+) -> Result<(), AtmError> {
+    let runtime = atm_daemon_bootstrap::assemble_default_runtime()?
+        .for_daemon()
+        .service_runtime;
+    let next = Arc::new(AtomicUsize::new(0));
+    let started = Instant::now();
+    let mut tasks = JoinSet::new();
+
+    for _ in 0..workers.get() {
+        let runtime = runtime.clone();
+        let next = Arc::clone(&next);
+        tasks.spawn(async move {
+            let mut accepted = 0_usize;
+            loop {
+                let sequence = next.fetch_add(1, Ordering::Relaxed);
+                if sequence >= messages.get() {
+                    return Ok::<usize, AtmError>(accepted);
+                }
+                let duplicate = runtime
+                    .save_message_if_absent_async(direct_storage_message(sequence))
+                    .await?;
+                if duplicate.is_some() {
+                    return Err(AtmError::daemon_unavailable(
+                        "direct storage benchmark generated a duplicate message key",
+                    ));
+                }
+                accepted += 1;
+            }
+        });
+    }
+
+    let mut accepted = 0_usize;
+    while let Some(result) = tasks.join_next().await {
+        accepted += result.map_err(|error| {
+            AtmError::daemon_unavailable(format!("direct storage benchmark task failed: {error}"))
+        })??;
+    }
+    let elapsed_seconds = started.elapsed().as_secs_f64();
+    if accepted != messages.get() {
+        return Err(AtmError::daemon_unavailable(format!(
+            "direct storage benchmark accepted {accepted} of {} messages",
+            messages
+        )));
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "kind": "async_storage_admission",
+            "requested_count": messages.get(),
+            "accepted_count": accepted,
+            "worker_count": workers.get(),
+            "elapsed_seconds": elapsed_seconds,
+            "admissions_per_second": accepted as f64 / elapsed_seconds,
+        })
+    );
+    Ok(())
+}
+
+fn direct_storage_message(sequence: usize) -> Message {
+    let team = TeamName::from_validated(DIRECT_STORAGE_TEAM);
+    Message {
+        team: team.clone(),
+        agent: AgentName::from_validated(DIRECT_STORAGE_RECIPIENT),
+        message_key: MessageKey::new(format!("atm:capacity-direct-{sequence}"))
+            .expect("nonempty key"),
+        envelope: MessageEnvelope {
+            from: AgentName::from_validated(DIRECT_STORAGE_SENDER),
+            source_chat_id: None,
+            text: format!("capacity-direct-{sequence}"),
+            timestamp: IsoTimestamp::now(),
+            read: false,
+            source_team: Some(team),
+            destination_chat_id: None,
+            summary: None,
+            message_id: None,
+            requires_ack: false,
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            parent_message_id: None,
+            thread_mode: None,
+            expires_at: None,
+            task_id: None,
+            extra: serde_json::Map::new(),
+        },
     }
 }
 
@@ -38,5 +204,81 @@ fn replacement_exit_code(error: &AtmError) -> i32 {
         64
     } else {
         1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BenchmarkHookMode, BenchmarkInvocation, direct_storage_message, parse_benchmark_invocation,
+        parse_nonzero_argument,
+    };
+
+    #[test]
+    fn direct_storage_messages_are_unique_and_target_the_capacity_recipient() {
+        let first = direct_storage_message(1);
+        let second = direct_storage_message(2);
+        assert_ne!(first.message_key, second.message_key);
+        assert_eq!(first.team.as_str(), "capacity-direct-team");
+        assert_eq!(first.agent.as_str(), "capacity-direct-recipient");
+        assert_eq!(
+            first
+                .envelope
+                .source_team
+                .as_ref()
+                .map(|team| team.as_str()),
+            Some("capacity-direct-team")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_zero_direct_storage_arguments() {
+        let error = parse_nonzero_argument(Some("0".to_owned()), "count")
+            .expect_err("zero must be rejected");
+        assert!(error.message().contains("positive integer"));
+    }
+
+    #[test]
+    fn parser_accepts_the_two_explicit_benchmark_modes() {
+        let daemon = parse_benchmark_invocation(["--hook-mode".to_owned(), "disabled".to_owned()])
+            .expect("hook-mode invocation parses");
+        assert!(matches!(
+            daemon,
+            BenchmarkInvocation::Daemon(BenchmarkHookMode::Disabled)
+        ));
+
+        let direct = parse_benchmark_invocation([
+            "--direct-storage-admission".to_owned(),
+            "10000".to_owned(),
+            "--workers".to_owned(),
+            "64".to_owned(),
+        ])
+        .expect("direct-storage invocation parses");
+        assert!(matches!(
+            direct,
+            BenchmarkInvocation::DirectStorageAdmission { messages, workers }
+                if messages.get() == 10_000 && workers.get() == 64
+        ));
+    }
+
+    #[test]
+    fn parser_rejects_ambiguous_direct_storage_invocations() {
+        for arguments in [
+            vec!["--direct-storage-admission", "100"],
+            vec!["--direct-storage-admission", "100", "--workers", "0"],
+            vec![
+                "--direct-storage-admission",
+                "100",
+                "--workers",
+                "2",
+                "extra",
+            ],
+        ] {
+            let error = parse_benchmark_invocation(arguments.into_iter().map(str::to_owned))
+                .expect_err("ambiguous invocation must be rejected");
+            assert!(
+                error.message().contains("usage") || error.message().contains("positive integer")
+            );
+        }
     }
 }

--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use atm_core::error::AtmError;
+use atm_core::observability::NullObservability;
+use atm_core::send::{SendMessageSource, WriteRequest, prepare_write_with_async_runtime};
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_daemon_bootstrap::BenchmarkHookMode;
 use atm_storage::{Message, MessageEnvelope, MessageKey};
@@ -18,11 +20,18 @@ use tokio::task::JoinSet;
 const DIRECT_STORAGE_TEAM: &str = "capacity-direct-team";
 const DIRECT_STORAGE_RECIPIENT: &str = "capacity-direct-recipient";
 const DIRECT_STORAGE_SENDER: &str = "capacity-direct-agent";
+const CORE_WRITE_TEAM: &str = "capacity-team";
+const CORE_WRITE_RECIPIENT: &str = "capacity-recipient";
+const CORE_WRITE_SENDER: &str = "capacity-agent";
 
 #[derive(Debug)]
 enum BenchmarkInvocation {
     Daemon(BenchmarkHookMode),
     DirectStorageAdmission {
+        messages: NonZeroUsize,
+        workers: NonZeroUsize,
+    },
+    DirectCoreWrite {
         messages: NonZeroUsize,
         workers: NonZeroUsize,
     },
@@ -36,6 +45,9 @@ async fn main() {
         }
         Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers }) => {
             run_direct_storage_admission(messages, workers).await
+        }
+        Ok(BenchmarkInvocation::DirectCoreWrite { messages, workers }) => {
+            run_direct_core_write(messages, workers).await
         }
         Err(error) => Err(error),
     };
@@ -70,24 +82,41 @@ fn parse_benchmark_invocation(
             BenchmarkHookMode::parse(&mode).map(BenchmarkInvocation::Daemon)
         }
         Some("--direct-storage-admission") => {
-            let messages = parse_nonzero_argument(args.next(), "direct-storage message count")?;
-            if args.next().as_deref() != Some("--workers") {
-                return Err(AtmError::config(
-                    "usage: atm-daemon-benchmark --direct-storage-admission <count> --workers <count>",
-                ));
-            }
-            let workers = parse_nonzero_argument(args.next(), "direct-storage worker count")?;
-            if args.next().is_some() {
-                return Err(AtmError::config(
-                    "usage: atm-daemon-benchmark --direct-storage-admission <count> --workers <count>",
-                ));
-            }
+            let (messages, workers) = parse_concurrent_arguments(
+                args,
+                "direct-storage",
+                "usage: atm-daemon-benchmark --direct-storage-admission <count> --workers <count>",
+            )?;
             Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers })
         }
+        Some("--direct-core-write") => {
+            let (messages, workers) = parse_concurrent_arguments(
+                args,
+                "direct-core-write",
+                "usage: atm-daemon-benchmark --direct-core-write <count> --workers <count>",
+            )?;
+            Ok(BenchmarkInvocation::DirectCoreWrite { messages, workers })
+        }
         _ => Err(AtmError::config(
-            "usage: atm-daemon-benchmark --hook-mode <active|disabled> | --direct-storage-admission <count> --workers <count>",
+            "usage: atm-daemon-benchmark --hook-mode <active|disabled> | --direct-storage-admission <count> --workers <count> | --direct-core-write <count> --workers <count>",
         )),
     }
+}
+
+fn parse_concurrent_arguments(
+    mut args: impl Iterator<Item = String>,
+    mode: &str,
+    usage: &str,
+) -> Result<(NonZeroUsize, NonZeroUsize), AtmError> {
+    let messages = parse_nonzero_argument(args.next(), &format!("{mode} message count"))?;
+    if args.next().as_deref() != Some("--workers") {
+        return Err(AtmError::config(usage));
+    }
+    let workers = parse_nonzero_argument(args.next(), &format!("{mode} worker count"))?;
+    if args.next().is_some() {
+        return Err(AtmError::config(usage));
+    }
+    Ok((messages, workers))
 }
 
 fn parse_nonzero_argument(value: Option<String>, name: &str) -> Result<NonZeroUsize, AtmError> {
@@ -199,6 +228,91 @@ fn direct_storage_message(sequence: usize) -> Message {
     }
 }
 
+/// Measures the shared canonical write preparation through the same Tokio
+/// admission lane, excluding only HTTP parsing, authentication, and response
+/// encoding. The capacity harness creates this mode's roster before invoking
+/// it, so every write follows the normal warmed-roster local-send path.
+async fn run_direct_core_write(
+    messages: NonZeroUsize,
+    workers: NonZeroUsize,
+) -> Result<(), AtmError> {
+    let runtime = atm_daemon_bootstrap::assemble_default_runtime()?
+        .for_daemon()
+        .service_runtime;
+    let home = atm_core::home::atm_home()?;
+    let next = Arc::new(AtomicUsize::new(0));
+    let started = Instant::now();
+    let mut tasks = JoinSet::new();
+
+    for _ in 0..workers.get() {
+        let runtime = runtime.clone();
+        let home = home.clone();
+        let next = Arc::clone(&next);
+        tasks.spawn(async move {
+            let mut accepted = 0_usize;
+            loop {
+                let sequence = next.fetch_add(1, Ordering::Relaxed);
+                if sequence >= messages.get() {
+                    return Ok::<usize, AtmError>(accepted);
+                }
+                prepare_write_with_async_runtime(
+                    direct_core_write_request(&home, sequence)?,
+                    &NullObservability,
+                    &runtime,
+                )
+                .await?;
+                accepted += 1;
+            }
+        });
+    }
+
+    let mut accepted = 0_usize;
+    while let Some(result) = tasks.join_next().await {
+        accepted += result.map_err(|error| {
+            AtmError::daemon_unavailable(format!(
+                "direct core-write benchmark task failed: {error}"
+            ))
+        })??;
+    }
+    let elapsed_seconds = started.elapsed().as_secs_f64();
+    if accepted != messages.get() {
+        return Err(AtmError::daemon_unavailable(format!(
+            "direct core-write benchmark accepted {accepted} of {} messages",
+            messages.get()
+        )));
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "kind": "canonical_core_write",
+            "requested_count": messages.get(),
+            "accepted_count": accepted,
+            "worker_count": workers.get(),
+            "elapsed_seconds": elapsed_seconds,
+            "admissions_per_second": accepted as f64 / elapsed_seconds,
+        })
+    );
+    Ok(())
+}
+
+fn direct_core_write_request(
+    home: &std::path::Path,
+    sequence: usize,
+) -> Result<WriteRequest, AtmError> {
+    WriteRequest::new(
+        home.to_path_buf(),
+        home.to_path_buf(),
+        AgentName::from_validated(CORE_WRITE_SENDER),
+        &format!("{CORE_WRITE_RECIPIENT}@{CORE_WRITE_TEAM}"),
+        TeamName::from_validated(CORE_WRITE_TEAM),
+        SendMessageSource::Inline(format!("capacity-core-{sequence}")),
+        None,
+        false,
+        None,
+        false,
+    )
+}
+
 fn replacement_exit_code(error: &AtmError) -> i32 {
     if error.is_validation() || error.code() == atm_core::error::AtmErrorCode::DaemonUnavailable {
         64
@@ -210,8 +324,8 @@ fn replacement_exit_code(error: &AtmError) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        BenchmarkHookMode, BenchmarkInvocation, direct_storage_message, parse_benchmark_invocation,
-        parse_nonzero_argument,
+        BenchmarkHookMode, BenchmarkInvocation, direct_core_write_request, direct_storage_message,
+        parse_benchmark_invocation, parse_nonzero_argument,
     };
 
     #[test]
@@ -229,6 +343,19 @@ mod tests {
                 .map(|team| team.as_str()),
             Some("capacity-direct-team")
         );
+    }
+
+    #[test]
+    fn direct_core_writes_use_the_canonical_capacity_address() {
+        let home = std::path::Path::new("/tmp/atm-capacity");
+        let request = direct_core_write_request(home, 7).expect("core request");
+        assert_eq!(request.caller_identity.as_str(), "capacity-agent");
+        assert_eq!(request.caller_team.as_str(), "capacity-team");
+        assert_eq!(
+            request.to.expect("destination").to_string(),
+            "capacity-recipient@capacity-team"
+        );
+        assert_eq!(request.home_dir, home);
     }
 
     #[test]
@@ -257,6 +384,19 @@ mod tests {
         assert!(matches!(
             direct,
             BenchmarkInvocation::DirectStorageAdmission { messages, workers }
+                if messages.get() == 10_000 && workers.get() == 64
+        ));
+
+        let core = parse_benchmark_invocation([
+            "--direct-core-write".to_owned(),
+            "10000".to_owned(),
+            "--workers".to_owned(),
+            "64".to_owned(),
+        ])
+        .expect("core invocation parses");
+        assert!(matches!(
+            core,
+            BenchmarkInvocation::DirectCoreWrite { messages, workers }
                 if messages.get() == 10_000 && workers.get() == 64
         ));
     }

--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -20,9 +20,9 @@ use tokio::task::JoinSet;
 const DIRECT_STORAGE_TEAM: &str = "capacity-direct-team";
 const DIRECT_STORAGE_RECIPIENT: &str = "capacity-direct-recipient";
 const DIRECT_STORAGE_SENDER: &str = "capacity-direct-agent";
-const CORE_WRITE_TEAM: &str = "capacity-team";
-const CORE_WRITE_RECIPIENT: &str = "capacity-recipient";
-const CORE_WRITE_SENDER: &str = "capacity-agent";
+const CORE_WRITE_TEAM: &str = "capacity-core-team";
+const CORE_WRITE_RECIPIENT: &str = "capacity-core-recipient";
+const CORE_WRITE_SENDER: &str = "capacity-core-agent";
 
 #[derive(Debug)]
 enum BenchmarkInvocation {
@@ -349,11 +349,11 @@ mod tests {
     fn direct_core_writes_use_the_canonical_capacity_address() {
         let home = std::path::Path::new("/tmp/atm-capacity");
         let request = direct_core_write_request(home, 7).expect("core request");
-        assert_eq!(request.caller_identity.as_str(), "capacity-agent");
-        assert_eq!(request.caller_team.as_str(), "capacity-team");
+        assert_eq!(request.caller_identity.as_str(), "capacity-core-agent");
+        assert_eq!(request.caller_team.as_str(), "capacity-core-team");
         assert_eq!(
             request.to.expect("destination").to_string(),
-            "capacity-recipient@capacity-team"
+            "capacity-core-recipient@capacity-core-team"
         );
         assert_eq!(request.home_dir, home);
     }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -23,10 +23,7 @@ use atm_core::protocol::{
     CompatibilityVerdict, ReleaseVersion, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
-use atm_core::send::{
-    WarningEntry, WriteOutcome, build_received_message_hook_dispatches_after_commit,
-    prepare_write_with_async_runtime,
-};
+use atm_core::send::{WarningEntry, WriteOutcome, prepare_write_with_async_runtime};
 
 use crate::CanonicalWriteHandler;
 use crate::RuntimeHealth;
@@ -172,6 +169,11 @@ impl StorageAndNudgeRouter {
         let canonical_request = prepared.outbound_request();
         let message_id = prepared.persisted_message_id();
         let persisted_timestamp = prepared.persisted_timestamp();
+        let received_hook_dispatches = if newly_persisted {
+            prepared.build_received_hook_dispatches(&self.service_runtime)
+        } else {
+            Ok(Vec::new())
+        };
         let outcome = prepared.finish(&self.service_runtime, self.observability.as_ref())?;
         Ok(CommittedWrite {
             outcome,
@@ -179,6 +181,7 @@ impl StorageAndNudgeRouter {
             message_id,
             persisted_timestamp,
             newly_persisted,
+            received_hook_dispatches,
         })
     }
 
@@ -221,8 +224,7 @@ impl StorageAndNudgeRouter {
 
     async fn emit_received_hook(
         &self,
-        request: &atm_core::send::WriteRequest,
-        message_id: atm_core::schema::AtmMessageId,
+        dispatches: Result<Vec<atm_core::boundary::BuiltInPostSendDispatch>, AtmError>,
         deadline: RequestDeadline,
     ) -> Vec<WarningEntry> {
         if deadline.expired() {
@@ -230,23 +232,7 @@ impl StorageAndNudgeRouter {
                 "received-message hook was skipped because the request deadline was exhausted after persistence",
             ))];
         }
-        let Some(target) = request.to.as_ref() else {
-            return vec![hook_warning(AtmError::validation(
-                "durably received message had no canonical destination for receiver hook",
-            ))];
-        };
-        let team = target
-            .team()
-            .cloned()
-            .unwrap_or_else(|| request.caller_team.clone());
-        let agent = target.agent().clone();
-        let dispatches = match build_received_message_hook_dispatches_after_commit(
-            &self.service_runtime,
-            &request.home_dir,
-            &team,
-            &agent,
-            message_id,
-        ) {
+        let dispatches = match dispatches {
             Ok(dispatches) => dispatches,
             Err(error) => return vec![hook_warning(error)],
         };
@@ -472,6 +458,7 @@ struct CommittedWrite {
     message_id: atm_core::schema::AtmMessageId,
     persisted_timestamp: atm_core::types::IsoTimestamp,
     newly_persisted: bool,
+    received_hook_dispatches: Result<Vec<atm_core::boundary::BuiltInPostSendDispatch>, AtmError>,
 }
 
 impl atm_core::boundary::sealed::Sealed for StorageAndNudgeRouter {}
@@ -508,10 +495,8 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             }
             if committed.newly_persisted {
                 let hook = self.clone();
-                let request = committed.canonical_request.clone();
-                let message_id = committed.message_id;
                 let warnings = hook
-                    .emit_received_hook(&request, message_id, deadline)
+                    .emit_received_hook(committed.received_hook_dispatches, deadline)
                     .await;
                 append_warnings(&mut committed.outcome, warnings);
             }
@@ -1243,6 +1228,35 @@ mod tests {
                 .expect("load emitted message")
                 .is_some(),
             "the emitted message remains durable after the write response"
+        );
+    }
+
+    #[test]
+    fn canonical_write_path_does_not_reopen_committed_records_for_hook_planning() {
+        // This is an architecture regression guard rather than a behavior
+        // assertion. The async storage admission already has the recipient,
+        // delivery snapshot, and logical messages needed to plan a hook.
+        // Reconstructing them by synchronously reading the just-persisted
+        // SQLite row turns every public write into a blocking read, including
+        // hook-disabled writes.
+        let production_source = include_str!("storage_and_nudge_router.rs")
+            .split("\n#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production source before test module");
+        let legacy_planner = [
+            "build_received_",
+            "message_hook_",
+            "dispatches_after_commit",
+        ]
+        .concat();
+        let storage_reload = ["load_", "message_", "record"].concat();
+        assert!(
+            !production_source.contains(&legacy_planner),
+            "the replacement write path must use PreparedWrite's retained hook plan"
+        );
+        assert!(
+            !production_source.contains(&storage_reload),
+            "the replacement write path must not synchronously reload a committed record"
         );
     }
 

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -23,8 +23,10 @@ just smoke graft-hermes [arguments accepted by the Hermes graft smoke]
 ```
 
 `just benchmark` is the separate, canonical performance gate; it is not a
-replacement for functional smoke coverage. `just benchmark-report` renders
-the benchmark evidence it produces.
+replacement for functional smoke coverage. Each successful run writes its
+immutable JSON, its XHTML panel, and the aggregate report beneath
+`site/reports/`; the recipe rebuilds the report automatically. Use
+`just benchmark-report` only to rebuild or inspect already-published evidence.
 
 The routed smoke implementations are deliberately not independent public
 commands:

--- a/scripts/smoke/benchmark_report.py
+++ b/scripts/smoke/benchmark_report.py
@@ -187,6 +187,19 @@ def render_run(result: dict[str, Any], artifact_id: str, report_dir: Path = REPO
             "n/a" if rates.get("p99") is None else f'{rates["p99"]:.2f}', rates["max"],
             "PASS" if result["passed"] else "FAIL",
         )
+    direct_sqlite = result.get("direct_sqlite_message_write")
+    direct_sqlite_html = "<p>Not captured by this historical run.</p>"
+    if direct_sqlite is not None:
+        direct_sqlite_html = (
+            "<table><thead><tr><th>Requested</th><th>Accepted</th><th>Workers</th>"
+            "<th>Elapsed seconds</th><th>Messages/second</th></tr></thead><tbody>"
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{:.3f}</td><td>{:.2f}</td></tr>"
+            "</tbody></table>"
+        ).format(
+            direct_sqlite["requested_count"], direct_sqlite["accepted_count"],
+            direct_sqlite["worker_count"], direct_sqlite["elapsed_seconds"],
+            direct_sqlite["admissions_per_second"],
+        )
     compose(
         template,
         {
@@ -201,6 +214,7 @@ def render_run(result: dict[str, Any], artifact_id: str, report_dir: Path = REPO
             "failure": result.get("failure", ""),
             "cleanup_failure": result.get("cleanup_failure", ""),
             "sample_html": sample_html,
+            "direct_sqlite_html": direct_sqlite_html,
         },
         output,
     )
@@ -230,6 +244,11 @@ def render_aggregate(records: Iterable[dict[str, Any]], report_root: Path = REPO
             "transport": result["transport"],
             "frames_per_connection": result["frames_per_connection"],
             "passed": result["passed"],
+            "direct_sqlite_admissions_per_second": (
+                result["direct_sqlite_message_write"]["admissions_per_second"]
+                if result.get("direct_sqlite_message_write") is not None
+                else None
+            ),
             "json_href": f"{REPORT_NAME}/{artifact_id}.json",
             "xhtml_href": f"{REPORT_NAME}/{artifact_id}.xhtml",
         })

--- a/scripts/smoke/benchmark_schema.py
+++ b/scripts/smoke/benchmark_schema.py
@@ -111,6 +111,31 @@ class DurabilityAfterRestart(BaseModel):
     passed: bool
 
 
+class DirectSQLiteMessageWrite(BaseModel):
+    """One direct Tokio admission measurement against the shared SQLite writer.
+
+    This is intentionally separate from the public HTTP transport profile: it
+    is the durable-message-write ceiling for the exact async store used by the
+    runtime, and makes a transport regression distinguishable from a storage
+    regression in the published evidence.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["async_storage_admission"] = "async_storage_admission"
+    requested_count: int = Field(gt=0)
+    accepted_count: int = Field(ge=0)
+    worker_count: int = Field(gt=0)
+    elapsed_seconds: float = Field(gt=0)
+    admissions_per_second: float = Field(gt=0)
+
+    @model_validator(mode="after")
+    def accepted_count_is_bounded(self) -> "DirectSQLiteMessageWrite":
+        if self.accepted_count > self.requested_count:
+            raise ValueError("accepted_count cannot exceed requested_count")
+        return self
+
+
 class BenchmarkSummary(BaseModel):
     """One immutable public artifact for one transport/frame benchmark run."""
 
@@ -138,6 +163,7 @@ class BenchmarkSummary(BaseModel):
     doctor_status: Optional[Literal["passed"]] = None
     doctor_after_restart_status: Optional[Literal["passed"]] = None
     durability_after_restart: Optional[DurabilityAfterRestart] = None
+    direct_sqlite_message_write: Optional[DirectSQLiteMessageWrite] = None
     thresholds: Optional[BenchmarkThresholds] = None
     metrics: Optional[BenchmarkMetrics] = None
     passed: bool
@@ -224,6 +250,13 @@ def compact_evidence(evidence: dict[str, Any]) -> BenchmarkSummary:
     response_bytes = sum(int(interval.get("application_wire_bytes", {}).get("response", 0)) for interval in intervals)
     first_failure = next((public_string(str(interval["first_failure"])) for interval in intervals if interval.get("first_failure")), None)
     thresholds = evidence.get("thresholds")
+    decomposition = evidence.get("decomposition", {})
+    # Runner evidence carries this diagnostic below `decomposition`.  Accepting
+    # the already-compact spelling too makes a report rebuild lossless when it
+    # reprocesses a published artifact.
+    direct_sqlite_message_write = evidence.get("direct_sqlite_message_write")
+    if direct_sqlite_message_write is None and isinstance(decomposition, dict):
+        direct_sqlite_message_write = decomposition.get("async_storage_admission")
     summary = {
         "generated_at": evidence["generated_at"],
         "host_label": evidence["host_label"],
@@ -243,6 +276,7 @@ def compact_evidence(evidence: dict[str, Any]) -> BenchmarkSummary:
         "doctor_status": evidence.get("doctor_status"),
         "doctor_after_restart_status": evidence.get("doctor_after_restart", {}).get("status"),
         "durability_after_restart": evidence.get("durability_after_restart"),
+        "direct_sqlite_message_write": direct_sqlite_message_write,
         "thresholds": thresholds,
         "metrics": {
             "interval_count": len(intervals),
@@ -297,6 +331,13 @@ def failed_summary(evidence: dict[str, Any]) -> BenchmarkSummary:
             "host_state_isolation": evidence.get("host_state_isolation"),
             "doctor_status": evidence.get("doctor_status"),
             "doctor_after_restart_status": evidence.get("doctor_after_restart", {}).get("status"),
+            "direct_sqlite_message_write": evidence.get("direct_sqlite_message_write")
+            if evidence.get("direct_sqlite_message_write") is not None
+            else (
+                evidence.get("decomposition", {}).get("async_storage_admission")
+                if isinstance(evidence.get("decomposition"), dict)
+                else None
+            ),
             "passed": False,
             "failure": public_string(str(evidence.get("failure") or "benchmark did not reach an interval")),
             "cleanup_failure": public_string(str(evidence["cleanup_failure"])) if evidence.get("cleanup_failure") else None,

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -554,10 +554,17 @@ def start_capacity_daemon(
 
 
 def prepare_capacity_roster(atm: Path, env: dict[str, str], home: Path) -> None:
-    """Create the sender and a distinct local durable-write recipient."""
-    for member in ("capacity-agent", "capacity-recipient"):
+    """Create separate public-write and decomposition-only benchmark rosters."""
+    for team, member in (
+        ("capacity-team", "capacity-agent"),
+        ("capacity-team", "capacity-recipient"),
+        # The direct canonical-core probe must never add rows to the public
+        # write profile's durability-count mailbox.
+        ("capacity-core-team", "capacity-core-agent"),
+        ("capacity-core-team", "capacity-core-recipient"),
+    ):
         result = command_result(
-            [str(atm), "teams", "add-member", "capacity-team", member, "--home-dir", str(home), "--json"],
+            [str(atm), "teams", "add-member", team, member, "--home-dir", str(home), "--json"],
             timeout=15.0,
             env=env,
         )

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -899,16 +899,18 @@ def run_cached_roster_heartbeat_probe(
     }
 
 
-def run_direct_storage_probe(
+def run_direct_probe(
     benchmark_daemon: Path,
     environment: dict[str, str],
     workers: int,
+    flag: str,
+    kind: str,
 ) -> dict[str, Any]:
-    """Measure only the Tokio async admission queue and its one SQLite writer."""
+    """Run one isolated benchmark-binary decomposition mode."""
     result = command_result(
         [
             str(benchmark_daemon),
-            "--direct-storage-admission",
+            flag,
             str(DIRECT_STORAGE_DIAGNOSTIC_WRITES),
             "--workers",
             str(workers),
@@ -918,22 +920,52 @@ def run_direct_storage_probe(
     )
     if result["exit_code"] != 0:
         detail = result["stderr"].strip() or result["stdout"].strip()
-        raise SmokeError(f"direct async storage probe failed: {detail}")
+        raise SmokeError(f"direct {kind} probe failed: {detail}")
     lines = [line for line in result["stdout"].splitlines() if line.strip()]
     try:
         payload = json.loads(lines[-1])
     except (IndexError, json.JSONDecodeError) as error:
-        raise SmokeError("direct async storage probe returned no JSON result") from error
+        raise SmokeError(f"direct {kind} probe returned no JSON result") from error
     if (
         not isinstance(payload, dict)
-        or payload.get("kind") != "async_storage_admission"
+        or payload.get("kind") != kind
         or payload.get("requested_count") != DIRECT_STORAGE_DIAGNOSTIC_WRITES
         or payload.get("accepted_count") != DIRECT_STORAGE_DIAGNOSTIC_WRITES
         or not isinstance(payload.get("admissions_per_second"), (int, float))
         or payload["admissions_per_second"] <= 0
     ):
-        raise SmokeError("direct async storage probe returned an invalid result")
+        raise SmokeError(f"direct {kind} probe returned an invalid result")
     return payload
+
+
+def run_direct_storage_probe(
+    benchmark_daemon: Path,
+    environment: dict[str, str],
+    workers: int,
+) -> dict[str, Any]:
+    """Measure only the Tokio async admission queue and its one SQLite writer."""
+    return run_direct_probe(
+        benchmark_daemon,
+        environment,
+        workers,
+        "--direct-storage-admission",
+        "async_storage_admission",
+    )
+
+
+def run_direct_core_write_probe(
+    benchmark_daemon: Path,
+    environment: dict[str, str],
+    workers: int,
+) -> dict[str, Any]:
+    """Measure canonical write preparation through the async admission seam."""
+    return run_direct_probe(
+        benchmark_daemon,
+        environment,
+        workers,
+        "--direct-core-write",
+        "canonical_core_write",
+    )
 
 
 def evidence_filename(directory: Path, evidence: dict[str, Any]) -> Path:
@@ -1157,6 +1189,11 @@ def run_capacity(
         home.mkdir(parents=True, exist_ok=False)
         prepare_capacity_roster(atm, env, home)
         evidence["decomposition"]["async_storage_admission"] = run_direct_storage_probe(
+            daemon,
+            env,
+            workers,
+        )
+        evidence["decomposition"]["canonical_core_write"] = run_direct_core_write_probe(
             daemon,
             env,
             workers,

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -71,7 +71,15 @@ DAEMON_OUTPUT_TAIL_LINES = 200
 GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
 HOOK_MODES = ("active", "disabled")
 DAEMON_SWITCH = ROOT / ".claude" / "skills" / "daemon-switch" / "scripts" / "daemon-switch.py"
-MANAGED_DAEMON_TIMEOUT_SECONDS = 30.0
+# The daemon-switch control plane can legitimately wait through its documented
+# launchctl unload/owner-repair windows (up to 20s + two 20x2s polls).  Its
+# outer timeout must cover that bounded recovery path; otherwise the runner
+# reports a false benchmark failure while the switch is still repairing the
+# selected singleton.
+MANAGED_DAEMON_TIMEOUT_SECONDS = 120.0
+DIAGNOSTIC_SAMPLE_COUNT = 3
+DIAGNOSTIC_DURATION_SECONDS = 3.0
+DIRECT_STORAGE_DIAGNOSTIC_WRITES = 10_000
 
 
 @dataclass(frozen=True)
@@ -82,6 +90,15 @@ class AdmissionResult:
     request_bytes: int = 0
     response_bytes: int = 0
     response_summary: str | None = None
+
+
+@dataclass(frozen=True)
+class HttpRequest:
+    """One public HTTP request with its documented success response."""
+
+    path: str
+    body: bytes
+    expected_status: int
 
 
 @dataclass(frozen=True)
@@ -570,6 +587,24 @@ def http_request_body(home: Path, sequence: int) -> bytes:
     return json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
 
+def cached_roster_heartbeat_body(sequence: int) -> bytes:
+    """Build a heartbeat that validates against the warmed roster snapshot.
+
+    The daemon's heartbeat route calls ``LocalServiceRuntime.load_roster_member``.
+    That method reads SQLite only for the first request of a team and serves its
+    immutable in-process snapshot thereafter.  The benchmark explicitly warms
+    that first request before recording these samples.
+    """
+    payload = {
+        "team": "capacity-team",
+        "member": "capacity-agent",
+        "pid": 90_000 + sequence,
+        "observed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "activity": "active_tool_use",
+    }
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
 def validate_transport(transport: str) -> str:
     """Keep platform transport selection explicit and comparable."""
     if transport not in {"uds", "tcp"}:
@@ -633,7 +668,7 @@ def read_http_response(
     return status, header_end + content_length, summary
 
 
-def submit_connection(endpoint: LocalEndpoint, bodies: list[bytes]) -> list[AdmissionResult]:
+def submit_connection(endpoint: LocalEndpoint, requests: list[HttpRequest]) -> list[AdmissionResult]:
     """Submit consecutive real requests over one public local connection."""
     started = time.perf_counter()
     capability = (
@@ -649,29 +684,33 @@ def submit_connection(endpoint: LocalEndpoint, bodies: list[bytes]) -> list[Admi
             if endpoint.kind == "tcp":
                 stream.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             stream.connect(endpoint.address)
-            requests = []
-            for index, body in enumerate(bodies):
-                connection = "close" if index + 1 == len(bodies) else "keep-alive"
-                requests.append(
-                    b"POST /v1/atm/messages HTTP/1.1\r\n"
-                    b"Content-Type: application/json\r\n"
+            frames = []
+            for index, request in enumerate(requests):
+                connection = "close" if index + 1 == len(requests) else "keep-alive"
+                frames.append(
+                    f"POST {request.path} HTTP/1.1\r\n".encode("ascii")
+                    + b"Content-Type: application/json\r\n"
                     + capability
-                    + f"Content-Length: {len(body)}\r\nConnection: {connection}\r\n\r\n".encode("ascii")
-                    + body
+                    + f"Content-Length: {len(request.body)}\r\nConnection: {connection}\r\n\r\n".encode("ascii")
+                    + request.body
                 )
 
             response_buffer = bytearray()
-            for start in range(0, len(requests), MAX_IN_FLIGHT_REQUESTS):
-                batch = requests[start:start + MAX_IN_FLIGHT_REQUESTS]
+            for start in range(0, len(frames), MAX_IN_FLIGHT_REQUESTS):
+                batch = frames[start:start + MAX_IN_FLIGHT_REQUESTS]
                 request_started = time.perf_counter()
                 stream.sendall(b"".join(batch))
-                for request in batch:
+                for request, frame in zip(requests[start:start + MAX_IN_FLIGHT_REQUESTS], batch):
                     status, response_bytes, response_summary = read_http_response(stream, response_buffer)
                     results.append(AdmissionResult(
                         status=status,
                         elapsed_ms=(time.perf_counter() - request_started) * 1_000,
-                        failure=None if status == 201 else f"HTTP {status}: {response_summary or 'no response body'}",
-                        request_bytes=len(request),
+                        failure=(
+                            None
+                            if status == request.expected_status
+                            else f"HTTP {status}: {response_summary or 'no response body'}"
+                        ),
+                        request_bytes=len(frame),
                         response_bytes=response_bytes,
                         response_summary=response_summary,
                     ))
@@ -689,6 +728,8 @@ def run_interval(
     frames_per_connection: int,
     workers: int,
     requested_messages: int = ADMISSIONS_PER_INTERVAL,
+    expected_status: int = 201,
+    minimum_admissions_per_second: float = 1_000.0,
 ) -> dict[str, Any]:
     """Run one exactly-sized admission interval without retrying failed writes."""
     if requested_messages <= 0:
@@ -708,8 +749,12 @@ def run_interval(
         for future in as_completed(futures):
             results.extend(future.result())
     elapsed_seconds = time.perf_counter() - started
-    accepted = sum(result.status == 201 for result in results)
-    failures = [result.failure or f"HTTP {result.status}" for result in results if result.status != 201]
+    accepted = sum(result.status == expected_status for result in results)
+    failures = [
+        result.failure or f"HTTP {result.status}"
+        for result in results
+        if result.status != expected_status
+    ]
     latencies = [result.elapsed_ms for result in results]
     latency_distribution = distribution(latencies) if latencies else {
         "min": 0.0,
@@ -746,7 +791,10 @@ def run_interval(
             (request_bytes + response_bytes) / elapsed_seconds if elapsed_seconds else 0.0
         ),
         "first_failure": failures[0] if failures else None,
-        "passed": error_free and elapsed_seconds <= requested_messages / 1_000,
+        "passed": error_free and (
+            minimum_admissions_per_second <= 0
+            or elapsed_seconds <= requested_messages / minimum_admissions_per_second
+        ),
     }
 
 
@@ -758,6 +806,9 @@ def run_profile(
     sample_count: int,
     workers: int,
     target_duration_seconds: float = TARGET_PROFILE_DURATION_SECONDS,
+    operation: str = "write",
+    expected_status: int = 201,
+    minimum_admissions_per_second: float = 1_000.0,
 ) -> dict[str, Any]:
     """Collect at least ten independent intervals over one sustained profile."""
     if sample_count <= 0:
@@ -766,16 +817,35 @@ def run_profile(
         raise SmokeError("capacity target duration must be positive")
 
     def submit(sequence: int, message_count: int) -> list[AdmissionResult]:
-        return submit_connection(endpoint, [
-            http_request_body(home, sequence + offset)
-            for offset in range(message_count)
-        ])
+        if operation == "write":
+            requests = [
+                HttpRequest("/v1/atm/messages", http_request_body(home, sequence + offset), 201)
+                for offset in range(message_count)
+            ]
+        elif operation == "cached_roster_heartbeat":
+            requests = [
+                HttpRequest(
+                    "/v1/atm/heartbeat",
+                    cached_roster_heartbeat_body(sequence + offset),
+                    200,
+                )
+                for offset in range(message_count)
+            ]
+        else:
+            raise SmokeError(f"unsupported capacity benchmark operation {operation!r}")
+        return submit_connection(endpoint, requests)
 
     intervals: list[dict[str, Any]] = []
     elapsed_seconds = 0.0
     while len(intervals) < sample_count or elapsed_seconds < target_duration_seconds:
         interval = run_interval(
-            submit, len(intervals), frames_per_connection, workers, requested_messages,
+            submit,
+            len(intervals),
+            frames_per_connection,
+            workers,
+            requested_messages,
+            expected_status=expected_status,
+            minimum_admissions_per_second=minimum_admissions_per_second,
         )
         intervals.append(interval)
         elapsed_seconds += float(interval["elapsed_seconds"])
@@ -784,6 +854,7 @@ def run_profile(
         if not interval.get("error_free", interval["passed"]):
             break
     return {
+        "operation": operation,
         "recipient": "capacity-recipient@capacity-team",
         "requested_messages_per_sample": requested_messages,
         "minimum_sample_count": sample_count,
@@ -793,6 +864,76 @@ def run_profile(
         "intervals": intervals,
         "passed": all(item["passed"] for item in intervals),
     }
+
+
+def run_cached_roster_heartbeat_probe(
+    endpoint: LocalEndpoint,
+    home: Path,
+    frames_per_connection: int,
+    workers: int,
+) -> dict[str, Any]:
+    """Warm and then measure the public no-SQLite heartbeat route."""
+    warmup = submit_connection(endpoint, [
+        HttpRequest("/v1/atm/heartbeat", cached_roster_heartbeat_body(0), 200),
+    ])
+    if len(warmup) != 1 or warmup[0].status != 200 or warmup[0].failure is not None:
+        detail = warmup[0].failure if warmup else "no response"
+        raise SmokeError(f"cached-roster heartbeat warmup failed: {detail}")
+    profile = run_profile(
+        endpoint,
+        home,
+        frames_per_connection,
+        ADMISSIONS_PER_INTERVAL,
+        DIAGNOSTIC_SAMPLE_COUNT,
+        workers,
+        target_duration_seconds=DIAGNOSTIC_DURATION_SECONDS,
+        operation="cached_roster_heartbeat",
+        expected_status=200,
+        minimum_admissions_per_second=0,
+    )
+    return {
+        "route": "/v1/atm/heartbeat",
+        "storage": "warmed LocalServiceRuntime roster snapshot; no SQLite reads after warmup",
+        "warmup": {"status": warmup[0].status, "passed": True},
+        "profile": profile,
+    }
+
+
+def run_direct_storage_probe(
+    benchmark_daemon: Path,
+    environment: dict[str, str],
+    workers: int,
+) -> dict[str, Any]:
+    """Measure only the Tokio async admission queue and its one SQLite writer."""
+    result = command_result(
+        [
+            str(benchmark_daemon),
+            "--direct-storage-admission",
+            str(DIRECT_STORAGE_DIAGNOSTIC_WRITES),
+            "--workers",
+            str(workers),
+        ],
+        timeout=MANAGED_DAEMON_TIMEOUT_SECONDS,
+        env=environment,
+    )
+    if result["exit_code"] != 0:
+        detail = result["stderr"].strip() or result["stdout"].strip()
+        raise SmokeError(f"direct async storage probe failed: {detail}")
+    lines = [line for line in result["stdout"].splitlines() if line.strip()]
+    try:
+        payload = json.loads(lines[-1])
+    except (IndexError, json.JSONDecodeError) as error:
+        raise SmokeError("direct async storage probe returned no JSON result") from error
+    if (
+        not isinstance(payload, dict)
+        or payload.get("kind") != "async_storage_admission"
+        or payload.get("requested_count") != DIRECT_STORAGE_DIAGNOSTIC_WRITES
+        or payload.get("accepted_count") != DIRECT_STORAGE_DIAGNOSTIC_WRITES
+        or not isinstance(payload.get("admissions_per_second"), (int, float))
+        or payload["admissions_per_second"] <= 0
+    ):
+        raise SmokeError("direct async storage probe returned an invalid result")
+    return payload
 
 
 def evidence_filename(directory: Path, evidence: dict[str, Any]) -> Path:
@@ -1005,6 +1146,7 @@ def run_capacity(
             ),
             "response_write": "included in each public admission response latency",
         },
+        "decomposition": {},
     }
     try:
         if isolation_mode == "backup_restore":
@@ -1014,6 +1156,11 @@ def run_capacity(
         before = count_atm_daemon_processes()
         home.mkdir(parents=True, exist_ok=False)
         prepare_capacity_roster(atm, env, home)
+        evidence["decomposition"]["async_storage_admission"] = run_direct_storage_probe(
+            daemon,
+            env,
+            workers,
+        )
         process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
         doctor = command_result(
             [str(atm), "doctor", "--json"],
@@ -1031,6 +1178,12 @@ def run_capacity(
         }
         if endpoint.kind == "uds" and not Path(str(endpoint.address)).exists():
             raise SmokeError(f"daemon did not publish public local socket {endpoint.address}")
+        evidence["decomposition"]["cached_roster_heartbeat"] = run_cached_roster_heartbeat_probe(
+            endpoint,
+            home,
+            frames_per_connection,
+            workers,
+        )
         profile = run_profile(
             endpoint,
             home,

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -314,6 +314,21 @@ class AdmissionCapacityTests(unittest.TestCase):
         with mock.patch.object(RUNNER, "command_result", return_value=command):
             self.assertEqual(RUNNER.daemon_switch_result("status", options, doctor=True), status)
 
+    def test_daemon_switch_timeout_covers_its_bounded_owner_repair_window(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        with mock.patch.object(
+            RUNNER,
+            "command_result",
+            return_value={"exit_code": 0, "stdout": "", "stderr": ""},
+        ) as command:
+            self.assertEqual(RUNNER.daemon_switch_result("quiesce", options), {})
+
+        self.assertEqual(
+            command.call_args.kwargs["timeout"],
+            RUNNER.MANAGED_DAEMON_TIMEOUT_SECONDS,
+        )
+        self.assertGreaterEqual(RUNNER.MANAGED_DAEMON_TIMEOUT_SECONDS, 100.0)
+
     def test_daemon_switch_status_requires_live_pair_proof(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
         status = healthy_managed_status()
@@ -383,6 +398,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                 mock.patch.object(RUNNER, "release_binary", side_effect=[atm, daemon]),
                 mock.patch.object(RUNNER, "runtime_environment", return_value={}),
                 mock.patch.object(RUNNER, "prepare_capacity_roster"),
+                mock.patch.object(RUNNER, "run_direct_storage_probe"),
                 mock.patch.object(
                     RUNNER, "start_capacity_daemon", side_effect=RUNNER.SmokeError("benchmark failed"),
                 ),
@@ -878,6 +894,67 @@ class AdmissionCapacityTests(unittest.TestCase):
             ],
         )
         self.assertEqual(command.call_args_list[1].args[0][4], "capacity-recipient")
+
+    def test_cached_roster_heartbeat_body_targets_the_warmed_capacity_member(self):
+        body = json.loads(RUNNER.cached_roster_heartbeat_body(17))
+        self.assertEqual(body["team"], "capacity-team")
+        self.assertEqual(body["member"], "capacity-agent")
+        self.assertEqual(body["pid"], 90_017)
+        self.assertEqual(body["activity"], "active_tool_use")
+        self.assertTrue(body["observed_at"].endswith("Z"))
+
+    def test_cached_roster_probe_warms_once_then_records_a_no_sqlite_profile(self):
+        warmup = RUNNER.AdmissionResult(status=200, elapsed_ms=0.1)
+        profile = {"passed": True, "operation": "cached_roster_heartbeat"}
+        endpoint = RUNNER.LocalEndpoint("uds", "/tmp/atm.sock")
+        with (
+            mock.patch.object(RUNNER, "submit_connection", return_value=[warmup]) as submit,
+            mock.patch.object(RUNNER, "run_profile", return_value=profile) as run_profile,
+        ):
+            result = RUNNER.run_cached_roster_heartbeat_probe(endpoint, Path("/tmp/home"), 1, 8)
+
+        self.assertEqual(result["warmup"], {"status": 200, "passed": True})
+        self.assertIn("no SQLite reads", result["storage"])
+        request = submit.call_args.args[1][0]
+        self.assertEqual(request.path, "/v1/atm/heartbeat")
+        self.assertEqual(request.expected_status, 200)
+        self.assertEqual(run_profile.call_args.kwargs["operation"], "cached_roster_heartbeat")
+        self.assertEqual(run_profile.call_args.kwargs["minimum_admissions_per_second"], 0)
+
+    def test_direct_storage_probe_requires_a_complete_json_result(self):
+        daemon = Path("/tmp/atm-daemon-benchmark")
+        payload = {
+            "kind": "async_storage_admission",
+            "requested_count": RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES,
+            "accepted_count": RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES,
+            "worker_count": 8,
+            "elapsed_seconds": 0.2,
+            "admissions_per_second": 50_000.0,
+        }
+        with mock.patch.object(
+            RUNNER,
+            "command_result",
+            return_value={"exit_code": 0, "stdout": json.dumps(payload) + "\n", "stderr": ""},
+        ) as command:
+            result = RUNNER.run_direct_storage_probe(daemon, {"ATM_HOME": "/tmp/home"}, 8)
+
+        self.assertEqual(result, payload)
+        self.assertEqual(
+            command.call_args.args[0],
+            [
+                str(daemon), "--direct-storage-admission",
+                str(RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES), "--workers", "8",
+            ],
+        )
+
+    def test_direct_storage_probe_rejects_a_partial_or_non_json_result(self):
+        with mock.patch.object(
+            RUNNER,
+            "command_result",
+            return_value={"exit_code": 0, "stdout": "not-json\n", "stderr": ""},
+        ):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "no JSON result"):
+                RUNNER.run_direct_storage_probe(Path("/tmp/daemon"), {}, 1)
 
     def test_interval_preserves_the_first_failure_and_requires_all_1000_responses(self):
         calls = 0

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -399,6 +399,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                 mock.patch.object(RUNNER, "runtime_environment", return_value={}),
                 mock.patch.object(RUNNER, "prepare_capacity_roster"),
                 mock.patch.object(RUNNER, "run_direct_storage_probe"),
+                mock.patch.object(RUNNER, "run_direct_core_write_probe"),
                 mock.patch.object(
                     RUNNER, "start_capacity_daemon", side_effect=RUNNER.SmokeError("benchmark failed"),
                 ),
@@ -955,6 +956,32 @@ class AdmissionCapacityTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(RUNNER.SmokeError, "no JSON result"):
                 RUNNER.run_direct_storage_probe(Path("/tmp/daemon"), {}, 1)
+
+    def test_direct_core_write_probe_uses_the_canonical_write_mode(self):
+        daemon = Path("/tmp/atm-daemon-benchmark")
+        payload = {
+            "kind": "canonical_core_write",
+            "requested_count": RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES,
+            "accepted_count": RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES,
+            "worker_count": 8,
+            "elapsed_seconds": 0.5,
+            "admissions_per_second": 20_000.0,
+        }
+        with mock.patch.object(
+            RUNNER,
+            "command_result",
+            return_value={"exit_code": 0, "stdout": json.dumps(payload) + "\n", "stderr": ""},
+        ) as command:
+            result = RUNNER.run_direct_core_write_probe(daemon, {"ATM_HOME": "/tmp/home"}, 8)
+
+        self.assertEqual(result, payload)
+        self.assertEqual(
+            command.call_args.args[0],
+            [
+                str(daemon), "--direct-core-write",
+                str(RUNNER.DIRECT_STORAGE_DIAGNOSTIC_WRITES), "--workers", "8",
+            ],
+        )
 
     def test_interval_preserves_the_first_failure_and_requires_all_1000_responses(self):
         calls = 0

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -507,7 +507,20 @@ class AdmissionCapacityTests(unittest.TestCase):
         )
 
     def test_evidence_file_retains_the_transport_schema_fields(self):
-        evidence = complete_evidence(frames_per_connection=16, messages_per_connection=16)
+        evidence = complete_evidence(
+            frames_per_connection=16,
+            messages_per_connection=16,
+            decomposition={
+                "async_storage_admission": {
+                    "kind": "async_storage_admission",
+                    "requested_count": 10_000,
+                    "accepted_count": 10_000,
+                    "worker_count": 64,
+                    "elapsed_seconds": 0.2,
+                    "admissions_per_second": 50_000.0,
+                },
+            },
+        )
         with tempfile.TemporaryDirectory() as temp:
             path = RUNNER.write_evidence(Path(temp), evidence)
             recorded = __import__("json").loads(path.read_text(encoding="utf-8"))
@@ -515,6 +528,10 @@ class AdmissionCapacityTests(unittest.TestCase):
         self.assertEqual(recorded["schema_version"], 3)
         self.assertEqual(recorded["transport"], "tcp")
         self.assertEqual(recorded["frames_per_connection"], 16)
+        self.assertEqual(
+            recorded["direct_sqlite_message_write"]["admissions_per_second"],
+            50_000.0,
+        )
 
     def test_profile_schema_distinguishes_minimum_from_actual_sample_count(self):
         interval = {"passed": True, "elapsed_seconds": 0.6}

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -895,6 +895,15 @@ class AdmissionCapacityTests(unittest.TestCase):
             ],
         )
         self.assertEqual(command.call_args_list[1].args[0][4], "capacity-recipient")
+        self.assertEqual(len(command.call_args_list), 4)
+        self.assertEqual(
+            command.call_args_list[2].args[0],
+            [
+                str(atm), "teams", "add-member", "capacity-core-team", "capacity-core-agent",
+                "--home-dir", str(capacity_home), "--json",
+            ],
+        )
+        self.assertEqual(command.call_args_list[3].args[0][4], "capacity-core-recipient")
 
     def test_cached_roster_heartbeat_body_targets_the_warmed_capacity_member(self):
         body = json.loads(RUNNER.cached_roster_heartbeat_body(17))

--- a/templates/benchmark-report/benchmark-report.html.j2
+++ b/templates/benchmark-report/benchmark-report.html.j2
@@ -34,7 +34,7 @@ required_variables:
   <p>Latest profile state: {{ profile_count }} profiles, {{ passed_count }} passed, {{ failed_count }} failed. {{ history_count }} historical runs retained.</p>
   <h2>UTC benchmark history</h2>
   <table>
-    <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Status</th><th>Evidence</th></tr></thead>
+    <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Direct SQLite msg/s</th><th>Status</th><th>Evidence</th></tr></thead>
     <tbody>
 {% for row in rows %}
       <tr>
@@ -42,6 +42,7 @@ required_variables:
         <td>{{ row.host_label | e }}</td>
         <td>{{ row.transport | e }}</td>
         <td>{{ row.frames_per_connection }}</td>
+        <td>{{ 'n/a' if row.direct_sqlite_admissions_per_second is none else '%.2f' | format(row.direct_sqlite_admissions_per_second) }}</td>
         <td class="{{ 'pass' if row.passed else 'fail' }}">{{ 'PASS' if row.passed else 'FAIL' }}</td>
         <td><a href="{{ row.json_href | e }}">JSON</a> · <a href="{{ row.xhtml_href | e }}">XHTML panel</a></td>
       </tr>

--- a/templates/benchmark-report/benchmark-run.xhtml.j2
+++ b/templates/benchmark-report/benchmark-run.xhtml.j2
@@ -14,6 +14,7 @@ required_variables:
   - failure
   - cleanup_failure
   - sample_html
+  - direct_sqlite_html
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
@@ -35,4 +36,6 @@ required_variables:
 {% endif %}
   <h2>Samples</h2>
 {{ sample_html | safe }}
+  <h2>Direct SQLite message-write ceiling</h2>
+{{ direct_sqlite_html | safe }}
 </section>


### PR DESCRIPTION
## Summary
- Decomposed the async HTTP admission path (Tokio+Axum runtime) to isolate SQLite vs HTTP/UDS request-processing cost, revealing the writer-thread lane was not the bottleneck.
- Removed the post-commit synchronous SQLite record reload from normal public writes, preserving hook warning semantics and host-qualified localhost compatibility.
- Added benchmark reporting automation that rebuilds canonical `site/reports` evidence per run (direct async SQLite admission, public UDS, public TCP profiles) as immutable JSON, XHTML panels, and an aggregate report.
- QA1-FIX-1: extracted the received-hook planning block from `prepare_persisted_write` into `crates/atm-core/src/send/received_hook.rs`, resolving RULE-002 (function-length) and RULE-003 (file-size) blocking lint findings (send/mod.rs 1005 -> 966 prod lines).

## Result
M5 managed UDS-F1 (hook-disabled): **17,799.23 msg/s** (p50 1.294ms, p99 7.056ms) — a claimed 4.7x improvement over the prior ~3.9k msg/s regression, now above develop's own M5 UDS-F1 baseline (~14.7k-15.6k p50). SQLite/core capacity benchmarks at ~47k msg/s; remaining gap to that ceiling is HTTP/UDS request-processing overhead, not storage.

**Caveat (quality-mgr QA-2):** the above throughput numbers are self-reported by arch-ctm and not yet backed by a committed benchmark JSON artifact in this PR's diff (only report-generation scaffolding was added, no captured run output). Treat as unverified pending an attached raw benchmark artifact.

## Test plan
- [x] `just test` (462 passing)
- [x] targeted benchmark/report/signing tests
- [x] `diff --check`
- [x] quality-mgr QA-1 (FAIL -> RULE-002/RULE-003 fixed)
- [x] quality-mgr QA-2 (PASS 2/2, CI 9/9 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
