### PR TITLE
fix(daemon-switch): prevent readiness-timeout split pairs

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -19,6 +19,15 @@ from typing import Sequence
 
 
 WINDOWS_SERVICE_NOT_FOUND = 1060
+LIVE_PAIR_READINESS_ATTEMPTS = 200
+# [cass: helpful starter-rust-logging] - retains the bounded readiness state
+# as one named operational contract rather than an unexplained retry literal.
+"""Bounded 20-second readiness window for a managed replacement daemon.
+
+The daemon owns durable storage and may need more than five seconds to
+complete startup on a real host.  Retrying this bounded probe is safer than
+rolling selectors back while the new daemon is still becoming ready.
+"""
 
 
 class SwitchError(RuntimeError):
@@ -368,14 +377,29 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         save_default_pair(*old_pair)
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, old_pair[0] if old_pair is not None else cli_link)
+    candidate_started = False
     try:
         replace_link(cli_link, cli_target)
         replace_link(daemon_link, daemon_target)
         run_service(args, "start")
+        candidate_started = True
         matched, detail = wait_for_live_pair(cli_target, daemon_target)
         if not matched:
             raise SwitchError(f"refusing a split CLI/daemon pair: {detail}")
     except Exception:
+        # Do not repoint selectors until the candidate service has stopped.
+        # A readiness timeout can occur while the candidate is still running;
+        # restoring the old links first would create exactly the split pair
+        # this command promises never to leave behind.
+        if candidate_started:
+            try:
+                run_service(args, "stop", allow_absent=True)
+                require_stopped_daemon(args, cli_target)
+            except SwitchError as recovery_error:
+                raise SwitchError(
+                    "candidate daemon could not be stopped after failed switch; "
+                    "selectors remain on the candidate to avoid a split pair"
+                ) from recovery_error
         if old_pair is not None:
             replace_link(cli_link, old_pair[0])
             replace_link(daemon_link, old_pair[1])
@@ -513,7 +537,7 @@ def live_pair_matches(cli: Path, daemon: Path | None = None) -> tuple[bool, str]
 def wait_for_live_pair(cli: Path, daemon: Path | None = None) -> tuple[bool, str]:
     """Allow the one managed daemon a bounded interval to become doctor-ready."""
     detail = "daemon did not report ready"
-    for _ in range(50):
+    for _ in range(LIVE_PAIR_READINESS_ATTEMPTS):
         matched, detail = live_pair_matches(cli, daemon)
         if matched:
             return True, detail

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -166,5 +166,72 @@ class HttpRuntimeOwnerLockTests(unittest.TestCase):
         self.assertIn("not healthy", detail)
 
 
+class ReadinessAndRollbackTests(unittest.TestCase):
+    def test_readiness_wait_accepts_a_daemon_ready_after_five_seconds(self) -> None:
+        calls = 0
+
+        def delayed_readiness(_cli: Path, _daemon: Path | None) -> tuple[bool, str]:
+            nonlocal calls
+            calls += 1
+            return (calls == 51, "ready" if calls == 51 else "starting")
+
+        with (
+            mock.patch.object(DAEMON_SWITCH, "live_pair_matches", side_effect=delayed_readiness),
+            mock.patch.object(DAEMON_SWITCH.time, "sleep"),
+        ):
+            self.assertEqual(
+                DAEMON_SWITCH.wait_for_live_pair(Path("/candidate/atm"), Path("/candidate/atm-daemon")),
+                (True, "ready"),
+            )
+
+    def test_failed_candidate_is_stopped_before_old_selectors_are_restored(self) -> None:
+        args = mock.Mock(yes=True, dry_run=False)
+        cli_link = Path("/selector/atm")
+        daemon_link = Path("/selector/atm-daemon")
+        old_cli = Path("/old/atm")
+        old_daemon = Path("/old/atm-daemon")
+        candidate_cli = Path("/candidate/atm")
+        candidate_daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(cli_link, daemon_link)),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "require_executable",
+                side_effect=[old_cli, old_daemon, candidate_cli, candidate_daemon],
+            ),
+            mock.patch.object(DAEMON_SWITCH, "validate_selectors"),
+            mock.patch.object(DAEMON_SWITCH, "save_default_pair"),
+            mock.patch.object(DAEMON_SWITCH, "run_service") as service,
+            mock.patch.object(DAEMON_SWITCH, "require_stopped_daemon") as stopped,
+            mock.patch.object(DAEMON_SWITCH, "replace_link") as replace,
+            mock.patch.object(DAEMON_SWITCH, "wait_for_live_pair", return_value=(False, "still starting")),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "split CLI/daemon pair"):
+                DAEMON_SWITCH.switch_pair(args, candidate_cli, candidate_daemon)
+
+        self.assertEqual(
+            service.call_args_list,
+            [
+                mock.call(args, "stop", allow_absent=True),
+                mock.call(args, "start"),
+                mock.call(args, "stop", allow_absent=True),
+                mock.call(args, "start"),
+            ],
+        )
+        self.assertEqual(
+            stopped.call_args_list,
+            [mock.call(args, old_cli), mock.call(args, candidate_cli)],
+        )
+        self.assertEqual(
+            replace.call_args_list,
+            [
+                mock.call(cli_link, candidate_cli),
+                mock.call(daemon_link, candidate_daemon),
+                mock.call(cli_link, old_cli),
+                mock.call(daemon_link, old_daemon),
+            ],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause

On M5, the managed Phase-AM daemon started after the old 5-second readiness window. The selector rollback restored old links while the new daemon stayed alive, leaving a split pair.

## Fix

- allow a bounded 20-second managed-daemon readiness window;
- stop and prove the candidate stopped before restoring previous selectors; retain candidate selectors if safe rollback cannot be proven.

## Validation

- `python3 -m pytest -q .claude/skills/daemon-switch/tests/test_daemon_switch.py` (11 passed)
- `python3 .just/tests/test_daemon_switch.py` (14 passed)