### PR TITLE
feat(skills): add hermes-gateway status/reset skill

### DIFF
--- a/.claude/skills/hermes-gateway/SKILL.md
+++ b/.claude/skills/hermes-gateway/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-gateway
-description: Check status of, or reset, a Hermes graft agent's gateway. Use when a Hermes-graft agent's published endpoint record is stale (wrong schema_version, wrong owner_generation, or workspace-rooted instead of roster-home-rooted) and sends are accepted but the receiver hook fails to decode or route them, or when simply checking whether a profile's gateway is up. Triggers: "restart hermes gateway", "hermes gateway", "hermes gateway status", "reset hermes gateway".
+description: "Check status of, or reset, a Hermes graft agent's gateway. Use when a Hermes-graft agent's published endpoint record is stale (wrong schema_version, wrong owner_generation, or workspace-rooted instead of roster-home-rooted) and sends are accepted but the receiver hook fails to decode or route them, or when simply checking whether a profile's gateway is up. Triggers: restart hermes gateway, hermes gateway, hermes gateway status, reset hermes gateway."
 ---
 
 # Hermes Gateway
@@ -14,6 +14,10 @@ authored by the `skillrx` Hermes-graft agent for this skill, at
 `.claude/skills/hermes-gateway/scripts/hermes_gateway`. Invoke it via that
 explicit relative path — do not assume a bare `hermes_gateway` command is on
 `PATH`.
+
+The utility itself enforces the same single-profile boundary: it requires one
+named profile for both status and reset and rejects an unknown profile. It
+never provides a fleet-wide reset command.
 
 ## Required Parameter
 
@@ -59,7 +63,9 @@ here.
 3. Identify whether the record's path is workspace-rooted (wrong) rather than
    roster-home-rooted (correct). Roster-home resolution is normally reached
    via a profile symlink; a broken or missing symlink is the most common root
-   cause of a workspace-rooted publish.
+   cause of a workspace-rooted publish. Do not repair the bridge or restart
+   the gateway until the bridge's **installed package** and this linkage are
+   both known; the gateway reads the bridge handshake at startup.
 
 ### Rules
 
@@ -77,7 +83,8 @@ here.
       hoc workspace checkout).
    b. Repair the endpoint-root linkage (recreate/repoint the profile symlink
       so bridge output resolves to the roster-home path the daemon looks up).
-   c. Restart its gateway so it republishes under `schema_version: 2` with a
+   c. Start the corrected installed bridge, then restart its gateway so the
+      gateway reads that handshake and republishes under `schema_version: 2` with a
       fresh `owner_generation` ULID:
       `.claude/skills/hermes-gateway/scripts/hermes_gateway --restart
       <agent_name>`. This uses `launchctl kickstart -k` on

--- a/.claude/skills/hermes-gateway/SKILL.md
+++ b/.claude/skills/hermes-gateway/SKILL.md
@@ -1,111 +1,54 @@
 ---
 name: hermes-gateway
-description: "Check status of, or reset, a Hermes graft agent's gateway. Use when a Hermes-graft agent's published endpoint record is stale (wrong schema_version, wrong owner_generation, or workspace-rooted instead of roster-home-rooted) and sends are accepted but the receiver hook fails to decode or route them, or when simply checking whether a profile's gateway is up. Triggers: restart hermes gateway, hermes gateway, hermes gateway status, reset hermes gateway."
+description: "List Hermes agent gateway status or reset one or more named Hermes agent gateways. Use when asked to check, list, restart, or reset a Hermes gateway. Triggers: hermes gateway status, list hermes agents, reset skillrx gateway, restart Hermes gateway."
 ---
 
 # Hermes Gateway
 
-Check status of, or reset, exactly one Hermes-graft agent's gateway. This
-skill never edits the published endpoint JSON by hand.
+List gateway state, inspect one Hermes agent, or reset one or more explicitly
+named agents. Invoke the vendored utility at
+`.claude/skills/hermes-gateway/scripts/hermes_gateway`; do not assume a bare
+`hermes_gateway` command is on `PATH`.
 
-This skill vendors `hermes_gateway`, a status/restart utility originally
-authored by the `skillrx` Hermes-graft agent for this skill, at
-`.claude/skills/hermes-gateway/scripts/hermes_gateway`. Invoke it via that
-explicit relative path — do not assume a bare `hermes_gateway` command is on
-`PATH`.
-
-The utility itself enforces the same single-profile boundary: it requires one
-named profile for both status and reset and rejects an unknown profile. It
-never provides a fleet-wide reset command.
-
-## Required Parameter
-
-- `agent_name` (**mandatory**) — the Hermes-graft agent whose gateway is being
-  checked or reset, e.g. `skillrx`. Every invocation must specify exactly one
-  `agent_name`; this skill does not support a fleet-wide or unscoped
-  operation.
+The utility rejects unknown profiles and accepts only explicit profile names
+for reset. It does not provide a wildcard or implicit fleet reset.
 
 ## Invocation
 
 ```
-/hermes-gateway <agent_name>              # status only (default)
-/hermes-gateway <agent_name> --reset      # full reset procedure
+/hermes-gateway --list                         # list every agent gateway state
+/hermes-gateway <agent_name>                    # inspect one named agent
+/hermes-gateway <agent_name> [<agent> ...] --reset # reset named agents
 ```
 
-Refuse to proceed without an explicit `agent_name`.
+- `--list` is status-only and makes no changes.
+- A named-agent status command makes no changes.
+- `--reset` follows one or more explicit names; it first prints each target's
+  state, then resets that target. It does not accept `all`.
 
-## Always Get Agent Info First
+## Status Procedure
 
-Regardless of whether the invocation requests status or `--reset`, always
-start by running:
+For one named agent, run:
 
 ```
 .claude/skills/hermes-gateway/scripts/hermes_gateway <agent_name>
 ```
 
-This reports the LaunchAgent PID, status (running/dead/stopped), and Telegram
-chat ID sourced from `~/.hermes/profiles/<agent_name>/channel_directory.json`.
-Use it to confirm the profile exists and to see its current state before
-deciding whether a reset is even warranted — a status-only invocation stops
-here.
+For an inventory, run `.claude/skills/hermes-gateway/scripts/hermes_gateway
+--list`. It reports every configured profile's LaunchAgent state and PID where
+available.
 
-## Reset Procedure (`--reset` only)
+## Reset Procedure
 
-### Preconditions
+1. Confirm explicit target names. Do not reset the gateway currently carrying
+   your own session without the user's confirmation.
+2. Run `.claude/skills/hermes-gateway/scripts/hermes_gateway <agent>
+   [<agent> ...] --reset`. The utility reports status before each action,
+   uses `launchctl kickstart -k` for loaded services, and bootstraps absent
+   services.
+3. Re-run the named-agent status command after the reset. Report any target
+   that remains stopped or dead; do not retry indefinitely.
 
-1. Confirm the target agent's current endpoint record location, typically
-   `<workspace>/.atm/graft/hermes/<agent_name>.json`.
-2. Read the record and note `schema_version`. The current contract requires
-   `schema_version: 2` with `owner_generation` (ULID), `owner_chat_id`,
-   `loopback`, and `capability` fields. Any older/absent schema version, or a
-   record missing those fields, is stale and in scope for reset.
-3. Identify whether the record's path is workspace-rooted (wrong) rather than
-   roster-home-rooted (correct). Roster-home resolution is normally reached
-   via a profile symlink; a broken or missing symlink is the most common root
-   cause of a workspace-rooted publish. Do not repair the bridge or restart
-   the gateway until the bridge's **installed package** and this linkage are
-   both known; the gateway reads the bridge handshake at startup.
+## Non-Goal
 
-### Rules
-
-1. **Never hand-edit the stale JSON record.** Editing the file only masks the
-   underlying linkage/version defect and produces an unverified proof.
-2. **Never fabricate or synthesize proof events.** A synthetic Telegram
-   `MessageEvent` or equivalent does not satisfy the live-proof requirement —
-   only an authenticated steer/send from the agent's real, running gateway
-   counts.
-3. **Never restart a gateway you are currently speaking through** without
-   explicit confirmation — `hermes_gateway --restart` kills the LaunchAgent
-   process, which drops the session driving it.
-4. Instruct `agent_name` to:
-   a. Run the installed `atm-graft` bridge from its real profile (not an ad
-      hoc workspace checkout).
-   b. Repair the endpoint-root linkage (recreate/repoint the profile symlink
-      so bridge output resolves to the roster-home path the daemon looks up).
-   c. Start the corrected installed bridge, then restart its gateway so the
-      gateway reads that handshake and republishes under `schema_version: 2` with a
-      fresh `owner_generation` ULID:
-      `.claude/skills/hermes-gateway/scripts/hermes_gateway --restart
-      <agent_name>`. This uses `launchctl kickstart -k` on
-      `ai.hermes.gateway-<agent_name>` if already running, or
-      `launchctl bootstrap` if stopped.
-   d. Prove the reset with one authenticated steer/send through the live
-      gateway.
-5. Poll for the endpoint record to update (short fixed interval, bounded
-   attempts — e.g. six 5-second polls), cross-checking
-   `.claude/skills/hermes-gateway/scripts/hermes_gateway <agent_name>` to
-   confirm the LaunchAgent actually came back up with a new PID. If the
-   record has not advanced past the stale `schema_version` after the bounded
-   poll window, escalate with the concrete diagnosis (record path, observed
-   vs required schema_version, PID/address last seen) rather than continuing
-   to poll indefinitely.
-6. Once the record shows `schema_version: 2` with all required fields, verify
-   the authenticated steer/send proof before declaring the reset complete.
-
-## Non-Goals
-
-- Does not reset more than one agent's gateway per invocation (`hermes_gateway
-  --restart all` is out of scope here — this skill is single-profile only).
-- Does not modify daemon-side lookup logic — this is an endpoint-publication
-  reset on the agent side only.
-- Does not accept a synthetic/simulated event as reset proof.
+Does not reset an unbounded set of agents; every reset target is named.

--- a/.claude/skills/hermes-gateway/SKILL.md
+++ b/.claude/skills/hermes-gateway/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: hermes-gateway
+description: Check status of, or reset, a Hermes graft agent's gateway. Use when a Hermes-graft agent's published endpoint record is stale (wrong schema_version, wrong owner_generation, or workspace-rooted instead of roster-home-rooted) and sends are accepted but the receiver hook fails to decode or route them, or when simply checking whether a profile's gateway is up. Triggers: "restart hermes gateway", "hermes gateway", "hermes gateway status", "reset hermes gateway".
+---
+
+# Hermes Gateway
+
+Check status of, or reset, exactly one Hermes-graft agent's gateway. This
+skill never edits the published endpoint JSON by hand — a reset always drives
+the agent to regenerate it from the installed `atm-graft` bridge.
+
+This skill vendors `hermes_gateway`, a status/restart utility originally
+authored by the `skillrx` Hermes-graft agent for this skill, at
+`.claude/skills/hermes-gateway/scripts/hermes_gateway`. Invoke it via that
+explicit relative path — do not assume a bare `hermes_gateway` command is on
+`PATH`.
+
+## Required Parameter
+
+- `agent_name` (**mandatory**) — the Hermes-graft agent whose gateway is being
+  checked or reset, e.g. `skillrx`. Every invocation must specify exactly one
+  `agent_name`; this skill does not support a fleet-wide or unscoped
+  operation.
+
+## Invocation
+
+```
+/hermes-gateway <agent_name>              # status only (default)
+/hermes-gateway <agent_name> --reset      # full reset procedure
+```
+
+Refuse to proceed without an explicit `agent_name`.
+
+## Always Get Agent Info First
+
+Regardless of whether the invocation requests status or `--reset`, always
+start by running:
+
+```
+.claude/skills/hermes-gateway/scripts/hermes_gateway <agent_name>
+```
+
+This reports the LaunchAgent PID, status (running/dead/stopped), and Telegram
+chat ID sourced from `~/.hermes/profiles/<agent_name>/channel_directory.json`.
+Use it to confirm the profile exists and to see its current state before
+deciding whether a reset is even warranted — a status-only invocation stops
+here.
+
+## Reset Procedure (`--reset` only)
+
+### Preconditions
+
+1. Confirm the target agent's current endpoint record location, typically
+   `<workspace>/.atm/graft/hermes/<agent_name>.json`.
+2. Read the record and note `schema_version`. The current contract requires
+   `schema_version: 2` with `owner_generation` (ULID), `owner_chat_id`,
+   `loopback`, and `capability` fields. Any older/absent schema version, or a
+   record missing those fields, is stale and in scope for reset.
+3. Identify whether the record's path is workspace-rooted (wrong) rather than
+   roster-home-rooted (correct). Roster-home resolution is normally reached
+   via a profile symlink; a broken or missing symlink is the most common root
+   cause of a workspace-rooted publish.
+
+### Rules
+
+1. **Never hand-edit the stale JSON record.** Editing the file only masks the
+   underlying linkage/version defect and produces an unverified proof.
+2. **Never fabricate or synthesize proof events.** A synthetic Telegram
+   `MessageEvent` or equivalent does not satisfy the live-proof requirement —
+   only an authenticated steer/send from the agent's real, running gateway
+   counts.
+3. **Never restart a gateway you are currently speaking through** without
+   explicit confirmation — `hermes_gateway --restart` kills the LaunchAgent
+   process, which drops the session driving it.
+4. Instruct `agent_name` to:
+   a. Run the installed `atm-graft` bridge from its real profile (not an ad
+      hoc workspace checkout).
+   b. Repair the endpoint-root linkage (recreate/repoint the profile symlink
+      so bridge output resolves to the roster-home path the daemon looks up).
+   c. Restart its gateway so it republishes under `schema_version: 2` with a
+      fresh `owner_generation` ULID:
+      `.claude/skills/hermes-gateway/scripts/hermes_gateway --restart
+      <agent_name>`. This uses `launchctl kickstart -k` on
+      `ai.hermes.gateway-<agent_name>` if already running, or
+      `launchctl bootstrap` if stopped.
+   d. Prove the reset with one authenticated steer/send through the live
+      gateway.
+5. Poll for the endpoint record to update (short fixed interval, bounded
+   attempts — e.g. six 5-second polls), cross-checking
+   `.claude/skills/hermes-gateway/scripts/hermes_gateway <agent_name>` to
+   confirm the LaunchAgent actually came back up with a new PID. If the
+   record has not advanced past the stale `schema_version` after the bounded
+   poll window, escalate with the concrete diagnosis (record path, observed
+   vs required schema_version, PID/address last seen) rather than continuing
+   to poll indefinitely.
+6. Once the record shows `schema_version: 2` with all required fields, verify
+   the authenticated steer/send proof before declaring the reset complete.
+
+## Non-Goals
+
+- Does not reset more than one agent's gateway per invocation (`hermes_gateway
+  --restart all` is out of scope here — this skill is single-profile only).
+- Does not modify daemon-side lookup logic — this is an endpoint-publication
+  reset on the agent side only.
+- Does not accept a synthetic/simulated event as reset proof.

--- a/.claude/skills/hermes-gateway/SKILL.md
+++ b/.claude/skills/hermes-gateway/SKILL.md
@@ -26,6 +26,18 @@ for reset. It does not provide a wildcard or implicit fleet reset.
 - `--reset` follows one or more explicit names; it first prints each target's
   state, then resets that target. It does not accept `all`.
 
+## Always Inspect Before Reset
+
+Always get the current state for every named agent before requesting a reset:
+
+```
+.claude/skills/hermes-gateway/scripts/hermes_gateway <agent_name>
+```
+
+Use that result to confirm the target and report its current PID or stopped
+state. Do not reset the gateway carrying your own active session without the
+user's confirmation.
+
 ## Status Procedure
 
 For one named agent, run:
@@ -40,13 +52,14 @@ available.
 
 ## Reset Procedure
 
-1. Confirm explicit target names. Do not reset the gateway currently carrying
-   your own session without the user's confirmation.
-2. Run `.claude/skills/hermes-gateway/scripts/hermes_gateway <agent>
+1. Inspect every target with the named-agent status command above.
+2. Confirm the explicit target names against that status. The reset interface
+   supports one or more named targets, never a wildcard or fleet reset.
+3. Run `.claude/skills/hermes-gateway/scripts/hermes_gateway <agent>
    [<agent> ...] --reset`. The utility reports status before each action,
    uses `launchctl kickstart -k` for loaded services, and bootstraps absent
    services.
-3. Re-run the named-agent status command after the reset. Report any target
+4. Re-run the named-agent status command after the reset. Report any target
    that remains stopped or dead; do not retry indefinitely.
 
 ## Non-Goal

--- a/.claude/skills/hermes-gateway/SKILL.md
+++ b/.claude/skills/hermes-gateway/SKILL.md
@@ -6,8 +6,7 @@ description: "Check status of, or reset, a Hermes graft agent's gateway. Use whe
 # Hermes Gateway
 
 Check status of, or reset, exactly one Hermes-graft agent's gateway. This
-skill never edits the published endpoint JSON by hand — a reset always drives
-the agent to regenerate it from the installed `atm-graft` bridge.
+skill never edits the published endpoint JSON by hand.
 
 This skill vendors `hermes_gateway`, a status/restart utility originally
 authored by the `skillrx` Hermes-graft agent for this skill, at

--- a/.claude/skills/hermes-gateway/scripts/hermes_gateway
+++ b/.claude/skills/hermes-gateway/scripts/hermes_gateway
@@ -16,10 +16,8 @@ HELP = """\
 hermes_gateway — manage Hermes gateway LaunchAgents by profile name.
 
 USAGE
-  hermes_gateway                          list all profiles with gateway status
   hermes_gateway <profile>                show detail for a single profile
   hermes_gateway --restart <profile>      restart one profile's gateway
-  hermes_gateway --restart all            restart all running gateways
   hermes_gateway --help                   show this help
 
 DESCRIPTION
@@ -43,10 +41,8 @@ EXIT CODES
   1   error (profile not found, plist missing, restart failed)
 
 EXAMPLES
-  $ hermes_gateway
   $ hermes_gateway skillrx
   $ hermes_gateway --restart alpha-prime
-  $ hermes_gateway --restart all
 """
 
 
@@ -139,18 +135,25 @@ def restart(profile: str) -> bool:
         return False
 
     info = _parse_launchctl(label)
-    if info.get("running"):
-        print(f"Restarting {profile} ({label})...")
-        subprocess.run(
-            ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
-            check=True,
-        )
-    else:
-        print(f"Bootstrapping {profile} ({label})...")
-        subprocess.run(
-            ["launchctl", "bootstrap", f"gui/{os.getuid()}", plist],
-            check=True,
-        )
+    try:
+        if info:
+            # A loaded-but-dead service still has a launchd record; bootstrap
+            # would fail there. Kickstart is correct for both live and dead
+            # loaded profiles.
+            print(f"Restarting {profile} ({label})...")
+            subprocess.run(
+                ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
+                check=True,
+            )
+        else:
+            print(f"Bootstrapping {profile} ({label})...")
+            subprocess.run(
+                ["launchctl", "bootstrap", f"gui/{os.getuid()}", plist],
+                check=True,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        print(f"ERROR: gateway reset command failed for {profile}: {error}", file=sys.stderr)
+        return False
 
     time.sleep(2)
     new_info = _parse_launchctl(label)
@@ -185,61 +188,56 @@ def fmt_row(profile: str, gateway_status: str, info: dict) -> str:
     return f"  {symbol} {profile:<20} {status:<8} chat={chat:<16} {detail}"
 
 
-def main():
-    if len(sys.argv) == 2 and sys.argv[1] in ("--help", "-h"):
+def known_profile(profile: str) -> bool:
+    """Reject misspelled profiles instead of reporting a fictional stopped one."""
+    return any(item.get("name") == profile for item in list_profiles())
+
+
+def show_status(profile: str) -> None:
+    """Display the single profile state used to decide whether reset is safe."""
+    label = gateway_label(profile)
+    info = _parse_launchctl(label)
+    chat = get_chat_id(profile) or "—"
+    pid = info.get("pid")
+    lex = info.get("last_exit")
+    if info.get("running"):
+        stat = f"running (PID {pid})"
+    elif lex is not None:
+        stat = f"dead (exit {lex})"
+    else:
+        stat = "stopped"
+    print(f"Profile:   {profile}")
+    print(f"Label:     {label}")
+    print(f"Chat ID:   {chat}")
+    print(f"Status:    {stat}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) == 1 and argv[0] in ("--help", "-h"):
         print(HELP)
-        return
+        return 0
 
-    if len(sys.argv) >= 3 and sys.argv[1] == "--restart":
-        target = sys.argv[2]
-        if target == "all":
-            profiles = list_profiles()
-            for p in profiles:
-                name = p["name"]
-                info = _parse_launchctl(gateway_label(name))
-                if info.get("running"):
-                    print(f"\n--- {name} ---")
-                    restart(name)
-        else:
-            restart(target)
-        return
+    restart_requested = len(argv) == 2 and argv[0] == "--restart"
+    status_requested = len(argv) == 1 and not argv[0].startswith("--")
+    if not restart_requested and not status_requested:
+        print("ERROR: specify exactly one profile, optionally with --restart", file=sys.stderr)
+        print(HELP, file=sys.stderr)
+        return 2
 
-    if len(sys.argv) == 2 and not sys.argv[1].startswith("--"):
-        profile = sys.argv[1]
-        label = gateway_label(profile)
-        info = _parse_launchctl(label)
-        chat = get_chat_id(profile) or "—"
-        pid = info.get("pid")
-        lex = info.get("last_exit")
-        if info.get("running"):
-            stat = f"running (PID {pid})"
-        elif lex is not None:
-            stat = f"dead (exit {lex})"
-        else:
-            stat = "stopped"
-        print(f"Profile:   {profile}")
-        print(f"Label:     {label}")
-        print(f"Chat ID:   {chat}")
-        print(f"Status:    {stat}")
-        return
+    profile = argv[1] if restart_requested else argv[0]
+    if not known_profile(profile):
+        print(f"ERROR: Hermes profile does not exist: {profile}", file=sys.stderr)
+        return 1
+    if restart_requested:
+        # Reset is deliberately never blind: the status record is emitted
+        # before the launchd action so the operator can stop a dangerous reset.
+        show_status(profile)
+        return 0 if restart(profile) else 1
 
-    # Default: list all
-    profiles = list_profiles()
-    print(f"{'':2} {'PROFILE':<20} {'STATUS':<8} {'CHAT':<18} DETAILS")
-    print(f"  {'─'*64}")
-    running, total, plisted = 0, 0, 0
-    for p in profiles:
-        name = p["name"]
-        has_plist = os.path.isfile(plist_path(name))
-        if has_plist:
-            plisted += 1
-        info = _parse_launchctl(gateway_label(name)) if has_plist else {}
-        if info.get("running"):
-            running += 1
-        total += 1
-        print(fmt_row(name, p.get("gateway_status", "unknown"), info))
-    print(f"\n  {running}/{plisted} gateways running  ({total} profiles total)")
+    show_status(profile)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.claude/skills/hermes-gateway/scripts/hermes_gateway
+++ b/.claude/skills/hermes-gateway/scripts/hermes_gateway
@@ -106,6 +106,17 @@ def _parse_launchctl(label: str) -> dict:
         return {}
 
 
+def process_is_alive(pid: int) -> bool:
+    """Return whether *pid* still names a process visible to this user."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def restart(profile: str) -> bool:
     label = gateway_label(profile)
     plist = plist_path(profile)
@@ -114,13 +125,15 @@ def restart(profile: str) -> bool:
         print(f"ERROR: no plist at {plist}")
         return False
 
-    info = _parse_launchctl(label)
+    old_info = _parse_launchctl(label)
+    old_pid = old_info.get("pid")
     try:
-        if info:
+        if old_info:
             # A loaded-but-dead service still has a launchd record; bootstrap
             # would fail there. Kickstart is correct for both live and dead
             # loaded profiles.
-            print(f"Restarting {profile} ({label})...")
+            suffix = f", old PID {old_pid}" if old_pid is not None else ""
+            print(f"Restarting {profile} ({label}{suffix})...")
             subprocess.run(
                 ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
                 check=True,
@@ -135,14 +148,28 @@ def restart(profile: str) -> bool:
         print(f"ERROR: gateway reset command failed for {profile}: {error}", file=sys.stderr)
         return False
 
-    time.sleep(2)
-    new_info = _parse_launchctl(label)
-    if new_info.get("running"):
-        print(f"  ✓ {profile} running (PID {new_info['pid']})")
-        return True
-    else:
-        print(f"  ✗ {profile} failed (exit {new_info.get('last_exit', '?')})")
-        return False
+    if old_pid is not None:
+        time.sleep(1)
+        if process_is_alive(old_pid):
+            print(f"  ✗ old PID {old_pid} is still alive — reset failed")
+            return False
+
+    # launchd may need a short time to create the replacement process. A
+    # successful reset must either start a service for the first time or
+    # replace the process which was previously running.
+    for _ in range(6):
+        time.sleep(2)
+        new_info = _parse_launchctl(label)
+        new_pid = new_info.get("pid")
+        if new_info.get("running") and (old_pid is None or new_pid != old_pid):
+            if old_pid is None:
+                print(f"  ✓ {profile} running (PID {new_pid})")
+            else:
+                print(f"  ✓ {profile} running (PID {new_pid}, was {old_pid})")
+            return True
+
+    print(f"  ✗ {profile} did not respawn within timeout (old PID {old_pid})")
+    return False
 
 
 def fmt_row(profile: str, info: dict) -> str:

--- a/.claude/skills/hermes-gateway/scripts/hermes_gateway
+++ b/.claude/skills/hermes-gateway/scripts/hermes_gateway
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+hermes_gateway – list/restart Hermes gateway LaunchAgents by profile name.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERMES_BASE = os.path.expanduser("~/.hermes")
+PROFILES_DIR = os.path.expanduser("~/.hermes/profiles")
+
+HELP = """\
+hermes_gateway — manage Hermes gateway LaunchAgents by profile name.
+
+USAGE
+  hermes_gateway                          list all profiles with gateway status
+  hermes_gateway <profile>                show detail for a single profile
+  hermes_gateway --restart <profile>      restart one profile's gateway
+  hermes_gateway --restart all            restart all running gateways
+  hermes_gateway --help                   show this help
+
+DESCRIPTION
+  Discovers Hermes profiles via 'hermes profile list', checks each profile's
+  gateway LaunchAgent (ai.hermes.gateway-{profile}) via launchctl, reads the
+  Telegram chat ID from each profile's channel_directory.json, and displays a
+  unified status table.
+
+  The --restart flag uses launchctl kickstart -k (for a running gateway) or
+  launchctl bootstrap (if stopped).  Restarting the gateway you are currently
+  speaking through will kill your session — use with care.
+
+DATA SOURCES
+  Profile list    hermes profile list (--json when available)
+  Gateway PID     launchctl list ai.hermes.gateway-{profile}
+  Chat ID         ~/.hermes/profiles/{profile}/channel_directory.json
+  LaunchAgent     ~/Library/LaunchAgents/ai.hermes.gateway-{profile}.plist
+
+EXIT CODES
+  0   success
+  1   error (profile not found, plist missing, restart failed)
+
+EXAMPLES
+  $ hermes_gateway
+  $ hermes_gateway skillrx
+  $ hermes_gateway --restart alpha-prime
+  $ hermes_gateway --restart all
+"""
+
+
+def get_chat_id(profile: str) -> str | None:
+    """Read chat_id from channel_directory.json."""
+    cd_path = (
+        os.path.join(HERMES_BASE, "channel_directory.json")
+        if profile == "default"
+        else os.path.join(PROFILES_DIR, profile, "channel_directory.json")
+    )
+    try:
+        with open(cd_path) as f:
+            d = json.load(f)
+        for ch in d.get("platforms", {}).get("telegram", []):
+            return ch.get("id")  # first telegram channel
+    except Exception:
+        pass
+    return None
+
+
+def list_profiles() -> list[dict]:
+    """Return list of {name, gateway_status} from hermes profile list --json."""
+    try:
+        raw = subprocess.run(
+            ["hermes", "profile", "list", "--json"],
+            capture_output=True, text=True, check=True,
+        )
+        data = json.loads(raw.stdout)
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and "profiles" in data:
+            return data["profiles"]
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pass
+
+    # Fallback: parse table
+    raw = subprocess.run(
+        ["hermes", "profile", "list"],
+        capture_output=True, text=True,
+    )
+    profiles = []
+    for line in raw.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("Profile") or line.startswith("─") or not line:
+            continue
+        parts = line.lstrip("◆").split()
+        name = parts[0]
+        # Status is usually 3rd column
+        status = parts[2] if len(parts) > 2 else "unknown"
+        profiles.append({"name": name, "gateway_status": status})
+    return profiles
+
+
+def gateway_label(profile: str) -> str:
+    return "ai.hermes.gateway" if profile == "default" else f"ai.hermes.gateway-{profile}"
+
+
+def plist_path(profile: str) -> str:
+    return os.path.expanduser(f"~/Library/LaunchAgents/{gateway_label(profile)}.plist")
+
+
+def _parse_launchctl(label: str) -> dict:
+    """Return {running, pid, last_exit} from launchctl list, or empty dict."""
+    try:
+        out = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode != 0:
+            return {}
+        result = {}
+        for line in out.stdout.splitlines():
+            line = line.strip().rstrip(";")
+            if line.startswith('"PID"'):
+                result["pid"] = int(line.split("=")[-1].strip().strip(";"))
+                result["running"] = True
+            elif line.startswith('"LastExitStatus"'):
+                result["last_exit"] = int(line.split("=")[-1].strip().strip(";"))
+        return result
+    except subprocess.TimeoutExpired:
+        return {}
+
+
+def restart(profile: str) -> bool:
+    label = gateway_label(profile)
+    plist = plist_path(profile)
+
+    if not os.path.isfile(plist):
+        print(f"ERROR: no plist at {plist}")
+        return False
+
+    info = _parse_launchctl(label)
+    if info.get("running"):
+        print(f"Restarting {profile} ({label})...")
+        subprocess.run(
+            ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
+            check=True,
+        )
+    else:
+        print(f"Bootstrapping {profile} ({label})...")
+        subprocess.run(
+            ["launchctl", "bootstrap", f"gui/{os.getuid()}", plist],
+            check=True,
+        )
+
+    time.sleep(2)
+    new_info = _parse_launchctl(label)
+    if new_info.get("running"):
+        print(f"  ✓ {profile} running (PID {new_info['pid']})")
+        return True
+    else:
+        print(f"  ✗ {profile} failed (exit {new_info.get('last_exit', '?')})")
+        return False
+
+
+def fmt_row(profile: str, gateway_status: str, info: dict) -> str:
+    label = gateway_label(profile)
+    plist_ok = os.path.isfile(plist_path(profile))
+
+    if info.get("running"):
+        status = "running"
+        detail = f"PID {info['pid']}"
+    elif info.get("last_exit") is not None:
+        status = "dead"
+        detail = f"exit {info['last_exit']}"
+    elif plist_ok:
+        status = "stopped"
+        detail = "not running"
+    else:
+        status = "—"
+        detail = "no plist"
+
+    chat = get_chat_id(profile) or "—"
+
+    symbol = {"running": "✓", "dead": "✗", "stopped": "—"}.get(status, " ")
+    return f"  {symbol} {profile:<20} {status:<8} chat={chat:<16} {detail}"
+
+
+def main():
+    if len(sys.argv) == 2 and sys.argv[1] in ("--help", "-h"):
+        print(HELP)
+        return
+
+    if len(sys.argv) >= 3 and sys.argv[1] == "--restart":
+        target = sys.argv[2]
+        if target == "all":
+            profiles = list_profiles()
+            for p in profiles:
+                name = p["name"]
+                info = _parse_launchctl(gateway_label(name))
+                if info.get("running"):
+                    print(f"\n--- {name} ---")
+                    restart(name)
+        else:
+            restart(target)
+        return
+
+    if len(sys.argv) == 2 and not sys.argv[1].startswith("--"):
+        profile = sys.argv[1]
+        label = gateway_label(profile)
+        info = _parse_launchctl(label)
+        chat = get_chat_id(profile) or "—"
+        pid = info.get("pid")
+        lex = info.get("last_exit")
+        if info.get("running"):
+            stat = f"running (PID {pid})"
+        elif lex is not None:
+            stat = f"dead (exit {lex})"
+        else:
+            stat = "stopped"
+        print(f"Profile:   {profile}")
+        print(f"Label:     {label}")
+        print(f"Chat ID:   {chat}")
+        print(f"Status:    {stat}")
+        return
+
+    # Default: list all
+    profiles = list_profiles()
+    print(f"{'':2} {'PROFILE':<20} {'STATUS':<8} {'CHAT':<18} DETAILS")
+    print(f"  {'─'*64}")
+    running, total, plisted = 0, 0, 0
+    for p in profiles:
+        name = p["name"]
+        has_plist = os.path.isfile(plist_path(name))
+        if has_plist:
+            plisted += 1
+        info = _parse_launchctl(gateway_label(name)) if has_plist else {}
+        if info.get("running"):
+            running += 1
+        total += 1
+        print(fmt_row(name, p.get("gateway_status", "unknown"), info))
+    print(f"\n  {running}/{plisted} gateways running  ({total} profiles total)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/hermes-gateway/scripts/hermes_gateway
+++ b/.claude/skills/hermes-gateway/scripts/hermes_gateway
@@ -9,31 +9,27 @@ import subprocess
 import sys
 import time
 
-HERMES_BASE = os.path.expanduser("~/.hermes")
-PROFILES_DIR = os.path.expanduser("~/.hermes/profiles")
-
 HELP = """\
 hermes_gateway — manage Hermes gateway LaunchAgents by profile name.
 
 USAGE
+  hermes_gateway --list                   list all profiles with gateway status
   hermes_gateway <profile>                show detail for a single profile
-  hermes_gateway --restart <profile>      restart one profile's gateway
+  hermes_gateway <profile> [...] --reset  reset named profiles
   hermes_gateway --help                   show this help
 
 DESCRIPTION
   Discovers Hermes profiles via 'hermes profile list', checks each profile's
-  gateway LaunchAgent (ai.hermes.gateway-{profile}) via launchctl, reads the
-  Telegram chat ID from each profile's channel_directory.json, and displays a
-  unified status table.
+  gateway LaunchAgent (ai.hermes.gateway-{profile}) via launchctl, and
+  displays a unified status table.
 
-  The --restart flag uses launchctl kickstart -k (for a running gateway) or
-  launchctl bootstrap (if stopped).  Restarting the gateway you are currently
+  The --reset flag uses launchctl kickstart -k (for a loaded gateway) or
+  launchctl bootstrap (if absent). Restarting the gateway you are currently
   speaking through will kill your session — use with care.
 
 DATA SOURCES
   Profile list    hermes profile list (--json when available)
   Gateway PID     launchctl list ai.hermes.gateway-{profile}
-  Chat ID         ~/.hermes/profiles/{profile}/channel_directory.json
   LaunchAgent     ~/Library/LaunchAgents/ai.hermes.gateway-{profile}.plist
 
 EXIT CODES
@@ -41,26 +37,10 @@ EXIT CODES
   1   error (profile not found, plist missing, restart failed)
 
 EXAMPLES
+  $ hermes_gateway --list
   $ hermes_gateway skillrx
-  $ hermes_gateway --restart alpha-prime
+  $ hermes_gateway alpha-prime skillrx --reset
 """
-
-
-def get_chat_id(profile: str) -> str | None:
-    """Read chat_id from channel_directory.json."""
-    cd_path = (
-        os.path.join(HERMES_BASE, "channel_directory.json")
-        if profile == "default"
-        else os.path.join(PROFILES_DIR, profile, "channel_directory.json")
-    )
-    try:
-        with open(cd_path) as f:
-            d = json.load(f)
-        for ch in d.get("platforms", {}).get("telegram", []):
-            return ch.get("id")  # first telegram channel
-    except Exception:
-        pass
-    return None
 
 
 def list_profiles() -> list[dict]:
@@ -165,7 +145,7 @@ def restart(profile: str) -> bool:
         return False
 
 
-def fmt_row(profile: str, gateway_status: str, info: dict) -> str:
+def fmt_row(profile: str, info: dict) -> str:
     label = gateway_label(profile)
     plist_ok = os.path.isfile(plist_path(profile))
 
@@ -182,10 +162,8 @@ def fmt_row(profile: str, gateway_status: str, info: dict) -> str:
         status = "—"
         detail = "no plist"
 
-    chat = get_chat_id(profile) or "—"
-
     symbol = {"running": "✓", "dead": "✗", "stopped": "—"}.get(status, " ")
-    return f"  {symbol} {profile:<20} {status:<8} chat={chat:<16} {detail}"
+    return f"  {symbol} {profile:<20} {status:<8} {detail}"
 
 
 def known_profile(profile: str) -> bool:
@@ -197,7 +175,6 @@ def show_status(profile: str) -> None:
     """Display the single profile state used to decide whether reset is safe."""
     label = gateway_label(profile)
     info = _parse_launchctl(label)
-    chat = get_chat_id(profile) or "—"
     pid = info.get("pid")
     lex = info.get("last_exit")
     if info.get("running"):
@@ -208,8 +185,26 @@ def show_status(profile: str) -> None:
         stat = "stopped"
     print(f"Profile:   {profile}")
     print(f"Label:     {label}")
-    print(f"Chat ID:   {chat}")
     print(f"Status:    {stat}")
+
+
+def list_status() -> None:
+    """Display every configured profile without changing gateway state."""
+    profiles = list_profiles()
+    print(f"{'':2} {'PROFILE':<20} {'STATUS':<8} DETAILS")
+    print(f"  {'─' * 64}")
+    running, total, plisted = 0, 0, 0
+    for item in profiles:
+        profile = item["name"]
+        has_plist = os.path.isfile(plist_path(profile))
+        if has_plist:
+            plisted += 1
+        info = _parse_launchctl(gateway_label(profile)) if has_plist else {}
+        if info.get("running"):
+            running += 1
+        total += 1
+        print(fmt_row(profile, info))
+    print(f"\n  {running}/{plisted} gateways running  ({total} profiles total)")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -218,24 +213,32 @@ def main(argv: list[str] | None = None) -> int:
         print(HELP)
         return 0
 
-    restart_requested = len(argv) == 2 and argv[0] == "--restart"
+    restart_requested = len(argv) >= 2 and argv[-1] == "--reset"
     status_requested = len(argv) == 1 and not argv[0].startswith("--")
+    list_requested = argv == ["--list"]
+    if list_requested:
+        list_status()
+        return 0
     if not restart_requested and not status_requested:
-        print("ERROR: specify exactly one profile, optionally with --restart", file=sys.stderr)
+        print("ERROR: specify a profile or --reset followed by one or more profiles", file=sys.stderr)
         print(HELP, file=sys.stderr)
         return 2
 
-    profile = argv[1] if restart_requested else argv[0]
-    if not known_profile(profile):
-        print(f"ERROR: Hermes profile does not exist: {profile}", file=sys.stderr)
+    profiles = argv[:-1] if restart_requested else argv
+    unknown = [profile for profile in profiles if profile == "all" or not known_profile(profile)]
+    if unknown:
+        print(f"ERROR: Hermes profile does not exist: {', '.join(unknown)}", file=sys.stderr)
         return 1
     if restart_requested:
-        # Reset is deliberately never blind: the status record is emitted
-        # before the launchd action so the operator can stop a dangerous reset.
-        show_status(profile)
-        return 0 if restart(profile) else 1
+        successful = True
+        for profile in profiles:
+            # Reset is deliberately never blind: status is emitted before each
+            # launchd action so the operator can stop a dangerous reset.
+            show_status(profile)
+            successful = restart(profile) and successful
+        return 0 if successful else 1
 
-    show_status(profile)
+    show_status(profiles[0])
     return 0
 
 

--- a/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
+++ b/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
@@ -29,8 +29,12 @@ class HermesGatewayTests(unittest.TestCase):
     def test_status_requires_one_known_profile(self) -> None:
         with mock.patch.object(self.module, "list_profiles", return_value=self.profiles):
             self.assertEqual(self.module.main(["missing"]), 1)
-            self.assertEqual(self.module.main([]), 2)
-            self.assertEqual(self.module.main(["--restart", "all"]), 1)
+            self.assertEqual(self.module.main(["all", "--reset"]), 1)
+
+    def test_empty_invocation_lists_profile_state(self) -> None:
+        with mock.patch.object(self.module, "list_status") as list_status:
+            self.assertEqual(self.module.main(["--list"]), 0)
+        list_status.assert_called_once_with()
 
     def test_dead_loaded_service_uses_kickstart_not_bootstrap(self) -> None:
         with (
@@ -52,10 +56,22 @@ class HermesGatewayTests(unittest.TestCase):
             mock.patch.object(self.module, "show_status") as status,
             mock.patch.object(self.module, "restart", return_value=True) as restart,
         ):
-            self.assertEqual(self.module.main(["--restart", "skillrx"]), 0)
+            self.assertEqual(self.module.main(["skillrx", "--reset"]), 0)
 
         status.assert_called_once_with("skillrx")
         restart.assert_called_once_with("skillrx")
+
+    def test_reset_supports_multiple_explicit_profiles(self) -> None:
+        profiles = [{"name": "skillrx"}, {"name": "alpha-prime"}]
+        with (
+            mock.patch.object(self.module, "list_profiles", return_value=profiles),
+            mock.patch.object(self.module, "show_status") as status,
+            mock.patch.object(self.module, "restart", return_value=True) as restart,
+        ):
+            self.assertEqual(self.module.main(["skillrx", "alpha-prime", "--reset"]), 0)
+
+        self.assertEqual(status.call_args_list, [mock.call("skillrx"), mock.call("alpha-prime")])
+        self.assertEqual(restart.call_args_list, [mock.call("skillrx"), mock.call("alpha-prime")])
 
     def test_restart_command_failure_is_reported_as_a_failure(self) -> None:
         with (

--- a/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
+++ b/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import subprocess
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "hermes_gateway"
+
+
+def load_module():
+    spec = importlib.util.spec_from_loader(
+        "hermes_gateway", SourceFileLoader("hermes_gateway", str(SCRIPT))
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class HermesGatewayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module()
+        self.profiles = [{"name": "skillrx"}]
+
+    def test_status_requires_one_known_profile(self) -> None:
+        with mock.patch.object(self.module, "list_profiles", return_value=self.profiles):
+            self.assertEqual(self.module.main(["missing"]), 1)
+            self.assertEqual(self.module.main([]), 2)
+            self.assertEqual(self.module.main(["--restart", "all"]), 1)
+
+    def test_dead_loaded_service_uses_kickstart_not_bootstrap(self) -> None:
+        with (
+            mock.patch.object(self.module.os.path, "isfile", return_value=True),
+            mock.patch.object(self.module, "_parse_launchctl", side_effect=[{"last_exit": 1}, {"pid": 9, "running": True}]),
+            mock.patch.object(self.module.subprocess, "run") as run,
+            mock.patch.object(self.module.time, "sleep"),
+        ):
+            self.assertTrue(self.module.restart("skillrx"))
+
+        run.assert_called_once_with(
+            ["launchctl", "kickstart", "-k", f"gui/{self.module.os.getuid()}/ai.hermes.gateway-skillrx"],
+            check=True,
+        )
+
+    def test_reset_prints_status_before_restarting(self) -> None:
+        with (
+            mock.patch.object(self.module, "known_profile", return_value=True),
+            mock.patch.object(self.module, "show_status") as status,
+            mock.patch.object(self.module, "restart", return_value=True) as restart,
+        ):
+            self.assertEqual(self.module.main(["--restart", "skillrx"]), 0)
+
+        status.assert_called_once_with("skillrx")
+        restart.assert_called_once_with("skillrx")
+
+    def test_restart_command_failure_is_reported_as_a_failure(self) -> None:
+        with (
+            mock.patch.object(self.module.os.path, "isfile", return_value=True),
+            mock.patch.object(self.module, "_parse_launchctl", return_value={"pid": 9, "running": True}),
+            mock.patch.object(
+                self.module.subprocess,
+                "run",
+                side_effect=subprocess.CalledProcessError(1, ["launchctl"]),
+            ),
+        ):
+            self.assertFalse(self.module.restart("skillrx"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
+++ b/.claude/skills/hermes-gateway/tests/test_hermes_gateway.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+from io import StringIO
 import importlib.util
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -49,6 +51,45 @@ class HermesGatewayTests(unittest.TestCase):
             ["launchctl", "kickstart", "-k", f"gui/{self.module.os.getuid()}/ai.hermes.gateway-skillrx"],
             check=True,
         )
+
+    def test_reset_verifies_old_pid_is_dead_then_reports_replacement(self) -> None:
+        output = StringIO()
+        with (
+            mock.patch.object(self.module.os.path, "isfile", return_value=True),
+            mock.patch.object(
+                self.module,
+                "_parse_launchctl",
+                side_effect=[{"pid": 41, "running": True}, {"pid": 42, "running": True}],
+            ),
+            mock.patch.object(self.module, "process_is_alive", return_value=False) as alive,
+            mock.patch.object(self.module.subprocess, "run"),
+            mock.patch.object(self.module.time, "sleep"),
+            redirect_stdout(output),
+        ):
+            self.assertTrue(self.module.restart("skillrx"))
+
+        alive.assert_called_once_with(41)
+        self.assertIn("PID 42, was 41", output.getvalue())
+
+    def test_reset_fails_when_old_pid_survives(self) -> None:
+        with (
+            mock.patch.object(self.module.os.path, "isfile", return_value=True),
+            mock.patch.object(self.module, "_parse_launchctl", return_value={"pid": 41, "running": True}),
+            mock.patch.object(self.module, "process_is_alive", return_value=True),
+            mock.patch.object(self.module.subprocess, "run"),
+            mock.patch.object(self.module.time, "sleep"),
+        ):
+            self.assertFalse(self.module.restart("skillrx"))
+
+    def test_reset_fails_if_replacement_does_not_arrive(self) -> None:
+        with (
+            mock.patch.object(self.module.os.path, "isfile", return_value=True),
+            mock.patch.object(self.module, "_parse_launchctl", side_effect=[{"pid": 41, "running": True}] + [{}] * 6),
+            mock.patch.object(self.module, "process_is_alive", return_value=False),
+            mock.patch.object(self.module.subprocess, "run"),
+            mock.patch.object(self.module.time, "sleep"),
+        ):
+            self.assertFalse(self.module.restart("skillrx"))
 
     def test_reset_prints_status_before_restarting(self) -> None:
         with (

--- a/.codex/skills/hermes-gateway
+++ b/.codex/skills/hermes-gateway
@@ -1,0 +1,1 @@
+../../.claude/skills/hermes-gateway


### PR DESCRIPTION
## Summary

Adds a repo-local `hermes-gateway` skill for checking status of, or resetting,
a single named Hermes-graft agent's gateway.

- Vendors `hermes_gateway` (originally authored by the `skillrx` Hermes-graft
  agent for this skill) at `.claude/skills/hermes-gateway/scripts/hermes_gateway`
  rather than assuming it's a bare command on `PATH`.
- Mandatory `agent_name` parameter — no fleet-wide or unscoped operation.
- Default invocation (`/hermes-gateway <agent>`) is status-only; `--reset`
  triggers the full endpoint-reset procedure. Status is always checked first,
  even on a `--reset` invocation, before any reset action is taken.
- Trigger phrases: "restart hermes gateway", "hermes gateway", "hermes
  gateway status", "reset hermes gateway".

## Test plan

- [ ] `python3 -m py_compile` on the vendored script (done locally, passes)
- [ ] arch-ctm / skillrx@hermes review
- [ ] arch-ctm mirrors this as a `.codex` skill on the same worktree