### PR TITLE
docs(al17): define deployable Hermes contract without formal release

### DIFF
--- a/docs/plans/phase-al/hermes-atm-live-proof-handoff.md
+++ b/docs/plans/phase-al/hermes-atm-live-proof-handoff.md
@@ -33,7 +33,7 @@ separate ATM sender durable write
   -> installed generic atm-graft wheel
   -> installed hermes-atm runtime in the active Hermes profile
   -> typed PyNudge callback on the gateway event loop
-  -> released GatewayRunner capability selects the configured existing
+  -> deployed GatewayRunner capability selects the configured existing
      Telegram session from explicit profile + ATM_CHAT_ID
   -> one visible host-originated Telegram notice
   -> internal event for that existing Telegram session
@@ -64,7 +64,7 @@ protecting user-session semantics:
 | --- | --- | --- |
 | Generic receiver/client | Cipher in `atm-core` | `atm-graft` remains a generic installed wheel: no Hermes/Telegram imports, direct storage, second client, replay, or host policy. |
 | Hermes composition | Cipher with SkillRX | `hermes-atm` is the separately installed integration package. It owns explicit profile configuration, event-loop handoff, and the documented runner call. It never selects an adapter or constructs a session itself. |
-| Live gateway seam | SkillRX in Hermes Agent | Hermes Agent owns the existing Telegram adapter/session, gateway lifecycle, visible notice, and queue behavior through the released runner capability. Hermes source changes are reviewed in Hermes Agent, not copied into `atm-core`. |
+| Live gateway seam | SkillRX in Hermes Agent | Hermes Agent owns the existing Telegram adapter/session, gateway lifecycle, visible notice, and queue behavior through the deployed runner capability. Hermes source changes are reviewed in Hermes Agent, not copied into `atm-core`. |
 | Live profile/harness | SkillRX | The `.hermes` profile receives a built wheel and declarative configuration only. Never import an ATM checkout with `PYTHONPATH`/`sys.path` or edit generated receiver JSON. |
 | Architecture/review | ATM integration owner | Decide boundary questions, review evidence, and direct a smallest isolated fix to the correct repository. |
 

--- a/docs/plans/phase-al/sprint-AL16-hermes-graft-live-proof.md
+++ b/docs/plans/phase-al/sprint-AL16-hermes-graft-live-proof.md
@@ -127,7 +127,7 @@ the public adapter is first added as a generic, documented `atm-graft` API in
 its own reviewed change; it is never reimplemented in `hermes-atm`.
 
 The separate Hermes host contract is equally explicit: `hermes-atm` may call
-only a **released, versioned** public Hermes lifecycle/injection capability
+only a **reviewed, immutable, deployed** public Hermes lifecycle/injection capability
 (`GatewayRunner.inject_internal_message(...)` for this MVP). A method that
 exists only in a dirty local Hermes checkout, an untracked test, or an
 undocumented startup-hook object is not a supported dependency. The package

--- a/docs/plans/phase-al/sprint-AL16-hermes-graft-live-proof.md
+++ b/docs/plans/phase-al/sprint-AL16-hermes-graft-live-proof.md
@@ -314,7 +314,8 @@ AL.16 is ready to merge only when:
 
 ## Follow-on sprints
 
-- [AL.17 — Hermes Gateway Lifecycle Binding](sprint-AL17-hermes-gateway-lifecycle.md)
-  consumes the released/tested package in the actual gateway process.
+- [AL.17 — Deployable Hermes Host Contract](sprint-AL17-hermes-gateway-lifecycle.md)
+  consumes the reviewed, immutable, deployed host contract in the actual
+  gateway process.
 - [AL.18 — Hermes Telegram Live Proof](sprint-AL18-hermes-telegram-live-proof.md)
   proves durable-write-to-safe-boundary delivery and recovery behavior.

--- a/docs/plans/phase-al/sprint-AL17-hermes-gateway-lifecycle.md
+++ b/docs/plans/phase-al/sprint-AL17-hermes-gateway-lifecycle.md
@@ -1,15 +1,28 @@
-# AL.17 — Released Hermes Host Contract for `hermes-atm`
+# AL.17 — Deployable Hermes Host Contract for `hermes-atm`
 
 **implementation repository:** Hermes Agent, then deployed into the live `.hermes` harness
 **ATM dependency:** AL.16's separately built `atm-graft` and `hermes-atm` candidate wheels
 **owners:** Hermes Agent maintainers (public host API), `skillrx@hermes` (profile operator and deployment evidence), Cipher-311d (ATM package coordination), ATM integration owner (boundary review)
-**goal:** make the Hermes capability consumed by `hermes-atm` a released, versioned, documented host contract rather than an M4-local source edit.
+**goal:** make the Hermes capability consumed by `hermes-atm` a reviewed, immutable, documented, deployed host contract rather than an M4-local source edit.
 
 ## Why this sprint exists
 
 The package-side MVP is deliberately small: a typed graft `PyNudge` calls the host runner with the configured Hermes profile and Telegram chat identity. The runner owns the real adapter, session key, visible notice, and agent-loop dispatch. That is the only safe way to keep ATM from manufacturing a Telegram session or coupling itself to private adapter internals.
 
-M4 has demonstrated an implementation of `GatewayRunner.inject_internal_message(...)`, but the implementation and its test presently exist only in a dirty local Hermes checkout. M5's released Hermes Agent 0.19 has no such public capability. A package that relies on the local edit may be useful exploratory evidence; it is not deployable software. AL.17 closes that portability gap.
+M4 has demonstrated an implementation of `GatewayRunner.inject_internal_message(...)`, but the implementation and its test presently exist only in a dirty local Hermes checkout. M5's installed Hermes Agent 0.19 has no such public capability. A package that relies on the local edit may be useful exploratory evidence; it is not deployable software. AL.17 closes that portability gap.
+
+## Contract artifact rule
+
+Hermes Agent has no formal public release process. Therefore **deployable** in
+AL.17–AL.19 has a concrete, auditable meaning: the host API is in a clean,
+reviewed Hermes Agent commit with an immutable SHA, and the active gateway
+imports an artifact built or installed from that exact commit. The report must
+record both the reviewed source SHA and active-process module provenance.
+
+A dirty checkout, untracked test, local monkey-patch, or a method copied into
+only one harness is not deployable. This rule deliberately does not require a
+PyPI upload or externally versioned Hermes distribution; it requires a
+reproducible reviewed deployment that M4 and M5 can identify and install.
 
 ## MVP delivery semantics
 
@@ -19,7 +32,7 @@ The supported MVP mode is **queue**. An ATM nudge is a local, host-originated ev
 durable ATM write
   -> recipient graft receiver
   -> installed hermes-atm callback
-  -> released GatewayRunner.inject_internal_message(...)
+  -> deployed GatewayRunner.inject_internal_message(...)
   -> one visible 📬 notice in the configured Telegram chat
   -> internal event in that exact existing Telegram session
   -> normal Hermes message pipeline
@@ -56,7 +69,9 @@ The exact spelling may differ only if the Hermes Agent documentation and the `he
 1. Move the existing local runner method, if it is still appropriate, into a clean Hermes Agent change with its implementation and regression tests.
 2. Test idle dispatch, busy same-session queueing, profile/chat isolation, notice emission, unavailable adapter/profile failures, and no hidden steer or interrupt call.
 3. Document the public plugin/profile lifecycle surface that supplies the runner and the compatibility version containing it.
-4. Review and release/install the Hermes Agent change through its own normal process. A local checkout diff or untracked test cannot satisfy this step.
+4. Review the Hermes Agent change, record its immutable SHA, and deploy the
+   exact resulting artifact through the supported gateway workflow. A local
+   checkout diff or untracked test cannot satisfy this step.
 
 ### B. Bind and verify `hermes-atm` against that published API
 
@@ -78,9 +93,11 @@ M4 and M5 must each perform the active-service capability inventory before live 
 
 ## Acceptance
 
-1. A released, documented Hermes Agent version exposes the required runner capability from a supported profile/plugin lifecycle context.
+1. A clean, reviewed, immutable, deployed Hermes Agent commit exposes the
+   required runner capability from a supported profile/plugin lifecycle context.
 2. Hermes-side tests prove profile isolation, visible notice behavior, idle dispatch, busy **queue** behavior, and the absence of interrupt/steer in the MVP path.
 3. `hermes-atm` uses only that public contract and fails closed when it is not available; tests prove no direct adapter or checkout-import fallback.
-4. The installed, active M4 gateway imports the released Hermes Agent and reviewed ATM wheels, publishes one generation-owned receiver, and passes the capability inventory.
-5. M5's active-service inventory is rerun against the released contract. AL.19 remains blocked if its installed Hermes version does not yet provide it; a CPython 3.11 wheel-only result is not a substitute.
+4. The installed, active M4 gateway imports the deployed Hermes artifact and
+   reviewed ATM wheels, publishes one generation-owned receiver, and passes the capability inventory.
+5. M5's active-service inventory is rerun against the deployed contract. AL.19 remains blocked if its installed Hermes artifact does not yet provide it; a CPython 3.11 wheel-only result is not a substitute.
 6. Hermes Agent and ATM package revisions, interpreter versions, and redacted deployment evidence are linked in the report. Only then may AL.18 claim a portable live proof.

--- a/docs/plans/phase-al/sprint-AL18-hermes-telegram-live-proof.md
+++ b/docs/plans/phase-al/sprint-AL18-hermes-telegram-live-proof.md
@@ -1,15 +1,17 @@
 # AL.18 — Installed `hermes-atm` Queue Live Proof
 
-**execution base:** the released Hermes Agent host contract from AL.17 plus reviewed `atm-graft` and `hermes-atm` wheels at frozen revisions
+**execution base:** the deployed Hermes Agent host contract from AL.17 plus reviewed `atm-graft` and `hermes-atm` wheels at frozen revisions
 **execution host:** M4/SkillRX's live Telegram profile
 **owners:** `skillrx@hermes` (live profile operator), Cipher-311d (ATM package and evidence coordination), Hermes Agent maintainer (host API review), ATM integration owner (acceptance review)
-**goal:** prove a real durable ATM write reaches one existing Telegram session through the released installed-package **queue** path.
+**goal:** prove a real durable ATM write reaches one existing Telegram session through the deployed installed-package **queue** path.
 
 ## Preconditions
 
 AL.18 does not begin live traffic until all of these are true:
 
-1. AL.17's public runner capability is released and present in the actual active gateway—not merely in a local Hermes checkout.
+1. AL.17's public runner capability is deployed from its reviewed immutable
+   Hermes commit and present in the actual active gateway—not merely in a local
+   Hermes checkout.
 2. The active process imports the installed `hermes-atm` and `atm-graft` wheels from their recorded locations, with no `sys.path`, `PYTHONPATH`, or worktree import.
 3. The target profile has explicit `ATM_HOME`, `ATM_IDENTITY`, `ATM_TEAM`, and `ATM_CHAT_ID`; the Tokio/Axum daemon and CLI are a matched healthy pair under `atm doctor --json`.
 4. The profile runtime publishes one schema-v2, generation-owned graft receiver. Endpoint files are never edited by hand or accepted as a v1 fallback.
@@ -67,9 +69,10 @@ Run the existing managed bridge/install tests; do not create a duplicate smoke r
 
 ## Acceptance
 
-1. The actual live gateway uses released Hermes Agent code and installed, reviewed ATM wheels; no local checkout dependency remains.
+1. The actual live gateway uses the deployed Hermes artifact recorded by AL.17
+   and installed, reviewed ATM wheels; no local checkout dependency remains.
 2. The idle durable-write proof produces exactly one visible `📬` notice and one normal result in the intended existing Telegram session.
 3. The busy proof uses that same Telegram session and demonstrates exactly one deferred **queue** drain, with no interrupt or steer.
 4. Profile/session isolation and all negative properties are proven.
 5. Ordinary post-wake read/ack behavior remains explicit and correctly routed.
-6. The indexed redacted report links exact artifacts, tests, CI, and the Hermes/ATM quality reviews. A missing released host contract, blocked row, or prototype-only result is reported as blocked—not as a live pass.
+6. The indexed redacted report links exact artifacts, tests, CI, and the Hermes/ATM quality reviews. A missing deployed host contract, blocked row, or prototype-only result is reported as blocked—not as a live pass.

--- a/docs/plans/phase-al/sprint-AL19-hermes-m5-py311-verify.md
+++ b/docs/plans/phase-al/sprint-AL19-hermes-m5-py311-verify.md
@@ -28,7 +28,7 @@ CPython 3.11 extension is compatible.
 | Distribution | Responsibility | Must not own |
 | --- | --- | --- |
 | `atm-graft` | Generic PyO3 receiver/client bindings and typed `PyNudge` delivery | Hermes imports, Telegram session policy, chat IDs, gateway lifecycle, or source-checkout coupling |
-| `hermes-atm` | Installed pure-Python composition: explicit profile configuration, receiver activation, event-loop handoff, visible notice, and selected-session delivery through the released `GatewayRunner.inject_internal_message(...)` contract | Direct storage/socket access, ATM-owned session, second receiver, retry/replay state, private PyO3 import, hard-coded profile, session-key construction, or direct adapter `handle_message` calls |
+| `hermes-atm` | Installed pure-Python composition: explicit profile configuration, receiver activation, event-loop handoff, visible notice, and selected-session delivery through the deployed `GatewayRunner.inject_internal_message(...)` contract | Direct storage/socket access, ATM-owned session, second receiver, retry/replay state, private PyO3 import, hard-coded profile, session-key construction, or direct adapter `handle_message` calls |
 
 The current MVP mode is Hermes's internal-event **queue** seam. It is the
 first supported delivery mode, not a permanent product preference. An active
@@ -71,7 +71,7 @@ profile—not a convenient shell Python—and record its executable, interpreter
 `sys.path`, Hermes Agent version, module root, documented plugin/startup
 context, and public capability keys.
 
-Probe the released `GatewayRunner.inject_internal_message(...)` contract. If
+Probe the deployed `GatewayRunner.inject_internal_message(...)` contract. If
 the active service does not provide it, record a versioned Hermes compatibility
 blocker and stop the live lane. Do not substitute private imports, direct
 adapter calls, or a source-tree patch.
@@ -102,7 +102,7 @@ it is never presented as a live service result.
    process imports installed wheels—not an ATM source checkout—and publishes
    one schema-v2, generation-owned receiver.
 4. Confirm `hermes-atm` supplies explicit profile/chat values only, while the
-   released runner resolves adapter and session identity. Fail closed for
+   deployed runner resolves adapter and session identity. Fail closed for
    missing configuration, missing adapter, or unavailable contract.
 
 ### E. Queue proof after the public contract exists
@@ -137,7 +137,7 @@ a pass from unreviewed or local-only code.
 | Row | Required evidence | Pass condition |
 | --- | --- | --- |
 | Runtime pair | selected CLI + daemon and doctor JSON | matched Tokio/Axum pair healthy |
-| Active Hermes capability | active-service interpreter/module root and API probe | released runner contract available in the actual service |
+| Active Hermes capability | active-service interpreter/module root and API probe | deployed runner contract available in the actual service |
 | CPython 3.11 package lane | wheel tags, isolated install/import, bridge/runtime tests | no checkout import; both packages usable |
 | Active M5 service lane | service interpreter/matching wheels and receiver lifecycle | installed package starts one current receiver |
 | Idle queue delivery | durable marker, notice, response | exactly one intended session processes it |
@@ -150,7 +150,7 @@ a pass from unreviewed or local-only code.
    without a source-tree dependency; final closure reruns this row on the
    reviewed candidate.
 2. The actual M5 Hermes service separately installs its matching wheels,
-   exposes the released runner contract, and starts one valid generation-owned
+   exposes the deployed runner contract, and starts one valid generation-owned
    receiver for the configured profile.
 3. Both idle and busy queue probes pass in only the intended Telegram session.
 4. Busy proof is demonstrably queue-based: no steer, interrupt, duplicate, or

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1160,7 +1160,7 @@ Sprint line:
 - `AL.16` `sprint-AL16-hermes-graft-live-proof.md` — installable generic
   `atm-graft` and Hermes-facing `hermes-atm` package boundary; package-side
   candidate is under review, while portable live proof is blocked on a
-  released Hermes host contract
+  reviewed, immutable, deployed Hermes host contract
 - `AL.17` `sprint-AL17-hermes-gateway-lifecycle.md` — released, documented
   Hermes runner lifecycle/injection contract for the queue MVP; required before
   a portable live package claim

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1161,9 +1161,9 @@ Sprint line:
   `atm-graft` and Hermes-facing `hermes-atm` package boundary; package-side
   candidate is under review, while portable live proof is blocked on a
   reviewed, immutable, deployed Hermes host contract
-- `AL.17` `sprint-AL17-hermes-gateway-lifecycle.md` — released, documented
-  Hermes runner lifecycle/injection contract for the queue MVP; required before
-  a portable live package claim
+- `AL.17` `sprint-AL17-hermes-gateway-lifecycle.md` — reviewed, immutable,
+  deployed Hermes runner lifecycle/injection contract for the queue MVP;
+  required before a portable live package claim
 - `AL.18` `sprint-AL18-hermes-telegram-live-proof.md` — installed-package M4
   idle and same-session busy queue proof after AL.17 is deployed
 - `AL.19` `sprint-AL19-hermes-m5-py311-verify.md` — M5 multi-interpreter


### PR DESCRIPTION
## Summary
- Redefines AL16-19's Hermes-contract acceptance bar from "released, versioned" to "deployable": a reviewed, immutable-SHA Hermes Agent commit whose exact artifact is actively imported/deployed by the gateway.
- Rationale: Hermes Agent has no formal public release process (no PyPI/versioned distribution), so a "released" bar is unsatisfiable as originally worded.
- Still fail-closed: explicitly excludes dirty checkouts, untracked tests, local monkey-patches, and single-harness-only methods. Does not lower the bar to "works on my machine."
- Mechanical terminology propagation across sprint-AL16/17/18/19 docs, the live-proof handoff doc, and project-plan.md's AL.16 summary line.

## Test plan
- [ ] Docs-only plan QA via quality-mgr (`review_mode: plan`)