### PR TITLE
fix(reports): separate current benchmark campaign

### DIFF
--- a/.just/tests/test_benchmark_report.py
+++ b/.just/tests/test_benchmark_report.py
@@ -124,8 +124,27 @@ class BenchmarkReportTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             output = REPORT.render_aggregate([failed, recovered], Path(directory))
             text = output.read_text(encoding="utf-8")
-        self.assertIn("Latest profile state: 1 profiles, 1 passed, 0 failed.", text)
-        self.assertIn("2 historical runs retained.", text)
+        self.assertIn("Current candidate campaign: mac-arm64-01 / tcp / unversioned", text)
+        self.assertIn("1/6 profiles, 1 passed, 0 failed; missing frames: 1, 2, 4, 16, 64.", text)
+        self.assertIn("2 immutable historical runs retained.", text)
+
+    def test_current_campaign_is_complete_only_for_all_six_frames_of_one_candidate(self) -> None:
+        base = REPORT.load_result(self.fixture("success-uds-f1.json"))
+        revision = "b" * 40
+        campaign = [
+            {
+                **base,
+                "generated_at": f"2026-08-01T02:{index:02d}:00Z",
+                "transport": "tcp",
+                "frames_per_connection": frame,
+                "source_revision": revision,
+            }
+            for index, frame in enumerate(sorted(REPORT.SUPPORTED_FRAMES))
+        ]
+        self.assertEqual(REPORT.current_campaign_results(campaign), campaign)
+        self.assertEqual(REPORT.campaign_status(campaign), "PASS")
+        self.assertEqual(REPORT.campaign_status(campaign[:-1]), "INFO")
+        self.assertEqual(REPORT.campaign_status([{**campaign[0], "passed": False}]), "FAIL")
 
 
 if __name__ == "__main__":

--- a/scripts/smoke/benchmark_report.py
+++ b/scripts/smoke/benchmark_report.py
@@ -232,6 +232,48 @@ def latest_profile_results(records: Iterable[dict[str, Any]]) -> list[dict[str, 
     return list(latest.values())
 
 
+def current_campaign_results(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the newest host/transport/revision evidence campaign.
+
+    A benchmark campaign is one candidate build exercised on one host and one
+    transport.  Keeping the source revision in the key prevents an older
+    failing profile from changing the status of a newer candidate, while the
+    aggregate table continues to retain every immutable result.
+    """
+    records = list(records)
+    if not records:
+        return []
+    newest = max(records, key=lambda result: result["generated_at"])
+    revision = newest.get("source_revision")
+    if revision is None:
+        # Legacy records did not carry a candidate revision.  For them, retain
+        # the pre-existing newest-profile interpretation rather than allowing
+        # a stale failure to poison a later recovery run.
+        return [
+            result
+            for result in latest_profile_results(records)
+            if (result["host_label"], result["transport"])
+            == (newest["host_label"], newest["transport"])
+        ]
+    key = (newest["host_label"], newest["transport"], revision)
+    return [
+        result
+        for result in records
+        if (result["host_label"], result["transport"], result.get("source_revision")) == key
+    ]
+
+
+def campaign_status(results: Iterable[dict[str, Any]]) -> str:
+    """Report PASS only for a complete, passing six-profile candidate."""
+    results = list(results)
+    if not results:
+        return "INFO"
+    if any(not result["passed"] for result in results):
+        return "FAIL"
+    frames = {result["frames_per_connection"] for result in results}
+    return "PASS" if frames == SUPPORTED_FRAMES else "INFO"
+
+
 def render_aggregate(records: Iterable[dict[str, Any]], report_root: Path = REPORTS_ROOT) -> Path:
     records = list(records)
     rows = []
@@ -254,13 +296,21 @@ def render_aggregate(records: Iterable[dict[str, Any]], report_root: Path = REPO
         })
     output = report_root / REPORT_HTML
     template = ROOT / "templates" / "benchmark-report" / "benchmark-report.html.j2"
-    latest = latest_profile_results(records)
+    campaign = current_campaign_results(records)
+    campaign_frames = {result["frames_per_connection"] for result in campaign}
+    campaign_missing_frames = sorted(SUPPORTED_FRAMES - campaign_frames)
+    campaign_reference = campaign[-1] if campaign else None
     compose(template, {
         "title": "ATM local transport benchmark", "generated_at": utc_now(),
-        "status": "PASS" if latest and all(result["passed"] for result in latest) else "FAIL" if latest else "INFO",
-        "rows": rows, "profile_count": len(latest),
-        "passed_count": sum(result["passed"] for result in latest),
-        "failed_count": sum(not result["passed"] for result in latest),
+        "status": campaign_status(campaign),
+        "rows": rows,
+        "campaign_host_label": campaign_reference["host_label"] if campaign_reference else "none",
+        "campaign_transport": campaign_reference["transport"] if campaign_reference else "none",
+        "campaign_source_revision": campaign_reference.get("source_revision") if campaign_reference else None,
+        "campaign_profile_count": len(campaign),
+        "campaign_passed_count": sum(result["passed"] for result in campaign),
+        "campaign_failed_count": sum(not result["passed"] for result in campaign),
+        "campaign_missing_frames": ", ".join(str(frame) for frame in campaign_missing_frames) or "none",
         "history_count": len(rows),
     }, output)
     return output

--- a/templates/benchmark-report/benchmark-report.html.j2
+++ b/templates/benchmark-report/benchmark-report.html.j2
@@ -7,9 +7,13 @@ required_variables:
   - generated_at
   - status
   - rows
-  - profile_count
-  - passed_count
-  - failed_count
+  - campaign_host_label
+  - campaign_transport
+  - campaign_source_revision
+  - campaign_profile_count
+  - campaign_passed_count
+  - campaign_failed_count
+  - campaign_missing_frames
   - history_count
 ---
 <!DOCTYPE html>
@@ -31,7 +35,7 @@ required_variables:
 <body>
   <h1>{{ title | e }}</h1>
   <p class="meta">Generated {{ generated_at | e }} · <span class="status {{ status | e }}">{{ status | e }}</span></p>
-  <p>Latest profile state: {{ profile_count }} profiles, {{ passed_count }} passed, {{ failed_count }} failed. {{ history_count }} historical runs retained.</p>
+  <p>Current candidate campaign: {{ campaign_host_label | e }} / {{ campaign_transport | e }} / {{ campaign_source_revision | default('unversioned', true) | e }} — {{ campaign_profile_count }}/{{ 6 }} profiles, {{ campaign_passed_count }} passed, {{ campaign_failed_count }} failed; missing frames: {{ campaign_missing_frames | e }}. {{ history_count }} immutable historical runs retained.</p>
   <h2>UTC benchmark history</h2>
   <table>
     <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Direct SQLite msg/s</th><th>Status</th><th>Evidence</th></tr></thead>


### PR DESCRIPTION
## Summary
Benchmark reports now show the current frozen candidate separately from immutable history, rather than commingling them.

Note: generated reports remain only on feature/al-14-smoke (not duplicated here).

## Test plan
- [x] 11 benchmark report tests
- [ ] quality-mgr QA-1