### PR TITLE
docs(hermes-atm): native tool requirements/ADR contract

### DIFF
--- a/.just/lint_atm_graft_python_boundary.py
+++ b/.just/lint_atm_graft_python_boundary.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Enforce Python-package dependency policy for the public atm_graft wheel."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+import tomllib
+
+BOUNDARY = Path("boundaries/atm-graft-python/hermes-graft-binding.toml")
+PACKAGE = Path("crates/atm-graft-python/pyproject.toml")
+EXPECTED = {"pydantic"}
+
+@dataclass(frozen=True)
+class Violation:
+    location: str
+    message: str
+
+def _name(spec: str) -> str:
+    return spec.split(";", 1)[0].split("[", 1)[0].split("=", 1)[0].split("<", 1)[0].split(">", 1)[0].strip()
+
+def collect_violations(root: Path) -> list[Violation]:
+    boundary = tomllib.loads((root / BOUNDARY).read_text(encoding="utf-8"))
+    package = tomllib.loads((root / PACKAGE).read_text(encoding="utf-8"))
+    declared = set(boundary.get("dependencies", {}).get("allowed_dependencies", []))
+    dependencies = {_name(value) for value in package.get("project", {}).get("dependencies", [])}
+    findings: list[Violation] = []
+    if dependencies != EXPECTED:
+        findings.append(Violation(str(PACKAGE), f"Python dependencies must be exactly {sorted(EXPECTED)}"))
+    if not dependencies <= declared:
+        findings.append(Violation(str(BOUNDARY), "allowed_dependencies must include every Python package dependency"))
+    contracts = boundary.get("contracts", {})
+    required = {"AtmSendRequest", "AtmReadRequest", "AtmListRequest", "AtmSendResult", "AtmReadResult", "AtmListResult"}
+    present = set(contracts.get("request_types", [])) | set(contracts.get("response_types", []))
+    if not required <= present:
+        findings.append(Violation(str(BOUNDARY), "contracts must name every native tool request/result type"))
+    return findings
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    findings = collect_violations(root)
+    for item in findings:
+        print(f"{item.location}: {item.message}")
+    raise SystemExit(bool(findings))

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -39,6 +39,7 @@ PYTHON_LINT_ORDER = (
     "lines",
     "spell",
     "hermes-adapter",
+    "atm-graft-python-boundary",
     "daemon-singleton",
     "pytests",
 )
@@ -145,6 +146,9 @@ def build_tasks(repo_root: Path) -> dict[str, LintTask]:
         "spell": LintTask("spell", [*python_command, str(repo_root / ".just/lint_codespell.py")]),
         "hermes-adapter": LintTask(
             "hermes-adapter", [*python_command, str(repo_root / ".just/lint_hermes_adapter.py")]
+        ),
+        "atm-graft-python-boundary": LintTask(
+            "atm-graft-python-boundary", [*python_command, str(repo_root / ".just/lint_atm_graft_python_boundary.py")]
         ),
         "fixed-sleep": LintTask(
             "fixed-sleep", [*python_command, str(repo_root / ".just/check_fixed_sleep_hygiene.py")]

--- a/.just/tests/test_lint_atm_graft_python_boundary.py
+++ b/.just/tests/test_lint_atm_graft_python_boundary.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import shutil, sys, tempfile, unittest
+
+JUST = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(JUST))
+from lint_atm_graft_python_boundary import collect_violations
+
+class Tests(unittest.TestCase):
+    def fixture(self, root):
+        for path in ("boundaries/atm-graft-python/hermes-graft-binding.toml", "crates/atm-graft-python/pyproject.toml"):
+            source = JUST.parent / path; target = root / path; target.parent.mkdir(parents=True, exist_ok=True); shutil.copy2(source, target)
+    def test_undeclared_dependency_fails(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.fixture(root); path = root / "crates/atm-graft-python/pyproject.toml"
+            path.write_text(path.read_text().replace('dependencies = ["pydantic>=2,<3"]', 'dependencies = ["pydantic>=2,<3", "other"]'))
+            self.assertTrue(collect_violations(root))

--- a/boundaries/atm-graft-python/hermes-graft-binding.toml
+++ b/boundaries/atm-graft-python/hermes-graft-binding.toml
@@ -22,7 +22,7 @@ io_forbidden = ["database_io", "direct_socket_io", "recipient_routing"]
 
 [dependencies]
 allowed_dependents = []
-allowed_dependencies = ["atm-core", "atm-graft"]
+allowed_dependencies = ["atm-core", "atm-graft", "pydantic"]
 forbidden_edges = [
   "atm-graft-python -> atm-daemon",
   "atm-graft-python -> atm-storage-rusqlite",
@@ -36,9 +36,9 @@ scope = "inside_owner_crate"
 forbidden = ["rusqlite::Connection", "reqwest::Client", "hyper::Client", "axum::Router"]
 
 [contracts]
-request_types = ["PyAgentAddress", "PyGraftSessionOptions"]
-response_types = ["PyMessage", "PyMailboxWorkCounts", "PyNudge"]
-error_types = ["AtmGraftError"]
+request_types = ["PyAgentAddress", "PyGraftSessionOptions", "AtmSendRequest", "AtmReadRequest", "AtmListRequest"]
+response_types = ["PyMessage", "PyMailboxWorkCounts", "PyNudge", "AtmSendResult", "AtmReadResult", "AtmListResult"]
+error_types = ["AtmGraftError", "AtmToolError"]
 notes = ["The binding delegates all mailbox state and transport to atm-graft; it neither stores mail nor chooses a host chat route."]
 
 [testing]

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "atm-graft"
 version = "1.4.1"
 requires-python = ">=3.9"
+dependencies = ["pydantic>=2,<3"]
 
 [tool.maturin]
 # A mixed wheel needs a Python package matching the first component.  The

--- a/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
+++ b/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
@@ -67,6 +67,11 @@ to make the one-profile path reliable.
    `{"kind":"error","error":{"code":...,"message":...,"recovery":...}}`.
    Unsupported host capability or registration failure is fail-closed and
    observable; it must never take down the gateway.
+10. The JSON boundary is owned by Pydantic v2 models in the ATM Python layer:
+    request/result pairs for send, read, and list plus a shared structured
+    error model. The handler validates JSON once, translates once to typed
+    graft calls, and serializes the model result once. Unknown fields and
+    invalid or mutating read requests fail before native transport.
 
 ## Consequences
 

--- a/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
+++ b/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
@@ -52,6 +52,21 @@ to make the one-profile path reliable.
    for this first release is a subsequent profile restart/reconnect, which
    produces the one ten-second durable-mail summary. This residual is explicit
    rather than hidden by an unbounded background mechanism.
+7. `hermes-atm` owns an optional, package-registered native-tool surface for
+   the configured profile: initially `atm_send`, `atm_read`, and `atm_list`.
+   Tool schemas and semantics are CLI-equivalent, but the configured profile
+   remains the sole source of identity, team, ATM home, and workspace root.
+   No tool parameter may replace that caller context.
+8. Those tools use the public `atm_graft` Python API only. They neither run the
+   CLI nor open a second transport/receiver, poll loop, retry queue, storage
+   handle, or daemon lifecycle path. A thin addition to the public Python API
+   is permitted only when it translates the same ordinary daemon operation
+   used by the CLI.
+9. Each tool returns a JSON-compatible discriminated union:
+   `{"kind":"success","result":...}` or
+   `{"kind":"error","error":{"code":...,"message":...,"recovery":...}}`.
+   Unsupported host capability or registration failure is fail-closed and
+   observable; it must never take down the gateway.
 
 ## Consequences
 
@@ -63,6 +78,10 @@ to make the one-profile path reliable.
   read contract; it adds no daemon session, mailbox table, queue, or protocol.
 - An in-session steer failure remains operator-observable residual risk until a
   separately approved bounded recovery design exists.
+- Tool use remains ordinary daemon API use, so mailbox authority and wake-up
+  ownership do not move into the Hermes package.
+- A single installed profile has one fixed caller context across receiver and
+  tools, preventing a tool invocation from impersonating another team member.
 
 ## Alternatives considered
 
@@ -74,6 +93,9 @@ to make the one-profile path reliable.
   profile's wake-ups and permits an old close to delete a successor record.
 - **Multi-chat endpoint registry now:** deferred; it adds policy/fan-out work
   before the required one-profile reliability path is proven.
+- **Shelling out to `atm` from a Hermes tool:** rejected because it creates a
+  second configuration/parsing boundary and cannot provide the typed,
+  in-process error contract required of a host-native tool.
 
 ## Follow-up work
 

--- a/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
+++ b/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
@@ -67,10 +67,10 @@ to make the one-profile path reliable.
    `{"kind":"error","error":{"code":...,"message":...,"recovery":...}}`.
    Unsupported host capability or registration failure is fail-closed and
    observable; it must never take down the gateway.
-10. The JSON boundary is owned by Pydantic v2 models in the ATM Python layer:
-    request/result pairs for send, read, and list plus a shared structured
-    error model. The handler validates JSON once, translates once to typed
-    graft calls, and serializes the model result once. Unknown fields and
+10. The JSON ingress boundary is owned by Pydantic v2 request models in the
+    ATM Python layer. The handler validates incoming JSON once, translates
+    once to typed graft calls, and directly serializes trusted typed outcomes.
+    Result/error data is not re-validated in production. Unknown fields and
     invalid or mutating read requests fail before native transport.
 
 ## Consequences

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -135,8 +135,10 @@ Initial crate requirement IDs:
   normal installed profile can use the registered tools without hand-editing
   package files or gateway code.
 - `REQ-GRAFT-HERMES-008` The public Python agent-tool ingress is modeled with
-  direct `pydantic` v2 request models: `AtmSendRequest`, `AtmReadRequest`, and
-  `AtmListRequest`. Hermes handlers accept JSON-compatible input and call
+  direct `pydantic` v2 request models owned by `hermes-atm` (not by the
+  generic typed `atm-graft` Maturin wheel): `AtmSendRequest`, `AtmReadRequest`,
+  and `AtmListRequest`. `pydantic` is a direct `hermes-atm` package dependency.
+  Hermes handlers accept JSON-compatible input and call
   `model_validate` exactly once before translating to typed `PyGraftSession`
   send/read/list calls. Models reject unknown fields; validation rejects
   invalid arguments and mutating read requests before native transport.

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -140,9 +140,10 @@ Initial crate requirement IDs:
   normal installed profile can use the registered tools without hand-editing
   package files or gateway code.
 - `REQ-GRAFT-HERMES-008` The public Python agent-tool ingress is modeled with
-  direct `pydantic` v2 request models owned by `hermes-atm` (not by the
-  generic typed `atm-graft` Maturin wheel): `AtmSendRequest`, `AtmReadRequest`,
-  and `AtmListRequest`. `pydantic` is a direct `hermes-atm` package dependency.
+  direct `pydantic` v2 request models owned by the public `atm-graft-python`
+  Maturin wheel: `AtmSendRequest`, `AtmReadRequest`, and `AtmListRequest`.
+  `pydantic` is a direct `atm-graft-python` package dependency. `hermes-atm`
+  consumes those models and remains a thin Hermes-only adapter.
   Hermes handlers accept JSON-compatible input and call
   `model_validate` exactly once before translating to typed `PyGraftSession`
   send/read/list calls. Models reject unknown fields; validation rejects

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -100,6 +100,36 @@ Initial crate requirement IDs:
   bucket counts through the ordinary daemon API, and emits at most one concise
   steer summary when unread or pending-ack counts are non-zero. The summary is
   advisory; it neither reads, acknowledges, persists, nor replays mail.
+- `REQ-GRAFT-HERMES-004` `hermes-atm` may register exactly the initial native
+  Hermes tools `atm_send`, `atm_read`, and `atm_list` through a verified public
+  Hermes tool-registration seam. Each tool's accepted arguments, defaults,
+  validation, selection semantics, bounded-result behavior, and mailbox
+  mutation behavior must match its corresponding `atm send`, `atm read`, or
+  `atm list` CLI command. The host's installed profile configuration supplies
+  ATM identity, team, home, and workspace root; a tool invocation must not
+  override any of those values.
+- `REQ-GRAFT-HERMES-005` Native Hermes tools use only the public installed
+  `atm_graft` Python API and the public Hermes registration API. They must not
+  invoke the `atm` executable, create a second daemon client/receiver,
+  introduce a poll or retry loop, call private extension symbols, or access
+  SQLite, storage, or daemon lifecycle/network internals directly. The
+  `atm_graft` Python surface may grow only as a thin typed translation of the
+  ordinary daemon API necessary for CLI-equivalent `send`, `read`, and `list`.
+- `REQ-GRAFT-HERMES-006` Every native tool result is JSON-compatible and uses
+  this discriminated union: success is
+  `{"kind":"success","result":...}`; failure is
+  `{"kind":"error","error":{"code":...,"message":...,"recovery":...}}`.
+  Failures must preserve a stable machine-readable code and provide a concrete
+  recovery action without exposing profile secrets. Registration or invocation
+  capability failures must fail closed and must not crash a running Hermes
+  gateway.
+- `REQ-GRAFT-HERMES-007` Coverage must prove CLI-equivalent argument
+  validation and mutation semantics, bounded `atm_list` defaults and limits,
+  identity/team non-overridability, discriminated success and error results,
+  idempotent registration, and clean-wheel package discovery. A live Hermes
+  proof is performed only after those isolated checks pass and must show a
+  normal installed profile can use the registered tools without hand-editing
+  package files or gateway code.
 
 AI.38 evidence note: the reference adapter calls only the injected Hermes
 `session.steer` port with a runtime session id resolved from the configured

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -130,6 +130,17 @@ Initial crate requirement IDs:
   proof is performed only after those isolated checks pass and must show a
   normal installed profile can use the registered tools without hand-editing
   package files or gateway code.
+- `REQ-GRAFT-HERMES-008` The public Python agent-tool boundary is modeled with
+  direct `pydantic` v2 dependencies: `AtmSendRequest`/`AtmSendResult`,
+  `AtmReadRequest`/`AtmReadResult`, `AtmListRequest`/`AtmListResult`, and the
+  shared `AtmToolError`. Hermes handlers accept JSON-compatible input, call
+  `model_validate`, translate exactly once to typed `PyGraftSession`
+  send/read/list calls, and return `model_dump(mode="json")` values. Models
+  reject unknown fields; validation rejects invalid arguments and mutating read
+  requests before native transport. Validation failures normalize to the
+  required JSON-safe error union. Raw JSON strings/dicts must never pass
+  through `atm_graft`, and no Python layer may reproduce HTTP serialization.
+  Tests cover model-validation success and failure for every public tool.
 
 AI.38 evidence note: the reference adapter calls only the injected Hermes
 `session.steer` port with a runtime session id resolved from the configured

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -111,6 +111,10 @@ Initial crate requirement IDs:
   The host's installed profile configuration supplies
   ATM identity, team, home, and workspace root; a tool invocation must not
   override any of those values.
+  `AtmSendRequest.requires_ack` is in scope, defaults to `false`, and maps to
+  the ordinary `SendRequest` / CLI `--ack-required` send semantics. This does
+  not add a graft or Python acknowledgement operation: acknowledging received
+  pending acknowledgements remains the canonical `atm ack` CLI path.
 - `REQ-GRAFT-HERMES-005` Native Hermes tools use only the public installed
   `atm_graft` Python API and the public Hermes registration API. They must not
   invoke the `atm` executable, create a second daemon client/receiver,
@@ -128,7 +132,8 @@ Initial crate requirement IDs:
   gateway.
 - `REQ-GRAFT-HERMES-007` Coverage must prove CLI-equivalent argument
   validation and mutation semantics, bounded `atm_list` defaults and limits,
-  identity/team non-overridability, native read's no-seen/no-ack mutation,
+  identity/team non-overridability, `requires_ack` default and send mapping,
+  and the absence of a graft/Python inbound-ack operation; native read's no-seen/no-ack mutation,
   discriminated success and error results,
   idempotent registration, and clean-wheel package discovery. A live Hermes
   proof is performed only after those isolated checks pass and must show a

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -103,9 +103,12 @@ Initial crate requirement IDs:
 - `REQ-GRAFT-HERMES-004` `hermes-atm` may register exactly the initial native
   Hermes tools `atm_send`, `atm_read`, and `atm_list` through a verified public
   Hermes tool-registration seam. Each tool's accepted arguments, defaults,
-  validation, selection semantics, bounded-result behavior, and mailbox
-  mutation behavior must match its corresponding `atm send`, `atm read`, or
-  `atm list` CLI command. The host's installed profile configuration supplies
+  validation, selection semantics, and bounded-result behavior must match its
+  corresponding `atm send`, `atm read`, or `atm list` CLI command. Native
+  `atm_read` is deliberately read-only: it uses `seen_state_update=false` and
+  rejects every mutation, acknowledgement, or mark-seen input. Its parity is
+  limited to supported read-only selection, filters, and result semantics.
+  The host's installed profile configuration supplies
   ATM identity, team, home, and workspace root; a tool invocation must not
   override any of those values.
 - `REQ-GRAFT-HERMES-005` Native Hermes tools use only the public installed
@@ -125,7 +128,8 @@ Initial crate requirement IDs:
   gateway.
 - `REQ-GRAFT-HERMES-007` Coverage must prove CLI-equivalent argument
   validation and mutation semantics, bounded `atm_list` defaults and limits,
-  identity/team non-overridability, discriminated success and error results,
+  identity/team non-overridability, native read's no-seen/no-ack mutation,
+  discriminated success and error results,
   idempotent registration, and clean-wheel package discovery. A live Hermes
   proof is performed only after those isolated checks pass and must show a
   normal installed profile can use the registered tools without hand-editing

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -126,6 +126,9 @@ Initial crate requirement IDs:
   this discriminated union: success is
   `{"kind":"success","result":...}`; failure is
   `{"kind":"error","error":{"code":...,"message":...,"recovery":...}}`.
+  `AtmToolError` is exactly that nested `error` object; it never wraps the
+  outer discriminated envelope. Its `layer` distinguishes ingress validation
+  from environment/runtime/native-client failures.
   Failures must preserve a stable machine-readable code and provide a concrete
   recovery action without exposing profile secrets. Registration or invocation
   capability failures must fail closed and must not crash a running Hermes

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -130,17 +130,19 @@ Initial crate requirement IDs:
   proof is performed only after those isolated checks pass and must show a
   normal installed profile can use the registered tools without hand-editing
   package files or gateway code.
-- `REQ-GRAFT-HERMES-008` The public Python agent-tool boundary is modeled with
-  direct `pydantic` v2 dependencies: `AtmSendRequest`/`AtmSendResult`,
-  `AtmReadRequest`/`AtmReadResult`, `AtmListRequest`/`AtmListResult`, and the
-  shared `AtmToolError`. Hermes handlers accept JSON-compatible input, call
-  `model_validate`, translate exactly once to typed `PyGraftSession`
-  send/read/list calls, and return `model_dump(mode="json")` values. Models
-  reject unknown fields; validation rejects invalid arguments and mutating read
-  requests before native transport. Validation failures normalize to the
-  required JSON-safe error union. Raw JSON strings/dicts must never pass
-  through `atm_graft`, and no Python layer may reproduce HTTP serialization.
-  Tests cover model-validation success and failure for every public tool.
+- `REQ-GRAFT-HERMES-008` The public Python agent-tool ingress is modeled with
+  direct `pydantic` v2 request models: `AtmSendRequest`, `AtmReadRequest`, and
+  `AtmListRequest`. Hermes handlers accept JSON-compatible input and call
+  `model_validate` exactly once before translating to typed `PyGraftSession`
+  send/read/list calls. Models reject unknown fields; validation rejects
+  invalid arguments and mutating read requests before native transport.
+  Trusted typed graft outcomes are converted directly to JSON-compatible
+  `AtmSendResult`, `AtmReadResult`, `AtmListResult`, or shared `AtmToolError`
+  result data; production must not re-validate the egress path. Validation
+  failures normalize to the required JSON-safe error union. Raw JSON
+  strings/dicts must never pass through `atm_graft`, and no Python layer may
+  reproduce HTTP serialization. Tests cover ingress model-validation success
+  and failure for every public tool.
 
 AI.38 evidence note: the reference adapter calls only the injected Hermes
 `session.steer` port with a runtime session id resolved from the configured


### PR DESCRIPTION
## Summary
Requirements/ADR contract for Hermes native ATM tools (CLI-equivalent `atm_send`/`read`/`list` schemas), kept as a dedicated plan branch off `develop` per team's request so it can go through QA review independent of the parallel implementation work on `feature/hermes-atm-tool-calls`.

- `docs/atm-graft/requirements.md`: REQ-GRAFT-HERMES-004 through 008 (CLI-parity scoping, error/result envelope incl. `AtmToolError` nesting, coverage checklist, mandatory Pydantic ingress validation).
- `docs/adr/ADR-043-hermes-graft-wake-up-ownership.md`: items 7-10 extending the wake-up ownership ADR to native tools, including the Pydantic dependency decision.
- `crates/atm-graft-python/pyproject.toml` + `boundaries/atm-graft-python/hermes-graft-binding.toml`: pydantic declared as a real dependency, boundary contract updated to name the new tool-call types.
- `.just/lint_atm_graft_python_boundary.py` (new) + test: a Python-packaging-aware boundary lint for atm-graft-python, mirroring the existing `lint_hermes_atm_boundary.py` pattern, wired into `just lint`, with a mutation test.

Went through 3 rounds of plan QA (quality-mgr):
- Round 1: FAIL -- Pydantic dependency not reconciled with the enforced boundary contract, several doc-completeness gaps.
- Round 2: FAIL -- ownership moved to atm-graft-python in prose but enforcement wasn't actually reconciled (a real regression: traded working enforcement for a substrate structurally incapable of checking Python packaging deps).
- Round 3 (this commit): pending final verification.

Two items from round 1 remain intentionally deferred as a separate, lower-priority thread (not blocking): the pre-existing ADR-043 item-3/steer contradiction with the shipped design, and the `docs/atm-graft/architecture.md` gap.

## Test plan
- [x] New `lint_atm_graft_python_boundary.py` + mutation test pass locally (per arch-ctm)
- [ ] quality-mgr final QA PASS (QA-HERMES-TOOLS-PLAN-3, in progress)