### PR TITLE
fix(daemon): avoid launchd cwd during bootstrap

### DIFF
--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -75,8 +75,24 @@ fn daemon_must_not_read_caller_workspace_config() {
     let root = workspace_root();
     let composition = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
     assert!(
-        composition.contains("assemble_default_runtime()?.for_daemon()"),
-        "replacement daemon composition must select the runtime view that disables caller workspace config"
+        composition.contains("assemble_daemon_runtime()?"),
+        "replacement daemon composition must select the daemon-only runtime assembly"
+    );
+    assert!(
+        composition.contains("pub fn assemble_daemon_runtime()")
+            && composition.contains(".map(RuntimeAssembly::for_daemon)"),
+        "daemon-only assembly must discard the workspace-backed configuration view"
+    );
+    assert!(
+        !composition
+            .split("pub fn assemble_daemon_runtime()")
+            .nth(1)
+            .unwrap_or_default()
+            .split("/// Starts the replacement Tokio/Axum daemon")
+            .next()
+            .unwrap_or_default()
+            .contains("current_dir"),
+        "daemon-only assembly must not resolve the process working directory"
     );
     let runtime_composition = read_source(&root.join("crates/atm-runtime/src/composition.rs"));
     assert!(

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -97,6 +97,17 @@ pub fn assemble_default_runtime() -> Result<RuntimeAssembly, AtmError> {
     )
 }
 
+/// Assemble the system-daemon runtime without inspecting a caller workspace.
+///
+/// A LaunchAgent may start with a working directory whose `getcwd(2)` blocks
+/// (for example while the workspace volume is being reconciled).  The daemon
+/// must not depend on that directory: [`RuntimeAssembly::for_daemon`] removes
+/// the workspace-backed config doctor before requests can be served.
+pub fn assemble_daemon_runtime() -> Result<RuntimeAssembly, AtmError> {
+    assemble_host_runtime(PathBuf::new(), Arc::new(LocalFileNonClaudeOutbound::new()))
+        .map(RuntimeAssembly::for_daemon)
+}
+
 /// Starts the replacement Tokio/Axum daemon as the only active serving path.
 ///
 /// The singleton guard is acquired before validation or binding. The runtime
@@ -145,7 +156,7 @@ async fn run_replacement_daemon_with_selector(
     let scope = current_host_runtime_scope()?;
     let _owner = DaemonOwnerGuard::acquire_at(scope.owner_lock.clone())?;
     let runtime_health = RuntimeHealth::with_owner(std::process::id());
-    let assembly = assemble_default_runtime()?.for_daemon();
+    let assembly = assemble_daemon_runtime()?;
     // The shipped daemon always keeps the injected receiver hook active.
     // Benchmark-only selection is available only from the separate binary.
     let selector = selector_factory(assembly.service_runtime.clone());


### PR DESCRIPTION
Fixes the M5 managed-daemon startup regression: the Tokio/Axum bootstrap called `current_dir()` before constructing a daemon-only runtime, even though `.for_daemon()` immediately discards caller workspace config. Under M5 launchd, `getcwd(2)` blocks indefinitely after owner-lock acquisition. This adds daemon-only assembly that never resolves cwd, plus an architecture regression guard. Validated: cargo fmt --check; cargo test -p atm-architecture daemon_must_not_read_caller_workspace_config; cargo test -p atm-daemon-bootstrap. Live M5 managed LaunchAgent validation follows this push.