### PR TITLE
fix: sync Python graft crate to workspace version base

### DIFF
--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -13,7 +13,9 @@ from lint_common import workspace_manifest_paths
 
 PYTHON_GRAFT_MANIFEST = Path("crates/atm-graft-python/Cargo.toml")
 VERSION_BASE_PATTERN = re.compile(
-    r"^(?P<base>\d+\.\d+\.\d+)(?:[-+][0-9A-Za-z.-]+)?$"
+    r"^(?P<base>\d+\.\d+\.\d+)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
 

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -11,6 +11,12 @@ from lint_common import workspace_crate_section_lines
 from lint_common import workspace_manifest_paths
 
 
+PYTHON_GRAFT_MANIFEST = Path("crates/atm-graft-python/Cargo.toml")
+VERSION_BASE_PATTERN = re.compile(
+    r"^(?P<base>\d+\.\d+\.\d+)(?:[-+][0-9A-Za-z.-]+)?$"
+)
+
+
 def fail(message: str) -> None:
     raise SystemExit(message)
 
@@ -62,6 +68,36 @@ def validate_workspace_version(repo_root: Path) -> str:
     if not workspace_version:
         fail("workspace version missing from Cargo.toml")
     return workspace_version
+
+
+def normalized_version_base(version: str, label: str) -> str:
+    """Return the numeric MAJOR.MINOR.PATCH base of a Cargo version."""
+
+    match = VERSION_BASE_PATTERN.fullmatch(version.strip())
+    if match is None:
+        fail(f"{label} ({version}) is not a valid Cargo semantic version")
+    return match.group("base")
+
+
+def validate_python_graft_version(repo_root: Path, workspace_version: str) -> None:
+    """Require the Maturin crate's explicit version to be the workspace base."""
+
+    manifest_path = repo_root / PYTHON_GRAFT_MANIFEST
+    rel_manifest = PYTHON_GRAFT_MANIFEST.as_posix()
+    manifest = tomllib.loads(read_text(manifest_path))
+    package = manifest.get("package", {})
+    actual = package.get("version") if isinstance(package, dict) else None
+    expected = normalized_version_base(workspace_version, "workspace version")
+    if not isinstance(actual, str) or not actual.strip():
+        fail(
+            f"{rel_manifest} [package].version ({actual!r}) must equal "
+            f"workspace version base ({expected})"
+        )
+    if actual != expected:
+        fail(
+            f"{rel_manifest} [package].version ({actual}) must equal "
+            f"workspace version base ({expected})"
+        )
 
 
 def expected_package_version(manifest: dict, workspace_version: str, manifest_label: str) -> str:
@@ -255,6 +291,7 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     config = version_sync_config(repo_root)
     workspace_version = validate_workspace_version(repo_root)
+    validate_python_graft_version(repo_root, workspace_version)
     validate_crate_versions(repo_root, workspace_version)
     validate_lockfile(repo_root, workspace_version)
 

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -83,6 +83,13 @@ class CheckVersionSyncTests(unittest.TestCase):
             validate_python_graft_version(repo_root, "1.4.1-beta-ai-15")
             validate_python_graft_version(repo_root, "1.4.1-beta-aj")
 
+    def test_python_graft_version_strips_combined_workspace_qualifiers(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.1")
+
+            validate_python_graft_version(repo_root, "1.4.1-beta-ai-15+build.7")
+
     def test_python_graft_version_rejects_wrong_patch(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
@@ -107,6 +114,19 @@ class CheckVersionSyncTests(unittest.TestCase):
             message = str(error.exception)
             self.assertIn("crates/atm-graft-python/Cargo.toml", message)
             self.assertIn("1.4.1-beta-ai", message)
+            self.assertIn("1.4.1", message)
+
+    def test_python_graft_version_rejects_python_build_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.1+local")
+
+            with self.assertRaises(SystemExit) as error:
+                validate_python_graft_version(repo_root, "1.4.1-beta-ai-15+build.7")
+
+            message = str(error.exception)
+            self.assertIn("crates/atm-graft-python/Cargo.toml", message)
+            self.assertIn("1.4.1+local", message)
             self.assertIn("1.4.1", message)
 
     def test_real_repository_python_graft_version_is_numeric_workspace_base(self) -> None:

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import tempfile
+import tomllib
 import unittest
 
 
@@ -14,6 +15,7 @@ from check_version_sync import validate_crate_versions
 from check_version_sync import validate_lockfile
 from check_version_sync import validate_winget_manifests
 from check_version_sync import success_message
+from check_version_sync import validate_python_graft_version
 
 
 ROOT_MANIFEST = """\
@@ -57,6 +59,63 @@ class CheckVersionSyncTests(unittest.TestCase):
             if crate_name == "atm":
                 extra = '\n[dependencies]\natm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }\n'
             (crate_dir / "Cargo.toml").write_text(crate_manifest(package_name, extra=extra), encoding="utf-8")
+
+    def write_python_graft_manifest(self, repo_root: Path, version: str) -> None:
+        manifest_path = repo_root / "crates/atm-graft-python/Cargo.toml"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            f'[package]\nname = "atm-graft-python"\nversion = "{version}"\n',
+            encoding="utf-8",
+        )
+
+    def test_python_graft_version_accepts_final_workspace_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.1")
+
+            validate_python_graft_version(repo_root, "1.4.1")
+
+    def test_python_graft_version_strips_prerelease_workspace_qualifier(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.1")
+
+            validate_python_graft_version(repo_root, "1.4.1-beta-ai-15")
+            validate_python_graft_version(repo_root, "1.4.1-beta-aj")
+
+    def test_python_graft_version_rejects_wrong_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.2")
+
+            with self.assertRaises(SystemExit) as error:
+                validate_python_graft_version(repo_root, "1.4.1-beta-ai-15")
+
+            message = str(error.exception)
+            self.assertIn("crates/atm-graft-python/Cargo.toml", message)
+            self.assertIn("1.4.2", message)
+            self.assertIn("1.4.1", message)
+
+    def test_python_graft_version_rejects_python_prerelease(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_python_graft_manifest(repo_root, "1.4.1-beta-ai")
+
+            with self.assertRaises(SystemExit) as error:
+                validate_python_graft_version(repo_root, "1.4.1-beta-ai-15")
+
+            message = str(error.exception)
+            self.assertIn("crates/atm-graft-python/Cargo.toml", message)
+            self.assertIn("1.4.1-beta-ai", message)
+            self.assertIn("1.4.1", message)
+
+    def test_real_repository_python_graft_version_is_numeric_workspace_base(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        workspace_version = tomllib.loads(
+            (repo_root / "Cargo.toml").read_text(encoding="utf-8")
+        )["workspace"]["package"]["version"]
+
+        validate_python_graft_version(repo_root, workspace_version)
 
     def test_validate_crate_versions_checks_all_member_manifests(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary\n- normalize the workspace Cargo version to numeric MAJOR.MINOR.PATCH\n- require crates/atm-graft-python/Cargo.toml package version to equal that base\n- add final/prerelease, wrong-patch, qualifier, and real-repository regression coverage\n\n## Verification\n- python3 -m unittest discover -s .just/tests -p 'test_check_version_sync.py'\n- python3 .just/check_version_sync.py\n- just lint\n- git diff --check\n\nNo daemon/runtime behavior or package dependency pins changed.