### PR TITLE
fix(hermes-atm): enable generated native tools plugin

### DIFF
--- a/.just/tests/test_atm_graft_python_models.py
+++ b/.just/tests/test_atm_graft_python_models.py
@@ -45,6 +45,42 @@ class AtmGraftPythonModelTests(unittest.TestCase):
             with self.assertRaises(Exception):
                 model.model_validate({"acknowledge": "01TEST"})
 
+    def test_tool_schema_describes_every_model_field(self):
+        models = load_models()
+        expected = {
+            models.AtmSendRequest: {"to", "body", "requires_ack"},
+            models.AtmReadRequest: {
+                "selection",
+                "message_id",
+                "task",
+                "contains",
+                "since",
+                "from_agent",
+            },
+            models.AtmListRequest: {
+                "selection",
+                "limit",
+                "task",
+                "contains",
+                "since",
+                "from_agent",
+            },
+        }
+        for model, fields in expected.items():
+            properties = model.model_json_schema()["properties"]
+            self.assertEqual(set(properties), fields)
+            for name in fields:
+                self.assertTrue(properties[name].get("description"), name)
+
+        send = models.AtmSendRequest.model_json_schema()["properties"]
+        self.assertIn("bare identity", send["to"]["description"])
+        self.assertIn("reviewer@release", send["to"]["description"])
+        self.assertIn("defaults to false", send["requires_ack"]["description"])
+        for model in (models.AtmReadRequest, models.AtmListRequest):
+            selection = model.model_json_schema()["properties"]["selection"]["description"]
+            for value in ("actionable", "all", "unread", "pending_ack"):
+                self.assertIn(value, selection)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/atm-graft-python/python/atm_graft/models.py
+++ b/crates/atm-graft-python/python/atm_graft/models.py
@@ -14,24 +14,83 @@ class _ToolRequest(BaseModel):
 
 
 class AtmSendRequest(_ToolRequest):
-    to: str = Field(min_length=1)
-    body: str = Field(min_length=1)
-    requires_ack: bool = False
+    to: str = Field(
+        min_length=1,
+        description=(
+            "Recipient ATM address. Use a bare identity for an agent on your current team "
+            "(for example, 'reviewer') or agent@team for another team "
+            "(for example, 'reviewer@release'). Required."
+        ),
+    )
+    body: str = Field(
+        min_length=1,
+        description="Non-empty message body to deliver to the recipient mailbox. Required.",
+    )
+    requires_ack: bool = Field(
+        default=False,
+        description="Set true when the recipient must acknowledge the message; defaults to false.",
+    )
 
 
 class AtmReadRequest(_ToolRequest):
-    selection: Literal["actionable", "all", "unread", "pending_ack"] = "actionable"
-    message_id: str | None = None
-    task: str | None = None
-    contains: str | None = None
-    since: str | None = None
-    from_agent: str | None = None
+    selection: Literal["actionable", "all", "unread", "pending_ack"] = Field(
+        default="actionable",
+        description=(
+            "Mailbox bucket to search: 'actionable' (default, unread or awaiting your "
+            "acknowledgement), 'all' (every visible message), 'unread' (not yet read), or "
+            "'pending_ack' (messages that require your acknowledgement)."
+        ),
+    )
+    message_id: str | None = Field(
+        default=None,
+        description="Exact ATM message identifier to read; omit to let the selection and filters choose a message.",
+    )
+    task: str | None = Field(
+        default=None,
+        description="Exact task identifier filter; omit to include messages from every task.",
+    )
+    contains: str | None = Field(
+        default=None,
+        description="Case-insensitive text filter for message content; omit for no text filter.",
+    )
+    since: str | None = Field(
+        default=None,
+        description="Inclusive ISO-8601 timestamp filter; omit to include messages of every age.",
+    )
+    from_agent: str | None = Field(
+        default=None,
+        description="Sender identity or agent@team filter; omit to include every sender.",
+    )
 
 
 class AtmListRequest(_ToolRequest):
-    selection: Literal["actionable", "all", "unread", "pending_ack"] = "actionable"
-    limit: int | None = Field(default=None, ge=1, le=10_000)
-    task: str | None = None
-    contains: str | None = None
-    since: str | None = None
-    from_agent: str | None = None
+    selection: Literal["actionable", "all", "unread", "pending_ack"] = Field(
+        default="actionable",
+        description=(
+            "Mailbox bucket to list: 'actionable' (default, unread or awaiting your "
+            "acknowledgement), 'all' (every visible message), 'unread' (not yet read), or "
+            "'pending_ack' (messages that require your acknowledgement)."
+        ),
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        le=10_000,
+        description="Maximum number of metadata rows to return, from 1 through 10000; omit for the ATM default.",
+    )
+    task: str | None = Field(
+        default=None,
+        description="Exact task identifier filter; omit to include rows from every task.",
+    )
+    contains: str | None = Field(
+        default=None,
+        description="Case-insensitive text filter for message content; omit for no text filter.",
+    )
+    since: str | None = Field(
+        default=None,
+        description="Inclusive ISO-8601 timestamp filter; omit to include rows of every age.",
+    )
+    from_agent: str | None = Field(
+        default=None,
+        description="Sender identity or agent@team filter; omit to include every sender.",
+    )

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["atm-graft>=1.4,<1.5", "PyYAML>=6"]
+dependencies = ["atm-graft>=1.4,<1.5"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "0.1.3"
+version = "0.1.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["atm-graft>=1.4,<1.5"]
+dependencies = ["atm-graft>=1.4,<1.5", "PyYAML>=6"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -10,6 +10,8 @@ import plistlib
 import sys
 from typing import Any, Mapping, Sequence
 
+import yaml
+
 
 HOOK_NAME = "hermes-atm"
 HOOK_MANIFEST = """name: hermes-atm
@@ -54,6 +56,7 @@ TOOLS_PLUGIN_NAME = "hermes-atm-native-tools"
 TOOLS_PLUGIN_MANIFEST = """name: hermes-atm-native-tools
 version: 1
 description: Native ATM mailbox tools backed by the typed atm-graft client.
+hermes_version: ">=0.20"
 kind: backend
 provides_tools:
   - atm_send
@@ -163,6 +166,50 @@ def _write_text_if_changed(path: Path, content: str) -> bool:
     return True
 
 
+def _enable_native_tools_plugin(profile_home: Path) -> bool:
+    """Add the package-owned native-tools plugin to Hermes' opt-in allow-list.
+
+    Hermes discovers user plugins from ``<HERMES_HOME>/plugins`` but does not
+    load them until their path-derived key is in ``plugins.enabled``.  The
+    installer owns both the generated plugin and this declarative enablement,
+    so a normal install followed by a gateway reset is sufficient; operators
+    never need to edit the profile configuration by hand.
+    """
+
+    config_path = profile_home / "config.yaml"
+    try:
+        existing = (
+            yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            if config_path.exists()
+            else {}
+        )
+    except (OSError, yaml.YAMLError) as error:
+        raise HermesAtmInstallError(
+            f"cannot read Hermes profile config {config_path}: {error}"
+        ) from error
+    if existing is None:
+        existing = {}
+    if not isinstance(existing, dict):
+        raise HermesAtmInstallError(f"Hermes profile config {config_path} must be a mapping")
+
+    plugins = existing.setdefault("plugins", {})
+    if not isinstance(plugins, dict):
+        raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
+    enabled = plugins.setdefault("enabled", [])
+    if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
+        raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
+    if TOOLS_PLUGIN_NAME in enabled:
+        return False
+    enabled.append(TOOLS_PLUGIN_NAME)
+    try:
+        rendered = yaml.safe_dump(existing, sort_keys=False, allow_unicode=True)
+    except yaml.YAMLError as error:
+        raise HermesAtmInstallError(
+            f"cannot serialize Hermes profile config {config_path}: {error}"
+        ) from error
+    return _write_text_if_changed(config_path, rendered)
+
+
 def install_profile(
     *,
     profile_home: Path,
@@ -207,6 +254,7 @@ def install_profile(
             ),
         )
     )
+    changed = _enable_native_tools_plugin(profile_home) or changed
     return {
         "hook_dir": str(hook_dir),
         "plugin_dir": str(plugin_dir),

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -10,9 +10,6 @@ import plistlib
 import sys
 from typing import Any, Mapping, Sequence
 
-import yaml
-
-
 HOOK_NAME = "hermes-atm"
 HOOK_MANIFEST = """name: hermes-atm
 description: Deliver ATM graft nudges through the Hermes public gateway runner API.
@@ -176,38 +173,38 @@ def _enable_native_tools_plugin(profile_home: Path) -> bool:
     never need to edit the profile configuration by hand.
     """
 
-    config_path = profile_home / "config.yaml"
     try:
-        existing = (
-            yaml.safe_load(config_path.read_text(encoding="utf-8"))
-            if config_path.exists()
-            else {}
-        )
-    except (OSError, yaml.YAMLError) as error:
+        from hermes_cli.config import load_config, save_config
+    except ImportError as error:
         raise HermesAtmInstallError(
-            f"cannot read Hermes profile config {config_path}: {error}"
+            "the active interpreter cannot import Hermes public config APIs"
         ) from error
-    if existing is None:
-        existing = {}
-    if not isinstance(existing, dict):
-        raise HermesAtmInstallError(f"Hermes profile config {config_path} must be a mapping")
 
-    plugins = existing.setdefault("plugins", {})
-    if not isinstance(plugins, dict):
-        raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
-    enabled = plugins.setdefault("enabled", [])
-    if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
-        raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
-    if TOOLS_PLUGIN_NAME in enabled:
-        return False
-    enabled.append(TOOLS_PLUGIN_NAME)
+    # Hermes' config API deliberately derives the active profile from
+    # HERMES_HOME.  Scope the override to this synchronous installer call so
+    # the caller's process environment is restored even when validation fails.
+    previous_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(profile_home)
     try:
-        rendered = yaml.safe_dump(existing, sort_keys=False, allow_unicode=True)
-    except yaml.YAMLError as error:
-        raise HermesAtmInstallError(
-            f"cannot serialize Hermes profile config {config_path}: {error}"
-        ) from error
-    return _write_text_if_changed(config_path, rendered)
+        config = load_config()
+        if not isinstance(config, dict):
+            raise HermesAtmInstallError("Hermes profile config must be a mapping")
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
+        enabled = plugins.setdefault("enabled", [])
+        if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
+            raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
+        if TOOLS_PLUGIN_NAME in enabled:
+            return False
+        enabled.append(TOOLS_PLUGIN_NAME)
+        save_config(config, merge_existing=True)
+        return True
+    finally:
+        if previous_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = previous_home
 
 
 def install_profile(

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -207,9 +207,21 @@ def register_tools(context: Any, *, identity: str, team: str, chat_id: str) -> N
 
     tools = AtmNativeTools(identity=identity, team=team, chat_id=chat_id)
     for name, handler, description in (
-        ("atm_send", tools.atm_send, "Send an ATM mailbox message."),
-        ("atm_read", tools.atm_read, "Read one ATM mailbox message without mutating it."),
-        ("atm_list", tools.atm_list, "List ATM mailbox metadata without mutating it."),
+        (
+            "atm_send",
+            tools.atm_send,
+            "Send one ordinary ATM mailbox message; use the ATM CLI for administrative or advanced operations.",
+        ),
+        (
+            "atm_read",
+            tools.atm_read,
+            "Read one ATM mailbox message without mutating it; use the ATM CLI for administrative or advanced operations.",
+        ),
+        (
+            "atm_list",
+            tools.atm_list,
+            "List ATM mailbox metadata without mutating it; use the ATM CLI for administrative or advanced operations.",
+        ),
     ):
         context.register_tool(
             name=name,

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -28,6 +28,19 @@ def _error(*, code: str, message: str, recovery: str, layer: str) -> ToolEnvelop
     }
 
 
+def _render_for_hermes(envelope: ToolEnvelope) -> str:
+    """Serialize the typed ATM union at Hermes' string-only tool boundary.
+
+    Hermes' public ``PluginContext.register_tool`` accepts structured JSON
+    schemas, but its normal tool execution pipeline accepts string results
+    (the only structured exception is Hermes' own multimodal envelope).  Keep
+    the discriminator and detailed error payload intact as JSON text instead
+    of leaking a Python ``dict`` into that host boundary.
+    """
+
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":"))
+
+
 def _validate(model: type[Any], arguments: Mapping[str, Any]) -> Any | ToolEnvelope:
     try:
         return model.model_validate(dict(arguments))
@@ -131,45 +144,51 @@ class AtmNativeTools:
             atm_graft.PyAgentAddress(identity, team, chat_id)
         )
 
-    def atm_send(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_send(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmSendRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
-            _send_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
+                _send_result,
+            )
         )
 
-    def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmReadRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.read_tool(
-                request.selection,
-                request.message_id,
-                request.task,
-                request.contains,
-                request.since,
-                request.from_agent,
-            ),
-            _read_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.read_tool(
+                    request.selection,
+                    request.message_id,
+                    request.task,
+                    request.contains,
+                    request.since,
+                    request.from_agent,
+                ),
+                _read_result,
+            )
         )
 
-    def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmListRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.list_tool(
-                request.selection,
-                request.limit,
-                request.task,
-                request.contains,
-                request.since,
-                request.from_agent,
-            ),
-            _list_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.list_tool(
+                    request.selection,
+                    request.limit,
+                    request.task,
+                    request.contains,
+                    request.since,
+                    request.from_agent,
+                ),
+                _list_result,
+            )
         )
 
 

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -149,6 +149,9 @@ class InstallerTests(unittest.TestCase):
                 json.loads((plugin / "config.json").read_text(encoding="utf-8")),
                 json.loads((hook / "config.json").read_text(encoding="utf-8")),
             )
+            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
+            self.assertIn("hermes-atm-native-tools", profile_config)
+            self.assertIn("enabled:", profile_config)
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
@@ -160,6 +163,28 @@ class InstallerTests(unittest.TestCase):
                     workspace_root="/tmp/workspace",
                 )["changed"]
             )
+
+    def test_install_preserves_existing_plugin_allowlist_and_enables_native_tools(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules():
+            profile_home = Path(temporary) / "profile"
+            profile_home.mkdir(parents=True)
+            (profile_home / "config.yaml").write_text(
+                "plugins:\n  enabled:\n    - another-plugin\nother: value\n",
+                encoding="utf-8",
+            )
+            install_profile(
+                profile_home=profile_home,
+                profile="skillrx",
+                identity="skillrx",
+                team="hermes",
+                chat_id="100000001",
+                atm_home="/tmp/atm",
+                workspace_root="/tmp/workspace",
+            )
+            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
+            self.assertIn("- another-plugin", profile_config)
+            self.assertIn("- hermes-atm-native-tools", profile_config)
+            self.assertIn("other: value", profile_config)
 
     def test_install_rejects_a_launch_agent_for_another_interpreter(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import redirect_stdout
 from io import StringIO
 import json
+import os
 from pathlib import Path
 import plistlib
 import runpy
@@ -61,6 +62,7 @@ class GatewayModules:
         self.original_config = sys.modules.get("gateway.config")
         self.original_run = sys.modules.get("gateway.run")
         self.original_hermes_cli = sys.modules.get("hermes_cli")
+        self.original_hermes_config = sys.modules.get("hermes_cli.config")
         self.original_plugins = sys.modules.get("hermes_cli.plugins")
 
         class Platform:
@@ -78,19 +80,34 @@ class GatewayModules:
         config.Platform = Platform
         run.GatewayRunner = GatewayRunner
         hermes_cli = types.ModuleType("hermes_cli")
+        hermes_config = types.ModuleType("hermes_cli.config")
         plugins = types.ModuleType("hermes_cli.plugins")
+
+        def load_config():
+            config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+            return json.loads(config_path.read_text()) if config_path.exists() else {}
+
+        def save_config(config, *, merge_existing=False):
+            del merge_existing
+            config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
 
         class PluginContext:
             def register_tool(self, **_kwargs):
                 return None
 
         plugins.PluginContext = PluginContext
+        hermes_config.load_config = load_config
+        hermes_config.save_config = save_config
         hermes_cli.plugins = plugins
+        hermes_cli.config = hermes_config
         gateway.config = config
         sys.modules["gateway"] = gateway
         sys.modules["gateway.config"] = config
         sys.modules["gateway.run"] = run
         sys.modules["hermes_cli"] = hermes_cli
+        sys.modules["hermes_cli.config"] = hermes_config
         sys.modules["hermes_cli.plugins"] = plugins
         self.runner = GatewayRunner()
         return self
@@ -101,6 +118,7 @@ class GatewayModules:
             ("gateway.config", self.original_config),
             ("gateway.run", self.original_run),
             ("hermes_cli", self.original_hermes_cli),
+            ("hermes_cli.config", self.original_hermes_config),
             ("hermes_cli.plugins", self.original_plugins),
         ):
             if value is None:
@@ -149,9 +167,8 @@ class InstallerTests(unittest.TestCase):
                 json.loads((plugin / "config.json").read_text(encoding="utf-8")),
                 json.loads((hook / "config.json").read_text(encoding="utf-8")),
             )
-            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
-            self.assertIn("hermes-atm-native-tools", profile_config)
-            self.assertIn("enabled:", profile_config)
+            profile_config = json.loads((profile_home / "config.yaml").read_text())
+            self.assertEqual(profile_config["plugins"]["enabled"], ["hermes-atm-native-tools"])
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
@@ -169,7 +186,7 @@ class InstallerTests(unittest.TestCase):
             profile_home = Path(temporary) / "profile"
             profile_home.mkdir(parents=True)
             (profile_home / "config.yaml").write_text(
-                "plugins:\n  enabled:\n    - another-plugin\nother: value\n",
+                json.dumps({"plugins": {"enabled": ["another-plugin"]}, "other": "value"}),
                 encoding="utf-8",
             )
             install_profile(
@@ -181,10 +198,12 @@ class InstallerTests(unittest.TestCase):
                 atm_home="/tmp/atm",
                 workspace_root="/tmp/workspace",
             )
-            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
-            self.assertIn("- another-plugin", profile_config)
-            self.assertIn("- hermes-atm-native-tools", profile_config)
-            self.assertIn("other: value", profile_config)
+            profile_config = json.loads((profile_home / "config.yaml").read_text())
+            self.assertEqual(
+                profile_config["plugins"]["enabled"],
+                ["another-plugin", "hermes-atm-native-tools"],
+            )
+            self.assertEqual(profile_config["other"], "value")
 
     def test_install_rejects_a_launch_agent_for_another_interpreter(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import types
 import unittest
@@ -86,12 +87,14 @@ class NativeToolsTests(unittest.TestCase):
     def test_send_validates_before_the_native_client_and_preserves_requires_ack(self):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         recipient = "native-tool-recipient@hermes"
-        result = tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
+        result = json.loads(
+            tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
+        )
         self.assertEqual(result["kind"], "success")
         self.assertEqual(result["result"]["message_id"], "test")
         self.assertEqual(self.session.calls, [(recipient, "hello", True)])
 
-        rejected = tools.atm_send({"to": recipient, "body": "hello", "unexpected": 1})
+        rejected = json.loads(tools.atm_send({"to": recipient, "body": "hello", "unexpected": 1}))
         self.assertEqual(rejected["kind"], "error")
         self.assertEqual(rejected["error"]["layer"], "ingress_validation")
         self.assertEqual(len(self.session.calls), 1)
@@ -100,7 +103,9 @@ class NativeToolsTests(unittest.TestCase):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         self.session.send_tool = lambda *_args: _TypedToolError()
 
-        result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+        result = json.loads(
+            tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+        )
 
         self.assertEqual(
             result,
@@ -125,6 +130,10 @@ class NativeToolsTests(unittest.TestCase):
         native_tools.register_tools(Context(), identity="skillrx", team="hermes", chat_id="local")
         self.assertEqual([call["name"] for call in calls], ["atm_send", "atm_read", "atm_list"])
         self.assertTrue(all(call["toolset"] == "atm" for call in calls))
+        for call in calls:
+            outcome = call["handler"]({})
+            self.assertIsInstance(outcome, str)
+            self.assertEqual(json.loads(outcome)["kind"], "error")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Enables the generated native tools plugin for hermes-atm's installer, following on from the native tool-call work merged in PR #848.

Commit: 1bff21f6

## Note before merge
This branch forked before two small TTL bookkeeping fixes landed on `integrate/phase-am` (65570a47, and an unpushed deferral edit to AM-DESIGN-ACK-CONSOLIDATION-001) — the diff currently shows those getting reverted as unrelated noise. **Merge `integrate/phase-am` forward into this branch before sending to QA** so the diff is clean.

## Test plan
- [ ] Merge integrate/phase-am forward
- [ ] quality-mgr QA pass