### PR TITLE
feat(AN.2): storage schema — template catalog + decomposed admission

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -124,7 +124,7 @@ allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", 
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
-allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "fs2", "serde_json", "tempfile", "tokio", "ulid"]
+allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs2", "serde_json", "tempfile", "tokio", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-client/Cargo.toml"
@@ -153,6 +153,10 @@ allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde",
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage-rusqlite/Cargo.toml"
 allowed_dependencies = ["async-trait", "atm-storage", "chrono", "rusqlite", "serde", "serde_json", "tempfile", "tokio", "tracing"]
+
+[[boundaries.manifest_dependency_allowlists]]
+owner_manifest_path = "crates/atm-template-sc-compose/Cargo.toml"
+allowed_dependencies = ["atm-core", "atm-storage", "serde_json"]
 
 [[boundaries.global_dependency_ownership]]
 dependency = "rusqlite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.4.1-beta-ai-1"
+version = "1.4.2-beta-am"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",

--- a/boundaries/atm-storage-rusqlite/template-catalog-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/template-catalog-sqlite.toml
@@ -20,12 +20,12 @@ io_owns = ["sqlite_template_catalog", "atomic_decomposed_admission"]
 io_forbidden = ["template_rendering", "http_runtime", "socket_io", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime-test-support"]
 allowed_dependencies = ["atm-storage", "rusqlite"]
 forbidden_edges = ["atm-storage-rusqlite -> atm-core", "atm-storage-rusqlite -> atm-runtime"]
 
 [references]
-scope = "outside_owner_crate"
+scope = "inside_owner_crate"
 forbidden = ["TemplateComposer", "MergedVars"]
 
 [contracts]

--- a/boundaries/atm-storage-rusqlite/template-catalog-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/template-catalog-sqlite.toml
@@ -1,0 +1,45 @@
+boundary_id = "BOUNDARY-TemplateCatalogSqlite"
+owner_package = "atm-storage-rusqlite"
+owner_crate_path = "atm_storage_rusqlite"
+name = "SqliteTemplateCatalogStore"
+
+[public]
+trait = "TemplateCatalogStore"
+
+[implementation]
+type = "SqliteTemplateCatalogStore"
+module = "atm_storage_rusqlite::template_catalog_store"
+visibility = "private"
+constructor = "private"
+
+[composition]
+roots = ["atm_storage_rusqlite::SqliteStorageBackend::new"]
+
+[ownership]
+io_owns = ["sqlite_template_catalog", "atomic_decomposed_admission"]
+io_forbidden = ["template_rendering", "http_runtime", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime"]
+allowed_dependencies = ["atm-storage", "rusqlite"]
+forbidden_edges = ["atm-storage-rusqlite -> atm-core", "atm-storage-rusqlite -> atm-runtime"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["TemplateComposer", "MergedVars"]
+
+[contracts]
+request_types = ["TemplateCatalogStore method inputs"]
+response_types = ["atm-storage template DTOs"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["connection_escape"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-TEMPLATE-CATALOG-SQLITE"]
+review_gates = ["single_writer_atomicity", "private_adapter"]
+
+[status]
+state = "concrete_landed"

--- a/boundaries/atm-storage/template-catalog-store.toml
+++ b/boundaries/atm-storage/template-catalog-store.toml
@@ -24,7 +24,7 @@ allowed_dependencies = ["atm-error", "serde", "serde_json"]
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 
 [references]
-scope = "outside_owner_crate"
+scope = "inside_owner_crate"
 forbidden = ["rusqlite::Connection", "TemplateComposer", "MergedVars"]
 
 [contracts]
@@ -33,7 +33,7 @@ response_types = ["StoredTemplate", "TemplateSummary", "DecomposedMessageAdmissi
 error_types = ["AtmError"]
 
 [testing]
-allowed_test_double_paths = ["atm_storage::template_catalog::InMemoryTemplateCatalogStore"]
+allowed_test_double_paths = ["crate::template_catalog::InMemoryTemplateCatalogStore"]
 forbidden_test_bypasses = ["sqlite_connection", "renderer_handle"]
 
 [enforcement]

--- a/boundaries/atm-storage/template-catalog-store.toml
+++ b/boundaries/atm-storage/template-catalog-store.toml
@@ -1,0 +1,44 @@
+boundary_id = "BOUNDARY-TemplateCatalogStore"
+owner_package = "atm-storage"
+owner_crate_path = "atm_storage"
+name = "TemplateCatalogStore"
+
+[public]
+trait = "TemplateCatalogStore"
+notes = "sealed backend-neutral immutable catalog and atomic decomposed-message admission capability"
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["template_catalog_contract"]
+io_forbidden = ["direct_sqlite_io", "template_rendering", "http_runtime", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-runtime", "atm-storage-rusqlite"]
+allowed_dependencies = ["atm-error", "serde", "serde_json"]
+forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["rusqlite::Connection", "TemplateComposer", "MergedVars"]
+
+[contracts]
+request_types = ["TemplateRegistration", "TemplateListFilter", "DecomposedMessageAdmission"]
+response_types = ["StoredTemplate", "TemplateSummary", "DecomposedMessageAdmissionOutcome"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = ["atm_storage::template_catalog::InMemoryTemplateCatalogStore"]
+forbidden_test_bypasses = ["sqlite_connection", "renderer_handle"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-TEMPLATE-CATALOG-STORE"]
+review_gates = ["sealed_capability", "leaf_dtos_only", "no_renderer_or_sql"]
+
+[status]
+state = "concrete_landed"

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -22,6 +22,7 @@ const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm-runtime", "atm-storage-rusqlite"),
     ("atm-storage", "atm-core"),
     ("atm-storage", "atm-storage-rusqlite"),
+    ("atm-storage-rusqlite", "atm-core"),
     ("atm-storage-rusqlite", "atm-runtime"),
     ("atm-graft", "atm-daemon"),
     ("atm-graft", "atm-daemon-bootstrap"),
@@ -1122,6 +1123,11 @@ fn atm_runtime_must_not_depend_on_atm_storage_rusqlite() {
 #[test]
 fn atm_storage_rusqlite_must_not_depend_on_atm_runtime() {
     assert_forbidden_edge_absent("atm-storage-rusqlite", "atm-runtime");
+}
+
+#[test]
+fn atm_storage_rusqlite_must_not_depend_on_atm_core() {
+    assert_forbidden_edge_absent("atm-storage-rusqlite", "atm-core");
 }
 
 #[test]

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -71,6 +71,8 @@ pub enum AtmErrorCode {
     SelfAddressedSendInvalid,
     EmptyNudgeTemplateBody,
     CallerContextRequestInvalid,
+    /// Template catalog content must be strict UTF-8 before any row is admitted.
+    TemplateContentNotUtf8,
     /// A template passed to the no-include render operation references another template.
     DecomposedTemplateIncludeForbidden,
     SerializationFailed,
@@ -201,6 +203,7 @@ impl AtmErrorCode {
             Self::SelfAddressedSendInvalid => "ATM_SELF_ADDRESSED_SEND_INVALID",
             Self::EmptyNudgeTemplateBody => "ATM_NUDGE_TEMPLATE_BODY_EMPTY",
             Self::CallerContextRequestInvalid => "ATM_CALLER_CONTEXT_REQUEST_INVALID",
+            Self::TemplateContentNotUtf8 => "TEMPLATE_CONTENT_NOT_UTF8",
             Self::DecomposedTemplateIncludeForbidden => "DECOMPOSED_TEMPLATE_INCLUDE_FORBIDDEN",
             Self::SerializationFailed => "ATM_SERIALIZATION_FAILED",
             Self::FilePolicyRejected => "ATM_FILE_POLICY_REJECTED",
@@ -346,6 +349,7 @@ fn parse_mailbox_or_validation_code(value: &str) -> Option<AtmErrorCode> {
         "ATM_SELF_ADDRESSED_SEND_INVALID" => AtmErrorCode::SelfAddressedSendInvalid,
         "ATM_NUDGE_TEMPLATE_BODY_EMPTY" => AtmErrorCode::EmptyNudgeTemplateBody,
         "ATM_CALLER_CONTEXT_REQUEST_INVALID" => AtmErrorCode::CallerContextRequestInvalid,
+        "TEMPLATE_CONTENT_NOT_UTF8" => AtmErrorCode::TemplateContentNotUtf8,
         "DECOMPOSED_TEMPLATE_INCLUDE_FORBIDDEN" => AtmErrorCode::DecomposedTemplateIncludeForbidden,
         "ATM_SERIALIZATION_FAILED" => AtmErrorCode::SerializationFailed,
         "ATM_FILE_POLICY_REJECTED" => AtmErrorCode::FilePolicyRejected,

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -14,6 +14,7 @@ mod observability;
 mod peer_config_store;
 mod roster_store;
 mod shared_db;
+mod template_catalog_schema;
 mod template_catalog_store;
 mod writer;
 

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -39,7 +39,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use shared_db::{SharedDb, deserialize_json};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use template_catalog_store::SqliteTemplateCatalogStore;
+use template_catalog_store::template_catalog_store;
 
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug)]
@@ -512,13 +512,21 @@ impl AsyncMessageStore for SqliteMessageStore {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SqliteStorageBackend {
     message_store: Arc<SqliteMessageStore>,
     roster_store: Arc<SqliteRosterStore>,
     nudge_template_override_store: Arc<SqliteNudgeTemplateOverrideStore>,
     peer_config_store: Arc<SqlitePeerConfigStore>,
-    template_catalog_store: Arc<SqliteTemplateCatalogStore>,
+    template_catalog_store: Arc<dyn TemplateCatalogStore>,
+}
+
+impl std::fmt::Debug for SqliteStorageBackend {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SqliteStorageBackend")
+            .finish_non_exhaustive()
+    }
 }
 
 /// Concrete SQLite selection owned by the SQLite backend and consumed only at
@@ -578,7 +586,7 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
-            template_catalog_store: Arc::new(SqliteTemplateCatalogStore::new(Arc::clone(&db))),
+            template_catalog_store: template_catalog_store(Arc::clone(&db)),
         })
     }
 
@@ -592,7 +600,7 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
-            template_catalog_store: Arc::new(SqliteTemplateCatalogStore::new(Arc::clone(&db))),
+            template_catalog_store: template_catalog_store(Arc::clone(&db)),
         })
     }
 

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -14,6 +14,7 @@ mod observability;
 mod peer_config_store;
 mod roster_store;
 mod shared_db;
+mod template_catalog_store;
 mod writer;
 
 #[cfg(test)]
@@ -22,6 +23,7 @@ pub use crate::observability::{
     NullSqliteObservability, SqliteObservability, SqliteObservabilityEvent,
     SqliteObservabilityOutcome,
 };
+use atm_storage::TemplateCatalogStore;
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, AsyncMessageStore,
     MailboxBucketCounts, Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore,
@@ -36,6 +38,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use shared_db::{SharedDb, deserialize_json};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use template_catalog_store::SqliteTemplateCatalogStore;
 
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug)]
@@ -514,6 +517,7 @@ pub struct SqliteStorageBackend {
     roster_store: Arc<SqliteRosterStore>,
     nudge_template_override_store: Arc<SqliteNudgeTemplateOverrideStore>,
     peer_config_store: Arc<SqlitePeerConfigStore>,
+    template_catalog_store: Arc<SqliteTemplateCatalogStore>,
 }
 
 /// Concrete SQLite selection owned by the SQLite backend and consumed only at
@@ -551,6 +555,7 @@ impl StorageFactory for SqliteStorageFactory {
             backend.roster_store(),
             backend.nudge_template_override_store(),
             backend.peer_config_store(),
+            backend.template_catalog_store(),
         ))
     }
 }
@@ -572,6 +577,7 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
+            template_catalog_store: Arc::new(SqliteTemplateCatalogStore::new(Arc::clone(&db))),
         })
     }
 
@@ -585,6 +591,7 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
+            template_catalog_store: Arc::new(SqliteTemplateCatalogStore::new(Arc::clone(&db))),
         })
     }
 
@@ -623,6 +630,10 @@ impl SqliteStorageBackend {
 
     pub fn peer_config_store(&self) -> Arc<dyn PeerConfigStore + Send + Sync> {
         self.peer_config_store.clone()
+    }
+
+    pub fn template_catalog_store(&self) -> Arc<dyn TemplateCatalogStore + Send + Sync> {
+        self.template_catalog_store.clone()
     }
 
     #[cfg(test)]
@@ -691,6 +702,11 @@ mod tests {
     };
     use atm_storage::schema::{AtmMessageId, MessageEnvelope};
     use atm_storage::types::{AgentName, IsoTimestamp, ModelName, TeamName};
+    use atm_storage::{
+        AtmError, DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome,
+        DecomposedMessageRecord, MergedVarsJson, TemplateFirstSeen, TemplateFrontmatter,
+        TemplateRegistration, TemplateRegistrationOutcome, TemplateSha,
+    };
     use chrono::Utc;
     use rusqlite::{Connection, params};
     use serde_json::Map;
@@ -734,6 +750,20 @@ mod tests {
         }
     }
 
+    fn template_registration(sha_seed: char) -> TemplateRegistration {
+        let content_bytes = b"---\nmetadata:\n  type: task\n---\nhello {{ name }}\n".to_vec();
+        TemplateRegistration {
+            sha: TemplateSha::new(sha_seed.to_string().repeat(64)).expect("template sha"),
+            template_type: Some("task".to_string()),
+            template_name: Some("example".to_string()),
+            content_text: String::from_utf8(content_bytes.clone()).expect("utf8 fixture"),
+            content_bytes,
+            frontmatter: TemplateFrontmatter::default(),
+            first_seen: TemplateFirstSeen::new(IsoTimestamp::now(), "test-agent")
+                .expect("first seen"),
+        }
+    }
+
     #[test]
     fn bundled_sqlite_exposes_fts5_for_the_template_catalog_gate() {
         let connection = Connection::open_in_memory().expect("open temporary SQLite database");
@@ -742,6 +772,217 @@ mod tests {
                 "CREATE VIRTUAL TABLE template_catalog_fts_gate USING fts5(template_text);",
             )
             .expect("atm template catalog requires bundled SQLite FTS5 support");
+    }
+
+    #[test]
+    fn sqlite_template_catalog_round_trips_bytes_and_admits_a_decomposed_row_atomically() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let message = message("atm:decomposed-template", "inline before decomposition");
+        backend
+            .message_store()
+            .save_message(&message)
+            .expect("seed canonical message");
+        let catalog = backend.template_catalog_store();
+        let template = template_registration('a');
+
+        assert_eq!(
+            catalog.register(template.clone()).expect("register"),
+            TemplateRegistrationOutcome::Inserted
+        );
+        assert_eq!(
+            catalog
+                .register(template.clone())
+                .expect("idempotent register"),
+            TemplateRegistrationOutcome::AlreadyRegistered
+        );
+        let loaded = catalog
+            .load(&template.sha)
+            .expect("load")
+            .expect("template exists");
+        assert_eq!(loaded.content_bytes, template.content_bytes);
+        assert_eq!(loaded.content_text, template.content_text);
+
+        let vars = MergedVarsJson::try_from_merged_object(
+            [("name".to_string(), serde_json::json!("Rand"))]
+                .into_iter()
+                .collect(),
+        )
+        .expect("vars");
+        let outcome = catalog
+            .admit_decomposed_message(DecomposedMessageAdmission {
+                template: template.clone(),
+                message: DecomposedMessageRecord {
+                    key: message.message_key.clone(),
+                    template_sha: template.sha.clone(),
+                    vars,
+                    category: Some("assignment".to_string()),
+                    tags: vec!["phase-an".to_string()],
+                    content_format: Some("markdown".to_string()),
+                },
+            })
+            .expect("atomic admission");
+        assert_eq!(
+            outcome,
+            DecomposedMessageAdmissionOutcome::Inserted {
+                template: TemplateRegistrationOutcome::AlreadyRegistered
+            }
+        );
+        backend
+            .shared_db_for_test()
+            .with_connection(|connection| {
+                let row = connection
+                    .query_row(
+                        "SELECT template_sha, vars_json FROM decomposed_messages
+                         WHERE team = ?1 AND agent = ?2",
+                        params![message.team.as_str(), message.agent.as_str()],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )
+                    .map_err(|error| {
+                        AtmError::mailbox_read(format!("view query failed: {error}"))
+                    })?;
+                assert_eq!(row.0, template.sha.as_str());
+                assert_eq!(row.1, r#"{"name":"Rand"}"#);
+                let message_text = connection
+                    .query_row(
+                        "SELECT message_text FROM mail_messages WHERE message_key = ?1",
+                        params![message.message_key.as_str()],
+                        |row| row.get::<_, Option<String>>(0),
+                    )
+                    .map_err(|error| {
+                        AtmError::mailbox_read(format!("mail row query failed: {error}"))
+                    })?;
+                assert_eq!(message_text, None);
+                Ok(())
+            })
+            .expect("view exposes decomposed state");
+    }
+
+    #[test]
+    fn failed_decomposed_update_rolls_back_its_new_template_registration() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let message = message("atm:decomposed-rollback", "inline");
+        backend
+            .message_store()
+            .save_message(&message)
+            .expect("seed canonical message");
+        backend
+            .shared_db_for_test()
+            .with_connection(|connection| {
+                connection
+                    .execute_batch(
+                        "CREATE TRIGGER fail_decomposed_update
+                         BEFORE UPDATE OF template_sha ON mail_messages
+                         BEGIN SELECT RAISE(ABORT, 'intentional decomposed failure'); END;",
+                    )
+                    .map_err(|error| {
+                        AtmError::mailbox_write(format!("install trigger failed: {error}"))
+                    })
+            })
+            .expect("install failure trigger");
+        let catalog = backend.template_catalog_store();
+        let template = template_registration('b');
+        let _error = catalog
+            .admit_decomposed_message(DecomposedMessageAdmission {
+                template: template.clone(),
+                message: DecomposedMessageRecord {
+                    key: message.message_key,
+                    template_sha: template.sha.clone(),
+                    vars: MergedVarsJson::try_from_merged_object(Default::default()).expect("vars"),
+                    category: None,
+                    tags: vec![],
+                    content_format: None,
+                },
+            })
+            .expect_err("update trigger rejects admission");
+        assert!(catalog.load(&template.sha).expect("load").is_none());
+    }
+
+    #[test]
+    fn shared_inbox_envelope_does_not_gain_template_storage_fields() {
+        let envelope = message("atm:shared-inbox-guard", "inline").envelope;
+        let serialized = serde_json::to_value(envelope).expect("serialize shared envelope");
+        for field in [
+            "template_sha",
+            "vars_json",
+            "category",
+            "content_format",
+            "tags_json",
+        ] {
+            assert!(
+                serialized.get(field).is_none(),
+                "{field} must remain storage-only"
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_and_historical_databases_expose_the_same_decomposed_query_surface() {
+        let fresh_root = tempfile::tempdir().expect("fresh root");
+        let fresh_path = fresh_root.path().join("fresh.db");
+        let _fresh = SqliteStorageBackend::new(&fresh_path).expect("fresh backend");
+
+        let historical_root = tempfile::tempdir().expect("historical root");
+        let historical_path = historical_root.path().join("historical.db");
+        Connection::open(&historical_path)
+            .expect("open historical fixture")
+            .execute_batch(
+                "CREATE TABLE mail_messages (
+                    team TEXT NOT NULL, agent TEXT NOT NULL, message_key TEXT NOT NULL,
+                    envelope_json TEXT NOT NULL, from_agent TEXT NOT NULL,
+                    source_chat_id TEXT NULL, destination_chat_id TEXT NULL,
+                    message_text TEXT NULL, summary TEXT NULL, message_at TEXT NOT NULL,
+                    message_id TEXT NULL, parent_message_id TEXT NULL, thread_mode TEXT NULL,
+                    recorded_at TEXT NULL,
+                    PRIMARY KEY (team, agent, message_key)
+                 );",
+            )
+            .expect("historical nullable-message-text fixture");
+        let _historical = SqliteStorageBackend::new(&historical_path).expect("migrate fixture");
+
+        let surface = |path: &std::path::Path| {
+            let connection = Connection::open(path).expect("inspect schema");
+            let columns = connection
+                .prepare("PRAGMA table_info(decomposed_messages)")
+                .expect("prepare view info")
+                .query_map([], |row| row.get::<_, String>(1))
+                .expect("query view info")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("decode view columns");
+            let message_text_not_null = connection
+                .query_row(
+                    "SELECT \"notnull\" FROM pragma_table_info('mail_messages') WHERE name = 'message_text'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .expect("message_text metadata");
+            (columns, message_text_not_null)
+        };
+        let expected_columns = vec![
+            "team",
+            "agent",
+            "from_agent",
+            "message_at",
+            "message_id",
+            "template_sha",
+            "template_type",
+            "vars_json",
+            "category",
+            "tags_json",
+            "summary",
+            "read",
+            "acknowledged_at",
+            "pending_ack_at",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+        assert_eq!(surface(&fresh_path), surface(&historical_path));
+        assert_eq!(surface(&fresh_path).0, expected_columns);
+        assert_eq!(
+            surface(&fresh_path).1,
+            0,
+            "fresh DDL keeps message_text nullable"
+        );
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -10,6 +10,10 @@ use atm_storage::contract::{
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::ThreadMode;
+use atm_storage::{
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, TemplateRegistration,
+    TemplateRegistrationOutcome,
+};
 #[cfg(test)]
 use rusqlite::OpenFlags;
 use rusqlite::{Connection, Error as RusqliteError, TransactionBehavior};
@@ -31,7 +35,12 @@ CREATE TABLE IF NOT EXISTS mail_messages (
     from_agent TEXT NOT NULL,
     source_chat_id TEXT NULL,
     destination_chat_id TEXT NULL,
-    message_text TEXT NOT NULL,
+    message_text TEXT NULL,
+    template_sha TEXT NULL,
+    vars_json TEXT NULL,
+    category TEXT NULL,
+    content_format TEXT NULL,
+    tags_json TEXT NOT NULL DEFAULT '[]',
     summary TEXT NULL,
     message_at TEXT NOT NULL,
     message_id TEXT NULL,
@@ -125,6 +134,31 @@ CREATE INDEX IF NOT EXISTS idx_mail_messages_mailbox
 -- so it cannot serve that global-key lookup without scanning a growing table.
 CREATE INDEX IF NOT EXISTS idx_mail_messages_message_key
     ON mail_messages(message_key);
+
+CREATE TABLE IF NOT EXISTS message_templates (
+    template_sha TEXT NOT NULL PRIMARY KEY,
+    template_type TEXT NULL,
+    template_name TEXT NULL,
+    content_bytes BLOB NOT NULL,
+    content_text TEXT NOT NULL,
+    schema_json TEXT NOT NULL DEFAULT '{}',
+    first_seen_at TEXT NOT NULL,
+    first_seen_by TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_templates_type
+    ON message_templates(template_type) WHERE template_type IS NOT NULL;
+
+CREATE VIEW IF NOT EXISTS decomposed_messages AS
+SELECT m.team, m.agent, m.from_agent, m.message_at, m.message_id,
+       m.template_sha, t.template_type, m.vars_json,
+       m.category, m.tags_json, m.summary,
+       s.read, s.acknowledged_at, s.pending_ack_at
+FROM mail_messages m
+JOIN message_templates t ON t.template_sha = m.template_sha
+LEFT JOIN mail_message_states s
+  ON (s.team, s.agent, s.message_key) = (m.team, m.agent, m.message_key)
+WHERE m.template_sha IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_mail_message_states_mailbox
     ON mail_message_states(team, agent);
@@ -296,7 +330,9 @@ impl SharedDb {
             WriteOpResult::UpsertMessage { inserted, .. } => Ok(inserted),
             WriteOpResult::Messages(_)
             | WriteOpResult::UpsertMessages
-            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::Acknowledged(_)
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for message upsert",
             )),
         }
@@ -325,7 +361,9 @@ impl SharedDb {
             )),
             WriteOpResult::Messages(_)
             | WriteOpResult::UpsertMessages
-            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::Acknowledged(_)
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for async message upsert",
             )),
         }
@@ -346,9 +384,38 @@ impl SharedDb {
             WriteOpResult::UpsertMessages => Ok(()),
             WriteOpResult::Messages(_)
             | WriteOpResult::UpsertMessage { .. }
-            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::Acknowledged(_)
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for atomic message commit",
             )),
+        }
+    }
+
+    pub(crate) fn submit_template_registration(
+        &self,
+        request: TemplateRegistration,
+    ) -> Result<TemplateRegistrationOutcome, AtmError> {
+        match self.writer.submit(WriteOp::RegisterTemplate(request))? {
+            WriteOpResult::TemplateRegistration(outcome) => Ok(outcome),
+            other => Err(AtmError::daemon_unavailable(format!(
+                "sqlite writer returned the wrong result for template registration: {other:?}"
+            ))),
+        }
+    }
+
+    pub(crate) fn submit_decomposed_message_admission(
+        &self,
+        admission: DecomposedMessageAdmission,
+    ) -> Result<DecomposedMessageAdmissionOutcome, AtmError> {
+        match self
+            .writer
+            .submit(WriteOp::AdmitDecomposedMessage(admission))?
+        {
+            WriteOpResult::DecomposedMessageAdmission(outcome) => Ok(outcome),
+            other => Err(AtmError::daemon_unavailable(format!(
+                "sqlite writer returned the wrong result for decomposed message admission: {other:?}"
+            ))),
         }
     }
 
@@ -364,7 +431,9 @@ impl SharedDb {
             WriteOpResult::Acknowledged(commit) => Ok(*commit),
             WriteOpResult::Messages(_)
             | WriteOpResult::UpsertMessage { .. }
-            | WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::UpsertMessages
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for acknowledgement admission",
             )),
         }
@@ -383,7 +452,9 @@ impl SharedDb {
             WriteOpResult::Acknowledged(commit) => Ok(*commit),
             WriteOpResult::Messages(_)
             | WriteOpResult::UpsertMessage { .. }
-            | WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::UpsertMessages
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for async acknowledgement admission",
             )),
         }
@@ -401,7 +472,9 @@ impl SharedDb {
             WriteOpResult::Messages(messages) => Ok(messages),
             WriteOpResult::UpsertMessage { .. }
             | WriteOpResult::UpsertMessages
-            | WriteOpResult::Acknowledged(_) => Err(AtmError::daemon_unavailable(
+            | WriteOpResult::Acknowledged(_)
+            | WriteOpResult::TemplateRegistration(_)
+            | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for async mailbox projection",
             )),
         }
@@ -549,6 +622,7 @@ pub(crate) fn ensure_schema(
         .execute_batch(DB_MIGRATIONS)
         .map_err(|error| sqlite_error(target, "failed to initialize sqlite schema", error))?;
     ensure_mail_message_columns(connection, target)?;
+    ensure_decomposed_messages_view(connection, target)?;
     ensure_team_roster_columns(connection, target)?;
     ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
@@ -614,7 +688,63 @@ fn ensure_mail_message_columns(
         "mail_messages",
         "message_id",
         "ALTER TABLE mail_messages ADD COLUMN message_id TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "template_sha",
+        "ALTER TABLE mail_messages ADD COLUMN template_sha TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "vars_json",
+        "ALTER TABLE mail_messages ADD COLUMN vars_json TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "category",
+        "ALTER TABLE mail_messages ADD COLUMN category TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "content_format",
+        "ALTER TABLE mail_messages ADD COLUMN content_format TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "tags_json",
+        "ALTER TABLE mail_messages ADD COLUMN tags_json TEXT NOT NULL DEFAULT '[]';",
     )
+}
+
+fn ensure_decomposed_messages_view(
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    connection
+        .execute_batch(
+            "DROP VIEW IF EXISTS decomposed_messages;
+             CREATE VIEW decomposed_messages AS
+             SELECT m.team, m.agent, m.from_agent, m.message_at, m.message_id,
+                    m.template_sha, t.template_type, m.vars_json,
+                    m.category, m.tags_json, m.summary,
+                    s.read, s.acknowledged_at, s.pending_ack_at
+             FROM mail_messages m
+             JOIN message_templates t ON t.template_sha = m.template_sha
+             LEFT JOIN mail_message_states s
+               ON (s.team, s.agent, s.message_key) = (m.team, m.agent, m.message_key)
+             WHERE m.template_sha IS NOT NULL;",
+        )
+        .map_err(|error| sqlite_error(target, "failed to create decomposed_messages view", error))
 }
 
 fn ensure_team_roster_columns(

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -10,10 +10,6 @@ use atm_storage::contract::{
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::ThreadMode;
-use atm_storage::{
-    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, TemplateRegistration,
-    TemplateRegistrationOutcome,
-};
 #[cfg(test)]
 use rusqlite::OpenFlags;
 use rusqlite::{Connection, Error as RusqliteError, TransactionBehavior};
@@ -134,31 +130,6 @@ CREATE INDEX IF NOT EXISTS idx_mail_messages_mailbox
 -- so it cannot serve that global-key lookup without scanning a growing table.
 CREATE INDEX IF NOT EXISTS idx_mail_messages_message_key
     ON mail_messages(message_key);
-
-CREATE TABLE IF NOT EXISTS message_templates (
-    template_sha TEXT NOT NULL PRIMARY KEY,
-    template_type TEXT NULL,
-    template_name TEXT NULL,
-    content_bytes BLOB NOT NULL,
-    content_text TEXT NOT NULL,
-    schema_json TEXT NOT NULL DEFAULT '{}',
-    first_seen_at TEXT NOT NULL,
-    first_seen_by TEXT NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_message_templates_type
-    ON message_templates(template_type) WHERE template_type IS NOT NULL;
-
-CREATE VIEW IF NOT EXISTS decomposed_messages AS
-SELECT m.team, m.agent, m.from_agent, m.message_at, m.message_id,
-       m.template_sha, t.template_type, m.vars_json,
-       m.category, m.tags_json, m.summary,
-       s.read, s.acknowledged_at, s.pending_ack_at
-FROM mail_messages m
-JOIN message_templates t ON t.template_sha = m.template_sha
-LEFT JOIN mail_message_states s
-  ON (s.team, s.agent, s.message_key) = (m.team, m.agent, m.message_key)
-WHERE m.template_sha IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_mail_message_states_mailbox
     ON mail_message_states(team, agent);
@@ -338,6 +309,12 @@ impl SharedDb {
         }
     }
 
+    /// Submits a feature-owned writer operation without exposing the writer
+    /// handle or its transaction lifecycle outside this state root.
+    pub(crate) fn submit_writer_op(&self, operation: WriteOp) -> Result<WriteOpResult, AtmError> {
+        self.writer.submit(operation)
+    }
+
     pub(crate) async fn submit_upsert_message_async(
         &self,
         record: Message,
@@ -389,33 +366,6 @@ impl SharedDb {
             | WriteOpResult::DecomposedMessageAdmission(_) => Err(AtmError::daemon_unavailable(
                 "sqlite writer returned the wrong result for atomic message commit",
             )),
-        }
-    }
-
-    pub(crate) fn submit_template_registration(
-        &self,
-        request: TemplateRegistration,
-    ) -> Result<TemplateRegistrationOutcome, AtmError> {
-        match self.writer.submit(WriteOp::RegisterTemplate(request))? {
-            WriteOpResult::TemplateRegistration(outcome) => Ok(outcome),
-            other => Err(AtmError::daemon_unavailable(format!(
-                "sqlite writer returned the wrong result for template registration: {other:?}"
-            ))),
-        }
-    }
-
-    pub(crate) fn submit_decomposed_message_admission(
-        &self,
-        admission: DecomposedMessageAdmission,
-    ) -> Result<DecomposedMessageAdmissionOutcome, AtmError> {
-        match self
-            .writer
-            .submit(WriteOp::AdmitDecomposedMessage(admission))?
-        {
-            WriteOpResult::DecomposedMessageAdmission(outcome) => Ok(outcome),
-            other => Err(AtmError::daemon_unavailable(format!(
-                "sqlite writer returned the wrong result for decomposed message admission: {other:?}"
-            ))),
         }
     }
 
@@ -622,7 +572,7 @@ pub(crate) fn ensure_schema(
         .execute_batch(DB_MIGRATIONS)
         .map_err(|error| sqlite_error(target, "failed to initialize sqlite schema", error))?;
     ensure_mail_message_columns(connection, target)?;
-    ensure_decomposed_messages_view(connection, target)?;
+    crate::template_catalog_schema::ensure_schema(connection, target)?;
     ensure_team_roster_columns(connection, target)?;
     ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
@@ -724,27 +674,6 @@ fn ensure_mail_message_columns(
         "tags_json",
         "ALTER TABLE mail_messages ADD COLUMN tags_json TEXT NOT NULL DEFAULT '[]';",
     )
-}
-
-fn ensure_decomposed_messages_view(
-    connection: &Connection,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    connection
-        .execute_batch(
-            "DROP VIEW IF EXISTS decomposed_messages;
-             CREATE VIEW decomposed_messages AS
-             SELECT m.team, m.agent, m.from_agent, m.message_at, m.message_id,
-                    m.template_sha, t.template_type, m.vars_json,
-                    m.category, m.tags_json, m.summary,
-                    s.read, s.acknowledged_at, s.pending_ack_at
-             FROM mail_messages m
-             JOIN message_templates t ON t.template_sha = m.template_sha
-             LEFT JOIN mail_message_states s
-               ON (s.team, s.agent, s.message_key) = (m.team, m.agent, m.message_key)
-             WHERE m.template_sha IS NOT NULL;",
-        )
-        .map_err(|error| sqlite_error(target, "failed to create decomposed_messages view", error))
 }
 
 fn ensure_team_roster_columns(

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -638,41 +638,6 @@ fn ensure_mail_message_columns(
         "mail_messages",
         "message_id",
         "ALTER TABLE mail_messages ADD COLUMN message_id TEXT NULL;",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "mail_messages",
-        "template_sha",
-        "ALTER TABLE mail_messages ADD COLUMN template_sha TEXT NULL;",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "mail_messages",
-        "vars_json",
-        "ALTER TABLE mail_messages ADD COLUMN vars_json TEXT NULL;",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "mail_messages",
-        "category",
-        "ALTER TABLE mail_messages ADD COLUMN category TEXT NULL;",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "mail_messages",
-        "content_format",
-        "ALTER TABLE mail_messages ADD COLUMN content_format TEXT NULL;",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "mail_messages",
-        "tags_json",
-        "ALTER TABLE mail_messages ADD COLUMN tags_json TEXT NOT NULL DEFAULT '[]';",
     )
 }
 
@@ -835,7 +800,7 @@ fn ensure_mail_messages_message_id_compat(
     )
 }
 
-fn ensure_column(
+pub(crate) fn ensure_column(
     connection: &Connection,
     target: &SharedDbTarget,
     table: &str,

--- a/crates/atm-storage-rusqlite/src/template_catalog_schema.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_schema.rs
@@ -1,0 +1,87 @@
+//! SQLite-owned schema and writer submission seam for immutable templates.
+//!
+//! Keeping this beside the catalog adapter prevents the generic shared-database
+//! root from accumulating feature-specific DDL or capability methods.
+
+use atm_storage::{
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, TemplateRegistration,
+    TemplateRegistrationOutcome,
+};
+use rusqlite::Connection;
+
+use crate::shared_db::{SharedDb, SharedDbTarget, sqlite_error};
+use crate::writer::{WriteOp, WriteOpResult};
+
+const TEMPLATE_CATALOG_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS message_templates (
+    template_sha TEXT NOT NULL PRIMARY KEY,
+    template_type TEXT NULL,
+    template_name TEXT NULL,
+    content_bytes BLOB NOT NULL,
+    content_text TEXT NOT NULL,
+    schema_json TEXT NOT NULL DEFAULT '{}',
+    first_seen_at TEXT NOT NULL,
+    first_seen_by TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_templates_type
+    ON message_templates(template_type) WHERE template_type IS NOT NULL;
+"#;
+
+const DECOMPOSED_MESSAGES_VIEW_V1: &str = r#"
+DROP VIEW IF EXISTS decomposed_messages;
+CREATE VIEW decomposed_messages AS
+SELECT m.team, m.agent, m.from_agent, m.message_at, m.message_id,
+       m.template_sha, t.template_type, m.vars_json,
+       m.category, m.tags_json, m.summary,
+       s.read, s.acknowledged_at, s.pending_ack_at
+FROM mail_messages m
+JOIN message_templates t ON t.template_sha = m.template_sha
+LEFT JOIN mail_message_states s
+  ON (s.team, s.agent, s.message_key) = (m.team, m.agent, m.message_key)
+WHERE m.template_sha IS NOT NULL;
+"#;
+
+pub(crate) fn ensure_schema(
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<(), atm_storage::AtmError> {
+    connection
+        .execute_batch(TEMPLATE_CATALOG_DDL)
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to initialize template catalog schema",
+                error,
+            )
+        })?;
+    connection
+        .execute_batch(DECOMPOSED_MESSAGES_VIEW_V1)
+        .map_err(|error| sqlite_error(target, "failed to create decomposed_messages view", error))
+}
+
+impl SharedDb {
+    pub(crate) fn submit_template_registration(
+        &self,
+        request: TemplateRegistration,
+    ) -> Result<TemplateRegistrationOutcome, atm_storage::AtmError> {
+        match self.submit_writer_op(WriteOp::RegisterTemplate(request))? {
+            WriteOpResult::TemplateRegistration(outcome) => Ok(outcome),
+            other => Err(atm_storage::AtmError::daemon_unavailable(format!(
+                "sqlite writer returned the wrong result for template registration: {other:?}"
+            ))),
+        }
+    }
+
+    pub(crate) fn submit_decomposed_message_admission(
+        &self,
+        admission: DecomposedMessageAdmission,
+    ) -> Result<DecomposedMessageAdmissionOutcome, atm_storage::AtmError> {
+        match self.submit_writer_op(WriteOp::AdmitDecomposedMessage(admission))? {
+            WriteOpResult::DecomposedMessageAdmission(outcome) => Ok(outcome),
+            other => Err(atm_storage::AtmError::daemon_unavailable(format!(
+                "sqlite writer returned the wrong result for decomposed message admission: {other:?}"
+            ))),
+        }
+    }
+}

--- a/crates/atm-storage-rusqlite/src/template_catalog_schema.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_schema.rs
@@ -3,14 +3,12 @@
 //! Keeping this beside the catalog adapter prevents the generic shared-database
 //! root from accumulating feature-specific DDL or capability methods.
 
+use crate::shared_db::{SharedDb, SharedDbTarget, SqliteConnection, ensure_column, sqlite_error};
+use crate::writer::{WriteOp, WriteOpResult};
 use atm_storage::{
     DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, TemplateRegistration,
     TemplateRegistrationOutcome,
 };
-use rusqlite::Connection;
-
-use crate::shared_db::{SharedDb, SharedDbTarget, sqlite_error};
-use crate::writer::{WriteOp, WriteOpResult};
 
 const TEMPLATE_CATALOG_DDL: &str = r#"
 CREATE TABLE IF NOT EXISTS message_templates (
@@ -43,9 +41,10 @@ WHERE m.template_sha IS NOT NULL;
 "#;
 
 pub(crate) fn ensure_schema(
-    connection: &Connection,
+    connection: &SqliteConnection,
     target: &SharedDbTarget,
 ) -> Result<(), atm_storage::AtmError> {
+    ensure_mail_message_template_columns(connection, target)?;
     connection
         .execute_batch(TEMPLATE_CATALOG_DDL)
         .map_err(|error| {
@@ -58,6 +57,50 @@ pub(crate) fn ensure_schema(
     connection
         .execute_batch(DECOMPOSED_MESSAGES_VIEW_V1)
         .map_err(|error| sqlite_error(target, "failed to create decomposed_messages view", error))
+}
+
+/// Applies catalog-owned compatibility columns before the catalog view refers
+/// to them. Keeping these migrations with the catalog DDL prevents the generic
+/// shared database root from owning feature-specific schema policy.
+fn ensure_mail_message_template_columns(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), atm_storage::AtmError> {
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "template_sha",
+        "ALTER TABLE mail_messages ADD COLUMN template_sha TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "vars_json",
+        "ALTER TABLE mail_messages ADD COLUMN vars_json TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "category",
+        "ALTER TABLE mail_messages ADD COLUMN category TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "content_format",
+        "ALTER TABLE mail_messages ADD COLUMN content_format TEXT NULL;",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "mail_messages",
+        "tags_json",
+        "ALTER TABLE mail_messages ADD COLUMN tags_json TEXT NOT NULL DEFAULT '[]';",
+    )
 }
 
 impl SharedDb {

--- a/crates/atm-storage-rusqlite/src/template_catalog_store.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_store.rs
@@ -57,7 +57,7 @@ impl TemplateCatalogStore for SqliteTemplateCatalogStore {
                 )
                 .optional()
                 .map_err(|error| self.db.error("failed to load immutable template", error))?
-                .map(|row| decode_stored_template(row))
+                .map(decode_stored_template)
                 .transpose()
         })
     }

--- a/crates/atm-storage-rusqlite/src/template_catalog_store.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_store.rs
@@ -9,13 +9,17 @@ use rusqlite::{OptionalExtension, params};
 
 use crate::shared_db::{SharedDb, deserialize_json};
 
+pub(crate) fn template_catalog_store(db: Arc<SharedDb>) -> Arc<dyn TemplateCatalogStore> {
+    Arc::new(SqliteTemplateCatalogStore::new(db))
+}
+
 #[derive(Debug)]
-pub(crate) struct SqliteTemplateCatalogStore {
+struct SqliteTemplateCatalogStore {
     db: Arc<SharedDb>,
 }
 
 impl SqliteTemplateCatalogStore {
-    pub(crate) fn new(db: Arc<SharedDb>) -> Self {
+    fn new(db: Arc<SharedDb>) -> Self {
         Self { db }
     }
 }

--- a/crates/atm-storage-rusqlite/src/template_catalog_store.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_store.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use atm_storage::{
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, StoredTemplate,
+    TemplateCatalogStore, TemplateFirstSeen, TemplateListFilter, TemplateRegistration,
+    TemplateRegistrationOutcome, TemplateSummary,
+};
+use rusqlite::{OptionalExtension, params};
+
+use crate::shared_db::{SharedDb, deserialize_json};
+
+#[derive(Debug)]
+pub(crate) struct SqliteTemplateCatalogStore {
+    db: Arc<SharedDb>,
+}
+
+impl SqliteTemplateCatalogStore {
+    pub(crate) fn new(db: Arc<SharedDb>) -> Self {
+        Self { db }
+    }
+}
+
+impl atm_storage::contract::sealed::Sealed for SqliteTemplateCatalogStore {}
+
+impl TemplateCatalogStore for SqliteTemplateCatalogStore {
+    fn register(
+        &self,
+        request: TemplateRegistration,
+    ) -> Result<TemplateRegistrationOutcome, atm_storage::AtmError> {
+        request.validate()?;
+        self.db.submit_template_registration(request)
+    }
+
+    fn load(
+        &self,
+        sha: &atm_storage::TemplateSha,
+    ) -> Result<Option<StoredTemplate>, atm_storage::AtmError> {
+        self.db.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT template_sha, template_type, template_name, content_bytes,
+                            content_text, schema_json, first_seen_at, first_seen_by
+                     FROM message_templates WHERE template_sha = ?1",
+                    params![sha.as_str()],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, Vec<u8>>(3)?,
+                            row.get::<_, String>(4)?,
+                            row.get::<_, String>(5)?,
+                            row.get::<_, String>(6)?,
+                            row.get::<_, String>(7)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|error| self.db.error("failed to load immutable template", error))?
+                .map(|row| decode_stored_template(row))
+                .transpose()
+        })
+    }
+
+    fn list(
+        &self,
+        filter: TemplateListFilter,
+    ) -> Result<Vec<TemplateSummary>, atm_storage::AtmError> {
+        self.db.with_connection(|connection| {
+            let mut statement = connection
+                .prepare(
+                    "SELECT template_sha, template_type, template_name, first_seen_at, first_seen_by
+                     FROM message_templates
+                     WHERE (?1 IS NULL OR template_type = ?1)
+                     ORDER BY first_seen_at ASC, template_sha ASC",
+                )
+                .map_err(|error| self.db.error("failed to prepare template listing", error))?;
+            statement
+                .query_map(params![filter.template_type.as_deref()], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                })
+                .map_err(|error| self.db.error("failed to execute template listing", error))?
+                .map(|row| {
+                    let (sha, template_type, template_name, first_seen_at, first_seen_by) = row
+                        .map_err(|error| {
+                            self.db.error("failed to decode template listing", error)
+                        })?;
+                    Ok(TemplateSummary {
+                        sha: sha.parse()?,
+                        template_type,
+                        template_name,
+                        first_seen: TemplateFirstSeen::new(
+                            first_seen_at.parse().map_err(|error| {
+                                atm_storage::AtmError::mailbox_read(format!(
+                                    "stored template first_seen_at is invalid: {error}"
+                                ))
+                            })?,
+                            first_seen_by,
+                        )?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn admit_decomposed_message(
+        &self,
+        admission: DecomposedMessageAdmission,
+    ) -> Result<DecomposedMessageAdmissionOutcome, atm_storage::AtmError> {
+        admission.validate()?;
+        self.db.submit_decomposed_message_admission(admission)
+    }
+}
+
+type StoredTemplateRow = (
+    String,
+    Option<String>,
+    Option<String>,
+    Vec<u8>,
+    String,
+    String,
+    String,
+    String,
+);
+
+fn decode_stored_template(row: StoredTemplateRow) -> Result<StoredTemplate, atm_storage::AtmError> {
+    let (
+        sha,
+        template_type,
+        template_name,
+        content_bytes,
+        content_text,
+        schema_json,
+        first_seen_at,
+        first_seen_by,
+    ) = row;
+    let frontmatter = deserialize_json(&schema_json, "template frontmatter")?;
+    let template = StoredTemplate {
+        sha: sha.parse()?,
+        template_type,
+        template_name,
+        content_bytes,
+        content_text,
+        frontmatter,
+        first_seen: TemplateFirstSeen::new(
+            first_seen_at.parse().map_err(|error| {
+                atm_storage::AtmError::mailbox_read(format!(
+                    "stored template first_seen_at is invalid: {error}"
+                ))
+            })?,
+            first_seen_by,
+        )?,
+    };
+    let projection = std::str::from_utf8(&template.content_bytes)
+        .map_err(|_| atm_storage::AtmError::template_content_not_utf8())?;
+    if projection != template.content_text {
+        return Err(atm_storage::AtmError::mailbox_read(
+            "stored template content_text does not match its UTF-8 byte projection",
+        ));
+    }
+    Ok(template)
+}

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -7,6 +7,10 @@ use atm_storage::contract::{
 use atm_storage::error::AtmError;
 use atm_storage::schema::MessageEnvelope;
 use atm_storage::types::{AgentName, IsoTimestamp, TeamName};
+use atm_storage::{
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, TemplateRegistration,
+    TemplateRegistrationOutcome,
+};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use std::sync::Arc;
@@ -28,6 +32,8 @@ pub(crate) enum WriteOp {
         source: AcknowledgementSource,
         builder: Arc<dyn AcknowledgementReplyBuilder>,
     },
+    RegisterTemplate(TemplateRegistration),
+    AdmitDecomposedMessage(DecomposedMessageAdmission),
 }
 
 impl std::fmt::Debug for WriteOp {
@@ -40,6 +46,14 @@ impl std::fmt::Debug for WriteOp {
                 .debug_struct("Acknowledge")
                 .field("source", source)
                 .finish_non_exhaustive(),
+            Self::RegisterTemplate(request) => formatter
+                .debug_tuple("RegisterTemplate")
+                .field(&request.sha)
+                .finish(),
+            Self::AdmitDecomposedMessage(admission) => formatter
+                .debug_tuple("AdmitDecomposedMessage")
+                .field(&admission.message.key)
+                .finish(),
         }
     }
 }
@@ -56,6 +70,8 @@ pub(crate) enum WriteOpResult {
     },
     UpsertMessages,
     Acknowledged(Box<AcknowledgementCommit>),
+    TemplateRegistration(TemplateRegistrationOutcome),
+    DecomposedMessageAdmission(DecomposedMessageAdmissionOutcome),
 }
 
 pub(crate) fn execute(
@@ -78,7 +94,127 @@ pub(crate) fn execute(
         WriteOp::Acknowledge { source, builder } => {
             execute_acknowledgement(source, builder, connection, cache, target)
         }
+        WriteOp::RegisterTemplate(request) => {
+            execute_template_registration(request, connection, target)
+        }
+        WriteOp::AdmitDecomposedMessage(admission) => {
+            execute_decomposed_message_admission(admission, connection, target)
+        }
     }
+}
+
+fn execute_template_registration(
+    request: &TemplateRegistration,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<WriteOpResult, AtmError> {
+    request.validate()?;
+    let inserted = insert_template_if_absent(request, connection, target)?;
+    Ok(WriteOpResult::TemplateRegistration(if inserted {
+        TemplateRegistrationOutcome::Inserted
+    } else {
+        TemplateRegistrationOutcome::AlreadyRegistered
+    }))
+}
+
+fn execute_decomposed_message_admission(
+    admission: &DecomposedMessageAdmission,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<WriteOpResult, AtmError> {
+    admission.validate()?;
+    let template_inserted = insert_template_if_absent(&admission.template, connection, target)?;
+    let existing_template_sha = connection
+        .query_row(
+            "SELECT template_sha FROM mail_messages WHERE message_key = ?1 LIMIT 1",
+            params![admission.message.key.as_str()],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(|error| {
+            sqlite_error(target, "failed to inspect decomposed message target", error)
+        })?
+        .ok_or_else(|| {
+            AtmError::mailbox_write("decomposed admission requires an existing canonical message")
+        })?;
+
+    if let Some(existing) = existing_template_sha {
+        if existing == admission.message.template_sha.as_str() {
+            return Ok(WriteOpResult::DecomposedMessageAdmission(
+                DecomposedMessageAdmissionOutcome::MessageAlreadyPresent,
+            ));
+        }
+        return Err(AtmError::validation(
+            "an existing decomposed message cannot be rebound to a different template SHA",
+        ));
+    }
+
+    let vars_json = serialize_json(admission.message.vars.as_map(), "decomposed message vars")?;
+    let tags_json = serialize_json(&admission.message.tags, "decomposed message tags")?;
+    let changed = connection
+        .execute(
+            "UPDATE mail_messages
+             SET template_sha = ?1, vars_json = ?2, category = ?3,
+                 tags_json = ?4, content_format = ?5, message_text = NULL
+             WHERE message_key = ?6 AND template_sha IS NULL",
+            params![
+                admission.message.template_sha.as_str(),
+                vars_json,
+                admission.message.category.as_deref(),
+                tags_json,
+                admission.message.content_format.as_deref(),
+                admission.message.key.as_str(),
+            ],
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to persist decomposed message columns",
+                error,
+            )
+        })?;
+    if changed != 1 {
+        return Err(AtmError::mailbox_write(
+            "decomposed admission did not update exactly one canonical message",
+        ));
+    }
+    Ok(WriteOpResult::DecomposedMessageAdmission(
+        DecomposedMessageAdmissionOutcome::Inserted {
+            template: if template_inserted {
+                TemplateRegistrationOutcome::Inserted
+            } else {
+                TemplateRegistrationOutcome::AlreadyRegistered
+            },
+        },
+    ))
+}
+
+fn insert_template_if_absent(
+    request: &TemplateRegistration,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<bool, AtmError> {
+    let schema_json = serialize_json(&request.frontmatter, "template frontmatter")?;
+    connection
+        .execute(
+            "INSERT INTO message_templates(
+                template_sha, template_type, template_name, content_bytes,
+                content_text, schema_json, first_seen_at, first_seen_by
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(template_sha) DO NOTHING",
+            params![
+                request.sha.as_str(),
+                request.template_type.as_deref(),
+                request.template_name.as_deref(),
+                request.content_bytes.as_slice(),
+                request.content_text.as_str(),
+                schema_json,
+                request.first_seen.at.to_string(),
+                request.first_seen.by.as_str(),
+            ],
+        )
+        .map(|changed| changed == 1)
+        .map_err(|error| sqlite_error(target, "failed to register immutable template", error))
 }
 
 fn execute_list_messages(

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -274,6 +274,12 @@ impl AtmError {
         Self::new(AtmErrorCode::MessageValidationFailed, message)
     }
 
+    /// Rejects a template before catalog or decomposed-message admission when
+    /// its immutable raw bytes cannot be represented by the UTF-8 projection.
+    pub fn template_content_not_utf8() -> Self {
+        Self::for_code(AtmErrorCode::TemplateContentNotUtf8)
+    }
+
     /// Builds a validation error whose recovery is specific to the rejected CLI input.
     pub fn validation_with_recovery(
         message: impl Into<String>,

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -145,6 +145,7 @@ const fn request_guidance(code: AtmErrorCode) -> Option<&'static str> {
         | AtmErrorCode::SelfAddressedSendInvalid
         | AtmErrorCode::EmptyNudgeTemplateBody
         | AtmErrorCode::CallerContextRequestInvalid
+        | AtmErrorCode::TemplateContentNotUtf8
         | AtmErrorCode::AckInvalidState
         | AtmErrorCode::ClearInvalidState => {
             Some("Correct the invalid ATM request or state before retrying.")

--- a/crates/atm-storage/src/factory.rs
+++ b/crates/atm-storage/src/factory.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     AsyncMessageStore, AtmError, MessageStore, NudgeTemplateOverrideStore, PeerConfigStore,
-    RosterStore,
+    RosterStore, TemplateCatalogStore,
 };
 
 /// Backend-neutral handles returned by the selected durable storage backend.
@@ -15,6 +15,7 @@ pub struct StorageHandles {
     roster_store: Arc<dyn RosterStore + Send + Sync>,
     nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
+    template_catalog_store: Arc<dyn TemplateCatalogStore + Send + Sync>,
 }
 
 impl fmt::Debug for StorageHandles {
@@ -28,6 +29,7 @@ impl fmt::Debug for StorageHandles {
                 &"dyn NudgeTemplateOverrideStore",
             )
             .field("peer_config_store", &"dyn PeerConfigStore")
+            .field("template_catalog_store", &"dyn TemplateCatalogStore")
             .finish()
     }
 }
@@ -39,6 +41,7 @@ impl StorageHandles {
         roster_store: Arc<dyn RosterStore + Send + Sync>,
         nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
         peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
+        template_catalog_store: Arc<dyn TemplateCatalogStore + Send + Sync>,
     ) -> Self {
         Self {
             message_store,
@@ -46,6 +49,7 @@ impl StorageHandles {
             roster_store,
             nudge_template_override_store,
             peer_config_store,
+            template_catalog_store,
         }
     }
 
@@ -70,6 +74,11 @@ impl StorageHandles {
 
     pub fn peer_config_store(&self) -> Arc<dyn PeerConfigStore + Send + Sync> {
         Arc::clone(&self.peer_config_store)
+    }
+
+    /// Returns the sealed immutable-template catalog capability.
+    pub fn template_catalog_store(&self) -> Arc<dyn TemplateCatalogStore + Send + Sync> {
+        Arc::clone(&self.template_catalog_store)
     }
 }
 

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -7,6 +7,7 @@ mod error_catalog;
 pub mod error_codes;
 pub mod factory;
 pub mod schema;
+pub mod template_catalog;
 pub mod tls;
 pub mod types;
 mod validation;
@@ -27,6 +28,11 @@ pub use error::AtmError;
 pub use error_codes::AtmErrorCode;
 pub use factory::{StorageFactory, StorageHandles};
 pub use schema::{AlertKind, AtmMessageId, InboxMessage, MessageEnvelope, PendingAck, ThreadMode};
+pub use template_catalog::{
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, DecomposedMessageRecord,
+    MergedVarsJson, MessageBody, StoredTemplate, TemplateCatalogStore, TemplateFirstSeen,
+    TemplateListFilter, TemplateRegistration, TemplateRegistrationOutcome, TemplateSummary,
+};
 pub use tls::{
     PinnedClientVerifier, TlsIdentity, certificate_fingerprint, install_tls_provider,
     normalize_fingerprint,

--- a/crates/atm-storage/src/template_catalog.rs
+++ b/crates/atm-storage/src/template_catalog.rs
@@ -1,0 +1,472 @@
+//! Backend-neutral immutable template-catalog contract.
+//!
+//! This module deliberately owns only durable DTOs and the sealed capability.
+//! It neither parses templates nor renders them; the core-owned composition
+//! boundary converts validated adapter output into these values exactly once.
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::contract::MessageKey;
+use crate::error::AtmError;
+use crate::types::{IsoTimestamp, TemplateFrontmatter, TemplateSha};
+
+/// The source representation selected before durable admission.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageBody {
+    Inline(String),
+    Decomposed {
+        template_sha: TemplateSha,
+        vars: MergedVarsJson,
+    },
+    FileRef(String),
+}
+
+/// The durable column projection of one [`MessageBody`] variant.
+///
+/// This is constructed exclusively by [`MessageBody::columns`], so callers
+/// cannot represent an inline/file-reference body with decomposition metadata,
+/// nor a decomposed body with `message_text`. AN.3 will pass this projection at
+/// its core-to-storage admission boundary.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MessageBodyColumns<'a> {
+    message_text: Option<&'a str>,
+    template_sha: Option<&'a TemplateSha>,
+    vars: Option<&'a MergedVarsJson>,
+}
+
+impl<'a> MessageBodyColumns<'a> {
+    #[must_use]
+    pub fn message_text(self) -> Option<&'a str> {
+        self.message_text
+    }
+
+    #[must_use]
+    pub fn template_sha(self) -> Option<&'a TemplateSha> {
+        self.template_sha
+    }
+
+    #[must_use]
+    pub fn vars(self) -> Option<&'a MergedVarsJson> {
+        self.vars
+    }
+}
+
+impl MessageBody {
+    /// Projects this tagged union onto its mutually exclusive durable columns.
+    #[must_use]
+    pub fn columns(&self) -> MessageBodyColumns<'_> {
+        match self {
+            Self::Inline(text) | Self::FileRef(text) => MessageBodyColumns {
+                message_text: Some(text),
+                template_sha: None,
+                vars: None,
+            },
+            Self::Decomposed { template_sha, vars } => MessageBodyColumns {
+                message_text: None,
+                template_sha: Some(template_sha),
+                vars: Some(vars),
+            },
+        }
+    }
+}
+
+/// Backend-neutral, already-merged JSON object persisted for a decomposed row.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MergedVarsJson(Map<String, Value>);
+
+impl MergedVarsJson {
+    /// Accepts only an object produced by the core-owned merge boundary.
+    pub fn try_from_merged_object(object: Map<String, Value>) -> Result<Self, AtmError> {
+        // `serde_json::Map` can only represent a JSON object. Keeping this
+        // constructor is intentional: callers cannot substitute an array or
+        // scalar when crossing the core/storage contract.
+        Ok(Self(object))
+    }
+
+    #[must_use]
+    pub fn as_map(&self) -> &Map<String, Value> {
+        &self.0
+    }
+}
+
+/// Who first made the immutable template visible to this storage backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateFirstSeen {
+    pub at: IsoTimestamp,
+    pub by: String,
+}
+
+impl TemplateFirstSeen {
+    pub fn new(at: IsoTimestamp, by: impl Into<String>) -> Result<Self, AtmError> {
+        let by = by.into();
+        if by.trim().is_empty() {
+            return Err(AtmError::validation(
+                "template first_seen_by must not be blank",
+            ));
+        }
+        Ok(Self { at, by })
+    }
+}
+
+/// Immutable registration input for a content-addressed template.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemplateRegistration {
+    pub sha: TemplateSha,
+    pub template_type: Option<String>,
+    pub template_name: Option<String>,
+    pub content_bytes: Vec<u8>,
+    pub content_text: String,
+    pub frontmatter: TemplateFrontmatter,
+    pub first_seen: TemplateFirstSeen,
+}
+
+impl TemplateRegistration {
+    /// Ensures bytes and strict UTF-8 projection agree before any write begins.
+    pub fn validate(&self) -> Result<(), AtmError> {
+        let content_text = std::str::from_utf8(&self.content_bytes)
+            .map_err(|_| AtmError::template_content_not_utf8())?;
+        if content_text != self.content_text {
+            return Err(AtmError::validation(
+                "template content_text must equal the strict UTF-8 projection of content_bytes",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemplateRegistrationOutcome {
+    Inserted,
+    AlreadyRegistered,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredTemplate {
+    pub sha: TemplateSha,
+    pub template_type: Option<String>,
+    pub template_name: Option<String>,
+    pub content_bytes: Vec<u8>,
+    pub content_text: String,
+    pub frontmatter: TemplateFrontmatter,
+    pub first_seen: TemplateFirstSeen,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TemplateListFilter {
+    pub template_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateSummary {
+    pub sha: TemplateSha,
+    pub template_type: Option<String>,
+    pub template_name: Option<String>,
+    pub first_seen: TemplateFirstSeen,
+}
+
+/// The decomposed-column portion of an already admitted canonical message.
+///
+/// The message key identifies the mailbox row to convert. This deliberately
+/// does not carry an envelope or renderer value: immutable envelope admission
+/// remains on `MessageStore`, while this capability atomically registers the
+/// template and records the storage-only decomposition columns.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecomposedMessageRecord {
+    pub key: MessageKey,
+    pub template_sha: TemplateSha,
+    pub vars: MergedVarsJson,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub content_format: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecomposedMessageAdmission {
+    pub template: TemplateRegistration,
+    pub message: DecomposedMessageRecord,
+}
+
+impl DecomposedMessageAdmission {
+    pub fn validate(&self) -> Result<(), AtmError> {
+        self.template.validate()?;
+        if self.message.template_sha != self.template.sha {
+            return Err(AtmError::validation(
+                "decomposed message template_sha must match the registered template SHA",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecomposedMessageAdmissionOutcome {
+    Inserted {
+        template: TemplateRegistrationOutcome,
+    },
+    MessageAlreadyPresent,
+}
+
+/// Sealed backend-neutral capability for immutable templates and the one
+/// atomic template-plus-decomposed-message transition.
+pub trait TemplateCatalogStore: crate::contract::sealed::Sealed + Send + Sync {
+    fn register(
+        &self,
+        request: TemplateRegistration,
+    ) -> Result<TemplateRegistrationOutcome, AtmError>;
+    fn load(&self, sha: &TemplateSha) -> Result<Option<StoredTemplate>, AtmError>;
+    fn list(&self, filter: TemplateListFilter) -> Result<Vec<TemplateSummary>, AtmError>;
+    fn admit_decomposed_message(
+        &self,
+        admission: DecomposedMessageAdmission,
+    ) -> Result<DecomposedMessageAdmissionOutcome, AtmError>;
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct InMemoryTemplateCatalogStore {
+    state: std::sync::Mutex<InMemoryTemplateCatalogState>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct InMemoryTemplateCatalogState {
+    templates: BTreeMap<TemplateSha, StoredTemplate>,
+    decomposed_messages: BTreeMap<MessageKey, TemplateSha>,
+    fail_next_admission: bool,
+}
+
+#[cfg(test)]
+impl InMemoryTemplateCatalogStore {
+    fn fail_next_admission_for_test(&self) {
+        self.state
+            .lock()
+            .expect("in-memory template catalog lock")
+            .fail_next_admission = true;
+    }
+}
+
+#[cfg(test)]
+impl crate::contract::sealed::Sealed for InMemoryTemplateCatalogStore {}
+
+#[cfg(test)]
+impl TemplateCatalogStore for InMemoryTemplateCatalogStore {
+    fn register(
+        &self,
+        request: TemplateRegistration,
+    ) -> Result<TemplateRegistrationOutcome, AtmError> {
+        request.validate()?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| AtmError::mailbox_write("in-memory template catalog lock poisoned"))?;
+        if state.templates.contains_key(&request.sha) {
+            return Ok(TemplateRegistrationOutcome::AlreadyRegistered);
+        }
+        state.templates.insert(
+            request.sha.clone(),
+            StoredTemplate {
+                sha: request.sha,
+                template_type: request.template_type,
+                template_name: request.template_name,
+                content_bytes: request.content_bytes,
+                content_text: request.content_text,
+                frontmatter: request.frontmatter,
+                first_seen: request.first_seen,
+            },
+        );
+        Ok(TemplateRegistrationOutcome::Inserted)
+    }
+
+    fn load(&self, sha: &TemplateSha) -> Result<Option<StoredTemplate>, AtmError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AtmError::mailbox_read("in-memory template catalog lock poisoned"))?
+            .templates
+            .get(sha)
+            .cloned())
+    }
+
+    fn list(&self, filter: TemplateListFilter) -> Result<Vec<TemplateSummary>, AtmError> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| AtmError::mailbox_read("in-memory template catalog lock poisoned"))?;
+        Ok(state
+            .templates
+            .values()
+            .filter(|template| {
+                filter
+                    .template_type
+                    .as_ref()
+                    .is_none_or(|kind| template.template_type.as_ref() == Some(kind))
+            })
+            .map(|template| TemplateSummary {
+                sha: template.sha.clone(),
+                template_type: template.template_type.clone(),
+                template_name: template.template_name.clone(),
+                first_seen: template.first_seen.clone(),
+            })
+            .collect())
+    }
+
+    fn admit_decomposed_message(
+        &self,
+        admission: DecomposedMessageAdmission,
+    ) -> Result<DecomposedMessageAdmissionOutcome, AtmError> {
+        admission.validate()?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| AtmError::mailbox_write("in-memory template catalog lock poisoned"))?;
+        if state
+            .decomposed_messages
+            .contains_key(&admission.message.key)
+        {
+            return Ok(DecomposedMessageAdmissionOutcome::MessageAlreadyPresent);
+        }
+        // Mutate the in-memory state only after the injected failure point,
+        // matching the concrete backend's all-or-nothing admission contract.
+        if state.fail_next_admission {
+            state.fail_next_admission = false;
+            return Err(AtmError::mailbox_write(
+                "in-memory template catalog injected decomposed-admission failure",
+            ));
+        }
+        let template_outcome = if state.templates.contains_key(&admission.template.sha) {
+            TemplateRegistrationOutcome::AlreadyRegistered
+        } else {
+            let request = admission.template;
+            state.templates.insert(
+                request.sha.clone(),
+                StoredTemplate {
+                    sha: request.sha,
+                    template_type: request.template_type,
+                    template_name: request.template_name,
+                    content_bytes: request.content_bytes,
+                    content_text: request.content_text,
+                    frontmatter: request.frontmatter,
+                    first_seen: request.first_seen,
+                },
+            );
+            TemplateRegistrationOutcome::Inserted
+        };
+        state
+            .decomposed_messages
+            .insert(admission.message.key, admission.message.template_sha);
+        Ok(DecomposedMessageAdmissionOutcome::Inserted {
+            template: template_outcome,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registration(bytes: Vec<u8>) -> TemplateRegistration {
+        TemplateRegistration {
+            sha: TemplateSha::new("a".repeat(64)).expect("sha"),
+            template_type: Some("task".to_string()),
+            template_name: Some("example".to_string()),
+            content_text: String::from_utf8(bytes.clone()).unwrap_or_default(),
+            content_bytes: bytes,
+            frontmatter: TemplateFrontmatter::default(),
+            first_seen: TemplateFirstSeen::new(IsoTimestamp::now(), "test").expect("first seen"),
+        }
+    }
+
+    #[test]
+    fn message_body_column_projection_keeps_source_variants_mutually_exclusive() {
+        let sha = TemplateSha::new("b".repeat(64)).expect("sha");
+        let vars = MergedVarsJson::try_from_merged_object(Map::from_iter([(
+            "priority".to_string(),
+            Value::String("high".to_string()),
+        )]))
+        .expect("vars");
+
+        for body in [
+            MessageBody::Inline("inline message".to_string()),
+            MessageBody::FileRef("docs/task.xml".to_string()),
+        ] {
+            let columns = body.columns();
+            assert!(columns.message_text().is_some());
+            assert!(columns.template_sha().is_none());
+            assert!(columns.vars().is_none());
+        }
+
+        let decomposed = MessageBody::Decomposed {
+            template_sha: sha.clone(),
+            vars: vars.clone(),
+        };
+        let columns = decomposed.columns();
+        assert!(columns.message_text().is_none());
+        assert_eq!(columns.template_sha(), Some(&sha));
+        assert_eq!(columns.vars(), Some(&vars));
+    }
+
+    #[test]
+    fn in_memory_contract_registration_is_idempotent_and_loads_exact_bytes() {
+        let store = InMemoryTemplateCatalogStore::default();
+        let request = registration(b"title: example\r\n".to_vec());
+        assert_eq!(
+            store.register(request.clone()).expect("insert"),
+            TemplateRegistrationOutcome::Inserted
+        );
+        assert_eq!(
+            store.register(request.clone()).expect("repeat"),
+            TemplateRegistrationOutcome::AlreadyRegistered
+        );
+        assert_eq!(
+            store
+                .load(&request.sha)
+                .expect("load")
+                .expect("template")
+                .content_bytes,
+            request.content_bytes
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_is_rejected_before_catalog_mutation() {
+        let store = InMemoryTemplateCatalogStore::default();
+        let request = registration(vec![0xff]);
+        assert_eq!(
+            store
+                .register(request.clone())
+                .expect_err("invalid utf8")
+                .code()
+                .as_str(),
+            "TEMPLATE_CONTENT_NOT_UTF8"
+        );
+        assert!(store.load(&request.sha).expect("load").is_none());
+    }
+
+    #[test]
+    fn in_memory_admission_failure_leaves_no_partial_catalog_or_message_state() {
+        let store = InMemoryTemplateCatalogStore::default();
+        let request = registration(b"template".to_vec());
+        let sha = request.sha.clone();
+        store.fail_next_admission_for_test();
+        let error = store
+            .admit_decomposed_message(DecomposedMessageAdmission {
+                template: request,
+                message: DecomposedMessageRecord {
+                    key: MessageKey::new("atm:in-memory-template").expect("key"),
+                    template_sha: sha.clone(),
+                    vars: MergedVarsJson::default(),
+                    category: None,
+                    tags: vec![],
+                    content_format: None,
+                },
+            })
+            .expect_err("injected admission failure");
+        assert_eq!(error.code().as_str(), "ATM_MAILBOX_WRITE_FAILED");
+        assert!(store.load(&sha).expect("load").is_none());
+    }
+}

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -77,6 +77,10 @@ Error codes should describe the failure class, not a specific prose message.
 - `ATM_MESSAGE_VALIDATION_FAILED`
 - `ATM_SELF_ADDRESSED_SEND_INVALID`
 - `ATM_SERIALIZATION_FAILED`
+- `TEMPLATE_CONTENT_NOT_UTF8` — template catalog registration rejected raw
+  content that has no strict UTF-8 projection; replace the source with UTF-8
+  text and retry. This is checked before either a catalog row or a decomposed
+  message row can become durable.
 
 #### 5.3.1 `ATM_MAILBOX_LOCK_TIMEOUT`
 
@@ -441,6 +445,7 @@ Classification rules:
 | `ATM_MESSAGE_VALIDATION_FAILED` | `operator_actionable` |
 | `ATM_SELF_ADDRESSED_SEND_INVALID` | `operator_actionable` |
 | `ATM_SERIALIZATION_FAILED` | `fail_closed` |
+| `TEMPLATE_CONTENT_NOT_UTF8` | `operator_actionable` |
 | `ATM_FILE_POLICY_REJECTED` | `operator_actionable` |
 | `ATM_FILE_REFERENCE_REWRITE_FAILED` | `operator_actionable` |
 | `ATM_WAIT_TIMEOUT` | `retryable` |

--- a/docs/atm-query-surface.md
+++ b/docs/atm-query-surface.md
@@ -1,0 +1,30 @@
+# ATM local query surface
+
+## `decomposed_messages` v1
+
+`decomposed_messages` is the versioned, read-only SQLite view for local
+consumers that need durable decomposed-template metadata. It is the supported
+SQL surface; the underlying `mail_messages`, `message_templates`, and
+`mail_message_states` tables remain implementation details.
+
+Version 1 exposes exactly these columns, in this order:
+
+1. `team`
+2. `agent`
+3. `from_agent`
+4. `message_at`
+5. `message_id`
+6. `template_sha`
+7. `template_type`
+8. `vars_json`
+9. `category`
+10. `tags_json`
+11. `summary`
+12. `read`
+13. `acknowledged_at`
+14. `pending_ack_at`
+
+The view contains only rows whose `template_sha` resolves to a durable,
+immutable catalog entry. It is created additively for both fresh and migrated
+SQLite databases. Future changes require a separately versioned view; callers
+must not depend on base-table column layout.


### PR DESCRIPTION
## Summary
- Sealed backend-neutral TemplateCatalogStore
- Immutable template catalog schema + atomic SQLite decomposed admission
- Additive mail migration; v1 decomposed_messages view/query docs
- Boundary manifests, strict UTF-8 error contract
- Fake/SQLite rollback + migration/shared-inbox tests

## Test plan
- `cargo fmt --check`, `cargo test --workspace`, `just lint`, `just test` (489 Python tests plus Cargo suite) — all PASS per arch-ctm's report

🤖 Generated with [Claude Code](https://claude.com/claude-code)