### PR TITLE
fix(phase-al): close PHASEAL-ENDING-QA-1 fail batch (doc completeness + boundary dedup)

### DIFF
--- a/.triage/phase-al/findings/AL-CLOSURE-001.ttl
+++ b/.triage/phase-al/findings/AL-CLOSURE-001.ttl
@@ -20,8 +20,9 @@
   triage:triagedAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
   triage:foundIn triage:AL15 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:reviewNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@origin HEAD, commit 7e44067d): requirement (2), the readiness.md closure artifact, is genuinely present and its content is accurate and honest -- correctly declares status: blocked frontmatter, distinguishes SOURCE-READY from PHYSICAL-PROOF-BLOCKED, and records a real close-out table plus a new Windows cross-host infrastructure waiver (VPN/hardware unavailable to the Windows operator, explicitly not an ATM runtime defect). Requirement (1) remains NOT met: docs/plans/phase-al/plan-phase-al.md frontmatter still reads status: draft, unchanged from ce43771271a0d05a746dff2411452f135d3574b6 through the current head -- confirmed via git show at both 09f4b0cd and 7e44067d. draft no longer describes reality (18 sprints merged, a real completion gate defined in readiness.md). Not closing: request arch-ctm harden plan-phase-al.md's status field to blocked (matching readiness.md's own frontmatter) so the two closure documents agree." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-001/AL-1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AL-CLOSURE-001/AL-1>
   a triage:Occurrence ;

--- a/.triage/phase-al/findings/AL-CLOSURE-001.ttl
+++ b/.triage/phase-al/findings/AL-CLOSURE-001.ttl
@@ -15,22 +15,27 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
   triage:foundIn triage:AL15 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T18:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:reviewNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@origin HEAD, commit 7e44067d): requirement (2), the readiness.md closure artifact, is genuinely present and its content is accurate and honest -- correctly declares status: blocked frontmatter, distinguishes SOURCE-READY from PHYSICAL-PROOF-BLOCKED, and records a real close-out table plus a new Windows cross-host infrastructure waiver (VPN/hardware unavailable to the Windows operator, explicitly not an ATM runtime defect). Requirement (1) remains NOT met: docs/plans/phase-al/plan-phase-al.md frontmatter still reads status: draft, unchanged from ce43771271a0d05a746dff2411452f135d3574b6 through the current head -- confirmed via git show at both 09f4b0cd and 7e44067d. draft no longer describes reality (18 sprints merged, a real completion gate defined in readiness.md). Not closing: request arch-ctm harden plan-phase-al.md's status field to blocked (matching readiness.md's own frontmatter) so the two closure documents agree." ;
+  triage:closureNote "INDEPENDENT REVIEW (quality-mgr, commit 82905dad8969675a85fc1272f9602a83c07dc9aa): git show 82905dad confirms plan-phase-al.md frontmatter changed status: draft -> status: blocked, now matching readiness.md's own frontmatter. Both requirements met. Closing." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-001/AL-1> ;
-  triage:triageRecordVersion "2" .
+  triage:triageRecordVersion "3" .
 
 <urn:atm:triage:occurrence/AL-CLOSURE-001/AL-1>
   a triage:Occurrence ;
   triage:file "docs/plans/phase-al/plan-phase-al.md" ;
   triage:line 3 ;
   triage:snippet "status: draft" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T18:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/AL/ce437712> .

--- a/.triage/phase-al/findings/AL-CLOSURE-002.ttl
+++ b/.triage/phase-al/findings/AL-CLOSURE-002.ttl
@@ -15,23 +15,28 @@
   triage:severity "important" ;
   triage:repeatable true ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-10T17:07:30Z"^^xsd:dateTime ;
   triage:foundIn triage:AL15 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@origin HEAD, commit d2e1cc04): re-read all three sprint-doc frontmatters and docs/project-plan.md's sprint line at the current branch head. sprint-AL1-runtime-contract.md now status: complete, sprint-AL3-received-hook.md now status: complete, sprint-AL7-peer-tls-m5-proof.md now status: abandoned. project-plan.md now tags AL.1[COMPLETE]/AL.3[COMPLETE]/AL.7[ABANDONED], matching each sprint doc's own frontmatter -- the cross-doc contradiction is resolved. Independently re-ran `just lint` in a disposable worktree pinned to d2e1cc047d822d176967accc46a496f73d562185: 25/25 clean, matching arch-ctm's claim. Closing." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-002/AL1-3> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-002/AL3-3> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-002/AL7-3> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AL-CLOSURE-002/AL1-3>
   a triage:Occurrence ;
   triage:file "docs/plans/phase-al/sprint-AL1-runtime-contract.md" ;
   triage:line 3 ;
   triage:snippet "status: in_progress" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/al-final-review/ce437712> .
@@ -41,8 +46,10 @@
   triage:file "docs/plans/phase-al/sprint-AL3-received-hook.md" ;
   triage:line 3 ;
   triage:snippet "status: in_progress" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/al-final-review/ce437712> .
@@ -52,8 +59,10 @@
   triage:file "docs/plans/phase-al/sprint-AL7-peer-tls-m5-proof.md" ;
   triage:line 3 ;
   triage:snippet "status: proposed" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/al-final-review/ce437712> .

--- a/.triage/phase-al/findings/AL-CLOSURE-003.ttl
+++ b/.triage/phase-al/findings/AL-CLOSURE-003.ttl
@@ -20,18 +20,34 @@
   triage:triagedAt "2026-08-10T17:30:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AL11 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:reviewNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@origin HEAD, commit 4ffbacbc): the missing-entries defect is genuinely fixed -- docs/project-plan.md now has an entry for every AL.10-AL.15 sprint (lines ~1162-1174) with tags AL.10[ABANDONED]/AL.11[SUPERSEDED]/AL.12[SUPERSEDED]/AL.13[COMPLETE]/AL.14[COMPLETE]/AL.15[BLOCKED]. AL.13's [COMPLETE] tag is now fully substantiated: independently read site/reports/smoke/macos/rand-m5.local/20260808T203610076893Z-pid39023-crosshost-ack/crosshost-ack.json (160 cases, genuine distinct ULIDs, correct M5<->M4 origin/destination alternation, all PASS) in addition to the already-verified crosshost-send.json -- both G6/AL.13 acceptance artifacts are real. HOWEVER AL.14's [COMPLETE] tag is FALSE: exhaustive repo-wide search (PR history, site/reports/, sprint doc acceptance criteria) found zero cwin<->M4 direct cross-host artifacts. PR #792 (feature/al-14-smoke, CLOSED not merged) is the only attempt and documents an explicit, unresolved failure: 'BLOCKED at first peer row: just smoke peer-preflight m5' / 'NOT RUN: cross-host send, cross-host acknowledgement, benchmark, benchmark-report' -- SSH from Windows to M5/M4 never resolved. PR #819 (merged) is docs-only site/reports content and never claims cwin cross-host evidence itself; its own PR description scopes it as M5-only + FastPC4-localhost-only. Not closing: this finding remains open until docs/project-plan.md's AL.14 tag is corrected to reflect the actual unproven state (e.g. AL.14 [BLOCKED], matching AL.15's own tag and the sprint doc's unmet acceptance criteria)." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-2-al14-false-complete> ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-1>
   a triage:Occurrence ;
   triage:file "docs/project-plan.md" ;
   triage:line 1147 ;
   triage:snippet "Sprint line section (lines 1147-1171): jumps from AL.9 (line 1159) directly to AL.16 (line 1160), missing AL.10, AL.11, AL.12, AL.13, AL.14, AL.15 entirely. Also missing [COMPLETE] tags on sprints AL.1, AL.4, AL.6, AL.7, AL.8, AL.9, AL.16, AL.17, AL.18." ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Missing-entries defect resolved by commit 4ffbacbc; superseded by AL-2 occurrence below for the surviving false-tag defect." ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce43771271a0d05a746dff2411452f135d3574b6" ;
+  triage:occursIn <urn:atm:triage:worktree/AL-MAIN/ce43771> .
+
+<urn:atm:triage:occurrence/AL-CLOSURE-003/AL-2-al14-false-complete>
+  a triage:Occurrence ;
+  triage:file "docs/project-plan.md" ;
+  triage:line 1171 ;
+  triage:snippet "`AL.14 [COMPLETE]` `sprint-AL14-cwin-direct-crosshost-smoke.md` -- cwin" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "fix/phase-al-ending-qa1-findings" ;
+  triage:headSha "4ffbacbc" ;
   triage:occursIn <urn:atm:triage:worktree/AL-MAIN/ce43771> .
 
 <urn:atm:triage:worktree/AL-MAIN/ce43771>

--- a/.triage/phase-al/findings/AL-CLOSURE-003.ttl
+++ b/.triage/phase-al/findings/AL-CLOSURE-003.ttl
@@ -15,15 +15,18 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-10T17:30:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AL11 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T18:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:reviewNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@origin HEAD, commit 4ffbacbc): the missing-entries defect is genuinely fixed -- docs/project-plan.md now has an entry for every AL.10-AL.15 sprint (lines ~1162-1174) with tags AL.10[ABANDONED]/AL.11[SUPERSEDED]/AL.12[SUPERSEDED]/AL.13[COMPLETE]/AL.14[COMPLETE]/AL.15[BLOCKED]. AL.13's [COMPLETE] tag is now fully substantiated: independently read site/reports/smoke/macos/rand-m5.local/20260808T203610076893Z-pid39023-crosshost-ack/crosshost-ack.json (160 cases, genuine distinct ULIDs, correct M5<->M4 origin/destination alternation, all PASS) in addition to the already-verified crosshost-send.json -- both G6/AL.13 acceptance artifacts are real. HOWEVER AL.14's [COMPLETE] tag is FALSE: exhaustive repo-wide search (PR history, site/reports/, sprint doc acceptance criteria) found zero cwin<->M4 direct cross-host artifacts. PR #792 (feature/al-14-smoke, CLOSED not merged) is the only attempt and documents an explicit, unresolved failure: 'BLOCKED at first peer row: just smoke peer-preflight m5' / 'NOT RUN: cross-host send, cross-host acknowledgement, benchmark, benchmark-report' -- SSH from Windows to M5/M4 never resolved. PR #819 (merged) is docs-only site/reports content and never claims cwin cross-host evidence itself; its own PR description scopes it as M5-only + FastPC4-localhost-only. Not closing: this finding remains open until docs/project-plan.md's AL.14 tag is corrected to reflect the actual unproven state (e.g. AL.14 [BLOCKED], matching AL.15's own tag and the sprint doc's unmet acceptance criteria)." ;
+  triage:closureNote "INDEPENDENT REVIEW (quality-mgr, commit 82905dad8969675a85fc1272f9602a83c07dc9aa): git show 82905dad confirms docs/project-plan.md's AL.14 tag changed from [COMPLETE] to [BLOCKED], with corrected wording ('local smoke and benchmark evidence retained; its Windows-originated direct-peer row is infrastructure-blocked') accurately reflecting the actual unproven cwin<->M4 direct-peer state. Closing." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-2-al14-false-complete> ;
-  triage:triageRecordVersion "2" .
+  triage:triageRecordVersion "3" .
 
 <urn:atm:triage:occurrence/AL-CLOSURE-003/AL-1>
   a triage:Occurrence ;
@@ -44,10 +47,13 @@
   triage:file "docs/project-plan.md" ;
   triage:line 1171 ;
   triage:snippet "`AL.14 [COMPLETE]` `sprint-AL14-cwin-direct-crosshost-smoke.md` -- cwin" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T18:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Corrected to AL.14 [BLOCKED] in commit 82905dad." ;
   triage:branch "fix/phase-al-ending-qa1-findings" ;
-  triage:headSha "4ffbacbc" ;
+  triage:headSha "82905dad" ;
   triage:occursIn <urn:atm:triage:worktree/AL-MAIN/ce43771> .
 
 <urn:atm:triage:worktree/AL-MAIN/ce43771>

--- a/.triage/phase-al/findings/RBQA-F101-AL.ttl
+++ b/.triage/phase-al/findings/RBQA-F101-AL.ttl
@@ -15,24 +15,29 @@
   triage:severity "important" ;
   triage:repeatable true ;
   triage:sweepScope "workspace" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-10T17:07:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AL9 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "INDEPENDENT REVIEW (quality-mgr, fix/phase-al-ending-qa1-findings@09f4b0cdda72c1d81aa8e35258bc40042e755f0c): recreated the commit in a disposable worktree and read the real diff. crates/atm-http-runtime/src/client.rs now owns a single selected_write_transport() and SAME_HOST_REQUEST_DEADLINE constant; crates/atm/src/composition.rs and crates/atm-graft/src/lib.rs delete their private duplicates and delegate to atm_http_runtime::selected_write_transport(...). crates/atm-graft/src/transport.rs imports the shared deadline constant. Independently re-ran all three claimed test/check commands in a fresh worktree pinned to this SHA: results matched arch-ctm's claim exactly (84/84, 17/17, clean cargo check). Grep confirmed no leftover duplicate definitions. Closing." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AL/AL-swt-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AL/AL-swt-2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AL/AL-shrd-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AL/AL-shrd-2> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/RBQA-F101-AL/AL-swt-1>
   a triage:Occurrence ;
   triage:file "crates/atm/src/composition.rs" ;
   triage:line 312 ;
   triage:snippet "fn selected_write_transport(&self, request: &SendRequest) -> Result<Arc<dyn DaemonApiClient..." ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce43771271a0d05a746dff2411452f135d3574b6" ;
   triage:occursIn <urn:atm:triage:worktree/AL-ce437712> .
@@ -42,8 +47,10 @@
   triage:file "crates/atm-graft/src/lib.rs" ;
   triage:line 367 ;
   triage:snippet "fn selected_write_transport(&self, request: &SendRequest) -> Result<Arc<dyn DaemonApiClient..." ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce43771271a0d05a746dff2411452f135d3574b6" ;
   triage:occursIn <urn:atm:triage:worktree/AL-ce437712> .
@@ -53,8 +60,10 @@
   triage:file "crates/atm/src/composition.rs" ;
   triage:line 47 ;
   triage:snippet "const SAME_HOST_REQUEST_DEADLINE: std::time::Duration = Duration::from_secs(3);" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce43771271a0d05a746dff2411452f135d3574b6" ;
   triage:occursIn <urn:atm:triage:worktree/AL-ce437712> .
@@ -64,8 +73,10 @@
   triage:file "crates/atm-graft/src/lib.rs" ;
   triage:line 42 ;
   triage:snippet "const SAME_HOST_REQUEST_DEADLINE: Duration = Duration::from_secs(3);" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:45:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce43771271a0d05a746dff2411452f135d3574b6" ;
   triage:occursIn <urn:atm:triage:worktree/AL-ce437712> .

--- a/.triage/phase-al/findings/RBQA-F102-AL.ttl
+++ b/.triage/phase-al/findings/RBQA-F102-AL.ttl
@@ -15,23 +15,29 @@
   triage:severity "minor" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady false ;
   triage:triagedAt "2026-08-10T17:12:43Z"^^xsd:dateTime ;
   triage:foundIn triage:AL9 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T19:05:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "INDEPENDENT REVIEW (quality-mgr, commit 258ee36257adf8912500526eb69b9d9619254b2f on fix/phase-al-ending-qa1-findings): recreated the commit in a disposable worktree and re-ran the test directly rather than trusting arch-ctm's self-reported '50/50' claim. crates/atm-architecture/tests/boundary_enforcement.rs now asserts positively that crates/atm-http-runtime/src/client.rs defines selected_write_transport (line 146) and SAME_HOST_REQUEST_DEADLINE (line 43), and negatively that crates/atm/src/composition.rs and crates/atm-graft/src/lib.rs do NOT redefine either -- a genuine strengthening, not the prior entrenching assertion. cargo test -p atm-architecture --test boundary_enforcement: 50 passed, 0 failed, 0 ignored, matching arch-ctm's claim exactly. This closure was independently verified earlier in the batch but the .ttl record itself was never updated to reflect it -- filing the closure now while reviewing PR #825's merge-gate, since the branch head (aebff7bc) still showed this record open." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F102-AL/AL9-1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/RBQA-F102-AL/AL9-1>
   a triage:Occurrence ;
   triage:file "crates/atm-architecture/tests/boundary_enforcement.rs" ;
   triage:line 2032 ;
   triage:snippet "fn al9_cli_and_graft_send_use_the_selected_runtime_client()" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:branch "integrate/phase-al" ;
-  triage:headSha "ce437712" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T19:05:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Test rewritten to assert single shared owner in commit 258ee362; independently re-run and confirmed 50/50 passing." ;
+  triage:branch "fix/phase-al-ending-qa1-findings" ;
+  triage:headSha "258ee362" ;
   triage:occursIn <urn:atm:triage:worktree/AL-integrate-ce437712> .
 
 <urn:atm:triage:worktree/AL-integrate-ce437712>

--- a/.triage/phase-al/findings/RBQA-F103-AL.ttl
+++ b/.triage/phase-al/findings/RBQA-F103-AL.ttl
@@ -15,23 +15,28 @@
   triage:severity "minor" ;
   triage:repeatable true ;
   triage:sweepScope "workspace" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-10T17:10:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AL9 ;
   triage:foundAt "2026-08-10T17:06:52Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-10T17:50:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "DISPOSITION (quality-mgr): split occurrence 2 (crates/atm-daemon, frozen legacy) as waived per standing never-patch-legacy-daemon rule; occurrences 1 and 3 (active Tokio path + CLI) required a genuine dedup fix. INDEPENDENT REVIEW of arch-ctm's fix (commit 9e303af7 on fix/phase-al-ending-qa1-findings): read the full diff (3 files) and recreated the commit in a disposable worktree. crates/atm-core/src/boundary/mod.rs now owns TMUX_DOUBLE_ENTER_DELAY and TMUX_NUDGE_CONFIRM_KEY as the single shared definitions; received_hook_selector.rs and internal_nudge.rs both delete their local consts and import from atm_core::boundary. crates/atm-daemon/src/message_received_emitter.rs confirmed absent from the diff and still independently defines its own const -- untouched, as required. Repo-wide grep at this commit found no third duplicate. Independently re-ran cargo fmt --all --check (clean), cargo test -p agent-team-mail --bin atm internal_nudge (8/8), cargo test -p atm-daemon-bootstrap --lib (8/8) -- all matched arch-ctm's claim exactly. Closing all three occurrences: 1 and 3 fixed, 2 waived." ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F103-AL/AL-CE437712-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F103-AL/AL-CE437712-2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F103-AL/AL-CE437712-3> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/RBQA-F103-AL/AL-CE437712-1>
   a triage:Occurrence ;
   triage:file "crates/atm-daemon-bootstrap/src/received_hook_selector.rs" ;
   triage:line 21 ;
   triage:snippet "const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:50:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/AL-integrate-phase-al/ce437712> .
@@ -41,8 +46,12 @@
   triage:file "crates/atm-daemon/src/message_received_emitter.rs" ;
   triage:line 12 ;
   triage:snippet "const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:50:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:waived true ;
+  triage:waivedReason "frozen legacy sync daemon, Phase-AM deletion target -- never patch" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/AL-integrate-phase-al/ce437712> .
@@ -52,8 +61,10 @@
   triage:file "crates/atm/src/commands/internal_nudge.rs" ;
   triage:line 31 ;
   triage:snippet "const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-10T17:50:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "ce437712" ;
   triage:occursIn <urn:atm:triage:worktree/AL-integrate-phase-al/ce437712> .

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2033,6 +2033,13 @@ fn al9_cli_and_graft_send_use_the_selected_runtime_client() {
     let root = workspace_root();
     let cli = read_source(&root.join("crates/atm/src/composition.rs"));
     let graft = read_source(&root.join("crates/atm-graft/src/lib.rs"));
+    let runtime_client = read_source(&root.join("crates/atm-http-runtime/src/client.rs"));
+
+    assert!(
+        runtime_client.contains("pub fn selected_write_transport")
+            && runtime_client.contains("SAME_HOST_REQUEST_DEADLINE"),
+        "AL.9 must keep the local-vs-direct-peer write decision and deadline in atm-http-runtime"
+    );
 
     for (consumer, source) in [("CLI", &cli), ("graft", &graft)] {
         assert!(
@@ -2040,8 +2047,9 @@ fn al9_cli_and_graft_send_use_the_selected_runtime_client() {
             "AL.9 {consumer} composition must select the runtime-owned local client for sends"
         );
         assert!(
-            source.contains("direct_peer_tcp_client(") && source.contains("direct_peer_port()"),
-            "AL.9 {consumer} host-qualified writes must choose the shared direct peer client before encoding"
+            !source.contains("fn selected_write_transport")
+                && !source.contains("const SAME_HOST_REQUEST_DEADLINE"),
+            "AL.9 {consumer} must delegate write-transport selection and its deadline to atm-http-runtime"
         );
     }
 
@@ -2057,9 +2065,10 @@ fn al9_cli_and_graft_send_use_the_selected_runtime_client() {
         .expect("graft send implementation");
     for (consumer, send) in [("CLI", cli_send), ("graft", graft_send)] {
         assert!(
-            send.contains(".selected_write_transport(&request)?")
-                && send.contains(".execute(ApiRequest::new(RequestEnvelope::Write"),
-            "AL.9 {consumer} send must await the selected DaemonApiClient write path"
+            send.contains(
+                "atm_http_runtime::selected_write_transport(&request, &self.async_transport)?"
+            ) && send.contains(".execute(ApiRequest::new(RequestEnvelope::Write"),
+            "AL.9 {consumer} send must await the runtime-selected DaemonApiClient write path"
         );
         assert!(
             !send.contains("legacy_dispatch")

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -11,6 +11,15 @@ pub use atm_storage::{
     TeamNudgeTemplateOverrideRow,
 };
 
+/// The retained tmux receiver nudge confirms its literal payload with two
+/// `send-keys Enter` events separated by this bounded delay. The active Tokio
+/// runtime and CLI command share this contract; frozen legacy daemon source
+/// remains reference-only until Phase AM removes it.
+pub const TMUX_DOUBLE_ENTER_DELAY: std::time::Duration = std::time::Duration::from_millis(275);
+
+/// Literal tmux key used for each confirmation in the shared nudge sequence.
+pub const TMUX_NUDGE_CONFIRM_KEY: &str = "Enter";
+
 /// Workspace-convention seal only; not compiler-enforced outside this crate.
 ///
 /// Only ATM workspace crates may implement boundary traits. Enforced by

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -8,17 +8,14 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use atm_core::LocalServiceRuntime;
 use atm_core::RequestDeadline;
 use atm_core::boundary::{
     self, AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, MessageReceivedHookSelector,
-    PostSendBuiltInTarget, PostSendEmissionPath,
+    PostSendBuiltInTarget, PostSendEmissionPath, TMUX_DOUBLE_ENTER_DELAY, TMUX_NUDGE_CONFIRM_KEY,
 };
 use atm_core::error::{AtmError, AtmErrorCode};
-
-const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);
 
 /// Builds the selector injected into every production replacement daemon.
 ///
@@ -148,7 +145,12 @@ impl AsyncMessageReceivedHookEmitter for TokioTmuxReceivedHook {
             )
             .await?;
             run_tmux(
-                ["send-keys", "-t", target.pane_id.as_str(), "Enter"],
+                [
+                    "send-keys",
+                    "-t",
+                    target.pane_id.as_str(),
+                    TMUX_NUDGE_CONFIRM_KEY,
+                ],
                 deadline,
             )
             .await?;
@@ -158,7 +160,12 @@ impl AsyncMessageReceivedHookEmitter for TokioTmuxReceivedHook {
                 .min(TMUX_DOUBLE_ENTER_DELAY);
             tokio::time::sleep(delay).await;
             run_tmux(
-                ["send-keys", "-t", target.pane_id.as_str(), "Enter"],
+                [
+                    "send-keys",
+                    "-t",
+                    target.pane_id.as_str(),
+                    TMUX_NUDGE_CONFIRM_KEY,
+                ],
                 deadline,
             )
             .await?;

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -27,6 +27,7 @@ use atm_daemon_client::{
     BootstrapTraceability, DaemonSupervisor, parse_bootstrap_agent, parse_bootstrap_team,
     resolve_daemon_bin, resolve_daemon_local_ipc_endpoint,
 };
+use atm_http_runtime::SAME_HOST_REQUEST_DEADLINE;
 
 mod nudge_sink;
 mod runtime;
@@ -39,7 +40,6 @@ use runtime::{
 };
 use transport::{GraftLocalIpcClientTransport, unexpected_response};
 
-const SAME_HOST_REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 pub(crate) const RECEIVE_LOOP_JOIN_DEADLINE: Duration = Duration::from_secs(5);
 
 pub use atm_core::{AtmConfig, GraftConfig};
@@ -332,7 +332,8 @@ impl GraftClient {
 #[async_trait::async_trait]
 impl AtmGraftClient for GraftClient {
     async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        let transport = self.selected_write_transport(&request)?;
+        let transport =
+            atm_http_runtime::selected_write_transport(&request, &self.async_transport)?;
         match transport
             .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
             .await?
@@ -357,25 +358,6 @@ impl AtmGraftClient for GraftClient {
             ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => Ok(outcome),
             other => Err(unexpected_response("ack", other)),
         }
-    }
-}
-
-impl GraftClient {
-    /// Selects the same shared peer client as the CLI for a host-qualified
-    /// write.  Graft never owns a peer protocol: this is one connector choice
-    /// before the canonical typed request is encoded.
-    fn selected_write_transport(
-        &self,
-        request: &SendRequest,
-    ) -> Result<Arc<dyn DaemonApiClient + Send + Sync>, AtmError> {
-        let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
-            return Ok(Arc::clone(&self.async_transport));
-        };
-        atm_http_runtime::direct_peer_tcp_client(
-            host.clone(),
-            atm_http_runtime::direct_peer_port(),
-            SAME_HOST_REQUEST_DEADLINE,
-        )
     }
 }
 

--- a/crates/atm-graft/src/transport.rs
+++ b/crates/atm-graft/src/transport.rs
@@ -14,7 +14,7 @@ use atm_daemon_client::{
 
 pub(crate) use atm_daemon_client::unexpected_response;
 
-use crate::SAME_HOST_REQUEST_DEADLINE;
+use atm_http_runtime::SAME_HOST_REQUEST_DEADLINE;
 
 #[derive(Debug)]
 pub(crate) struct GraftLocalIpcClientTransport {

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -22,6 +22,7 @@ use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
 use atm_core::protocol::RequestEnvelope;
 use atm_core::schema::AtmMessageId;
+use atm_core::send::SendRequest;
 use atm_core::types::{HostName, IsoTimestamp};
 
 use reqwest::header::{HeaderName, HeaderValue};
@@ -33,6 +34,13 @@ use reqwest::header::{HeaderName, HeaderValue};
 /// every replacement daemon owns this protocol port on its active IPv4
 /// interfaces.
 pub const DIRECT_PEER_TCP_PORT: u16 = 43_101;
+
+/// One bounded budget for the selected write connector.
+///
+/// CLI and graft deliberately share this value and
+/// [`selected_write_transport`], so a host-qualified write cannot acquire a
+/// different deadline or silently select a different connector by caller.
+pub const SAME_HOST_REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 
 /// Returns the fixed direct-peer protocol port.
 #[must_use]
@@ -127,6 +135,22 @@ pub fn direct_peer_tcp_client(
     let connector = DirectPeerTcpConnector::new(host, port)?;
     let client = Arc::new(HttpRuntimeClient::new(Arc::new(connector), request_timeout));
     Ok(Arc::new(DirectPeerWriteClient { client }))
+}
+
+/// Selects the one physical connector for a canonical write before encoding.
+///
+/// An unqualified recipient stays on the caller-supplied, owner-authorized
+/// same-host client. A host-qualified recipient is an explicit direct-peer
+/// request and selects the shared direct-peer HTTP client; configuration or
+/// connection failures never downgrade it to same-host IPC.
+pub fn selected_write_transport<'client>(
+    request: &SendRequest,
+    same_host_transport: &Arc<dyn DaemonApiClient + Send + Sync + 'client>,
+) -> Result<Arc<dyn DaemonApiClient + Send + Sync + 'client>, AtmError> {
+    let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
+        return Ok(Arc::clone(same_host_transport));
+    };
+    direct_peer_tcp_client(host.clone(), direct_peer_port(), SAME_HOST_REQUEST_DEADLINE)
 }
 
 /// Builds the one selected same-host client for retained write call chains.

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -79,8 +79,8 @@ const ABORT_JOIN_GRACE: Duration = Duration::from_millis(100);
 #[cfg(unix)]
 pub use client::unix_socket_client;
 pub use client::{
-    DIRECT_PEER_TCP_PORT, direct_peer_port, direct_peer_tcp_client, loopback_tcp_client,
-    preferred_local_client,
+    DIRECT_PEER_TCP_PORT, SAME_HOST_REQUEST_DEADLINE, direct_peer_port, direct_peer_tcp_client,
+    loopback_tcp_client, preferred_local_client, selected_write_transport,
 };
 pub use loopback_tcp::LoopbackTcpConfig;
 pub use message_handler::{

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use atm_core::boundary::{
     BuiltInNudgeSinkTarget, InternalNudgeEnvelope, PostSendHookEvent, ResolvedBuiltInNudgeTemplate,
+    TMUX_DOUBLE_ENTER_DELAY, TMUX_NUDGE_CONFIRM_KEY,
 };
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::graft::{
@@ -28,7 +29,6 @@ const GRAFT_POST_SEND_IO_DEADLINE: Duration = Duration::from_secs(3);
 use std::collections::BTreeMap;
 
 const INTERNAL_NUDGE_ENV: &str = "ATM_INTERNAL_NUDGE";
-const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);
 const TMUX_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const TMUX_PROGRAM_ENV: &str = "ATM_TEST_TMUX_BIN";
@@ -144,7 +144,7 @@ impl TmuxNudgeSink {
         run_tmux_command(
             {
                 let mut command = tmux_command();
-                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command.args(["send-keys", "-t", pane_id.as_str(), TMUX_NUDGE_CONFIRM_KEY]);
                 command
             },
             "send first Enter to nudge pane",
@@ -153,7 +153,7 @@ impl TmuxNudgeSink {
         run_tmux_command(
             {
                 let mut command = tmux_command();
-                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command.args(["send-keys", "-t", pane_id.as_str(), TMUX_NUDGE_CONFIRM_KEY]);
                 command
             },
             "send second Enter to nudge pane",
@@ -259,7 +259,8 @@ mod tests {
 
     use atm_core::boundary::{
         BuiltInNudgeSinkTarget, BuiltInNudgeTemplateKind, InternalNudgeEnvelope, PostSendHookEvent,
-        ResolvedBuiltInNudgeTemplate, built_in_nudge_template_kind_from_post_send_event,
+        ResolvedBuiltInNudgeTemplate, TMUX_DOUBLE_ENTER_DELAY,
+        built_in_nudge_template_kind_from_post_send_event,
     };
     use atm_core::send::default_template;
     use atm_core::test_support::{EnvGuard, TEST_ARCH_CTM, TEST_LEAD, TEST_TEAM};
@@ -267,8 +268,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        INTERNAL_NUDGE_ENV, InternalNudgeCommand, InternalNudgeInput, TMUX_DOUBLE_ENTER_DELAY,
-        TMUX_PROGRAM_ENV, render_template,
+        INTERNAL_NUDGE_ENV, InternalNudgeCommand, InternalNudgeInput, TMUX_PROGRAM_ENV,
+        render_template,
     };
 
     fn base_event() -> PostSendHookEvent {

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -36,6 +36,7 @@ use atm_daemon_client::{
 };
 #[cfg(test)]
 use atm_daemon_client::{HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard};
+use atm_http_runtime::SAME_HOST_REQUEST_DEADLINE;
 #[cfg(test)]
 use atm_runtime_test_support::{
     SQLITE_RUNTIME_PATH_ENV,
@@ -44,7 +45,6 @@ use atm_runtime_test_support::{
 
 use crate::observability::CliObservability;
 
-const SAME_HOST_REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(3);
 static INSTALL_RETAINED_RUNTIME_FACTORY: Once = Once::new();
 
 #[cfg(not(test))]
@@ -277,7 +277,8 @@ impl<'a> CliComposition<'a> {
     }
 
     pub(crate) async fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        let transport = self.selected_write_transport(&request)?;
+        let transport =
+            atm_http_runtime::selected_write_transport(&request, &self.async_transport)?;
         match transport
             .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
             .await?
@@ -302,25 +303,6 @@ impl<'a> CliComposition<'a> {
             }
             other => Err(unexpected_response("send", other)),
         }
-    }
-
-    /// Selects the physical connector once before a canonical write is
-    /// encoded.  An unqualified address remains on the owner-authorized local
-    /// client.  A host-qualified address is an explicit peer request and
-    /// cannot downgrade to local IPC after any peer configuration or
-    /// connection failure.
-    fn selected_write_transport(
-        &self,
-        request: &SendRequest,
-    ) -> Result<Arc<dyn DaemonApiClient + Send + Sync + 'a>, AtmError> {
-        let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
-            return Ok(Arc::clone(&self.async_transport));
-        };
-        atm_http_runtime::direct_peer_tcp_client(
-            host.clone(),
-            atm_http_runtime::direct_peer_port(),
-            SAME_HOST_REQUEST_DEADLINE,
-        )
     }
 
     pub(crate) fn ack(&self, request: AckRequest) -> Result<AckOutcome, AtmError> {

--- a/docs/plans/phase-al/plan-phase-al.md
+++ b/docs/plans/phase-al/plan-phase-al.md
@@ -1,6 +1,6 @@
 ---
 title: Phase AL Plan — `atm-http-runtime`
-status: draft
+status: blocked
 branch: plan/tokio-migration
 baseline: develop @ 67401907039f92e58e883273f02372a637202f70
 ---

--- a/docs/plans/phase-al/readiness.md
+++ b/docs/plans/phase-al/readiness.md
@@ -25,8 +25,8 @@ final physical proof.
 | AL-CLOSURE-002 | corrected | `d2e1cc04`: AL.1/AL.3 completion metadata reconciled; unimplemented AL.7 TLS scope explicitly abandoned and quarantined |
 | AL-CLOSURE-003 | corrected | `4ffbacbc`: `docs/project-plan.md` records AL.10-AL.15 historical and current outcomes consistently |
 | RBQA-F101-AL | corrected | `09f4b0cd`: `atm-http-runtime` owns write-connector selection and its deadline; CLI/graft delegate |
-| RBQA-F102-AL | follow-up | the architecture assertion still describes the former F101 duplication and must be rewritten only after the F101 change is available to the reviewer |
-| RBQA-F103-AL | disposition required | its requested edit includes frozen legacy `atm-daemon` source. The active Tokio/Axum path may not patch that retained reference source; QA must record a waiver or an active-runtime-only replacement scope. |
+| RBQA-F102-AL | corrected | `258ee362`: the architecture gate now enforces `atm-http-runtime` as the sole write-transport owner |
+| RBQA-F103-AL | corrected/waived | `9e303af7`: active Tokio bootstrap and CLI use the `atm-core` contract; the frozen legacy daemon occurrence is waived for Phase AM deletion |
 | AL-CLOSURE-004 | pending physical proof | intentionally out of this documentation/source cleanup; final AL.9 physical-proof run is required |
 
 ## Required physical proof before completion

--- a/docs/plans/phase-al/readiness.md
+++ b/docs/plans/phase-al/readiness.md
@@ -37,9 +37,20 @@ At a single SHA/version-selected candidate, retain and index the following:
 | --- | --- |
 | macOS local | managed runtime doctor, localhost/local-IP smoke, UDS and TCP benchmark reports |
 | M5↔M4 direct peer | bidirectional send/read and requires-ack/reply, plus M5 benchmark and graft proof |
-| Windows local and direct peer | managed runtime doctor, local benchmark/report, direct public-CLI evidence correlated with M4 |
+| Windows local | managed runtime doctor and local benchmark/report |
 | Runtime ownership | exactly one active listener and endpoint-record publisher for every enabled endpoint |
 | Regression | `just lint`, `just test`, and the Phase AL architecture gates pass at the frozen candidate |
 
 The final closeout must link all retained reports from `site/reports/index.html`
 and name the exact candidate SHA, version, hosts, and report paths.
+
+## Windows cross-host infrastructure waiver
+
+Windows-originated M4/M5 direct-peer proof is deferred indefinitely: the
+available Windows operator has neither the required VPN route/DNS resolution
+nor reachable M4/M5 hardware. This is an infrastructure limitation, not an
+ATM runtime or Windows-code defect, and no SSH, raw-IP configuration, second
+daemon, or alternate runner may be introduced to simulate it. The waiver does
+not reduce the required Windows local doctor/benchmark evidence or the M5↔M4
+direct-peer proof. Quality management owns the corresponding triage-record
+disposition.

--- a/docs/plans/phase-al/readiness.md
+++ b/docs/plans/phase-al/readiness.md
@@ -1,0 +1,45 @@
+---
+title: Phase AL readiness
+status: blocked
+---
+
+# Phase AL readiness
+
+## Candidate status
+
+- **SOURCE-READY (active Tokio/Axum runtime):** yes. The candidate's daemon
+  executable composes `atm-http-runtime`; retained synchronous daemon source
+  is reference-only and is not an active listener or publisher.
+- **PHYSICAL-PROOF-BLOCKED (Phase AL completion):** yes. The authoritative
+  Phase AL completion gate remains blocked until AL.9's final physical-proof
+  matrix runs against one frozen candidate and satisfies every required row.
+
+This is deliberately not a `complete` declaration. A source-clean candidate,
+unit tests, or historical host evidence cannot substitute for the required
+final physical proof.
+
+## Close-out record
+
+| Item | State | Evidence |
+| --- | --- | --- |
+| AL-CLOSURE-002 | corrected | `d2e1cc04`: AL.1/AL.3 completion metadata reconciled; unimplemented AL.7 TLS scope explicitly abandoned and quarantined |
+| AL-CLOSURE-003 | corrected | `4ffbacbc`: `docs/project-plan.md` records AL.10-AL.15 historical and current outcomes consistently |
+| RBQA-F101-AL | corrected | `09f4b0cd`: `atm-http-runtime` owns write-connector selection and its deadline; CLI/graft delegate |
+| RBQA-F102-AL | follow-up | the architecture assertion still describes the former F101 duplication and must be rewritten only after the F101 change is available to the reviewer |
+| RBQA-F103-AL | disposition required | its requested edit includes frozen legacy `atm-daemon` source. The active Tokio/Axum path may not patch that retained reference source; QA must record a waiver or an active-runtime-only replacement scope. |
+| AL-CLOSURE-004 | pending physical proof | intentionally out of this documentation/source cleanup; final AL.9 physical-proof run is required |
+
+## Required physical proof before completion
+
+At a single SHA/version-selected candidate, retain and index the following:
+
+| Proof | Required result |
+| --- | --- |
+| macOS local | managed runtime doctor, localhost/local-IP smoke, UDS and TCP benchmark reports |
+| M5↔M4 direct peer | bidirectional send/read and requires-ack/reply, plus M5 benchmark and graft proof |
+| Windows local and direct peer | managed runtime doctor, local benchmark/report, direct public-CLI evidence correlated with M4 |
+| Runtime ownership | exactly one active listener and endpoint-record publisher for every enabled endpoint |
+| Regression | `just lint`, `just test`, and the Phase AL architecture gates pass at the frozen candidate |
+
+The final closeout must link all retained reports from `site/reports/index.html`
+and name the exact candidate SHA, version, hosts, and report paths.

--- a/docs/plans/phase-al/sprint-AL1-runtime-contract.md
+++ b/docs/plans/phase-al/sprint-AL1-runtime-contract.md
@@ -1,6 +1,6 @@
 ---
 title: AL.1 Runtime Contract and Crate Boundary
-status: in_progress
+status: complete
 branch: feature/pal-s1-runtime-contract
 worktree: ../atm-core-worktrees/feature/pal-s1-runtime-contract
 target: integrate/phase-al

--- a/docs/plans/phase-al/sprint-AL3-received-hook.md
+++ b/docs/plans/phase-al/sprint-AL3-received-hook.md
@@ -1,6 +1,6 @@
 ---
 title: AL.3 Post-Persistence Received Hook
-status: in_progress
+status: complete
 branch: feature/pal-s3-received-hook
 worktree: ../atm-core-worktrees/feature/pal-s3-received-hook
 target: integrate/phase-al

--- a/docs/plans/phase-al/sprint-AL7-peer-tls-m5-proof.md
+++ b/docs/plans/phase-al/sprint-AL7-peer-tls-m5-proof.md
@@ -1,12 +1,21 @@
 ---
 title: AL.7 Authenticated Peer TLS Adapter and M5 Proof
-status: proposed
+status: abandoned
 branch: feature/pal-s7-peer-tls-m5-proof
 worktree: ../atm-core-worktrees/feature/pal-s7-peer-tls-m5-proof
 target: integrate/phase-al
 ---
 
 # AL.7 — Authenticated Peer TLS Adapter and M5 Proof
+
+## Status: abandoned
+
+AL.7's mTLS/TLS-adapter scope was explicitly removed from the Phase AL MVP
+before implementation. The retained `atm-peer-tls-interop` material remains
+quarantined reference only; it is neither linked into the active Tokio/Axum
+runtime nor evidence for direct-peer delivery. AL.9/AL.13-AL.15 instead prove
+the selected direct-peer HTTP path. Reopening authenticated peer TLS requires
+a separately approved phase and plan.
 
 **recommended_agent:** arch-ctm/deep-reasoning; M5 team executes the remote
 clean-checkout proof.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1159,6 +1159,20 @@ Sprint line:
   static boundary proof
 - `AL.9` `sprint-AL9-physical-proof-ledger-freeze.md` — physical adapter
   matrix, benchmark, cutover/abort, AM ledger freeze
+- `AL.10 [ABANDONED]` — proposed M4 hardware-smoke work was superseded before
+  a sprint record was accepted; its useful evidence moved to the direct M5 and
+  cwin tracks below
+- `AL.11 [SUPERSEDED]` — historical M5 hardware-smoke dispatch, replaced by
+  the pinned-candidate, direct-peer AL.13 plan
+- `AL.12 [SUPERSEDED]` — historical cwin hardware-smoke dispatch, replaced by
+  the direct public-CLI AL.14 plan
+- `AL.13 [COMPLETE]` `sprint-AL13-m5-direct-crosshost-smoke.md` — M5↔M4
+  direct-peer smoke and benchmark evidence
+- `AL.14 [COMPLETE]` `sprint-AL14-cwin-direct-crosshost-smoke.md` — cwin
+  local/direct-peer smoke and benchmark evidence
+- `AL.15 [BLOCKED]` `sprint-AL15-direct-crosshost-evidence-closeout.md` —
+  coordinator closeout remains blocked until AL.9's final physical-proof rows
+  are rerun and accepted at one frozen candidate
 - `AL.16` `sprint-AL16-hermes-graft-live-proof.md` — installable generic
   `atm-graft` and Hermes-facing `hermes-atm` package boundary; package-side
   candidate is under review, while portable live proof is blocked on a

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1145,14 +1145,16 @@ Status summary:
   [Phase AL plan](./plans/phase-al/plan-phase-al.md).
 
 Sprint line:
-- `AL.1` `sprint-AL1-runtime-contract.md` — runtime contract and archived-hook
+- `AL.1 [COMPLETE]` `sprint-AL1-runtime-contract.md` — runtime contract and archived-hook
   transplant
 - `AL.2 [COMPLETE]` `sprint-AL2-canonical-handler.md` — canonical handler
 - `AL.3 [COMPLETE]` `sprint-AL3-received-hook.md` — received hook wiring
 - `AL.4` `sprint-AL4-shared-client.md` — shared client
 - `AL.5 [COMPLETE]` `sprint-AL5-unix-uds.md` — Unix UDS listener
 - `AL.6` `sprint-AL6-loopback-tcp.md` — loopback TCP listener
-- `AL.7` `sprint-AL7-peer-tls-m5-proof.md` — peer TLS / M5 proof
+- `AL.7 [ABANDONED]` `sprint-AL7-peer-tls-m5-proof.md` — mTLS peer adapter
+  removed from the Phase AL MVP before implementation; retained TLS material
+  stays quarantined reference only
 - `AL.8` `sprint-AL8-daemon-composition-proof.md` — daemon composition and
   static boundary proof
 - `AL.9` `sprint-AL9-physical-proof-ledger-freeze.md` — physical adapter

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1168,8 +1168,9 @@ Sprint line:
   the direct public-CLI AL.14 plan
 - `AL.13 [COMPLETE]` `sprint-AL13-m5-direct-crosshost-smoke.md` — M5↔M4
   direct-peer smoke and benchmark evidence
-- `AL.14 [COMPLETE]` `sprint-AL14-cwin-direct-crosshost-smoke.md` — cwin
-  local/direct-peer smoke and benchmark evidence
+- `AL.14 [BLOCKED]` `sprint-AL14-cwin-direct-crosshost-smoke.md` — cwin
+  local smoke and benchmark evidence retained; its Windows-originated
+  direct-peer row is infrastructure-blocked
 - `AL.15 [BLOCKED]` `sprint-AL15-direct-crosshost-evidence-closeout.md` —
   coordinator closeout remains blocked until AL.9's final physical-proof rows
   are rerun and accepted at one frozen candidate


### PR DESCRIPTION
## Summary
- Hardens phase-al closeout docs: plan-phase-al.md and AL.14/project-plan.md status corrected from false draft/COMPLETE to blocked, matching actual unproven Windows-originated M4/M5 crosshost state.
- Adds docs/plans/phase-al/readiness.md closure artifact (previously missing, unlike sibling phases), including a documented Windows cross-host infrastructure waiver (no VPN/DNS route or reachable M4/M5 hardware for the available Windows operator) — waives only Windows-originated crosshost proof, retains Windows-local doctor/benchmark evidence and macOS M5<->M4 direct-peer proof requirements.
- RBQA-F101-AL: dedups selected_write_transport/SAME_HOST_REQUEST_DEADLINE into atm-http-runtime as sole owner; atm/composition.rs and atm-graft/lib.rs now delegate.
- RBQA-F102-AL: rewrites boundary_enforcement.rs guard test to assert the new single-owner pattern instead of entrenching the old duplication.
- RBQA-F103-AL: shares TMUX_DOUBLE_ENTER_DELAY/TMUX_NUDGE_CONFIRM_KEY via atm-core::boundary for the active Tokio path and CLI; frozen legacy sync daemon emitter left untouched and waived (Phase-AM deletion target, never patched per standing rule).

## Findings closed (quality-mgr independently re-verified, not self-report)
AL-CLOSURE-001, AL-CLOSURE-002, AL-CLOSURE-003, RBQA-F101-AL, RBQA-F102-AL, RBQA-F103-AL — all CLOSED.

## Test plan
- [x] cargo fmt/clippy/build/test (925+ tests, per quality-mgr re-run)
- [x] boundary_enforcement.rs 50/50
- [x] atm-daemon-bootstrap --lib 8/8, internal_nudge 8/8
- [x] just lint 25/25

Remaining open on phase-al (out of scope for this PR, deferred to the final integrate/phase-al -> develop evidence pass): AL-CLOSURE-004, ATM-QA-004-AL9, ATM-QA-007-AL9.