### PR TITLE
docs(am3): retire remaining composition references (AM3-STALE-DOCS-LEGACY-PATHS)

### DIFF
--- a/docs/atm-daemon/startup-state-machine.md
+++ b/docs/atm-daemon/startup-state-machine.md
@@ -36,9 +36,10 @@ Each machine must satisfy:
   - `crates/atm-daemon-client/src/lib.rs`
   - `crates/atm/src/composition.rs`
 - daemon runtime lifecycle root:
-  - `crates/atm-daemon/src/composition.rs`
+  - active: `atm_daemon_bootstrap::run_replacement_daemon_with_observability`
+  - historical/retired: `crates/atm-daemon/src/composition.rs` (deleted by
+    AM.3)
 - startup dependencies that may fail:
-  - `crates/atm-daemon/src/composition.rs`
   - `crates/atm-rusqlite/src/shared_db.rs`
 ## Machine 1: CLI Bootstrap
 
@@ -60,13 +61,13 @@ Source:
 
 - [runtime-lifecycle-state-machine.mmd](./runtime-lifecycle-state-machine.mmd)
 
-Code:
+Historical retired code (deleted by AM.3):
 
 - `crates/atm-daemon/src/composition.rs::RuntimeLifecycle`
 - `crates/atm-daemon/src/composition.rs::RuntimeComposition::start`
 
-This machine owns the legal daemon lifecycle transitions and fail-closed
-rollback to `Stopped`.
+The active replacement bootstrap owns the legal daemon lifecycle transitions
+and fail-closed rollback to `Stopped`.
 
 ## Machine 3: Reachable-Daemon Request Outcomes
 

--- a/docs/atm-daemon/state-diagrams.md
+++ b/docs/atm-daemon/state-diagrams.md
@@ -16,7 +16,8 @@ Diagram rule:
   caller-visible or `doctor`-visible outcomes that QA can test directly
 
 Current implementation seam:
-- `crates/atm-daemon/src/composition.rs`
+- historical/retired: `crates/atm-daemon/src/composition.rs` (deleted by
+  AM.3)
 - `crates/atm-daemon-client/src/lib.rs`
 
 Diagrams:


### PR DESCRIPTION
Trivial fast-follow closing the last open finding from QA-AM3-2
(AM3-STALE-DOCS-LEGACY-PATHS). Marks the 2 remaining sibling doc references
to the deleted composition.rs as retired/historical, matching the pattern
already applied to boundaries.md/recovery-text-rules.md/observability.md/
architecture.md in PR #828.

Docs only. just lint 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)