### PR TITLE
fix(benchmark): isolate TCP profile identities

### DIFF
--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -8,6 +8,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
+use std::{env, process};
 
 use atm_core::error::AtmError;
 use atm_core::observability::NullObservability;
@@ -144,6 +145,7 @@ async fn run_direct_storage_admission(
     let runtime = atm_daemon_bootstrap::assemble_default_runtime()?
         .for_daemon()
         .service_runtime;
+    let run_id = env::var("ATM_CAPACITY_RUN_ID").unwrap_or_else(|_| process::id().to_string());
     let next = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();
     let mut tasks = JoinSet::new();
@@ -151,6 +153,7 @@ async fn run_direct_storage_admission(
     for _ in 0..workers.get() {
         let runtime = runtime.clone();
         let next = Arc::clone(&next);
+        let run_id = run_id.clone();
         tasks.spawn(async move {
             let mut accepted = 0_usize;
             loop {
@@ -159,7 +162,7 @@ async fn run_direct_storage_admission(
                     return Ok::<usize, AtmError>(accepted);
                 }
                 let duplicate = runtime
-                    .save_message_if_absent_async(direct_storage_message(sequence))
+                    .save_message_if_absent_async(direct_storage_message(&run_id, sequence))
                     .await?;
                 if duplicate.is_some() {
                     return Err(AtmError::daemon_unavailable(
@@ -198,17 +201,17 @@ async fn run_direct_storage_admission(
     Ok(())
 }
 
-fn direct_storage_message(sequence: usize) -> Message {
+fn direct_storage_message(run_id: &str, sequence: usize) -> Message {
     let team = TeamName::from_validated(DIRECT_STORAGE_TEAM);
     Message {
         team: team.clone(),
         agent: AgentName::from_validated(DIRECT_STORAGE_RECIPIENT),
-        message_key: MessageKey::new(format!("atm:capacity-direct-{sequence}"))
+        message_key: MessageKey::new(format!("atm:capacity-direct-{run_id}-{sequence}"))
             .expect("nonempty key"),
         envelope: MessageEnvelope {
             from: AgentName::from_validated(DIRECT_STORAGE_SENDER),
             source_chat_id: None,
-            text: format!("capacity-direct-{sequence}"),
+            text: format!("capacity-direct-{run_id}-{sequence}"),
             timestamp: IsoTimestamp::now(),
             read: false,
             source_team: Some(team),
@@ -299,12 +302,17 @@ fn direct_core_write_request(
     home: &std::path::Path,
     sequence: usize,
 ) -> Result<WriteRequest, AtmError> {
+    let team = env::var("ATM_CAPACITY_CORE_TEAM").unwrap_or_else(|_| CORE_WRITE_TEAM.to_owned());
+    let sender =
+        env::var("ATM_CAPACITY_CORE_AGENT").unwrap_or_else(|_| CORE_WRITE_SENDER.to_owned());
+    let recipient =
+        env::var("ATM_CAPACITY_CORE_RECIPIENT").unwrap_or_else(|_| CORE_WRITE_RECIPIENT.to_owned());
     WriteRequest::new(
         home.to_path_buf(),
         home.to_path_buf(),
-        AgentName::from_validated(CORE_WRITE_SENDER),
-        &format!("{CORE_WRITE_RECIPIENT}@{CORE_WRITE_TEAM}"),
-        TeamName::from_validated(CORE_WRITE_TEAM),
+        AgentName::from_validated(&sender),
+        &format!("{recipient}@{team}"),
+        TeamName::from_validated(&team),
         SendMessageSource::Inline(format!("capacity-core-{sequence}")),
         None,
         false,
@@ -330,8 +338,8 @@ mod tests {
 
     #[test]
     fn direct_storage_messages_are_unique_and_target_the_capacity_recipient() {
-        let first = direct_storage_message(1);
-        let second = direct_storage_message(2);
+        let first = direct_storage_message("test-run", 1);
+        let second = direct_storage_message("test-run", 2);
         assert_ne!(first.message_key, second.message_key);
         assert_eq!(first.team.as_str(), "capacity-direct-team");
         assert_eq!(first.agent.as_str(), "capacity-direct-recipient");

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -28,6 +28,7 @@ import tempfile
 from threading import Lock, Thread
 import time
 from typing import Any, Callable
+import uuid
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_EVIDENCE_DIR = ROOT / "site" / "reports" / "send-message-benchmark"
@@ -108,6 +109,43 @@ class LocalEndpoint:
     kind: str
     address: str | tuple[str, int]
     capability: str | None = None
+
+
+@dataclass(frozen=True)
+class CapacityRoster:
+    """Unique roster names for one isolated benchmark profile."""
+
+    run_id: str
+    team: str
+    agent: str
+    recipient: str
+    core_team: str
+    core_agent: str
+    core_recipient: str
+
+    @classmethod
+    def unique(cls) -> "CapacityRoster":
+        suffix = uuid.uuid4().hex[:12]
+        return cls(
+            run_id=suffix,
+            team=f"capacity-team-{suffix}",
+            agent=f"capacity-agent-{suffix}",
+            recipient=f"capacity-recipient-{suffix}",
+            core_team=f"capacity-core-team-{suffix}",
+            core_agent=f"capacity-core-agent-{suffix}",
+            core_recipient=f"capacity-core-recipient-{suffix}",
+        )
+
+
+DEFAULT_CAPACITY_ROSTER = CapacityRoster(
+    run_id="default",
+    team="capacity-team",
+    agent="capacity-agent",
+    recipient="capacity-recipient",
+    core_team="capacity-core-team",
+    core_agent="capacity-core-agent",
+    core_recipient="capacity-core-recipient",
+)
 
 
 @dataclass
@@ -444,13 +482,19 @@ def validate_hook_mode(value: str) -> str:
     return value
 
 
-def runtime_environment(atm_home: Path) -> dict[str, str]:
+def runtime_environment(
+    atm_home: Path, roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
+) -> dict[str, str]:
     environment = dict(os.environ)
     environment.update(
         {
             "ATM_HOME": str(atm_home),
-            "ATM_IDENTITY": "capacity-agent",
-            "ATM_TEAM": "capacity-team",
+            "ATM_IDENTITY": roster.agent,
+            "ATM_TEAM": roster.team,
+            "ATM_CAPACITY_RUN_ID": roster.run_id,
+            "ATM_CAPACITY_CORE_TEAM": roster.core_team,
+            "ATM_CAPACITY_CORE_AGENT": roster.core_agent,
+            "ATM_CAPACITY_CORE_RECIPIENT": roster.core_recipient,
             "ATM_DAEMON_READY_STDOUT": "1",
         }
     )
@@ -553,15 +597,20 @@ def start_capacity_daemon(
     return process, output
 
 
-def prepare_capacity_roster(atm: Path, env: dict[str, str], home: Path) -> None:
+def prepare_capacity_roster(
+    atm: Path,
+    env: dict[str, str],
+    home: Path,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
+) -> None:
     """Create separate public-write and decomposition-only benchmark rosters."""
     for team, member in (
-        ("capacity-team", "capacity-agent"),
-        ("capacity-team", "capacity-recipient"),
+        (roster.team, roster.agent),
+        (roster.team, roster.recipient),
         # The direct canonical-core probe must never add rows to the public
         # write profile's durability-count mailbox.
-        ("capacity-core-team", "capacity-core-agent"),
-        ("capacity-core-team", "capacity-core-recipient"),
+        (roster.core_team, roster.core_agent),
+        (roster.core_team, roster.core_recipient),
     ):
         result = command_result(
             [str(atm), "teams", "add-member", team, member, "--home-dir", str(home), "--json"],
@@ -574,14 +623,18 @@ def prepare_capacity_roster(atm: Path, env: dict[str, str], home: Path) -> None:
             )
 
 
-def http_request_body(home: Path, sequence: int) -> bytes:
+def http_request_body(
+    home: Path,
+    sequence: int,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
+) -> bytes:
     """Build the documented /v1/atm/messages request; no dispatcher shortcut."""
     payload = {
         "home_dir": str(home),
         "current_dir": str(home),
-        "caller_identity": "capacity-agent",
-        "caller_team": "capacity-team",
-        "to": {"agent": "capacity-recipient", "team": "capacity-team"},
+        "caller_identity": roster.agent,
+        "caller_team": roster.team,
+        "to": {"agent": roster.recipient, "team": roster.team},
         "message_source": {"Inline": f"capacity-{sequence}"},
         "summary_override": None,
         "requires_ack": False,
@@ -594,7 +647,10 @@ def http_request_body(home: Path, sequence: int) -> bytes:
     return json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
 
-def cached_roster_heartbeat_body(sequence: int) -> bytes:
+def cached_roster_heartbeat_body(
+    sequence: int,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
+) -> bytes:
     """Build a heartbeat that validates against the warmed roster snapshot.
 
     The daemon's heartbeat route calls ``LocalServiceRuntime.load_roster_member``.
@@ -603,8 +659,8 @@ def cached_roster_heartbeat_body(sequence: int) -> bytes:
     that first request before recording these samples.
     """
     payload = {
-        "team": "capacity-team",
-        "member": "capacity-agent",
+        "team": roster.team,
+        "member": roster.agent,
         "pid": 90_000 + sequence,
         "observed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "activity": "active_tool_use",
@@ -816,6 +872,7 @@ def run_profile(
     operation: str = "write",
     expected_status: int = 201,
     minimum_admissions_per_second: float = 1_000.0,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
 ) -> dict[str, Any]:
     """Collect at least ten independent intervals over one sustained profile."""
     if sample_count <= 0:
@@ -826,14 +883,18 @@ def run_profile(
     def submit(sequence: int, message_count: int) -> list[AdmissionResult]:
         if operation == "write":
             requests = [
-                HttpRequest("/v1/atm/messages", http_request_body(home, sequence + offset), 201)
+                HttpRequest(
+                    "/v1/atm/messages",
+                    http_request_body(home, sequence + offset, roster),
+                    201,
+                )
                 for offset in range(message_count)
             ]
         elif operation == "cached_roster_heartbeat":
             requests = [
                 HttpRequest(
                     "/v1/atm/heartbeat",
-                    cached_roster_heartbeat_body(sequence + offset),
+                    cached_roster_heartbeat_body(sequence + offset, roster),
                     200,
                 )
                 for offset in range(message_count)
@@ -862,7 +923,7 @@ def run_profile(
             break
     return {
         "operation": operation,
-        "recipient": "capacity-recipient@capacity-team",
+        "recipient": f"{roster.recipient}@{roster.team}",
         "requested_messages_per_sample": requested_messages,
         "minimum_sample_count": sample_count,
         "sample_count": len(intervals),
@@ -878,10 +939,15 @@ def run_cached_roster_heartbeat_probe(
     home: Path,
     frames_per_connection: int,
     workers: int,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
 ) -> dict[str, Any]:
     """Warm and then measure the public no-SQLite heartbeat route."""
     warmup = submit_connection(endpoint, [
-        HttpRequest("/v1/atm/heartbeat", cached_roster_heartbeat_body(0), 200),
+        HttpRequest(
+            "/v1/atm/heartbeat",
+            cached_roster_heartbeat_body(0, roster),
+            200,
+        ),
     ])
     if len(warmup) != 1 or warmup[0].status != 200 or warmup[0].failure is not None:
         detail = warmup[0].failure if warmup else "no response"
@@ -897,6 +963,7 @@ def run_cached_roster_heartbeat_probe(
         operation="cached_roster_heartbeat",
         expected_status=200,
         minimum_admissions_per_second=0,
+        roster=roster,
     )
     return {
         "route": "/v1/atm/heartbeat",
@@ -1008,7 +1075,11 @@ def write_evidence(directory: Path, evidence: dict[str, Any]) -> Path:
     return path
 
 
-def verify_durable_admissions(db_path: Path, expected_count: int) -> dict[str, int | bool | str]:
+def verify_durable_admissions(
+    db_path: Path,
+    expected_count: int,
+    roster: CapacityRoster = DEFAULT_CAPACITY_ROSTER,
+) -> dict[str, int | bool | str]:
     """Count every benchmark admission in the isolated store after restart.
 
     Admission itself always traverses the public authenticated HTTP boundary.
@@ -1021,7 +1092,7 @@ def verify_durable_admissions(db_path: Path, expected_count: int) -> dict[str, i
         with closing(sqlite3.connect(uri, uri=True)) as connection:
             row = connection.execute(
                 "SELECT COUNT(*) FROM mail_messages WHERE team = ?1 AND agent = ?2;",
-                ("capacity-team", "capacity-recipient"),
+                (roster.team, roster.recipient),
             ).fetchone()
         observed_count = int(row[0]) if row is not None else 0
     except (OSError, sqlite3.Error, TypeError, ValueError) as error:
@@ -1148,7 +1219,8 @@ def run_capacity(
         )
     atm = release_binary("atm")
     daemon = release_binary("atm-daemon-benchmark")
-    env = runtime_environment(home)
+    roster = CapacityRoster.unique()
+    env = runtime_environment(home, roster)
     process: subprocess.Popen[str] | None = None
     daemon_output: DaemonOutputCapture | None = None
     managed_lifecycle: ManagedDaemonLifecycle | None = None
@@ -1194,7 +1266,7 @@ def run_capacity(
             managed_lifecycle.begin()
         before = count_atm_daemon_processes()
         home.mkdir(parents=True, exist_ok=False)
-        prepare_capacity_roster(atm, env, home)
+        prepare_capacity_roster(atm, env, home, roster)
         evidence["decomposition"]["async_storage_admission"] = run_direct_storage_probe(
             daemon,
             env,
@@ -1227,6 +1299,7 @@ def run_capacity(
             home,
             frames_per_connection,
             workers,
+            roster,
         )
         profile = run_profile(
             endpoint,
@@ -1235,6 +1308,7 @@ def run_capacity(
             requested_messages,
             sample_count,
             workers,
+            roster=roster,
         )
         evidence["runs"] = [profile]
         evidence["sample_count"] = profile["sample_count"]
@@ -1270,7 +1344,9 @@ def run_capacity(
         # needs the asserted healthy result after the restart.
         evidence["doctor_after_restart"] = {"status": "passed"}
         evidence["durability_after_restart"] = verify_durable_admissions(
-            os_account_home() / ".atm" / "db" / "mail.db", expected_accepted_count,
+            os_account_home() / ".atm" / "db" / "mail.db",
+            expected_accepted_count,
+            roster,
         )
     except (OSError, ValueError, SmokeError) as error:
         evidence["passed"] = False

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -922,6 +922,29 @@ class AdmissionCapacityTests(unittest.TestCase):
         )
         self.assertEqual(command.call_args_list[3].args[0][4], "capacity-core-recipient")
 
+    def test_capacity_roster_is_unique_per_profile(self):
+        first = RUNNER.CapacityRoster.unique()
+        second = RUNNER.CapacityRoster.unique()
+
+        self.assertNotEqual(first.team, second.team)
+        self.assertNotEqual(first.agent, second.agent)
+        self.assertNotEqual(first.recipient, second.recipient)
+        self.assertNotEqual(first.core_team, second.core_team)
+        self.assertNotEqual(first.core_agent, second.core_agent)
+        self.assertNotEqual(first.core_recipient, second.core_recipient)
+
+    def test_custom_capacity_roster_flows_to_public_request(self):
+        roster = RUNNER.CapacityRoster.unique()
+        body = json.loads(
+            RUNNER.http_request_body(Path("/tmp/atm-capacity-test"), 42, roster)
+        )
+
+        self.assertEqual(body["caller_identity"], roster.agent)
+        self.assertEqual(body["caller_team"], roster.team)
+        self.assertEqual(
+            body["to"], {"agent": roster.recipient, "team": roster.team}
+        )
+
     def test_cached_roster_heartbeat_body_targets_the_warmed_capacity_member(self):
         body = json.loads(RUNNER.cached_roster_heartbeat_body(17))
         self.assertEqual(body["team"], "capacity-team")


### PR DESCRIPTION
## Summary
Unique roster/run identities for repeated TCP profiles, preventing benchmark cross-contamination between repeated runs of the same profile.

## Test plan
- [x] 71 capacity tests
- [x] bootstrap tests
- [x] fmt
- [ ] quality-mgr QA-1