### PR TITLE
fix(windows): harden daemon switch smoke workflow

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -18,6 +18,9 @@ import time
 from typing import Sequence
 
 
+WINDOWS_SERVICE_NOT_FOUND = 1060
+
+
 class SwitchError(RuntimeError):
     """A precondition that protects the singleton daemon was not met."""
 
@@ -119,15 +122,30 @@ def service_commands(args: argparse.Namespace, action: str) -> list[str]:
         plist = str(Path(args.launch_agent_plist).expanduser())
         return ["launchctl", "bootstrap", domain, plist]
     if system == "Windows":
-        return ["sc", action, args.service]
+        return ["sc.exe", action, args.service]
     return ["systemctl", "--user", action, args.service]
+
+
+def windows_service_missing(result: subprocess.CompletedProcess[str]) -> bool:
+    """Recognize only SCM's missing-service result for an optional stop."""
+    if result.returncode == WINDOWS_SERVICE_NOT_FOUND:
+        return True
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return "1060" in output and "openservice" in output
 
 
 def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = False) -> None:
     command = service_commands(args, action)
     if platform.system() != "Darwin":
         result = run(command, timeout=20.0)
-        if result.returncode == 0 or (allow_absent and action == "stop"):
+        if result.returncode == 0 or (
+            allow_absent
+            and action == "stop"
+            and (
+                platform.system() != "Windows"
+                or windows_service_missing(result)
+            )
+        ):
             return
         detail = (result.stderr or result.stdout).strip()
         raise SwitchError(f"service {action} failed: {' '.join(command)}: {detail}")
@@ -503,11 +521,33 @@ def wait_for_live_pair(cli: Path, daemon: Path | None = None) -> tuple[bool, str
     return False, detail
 
 
+def windows_service_status(service: str) -> dict[str, object]:
+    """Expose SCM state so status cannot imply an absent service is managed."""
+    result = run(["sc.exe", "query", service], timeout=5.0)
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0:
+        return {
+            "installed": False,
+            "state": "absent" if windows_service_missing(result) else "unknown",
+            "detail": output.strip() or f"sc.exe exited with {result.returncode}",
+        }
+
+    state = "unknown"
+    for line in output.splitlines():
+        if "STATE" not in line or ":" not in line:
+            continue
+        state = line.split(":", 1)[1].strip().split(maxsplit=1)[-1].lower()
+        break
+    return {"installed": True, "state": state}
+
+
 def status(args: argparse.Namespace) -> None:
     cli, daemon = selected_links(args)
     service = {"platform": platform.system(), "service": args.service}
     if platform.system() == "Darwin" and args.service:
         service["launch_agent_plist"] = args.launch_agent_plist
+    if platform.system() == "Windows" and args.service:
+        service["windows"] = windows_service_status(args.service)
     result: dict[str, object] = {
         "atm": {"selector": str(cli), "target": str(cli.resolve()), "version": version(cli)},
         "atm_daemon": {"selector": str(daemon), "target": str(daemon.resolve())},

--- a/.just/run_smoke.py
+++ b/.just/run_smoke.py
@@ -1,0 +1,36 @@
+"""Dispatch the canonical smoke runners without relying on a host shell."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPECIAL_RUNNERS = {
+    "peer-pair": ROOT / "scripts" / "smoke" / "run_peer_pair.py",
+    "inbound-peer": ROOT / "scripts" / "smoke" / "run_inbound_peer_smoke.py",
+    "inbound-peer-combine": ROOT / "scripts" / "smoke" / "combine_inbound_peer_smoke.py",
+    "graft-hermes": ROOT / "scripts" / "phase-ai" / "run-hermes-graft-smoke.py",
+}
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("smoke feature is required", file=sys.stderr)
+        return 2
+
+    feature, *args = sys.argv[1:]
+    runner = SPECIAL_RUNNERS.get(feature)
+    command = [sys.executable, str(runner), *args] if runner else [
+        sys.executable,
+        str(ROOT / "scripts" / "smoke" / "run_feature_smoke.py"),
+        feature,
+        *args,
+    ]
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -229,6 +229,42 @@ class DaemonSwitchTests(unittest.TestCase):
         self.assertEqual(parsed.service, "atm-daemon")
         self.assertEqual(parsed.launch_agent_plist, "/tmp/atm-daemon.plist")
 
+    def test_windows_status_reports_absent_service(self) -> None:
+        missing = subprocess.CompletedProcess(
+            ["sc.exe", "query", "atm-daemon"],
+            self.module.WINDOWS_SERVICE_NOT_FOUND,
+            "",
+            "[SC] OpenService FAILED 1060:\r\nThe specified service does not exist.\r\n",
+        )
+        with (
+            mock.patch.object(self.module.platform, "system", return_value="Windows"),
+            mock.patch.object(self.module, "run", return_value=missing) as run,
+        ):
+            self.assertEqual(
+                self.module.windows_service_status("atm-daemon"),
+                {
+                    "installed": False,
+                    "state": "absent",
+                    "detail": "[SC] OpenService FAILED 1060:\r\nThe specified service does not exist.",
+                },
+            )
+        run.assert_called_once_with(["sc.exe", "query", "atm-daemon"], timeout=5.0)
+
+    def test_windows_optional_stop_does_not_hide_access_denied(self) -> None:
+        denied = subprocess.CompletedProcess(
+            ["sc.exe", "stop", "atm-daemon"],
+            5,
+            "",
+            "[SC] OpenSCManager FAILED 5: Access is denied.",
+        )
+        args = argparse.Namespace(service="atm-daemon")
+        with (
+            mock.patch.object(self.module.platform, "system", return_value="Windows"),
+            mock.patch.object(self.module, "run", return_value=denied),
+        ):
+            with self.assertRaisesRegex(self.module.SwitchError, "Access is denied"):
+                self.module.run_service(args, "stop", allow_absent=True)
+
     def test_macos_start_retries_bootstrap_after_unload_race(self) -> None:
         args = argparse.Namespace(service="atm-daemon", launch_agent_plist="/tmp/atm-daemon.plist")
         results = [

--- a/.just/tests/test_run_smoke.py
+++ b/.just/tests/test_run_smoke.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".just" / "run_smoke.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_smoke", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SmokeDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module()
+
+    def test_special_feature_uses_its_canonical_runner(self) -> None:
+        completed = mock.Mock(returncode=0)
+        with (
+            mock.patch.object(sys, "argv", [str(SCRIPT), "graft-hermes", "--report"]),
+            mock.patch.object(self.module.subprocess, "run", return_value=completed) as run,
+        ):
+            self.assertEqual(self.module.main(), 0)
+
+        run.assert_called_once_with(
+            [
+                sys.executable,
+                str(self.module.SPECIAL_RUNNERS["graft-hermes"]),
+                "--report",
+            ],
+            cwd=ROOT,
+            check=False,
+        )
+
+    def test_normal_feature_uses_the_shared_feature_runner(self) -> None:
+        completed = mock.Mock(returncode=7)
+        with (
+            mock.patch.object(sys, "argv", [str(SCRIPT), "localhost"]),
+            mock.patch.object(self.module.subprocess, "run", return_value=completed) as run,
+        ):
+            self.assertEqual(self.module.main(), 7)
+
+        run.assert_called_once_with(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "smoke" / "run_feature_smoke.py"),
+                "localhost",
+            ],
+            cwd=ROOT,
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Justfile
+++ b/Justfile
@@ -184,7 +184,7 @@ validate target='all':
 # `local-ip` then adds the enabled, dynamically discovered advertised host.
 # Cross-host stages use public ATM clients against already-running peer daemons.
 smoke feature='normal' *args:
-    if [ "{{feature}}" = "peer-pair" ]; then {{python_cmd}} scripts/smoke/run_peer_pair.py {{args}}; elif [ "{{feature}}" = "inbound-peer" ]; then {{python_cmd}} scripts/smoke/run_inbound_peer_smoke.py {{args}}; elif [ "{{feature}}" = "inbound-peer-combine" ]; then {{python_cmd}} scripts/smoke/combine_inbound_peer_smoke.py {{args}}; elif [ "{{feature}}" = "graft-hermes" ]; then {{python_cmd}} scripts/phase-ai/run-hermes-graft-smoke.py {{args}}; else {{python_cmd}} scripts/smoke/run_feature_smoke.py {{feature}} {{args}}; fi
+    {{python_cmd}} .just/run_smoke.py {{feature}} {{args}}
 
 # Run one isolated, release-built local admission benchmark. On Unix choose
 # UDS or loopback TCP; Windows accepts TCP only. The runner rejects ambient

--- a/crates/atm-daemon-bootstrap/src/owner_gate.rs
+++ b/crates/atm-daemon-bootstrap/src/owner_gate.rs
@@ -7,6 +7,8 @@
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
+#[cfg(windows)]
+use std::path::Path;
 use std::path::PathBuf;
 
 use atm_core::error::AtmError;
@@ -59,6 +61,7 @@ impl DaemonOwnerGuard {
         lock_file.sync_data().map_err(|source| {
             AtmError::daemon_unavailable("failed to commit daemon owner record").with_cause(source)
         })?;
+        sync_owner_record_shadow(&lock_path, &record)?;
         Ok(Self {
             lock_file,
             lock_path,
@@ -77,9 +80,48 @@ impl Drop for DaemonOwnerGuard {
         let _ = self.lock_file.set_len(0);
         let _ = self.lock_file.seek(SeekFrom::Start(0));
         let _ = self.lock_file.sync_data();
+        let _ = sync_owner_record_shadow(&self.lock_path, "");
         let _ = self.lock_file.unlock();
-        let _ = &self.lock_path;
     }
+}
+
+#[cfg(windows)]
+fn sync_owner_record_shadow(lock_path: &Path, record: &str) -> Result<(), AtmError> {
+    let shadow_path = lock_path.with_file_name(format!(
+        "{}.meta",
+        lock_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("owner.lock")
+    ));
+    let temp_path = shadow_path.with_file_name(format!(
+        ".{}.tmp.{}.shadow",
+        shadow_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("owner.lock.meta"),
+        std::process::id()
+    ));
+    let mut file = File::create(&temp_path).map_err(|source| {
+        AtmError::daemon_unavailable("failed to create daemon owner shadow record")
+            .with_cause(source)
+    })?;
+    file.write_all(record.as_bytes()).map_err(|source| {
+        AtmError::daemon_unavailable("failed to write daemon owner shadow record")
+            .with_cause(source)
+    })?;
+    file.sync_all().map_err(|source| {
+        AtmError::daemon_unavailable("failed to sync daemon owner shadow record").with_cause(source)
+    })?;
+    fs::rename(&temp_path, &shadow_path).map_err(|source| {
+        AtmError::daemon_unavailable("failed to publish daemon owner shadow record")
+            .with_cause(source)
+    })
+}
+
+#[cfg(not(windows))]
+fn sync_owner_record_shadow(_lock_path: &PathBuf, _record: &str) -> Result<(), AtmError> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -113,5 +155,24 @@ mod tests {
         let _first = DaemonOwnerGuard::acquire_at(lock.clone()).expect("first owner acquires");
         let error = DaemonOwnerGuard::acquire_at(lock).expect_err("second owner is rejected");
         assert_eq!(error.code().as_str(), "ATM_DAEMON_SERVING_STATE_REJECTED");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_owner_shadow_tracks_and_clears_the_serving_record() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let lock = temporary_directory.path().join("owner.lock");
+        let shadow = temporary_directory.path().join("owner.lock.meta");
+        {
+            let guard = DaemonOwnerGuard::acquire_at(lock).expect("owner acquires");
+            let record = std::fs::read_to_string(&shadow).expect("shadow record exists");
+            assert!(record.starts_with(&format!("{}:", std::process::id())));
+            assert!(record.contains(&guard.instance_id().to_string()));
+        }
+        assert!(
+            std::fs::read_to_string(shadow)
+                .expect("cleared shadow record exists")
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Summary
Windows SCM ownership/status hardening plus canonical smoke dispatch for daemon-switch.

## Test plan
- [x] daemon-switch tests (14)
- [x] smoke-dispatch tests (2)
- [x] cargo test -p atm-daemon-bootstrap
- [x] fmt
- [ ] quality-mgr QA-1