### PR TITLE
fix(graft): recover native tools after daemon restart

### DIFF
--- a/.just/tests/test_atm_graft_python_models.py
+++ b/.just/tests/test_atm_graft_python_models.py
@@ -45,6 +45,42 @@ class AtmGraftPythonModelTests(unittest.TestCase):
             with self.assertRaises(Exception):
                 model.model_validate({"acknowledge": "01TEST"})
 
+    def test_tool_schema_describes_every_model_field(self):
+        models = load_models()
+        expected = {
+            models.AtmSendRequest: {"to", "body", "requires_ack"},
+            models.AtmReadRequest: {
+                "selection",
+                "message_id",
+                "task",
+                "contains",
+                "since",
+                "from_agent",
+            },
+            models.AtmListRequest: {
+                "selection",
+                "limit",
+                "task",
+                "contains",
+                "since",
+                "from_agent",
+            },
+        }
+        for model, fields in expected.items():
+            properties = model.model_json_schema()["properties"]
+            self.assertEqual(set(properties), fields)
+            for name in fields:
+                self.assertTrue(properties[name].get("description"), name)
+
+        send = models.AtmSendRequest.model_json_schema()["properties"]
+        self.assertIn("bare identity", send["to"]["description"])
+        self.assertIn("reviewer@release", send["to"]["description"])
+        self.assertIn("defaults to false", send["requires_ack"]["description"])
+        for model in (models.AtmReadRequest, models.AtmListRequest):
+            selection = model.model_json_schema()["properties"]["selection"]["description"]
+            for value in ("actionable", "all", "unread", "pending_ack"):
+                self.assertIn(value, selection)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_atm_graft_python_models.py
+++ b/.just/tests/test_atm_graft_python_models.py
@@ -37,6 +37,28 @@ class AtmGraftPythonModelTests(unittest.TestCase):
                 {"to": "team-lead@atm-dev", "body": "hello", "identity": "override"}
             )
 
+    def test_send_acknowledgement_shape_omits_destination_and_disallows_nested_ack(self):
+        models = load_models()
+        acknowledgement = models.AtmSendRequest.model_validate(
+            {"body": "received", "acknowledges_message_id": "01KZSV6V4JDE569ENXJD8KZ0RC"}
+        )
+        self.assertIsNone(acknowledgement.to)
+        self.assertFalse(acknowledgement.requires_ack)
+        for invalid in (
+            {
+                "to": "team-lead@atm-dev",
+                "body": "received",
+                "acknowledges_message_id": "01KZSV6V4JDE569ENXJD8KZ0RC",
+            },
+            {
+                "body": "received",
+                "requires_ack": True,
+                "acknowledges_message_id": "01KZSV6V4JDE569ENXJD8KZ0RC",
+            },
+        ):
+            with self.assertRaises(Exception):
+                models.AtmSendRequest.model_validate(invalid)
+
     def test_read_and_list_reject_mutating_arguments(self):
         models = load_models()
         for model in (models.AtmReadRequest, models.AtmListRequest):
@@ -48,7 +70,7 @@ class AtmGraftPythonModelTests(unittest.TestCase):
     def test_tool_schema_describes_every_model_field(self):
         models = load_models()
         expected = {
-            models.AtmSendRequest: {"to", "body", "requires_ack"},
+            models.AtmSendRequest: {"to", "body", "requires_ack", "acknowledges_message_id"},
             models.AtmReadRequest: {
                 "selection",
                 "message_id",
@@ -76,6 +98,7 @@ class AtmGraftPythonModelTests(unittest.TestCase):
         self.assertIn("bare identity", send["to"]["description"])
         self.assertIn("reviewer@release", send["to"]["description"])
         self.assertIn("defaults to false", send["requires_ack"]["description"])
+        self.assertIn("Acknowledge", send["acknowledges_message_id"]["description"])
         for model in (models.AtmReadRequest, models.AtmListRequest):
             selection = model.model_json_schema()["properties"]["selection"]["description"]
             for value in ("actionable", "all", "unread", "pending_ack"):

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2119,6 +2119,7 @@ fn phase_am_cli_and_graft_nonwrite_requests_use_the_http_client_boundary() {
     let graft_client = graft
         .split("pub struct GraftClient")
         .nth(1)
+        .and_then(|source| source.split("pub struct GraftSession").next())
         .expect("graft client source");
 
     let consumers: [(&str, &str, &[&str]); 2] = [
@@ -2141,7 +2142,6 @@ fn phase_am_cli_and_graft_nonwrite_requests_use_the_http_client_boundary() {
                 "async fn execute_request",
                 "async fn read_message",
                 "pub async fn mailbox_work_counts",
-                "pub async fn read",
             ],
         ),
     ];

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -170,6 +170,19 @@ impl WriteRequest {
         self
     }
 
+    /// Select the canonical acknowledgement write shape.
+    ///
+    /// Acknowledgements have no caller-supplied destination and can never ask
+    /// for another acknowledgement. They otherwise continue through the same
+    /// write pipeline as ordinary sends.
+    #[must_use]
+    pub fn with_acknowledges_message_id(mut self, message_id: AtmMessageId) -> Self {
+        self.to = None;
+        self.requires_ack = false;
+        self.acknowledges_message_id = Some(message_id);
+        self
+    }
+
     #[must_use]
     pub fn with_origin_metadata(
         mut self,

--- a/crates/atm-graft-python/python/atm_graft/models.py
+++ b/crates/atm-graft-python/python/atm_graft/models.py
@@ -17,7 +17,11 @@ class AtmSendRequest(_ToolRequest):
     to: str | None = Field(
         default=None,
         min_length=1,
-        description="Destination as agent@team for an ordinary message. Omit it when acknowledging a message.",
+        description=(
+            "Recipient ATM address for an ordinary message. Use a bare identity for an agent "
+            "on your current team (for example, 'reviewer') or agent@team for another team "
+            "(for example, 'reviewer@release'). Omit it when acknowledging a message."
+        ),
     )
     body: str = Field(
         min_length=1,
@@ -25,7 +29,7 @@ class AtmSendRequest(_ToolRequest):
     )
     requires_ack: bool = Field(
         default=False,
-        description="Request an acknowledgement for an ordinary outbound message.",
+        description="Set true when an ordinary recipient must acknowledge the message; defaults to false.",
     )
     acknowledges_message_id: str | None = Field(
         default=None,

--- a/crates/atm-graft-python/python/atm_graft/models.py
+++ b/crates/atm-graft-python/python/atm_graft/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class _ToolRequest(BaseModel):
@@ -14,22 +14,38 @@ class _ToolRequest(BaseModel):
 
 
 class AtmSendRequest(_ToolRequest):
-    to: str = Field(
+    to: str | None = Field(
+        default=None,
         min_length=1,
-        description=(
-            "Recipient ATM address. Use a bare identity for an agent on your current team "
-            "(for example, 'reviewer') or agent@team for another team "
-            "(for example, 'reviewer@release'). Required."
-        ),
+        description="Destination as agent@team for an ordinary message. Omit it when acknowledging a message.",
     )
     body: str = Field(
         min_length=1,
-        description="Non-empty message body to deliver to the recipient mailbox. Required.",
+        description="Message body, or the acknowledgement reply text when acknowledges_message_id is set.",
     )
     requires_ack: bool = Field(
         default=False,
-        description="Set true when the recipient must acknowledge the message; defaults to false.",
+        description="Request an acknowledgement for an ordinary outbound message.",
     )
+    acknowledges_message_id: str | None = Field(
+        default=None,
+        description=(
+            "Acknowledge this pending-ack message instead of sending a new message. "
+            "When set, omit to and keep requires_ack false."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_write_shape(self) -> "AtmSendRequest":
+        if self.acknowledges_message_id is None:
+            if self.to is None:
+                raise ValueError("to is required for an ordinary message")
+            return self
+        if self.to is not None:
+            raise ValueError("to must be omitted when acknowledging a message")
+        if self.requires_ack:
+            raise ValueError("requires_ack must be false when acknowledging a message")
+        return self
 
 
 class AtmReadRequest(_ToolRequest):

--- a/crates/atm-graft-python/python/atm_graft/models.py
+++ b/crates/atm-graft-python/python/atm_graft/models.py
@@ -14,24 +14,83 @@ class _ToolRequest(BaseModel):
 
 
 class AtmSendRequest(_ToolRequest):
-    to: str = Field(min_length=1)
-    body: str = Field(min_length=1)
-    requires_ack: bool = False
+    to: str = Field(
+        min_length=1,
+        description=(
+            "Recipient ATM address. Use a bare identity for an agent on your current team "
+            "(for example, 'reviewer') or agent@team for another team "
+            "(for example, 'reviewer@release'). Required."
+        ),
+    )
+    body: str = Field(
+        min_length=1,
+        description="Non-empty message body to deliver to the recipient mailbox. Required.",
+    )
+    requires_ack: bool = Field(
+        default=False,
+        description="Set true when the recipient must acknowledge the message; defaults to false.",
+    )
 
 
 class AtmReadRequest(_ToolRequest):
-    selection: Literal["actionable", "all", "unread", "pending_ack"] = "actionable"
-    message_id: str | None = None
-    task: str | None = None
-    contains: str | None = None
-    since: str | None = None
-    from_agent: str | None = None
+    selection: Literal["actionable", "all", "unread", "pending_ack"] = Field(
+        default="actionable",
+        description=(
+            "Mailbox bucket to search: 'actionable' (default, unread or awaiting your "
+            "acknowledgement), 'all' (every visible message), 'unread' (not yet read), or "
+            "'pending_ack' (messages that require your acknowledgement)."
+        ),
+    )
+    message_id: str | None = Field(
+        default=None,
+        description="Exact ATM message identifier to read; omit to let the selection and filters choose a message.",
+    )
+    task: str | None = Field(
+        default=None,
+        description="Exact task identifier filter; omit to include messages from every task.",
+    )
+    contains: str | None = Field(
+        default=None,
+        description="Case-insensitive text filter for message content; omit for no text filter.",
+    )
+    since: str | None = Field(
+        default=None,
+        description="Inclusive ISO-8601 timestamp filter; omit to include messages of every age.",
+    )
+    from_agent: str | None = Field(
+        default=None,
+        description="Sender identity or agent@team filter; omit to include every sender.",
+    )
 
 
 class AtmListRequest(_ToolRequest):
-    selection: Literal["actionable", "all", "unread", "pending_ack"] = "actionable"
-    limit: int | None = Field(default=None, ge=1, le=10_000)
-    task: str | None = None
-    contains: str | None = None
-    since: str | None = None
-    from_agent: str | None = None
+    selection: Literal["actionable", "all", "unread", "pending_ack"] = Field(
+        default="actionable",
+        description=(
+            "Mailbox bucket to list: 'actionable' (default, unread or awaiting your "
+            "acknowledgement), 'all' (every visible message), 'unread' (not yet read), or "
+            "'pending_ack' (messages that require your acknowledgement)."
+        ),
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        le=10_000,
+        description="Maximum number of metadata rows to return, from 1 through 10000; omit for the ATM default.",
+    )
+    task: str | None = Field(
+        default=None,
+        description="Exact task identifier filter; omit to include rows from every task.",
+    )
+    contains: str | None = Field(
+        default=None,
+        description="Case-insensitive text filter for message content; omit for no text filter.",
+    )
+    since: str | None = Field(
+        default=None,
+        description="Inclusive ISO-8601 timestamp filter; omit to include rows of every age.",
+    )
+    from_agent: str | None = Field(
+        default=None,
+        description="Sender identity or agent@team filter; omit to include every sender.",
+    )

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -16,13 +16,17 @@ use atm_core::caller_context::activity_observation_for_resolved_caller;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::graft::AtmGraftClient;
 use atm_core::home::{atm_home, command_invocation_dir};
-use atm_core::list::{ListOutcome, ListQuery};
+use atm_core::list::ListQuery;
 use atm_core::read::{ReadOutcome, ReadQuery};
 use atm_core::schema::AtmMessageId;
-use atm_core::send::{SendMessageSource, SendRequest, WriteOutcome};
+use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TeamName};
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+
+mod tool_types;
+
+pub use tool_types::{AtmListResult, AtmListRow, AtmReadResult, AtmSendResult, AtmToolError};
 
 fn python_extension_runtime() -> PyResult<&'static Mutex<tokio::runtime::Runtime>> {
     static RUNTIME: OnceLock<Mutex<tokio::runtime::Runtime>> = OnceLock::new();
@@ -184,166 +188,6 @@ pub struct PyMessage {
     source: PyAgentAddress,
     #[pyo3(get)]
     body: String,
-}
-
-/// Typed, JSON-compatible projection of the canonical send outcome.
-#[pyclass(skip_from_py_object)]
-#[derive(Clone, Debug)]
-pub struct AtmSendResult {
-    #[pyo3(get)]
-    message_id: String,
-    #[pyo3(get)]
-    requires_ack: bool,
-    #[pyo3(get)]
-    outcome: String,
-}
-
-impl From<WriteOutcome> for AtmSendResult {
-    fn from(outcome: WriteOutcome) -> Self {
-        match outcome {
-            WriteOutcome::Sent(outcome) => Self {
-                message_id: outcome.message_id.to_string(),
-                requires_ack: outcome.requires_ack,
-                outcome: outcome.outcome.as_str().to_owned(),
-            },
-            WriteOutcome::Acknowledged(outcome) => Self {
-                message_id: match outcome.reply_disposition {
-                    atm_core::ack::AckReplyDisposition::Sent {
-                        reply_message_id, ..
-                    } => reply_message_id.to_string(),
-                },
-                requires_ack: false,
-                outcome: "acknowledged".to_owned(),
-            },
-        }
-    }
-}
-
-/// Typed, read-only projection of the canonical mailbox read outcome.
-#[pyclass(skip_from_py_object)]
-#[derive(Clone, Debug)]
-pub struct AtmReadResult {
-    #[pyo3(get)]
-    count: usize,
-    #[pyo3(get)]
-    match_count: usize,
-    #[pyo3(get)]
-    additional_match_count: usize,
-    #[pyo3(get)]
-    mutation_applied: bool,
-    #[pyo3(get)]
-    message: Option<PyMessage>,
-}
-
-impl AtmReadResult {
-    fn from_outcome(outcome: ReadOutcome) -> PyResult<Self> {
-        let count = outcome.count;
-        let match_count = outcome.match_count;
-        let additional_match_count = outcome.additional_match_count;
-        let mutation_applied = outcome.mutation_applied;
-        let message = PyMessage::from_read(outcome)?.into_iter().next();
-        Ok(Self {
-            count,
-            match_count,
-            additional_match_count,
-            mutation_applied,
-            message,
-        })
-    }
-}
-
-/// One typed row in a bounded native mailbox list result.
-#[pyclass(skip_from_py_object)]
-#[derive(Clone, Debug)]
-pub struct AtmListRow {
-    #[pyo3(get)]
-    message_id: Option<String>,
-    #[pyo3(get)]
-    summary: String,
-    #[pyo3(get)]
-    from_agent: String,
-    #[pyo3(get)]
-    timestamp: String,
-    #[pyo3(get)]
-    read: bool,
-    #[pyo3(get)]
-    pending_ack: bool,
-    #[pyo3(get)]
-    task_id: Option<String>,
-}
-
-impl From<atm_core::list::ListRow> for AtmListRow {
-    fn from(row: atm_core::list::ListRow) -> Self {
-        Self {
-            message_id: row.message_id.map(|id| id.to_string()),
-            summary: row.summary,
-            from_agent: row.from.to_string(),
-            timestamp: row.timestamp.to_string(),
-            read: row.read,
-            pending_ack: row.pending_ack,
-            task_id: row.task_id.map(|id| id.to_string()),
-        }
-    }
-}
-
-/// Typed, bounded projection of the canonical mailbox list outcome.
-#[pyclass(skip_from_py_object)]
-#[derive(Clone, Debug)]
-pub struct AtmListResult {
-    #[pyo3(get)]
-    count: usize,
-    #[pyo3(get)]
-    rows: Vec<AtmListRow>,
-}
-
-impl From<ListOutcome> for AtmListResult {
-    fn from(outcome: ListOutcome) -> Self {
-        Self {
-            count: outcome.count,
-            rows: outcome.rows.into_iter().map(AtmListRow::from).collect(),
-        }
-    }
-}
-
-/// Structured native-tool error data used by Python adapters' failure envelope.
-#[pyclass(skip_from_py_object)]
-#[derive(Clone, Debug)]
-pub struct AtmToolError {
-    #[pyo3(get)]
-    code: String,
-    #[pyo3(get)]
-    message: String,
-    #[pyo3(get)]
-    recovery: String,
-    #[pyo3(get)]
-    layer: String,
-}
-
-impl AtmToolError {
-    fn from_native_error(py: Python<'_>, error: &PyErr) -> Self {
-        let value = error.value(py);
-        let attribute = |name: &str| {
-            value
-                .getattr(name)
-                .ok()
-                .and_then(|attribute| attribute.extract::<String>().ok())
-        };
-        Self {
-            code: attribute("code").unwrap_or_else(|| "ATM_NATIVE_OPERATION_FAILED".to_owned()),
-            message: attribute("message").unwrap_or_else(|| error.to_string()),
-            recovery: "verify the local ATM daemon and configured identity, then retry".to_owned(),
-            layer: "native_client".to_owned(),
-        }
-    }
-
-    fn is_daemon_unavailable(&self) -> bool {
-        self.code == AtmErrorCode::DaemonUnavailable.as_str()
-    }
-
-    fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
-        self.recovery = recovery.into();
-        self
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -534,6 +378,8 @@ pub struct PyGraftSession {
     reconnect_replacement: Mutex<Option<GraftClient>>,
     #[cfg(test)]
     reconnect_attempts: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    reconnect_fallback_attempts: std::sync::atomic::AtomicUsize,
 }
 
 impl PyGraftSession {
@@ -567,7 +413,12 @@ impl PyGraftSession {
                 .lock()
                 .map_err(|_| PyRuntimeError::new_err("ATM graft reconnect lock poisoned"))?
                 .clone()
-                .unwrap_or(GraftClient::connect_existing().map_err(atm_error)?)
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    self.reconnect_fallback_attempts
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    GraftClient::connect_existing().map_err(atm_error)
+                })?
         };
         #[cfg(not(test))]
         let replacement = GraftClient::connect_existing().map_err(atm_error)?;
@@ -711,6 +562,11 @@ impl PyGraftSession {
         requires_ack: bool,
         acknowledges_message_id: Option<String>,
     ) -> PyResult<AtmSendResult> {
+        if to.is_none() && acknowledges_message_id.is_none() {
+            return Err(PyValueError::new_err(
+                "ATM send requires either a destination or acknowledges_message_id",
+            ));
+        }
         let (home_dir, current_dir) = Self::command_paths()?;
         let caller_team = self.caller_team()?;
         let acknowledgement = acknowledges_message_id
@@ -864,6 +720,8 @@ impl PyGraftSession {
             reconnect_replacement: Mutex::new(None),
             #[cfg(test)]
             reconnect_attempts: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            reconnect_fallback_attempts: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -1192,7 +1050,58 @@ mod tests {
                 replacement,
             ))),
             reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
         }
+    }
+
+    #[test]
+    fn configured_fake_reconnect_does_not_open_the_live_client() {
+        let initial = Arc::new(FakeClientTransport::new(Box::new(|_| {
+            panic!("reconnect must not use the initial transport")
+        })));
+        let replacement = Arc::new(FakeClientTransport::new(Box::new(|_| {
+            panic!("reconnect must not invoke the replacement transport")
+        })));
+        let session = test_session(initial, replacement);
+
+        session
+            .reconnect_client()
+            .expect("configured fake replacement reconnects");
+
+        assert_eq!(session.reconnect_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            session.reconnect_fallback_attempts.load(Ordering::SeqCst),
+            0,
+            "a configured fake must prevent any eager live-client connection"
+        );
+    }
+
+    #[test]
+    fn ffi_send_rejects_missing_destination_and_acknowledgement() {
+        Python::initialize();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_transport = Arc::clone(&calls);
+        let session = test_session(
+            Arc::new(FakeClientTransport::new(Box::new(move |_| {
+                calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                panic!("invalid FFI input must not reach the daemon client")
+            }))),
+            Arc::new(FakeClientTransport::new(Box::new(|_| {
+                panic!("invalid FFI input must not reconnect")
+            }))),
+        );
+
+        let error = session
+            .send_outcome(None, "missing destination".to_owned(), false, None)
+            .expect_err("FFI send must reject an operation without destination or acknowledgement");
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires either a destination or acknowledges_message_id")
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(session.reconnect_attempts.load(Ordering::SeqCst), 0);
     }
 
     fn host_nudge(event: PostSendHookEvent) -> HostNudge {
@@ -1304,6 +1213,7 @@ mod tests {
             receiver: Mutex::new(None),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
         };
 
         let error = session
@@ -1494,6 +1404,7 @@ mod tests {
             receiver: Mutex::new(None),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
         };
 
         Python::attach(|py| {
@@ -1762,6 +1673,7 @@ mod tests {
             receiver: Mutex::new(None),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
         };
         let recipient =
             PyAgentAddress::new(TEST_RECIPIENT.to_string(), TEST_TEAM.to_string(), None)
@@ -1820,6 +1732,7 @@ mod tests {
             receiver: Mutex::new(None),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
         };
         let options = PyGraftSessionOptions {
             workspace_root: tempdir.path().display().to_string(),

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -325,13 +325,30 @@ impl AtmToolError {
     }
 
     fn is_daemon_unavailable(&self) -> bool {
-        self.code == "ATM_DAEMON_UNAVAILABLE"
+        self.code == AtmErrorCode::DaemonUnavailable.as_str()
     }
 
     fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
         self.recovery = recovery.into();
         self
     }
+}
+
+#[derive(Clone, Copy)]
+enum DaemonRecoveryPolicy {
+    /// Refresh the client but do not replay a possibly accepted write.
+    RefreshOnly,
+    /// Refresh the client and replay one read-only request.
+    RetryOnce,
+}
+
+enum DaemonRecovery<T> {
+    Completed(T),
+    Failed {
+        error: PyErr,
+        refreshed: bool,
+        refresh_error: Option<PyErr>,
+    },
 }
 
 impl PyMessage {
@@ -501,6 +518,10 @@ pub struct PyGraftSession {
     // mutable lifecycle handles therefore need real synchronization.
     client: Mutex<Option<GraftClient>>,
     receiver: Mutex<Option<GraftSession>>,
+    #[cfg(test)]
+    reconnect_replacement: Mutex<Option<GraftClient>>,
+    #[cfg(test)]
+    reconnect_attempts: std::sync::atomic::AtomicUsize,
 }
 
 impl PyGraftSession {
@@ -526,6 +547,17 @@ impl PyGraftSession {
         // Re-resolve the one selected daemon endpoint.  A managed restart may
         // replace its Unix socket and invalidate a long-lived embedded host's
         // pooled transport; this never starts a competing daemon.
+        #[cfg(test)]
+        let replacement = {
+            self.reconnect_attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.reconnect_replacement
+                .lock()
+                .map_err(|_| PyRuntimeError::new_err("ATM graft reconnect lock poisoned"))?
+                .clone()
+                .unwrap_or(GraftClient::connect_existing().map_err(atm_error)?)
+        };
+        #[cfg(not(test))]
         let replacement = GraftClient::connect_existing().map_err(atm_error)?;
         let mut client = self
             .client
@@ -717,6 +749,77 @@ impl PyGraftSession {
             .map(AtmListResult::from)
             .map_err(atm_error)
     }
+
+    /// Execute one native operation and recover a stale local client exactly
+    /// once when the managed daemon has cycled.  Writes are never replayed;
+    /// read-only operations may retry once on the refreshed client.
+    fn with_daemon_recovery<T: Send>(
+        &self,
+        py: Python<'_>,
+        policy: DaemonRecoveryPolicy,
+        mut operation: impl FnMut() -> PyResult<T> + Send,
+    ) -> DaemonRecovery<T> {
+        let error = match py.detach(&mut operation) {
+            Ok(value) => return DaemonRecovery::Completed(value),
+            Err(error) => error,
+        };
+        if !AtmToolError::from_native_error(py, &error).is_daemon_unavailable() {
+            return DaemonRecovery::Failed {
+                error,
+                refreshed: false,
+                refresh_error: None,
+            };
+        }
+
+        match py.detach(|| self.reconnect_client()) {
+            Err(refresh_error) => DaemonRecovery::Failed {
+                error,
+                refreshed: false,
+                refresh_error: Some(refresh_error),
+            },
+            Ok(()) if matches!(policy, DaemonRecoveryPolicy::RefreshOnly) => {
+                DaemonRecovery::Failed {
+                    error,
+                    refreshed: true,
+                    refresh_error: None,
+                }
+            }
+            Ok(()) => match py.detach(&mut operation) {
+                Ok(value) => DaemonRecovery::Completed(value),
+                Err(error) => DaemonRecovery::Failed {
+                    error,
+                    refreshed: true,
+                    refresh_error: None,
+                },
+            },
+        }
+    }
+
+    fn tool_error_from_recovery<T>(
+        py: Python<'_>,
+        recovery: DaemonRecovery<T>,
+    ) -> Result<T, AtmToolError> {
+        match recovery {
+            DaemonRecovery::Completed(value) => Ok(value),
+            DaemonRecovery::Failed {
+                error,
+                refreshed: true,
+                refresh_error: None,
+            } => Err(AtmToolError::from_native_error(py, &error).with_recovery(
+                "the native ATM session was refreshed after a transient failure; retry this send once. The failed send was not replayed to avoid duplicate delivery",
+            )),
+            DaemonRecovery::Failed {
+                error,
+                refresh_error: Some(refresh_error),
+                ..
+            } => Err(AtmToolError::from_native_error(py, &error).with_recovery(format!(
+                "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
+            ))),
+            DaemonRecovery::Failed { error, .. } => {
+                Err(AtmToolError::from_native_error(py, &error))
+            }
+        }
+    }
 }
 
 #[pymethods]
@@ -729,6 +832,10 @@ impl PyGraftSession {
             // selected for this machine; it must never auto-start another one.
             client: Mutex::new(Some(GraftClient::connect_existing().map_err(atm_error)?)),
             receiver: Mutex::new(None),
+            #[cfg(test)]
+            reconnect_replacement: Mutex::new(None),
+            #[cfg(test)]
+            reconnect_attempts: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -743,12 +850,22 @@ impl PyGraftSession {
         let to = to.to_typed()?.to_string();
         // `detach` is PyO3 0.29's replacement for `allow_threads`: all
         // runtime blocking happens without holding the Python GIL.
-        py.detach(|| self.send_outcome(to, body, requires_ack))
+        match self.with_daemon_recovery(py, DaemonRecoveryPolicy::RefreshOnly, || {
+            self.send_outcome(to.clone(), body.clone(), requires_ack)
+        }) {
+            DaemonRecovery::Completed(outcome) => Ok(outcome),
+            DaemonRecovery::Failed { error, .. } => Err(error),
+        }
     }
 
     fn read(&self, py: Python<'_>) -> PyResult<Vec<PyMessage>> {
         let query = self.build_read_query(true)?;
-        let outcome = py.detach(|| self.read_outcome(query))?;
+        let outcome = match self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
+            self.read_outcome(query.clone())
+        }) {
+            DaemonRecovery::Completed(outcome) => outcome,
+            DaemonRecovery::Failed { error, .. } => return Err(error),
+        };
         outcome
             .message
             .map_or_else(|| Ok(Vec::new()), |message| Ok(vec![message]))
@@ -756,7 +873,13 @@ impl PyGraftSession {
 
     fn list(&self, py: Python<'_>) -> PyResult<usize> {
         let query = self.build_list_query("actionable", None, None, None, None, None)?;
-        py.detach(|| self.list_outcome(query).map(|outcome| outcome.count))
+        match self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
+            self.list_outcome(query.clone())
+                .map(|outcome| outcome.count)
+        }) {
+            DaemonRecovery::Completed(count) => Ok(count),
+            DaemonRecovery::Failed { error, .. } => Err(error),
+        }
     }
 
     /// Refresh the selected same-host client after a managed daemon cycle.
@@ -776,24 +899,14 @@ impl PyGraftSession {
         body: String,
         requires_ack: bool,
     ) -> PyResult<Py<PyAny>> {
-        match py.detach(|| self.send_outcome(to, body, requires_ack)) {
+        match Self::tool_error_from_recovery(
+            py,
+            self.with_daemon_recovery(py, DaemonRecoveryPolicy::RefreshOnly, || {
+                self.send_outcome(to.clone(), body.clone(), requires_ack)
+            }),
+        ) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => {
-                let tool_error = AtmToolError::from_native_error(py, &error);
-                let tool_error = if tool_error.is_daemon_unavailable() {
-                    match py.detach(|| self.reconnect_client()) {
-                        Ok(()) => tool_error.with_recovery(
-                            "the native ATM session was refreshed after a transient failure; retry this send once. The failed send was not replayed to avoid duplicate delivery",
-                        ),
-                        Err(refresh_error) => tool_error.with_recovery(format!(
-                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
-                        )),
-                    }
-                } else {
-                    tool_error
-                };
-                Ok(Py::new(py, tool_error)?.into_any())
-            }
+            Err(error) => Ok(Py::new(py, error)?.into_any()),
         }
     }
 
@@ -817,31 +930,14 @@ impl PyGraftSession {
             since.as_deref(),
             from_agent.as_deref(),
         )?;
-        match py.detach(|| self.read_outcome(query.clone())) {
+        match Self::tool_error_from_recovery(
+            py,
+            self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
+                self.read_outcome(query.clone())
+            }),
+        ) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => {
-                let tool_error = AtmToolError::from_native_error(py, &error);
-                if !tool_error.is_daemon_unavailable() {
-                    return Ok(Py::new(py, tool_error)?.into_any());
-                }
-                if let Err(refresh_error) = py.detach(|| self.reconnect_client()) {
-                    return Ok(Py::new(
-                        py,
-                        tool_error.with_recovery(format!(
-                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
-                        )),
-                    )?
-                    .into_any());
-                }
-                match py.detach(|| self.read_outcome(query)) {
-                    Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-                    Err(retry_error) => Ok(Py::new(
-                        py,
-                        AtmToolError::from_native_error(py, &retry_error),
-                    )?
-                    .into_any()),
-                }
-            }
+            Err(error) => Ok(Py::new(py, error)?.into_any()),
         }
     }
 
@@ -865,42 +961,29 @@ impl PyGraftSession {
             since.as_deref(),
             from_agent.as_deref(),
         )?;
-        match py.detach(|| self.list_outcome(query.clone())) {
+        match Self::tool_error_from_recovery(
+            py,
+            self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
+                self.list_outcome(query.clone())
+            }),
+        ) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => {
-                let tool_error = AtmToolError::from_native_error(py, &error);
-                if !tool_error.is_daemon_unavailable() {
-                    return Ok(Py::new(py, tool_error)?.into_any());
-                }
-                if let Err(refresh_error) = py.detach(|| self.reconnect_client()) {
-                    return Ok(Py::new(
-                        py,
-                        tool_error.with_recovery(format!(
-                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
-                        )),
-                    )?
-                    .into_any());
-                }
-                match py.detach(|| self.list_outcome(query)) {
-                    Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-                    Err(retry_error) => Ok(Py::new(
-                        py,
-                        AtmToolError::from_native_error(py, &retry_error),
-                    )?
-                    .into_any()),
-                }
-            }
+            Err(error) => Ok(Py::new(py, error)?.into_any()),
         }
     }
 
     fn mailbox_work_counts(&self, py: Python<'_>) -> PyResult<PyMailboxWorkCounts> {
         let query = self.build_read_query(false)?;
-        py.detach(|| {
-            self.read_raw(query).map(|outcome| PyMailboxWorkCounts {
-                unread: outcome.bucket_counts.unread,
-                pending_ack: outcome.bucket_counts.pending_ack,
-            })
-        })
+        match self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
+            self.read_raw(query.clone())
+                .map(|outcome| PyMailboxWorkCounts {
+                    unread: outcome.bucket_counts.unread,
+                    pending_ack: outcome.bucket_counts.pending_ack,
+                })
+        }) {
+            DaemonRecovery::Completed(counts) => Ok(counts),
+            DaemonRecovery::Failed { error, .. } => Err(error),
+        }
     }
 
     fn activate_receiver(
@@ -985,8 +1068,10 @@ mod tests {
         PyGraftSessionOptions, PyMailboxWorkCounts, PyNudge, PythonNudgeInjector, atm_error,
     };
     use atm_core::boundary::PostSendHookEvent;
-    use atm_core::error::AtmError;
-    use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::error::{AtmError, AtmErrorCode};
+    use atm_core::list::ListOutcome;
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::read::{BucketCounts, ReadOutcome};
     use atm_core::send::{SendCommandOutcome, SendOutcome};
     use atm_core::transport::testing::FakeClientTransport;
     use atm_core::types::{AgentName, ChatId, CommandAction, ReadSelection, TeamName};
@@ -994,12 +1079,84 @@ mod tests {
     use pyo3::prelude::{Py, Python};
     use pyo3::types::{PyAnyMethods, PyModule};
     use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
     const TEST_RECIPIENT: &str = "test-recipient";
     const TEST_SENDER: &str = "test-sender";
     const TEST_TEAM: &str = "test-team";
+
+    fn send_outcome() -> SendOutcome {
+        SendOutcome {
+            action: CommandAction::Send,
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_RECIPIENT),
+            sender: AgentName::from_validated(TEST_SENDER),
+            outcome: SendCommandOutcome::Sent,
+            message_id: atm_core::schema::AtmMessageId::new(),
+            requires_ack: false,
+            task_id: None,
+            summary: None,
+            message: None,
+            warnings: Vec::new(),
+            dry_run: false,
+        }
+    }
+
+    fn read_outcome() -> ReadOutcome {
+        ReadOutcome {
+            action: CommandAction::Read,
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_SENDER),
+            selection_mode: ReadSelection::Actionable,
+            mutation_applied: false,
+            count: 0,
+            message: None,
+            selected_message_id: None,
+            match_count: 0,
+            additional_match_count: 0,
+            bucket_counts: BucketCounts {
+                unread: 2,
+                pending_ack: 3,
+                history: 5,
+            },
+        }
+    }
+
+    fn list_outcome() -> ListOutcome {
+        ListOutcome {
+            action: CommandAction::List,
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_SENDER),
+            selection_mode: ReadSelection::Actionable,
+            history_collapsed: false,
+            count: 0,
+            rows: Vec::new(),
+            bucket_counts: BucketCounts {
+                unread: 2,
+                pending_ack: 3,
+                history: 5,
+            },
+        }
+    }
+
+    fn test_session(
+        initial: Arc<FakeClientTransport>,
+        replacement: Arc<FakeClientTransport>,
+    ) -> PyGraftSession {
+        let caller = PyAgentAddress::new(TEST_SENDER.to_string(), TEST_TEAM.to_string(), None)
+            .expect("caller");
+        PyGraftSession {
+            caller: caller.to_typed().expect("typed caller"),
+            client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(initial))),
+            receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(Some(GraftClient::from_fake_transport_for_test(
+                replacement,
+            ))),
+            reconnect_attempts: AtomicUsize::new(0),
+        }
+    }
 
     fn host_nudge(event: PostSendHookEvent) -> HostNudge {
         HostNudge {
@@ -1108,6 +1265,8 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(None),
             receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
         };
 
         let error = session
@@ -1296,6 +1455,8 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(None),
             receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
         };
 
         Python::attach(|py| {
@@ -1330,6 +1491,206 @@ mod tests {
     }
 
     #[test]
+    fn send_tool_refreshes_once_without_replaying_a_failed_write() {
+        Python::initialize();
+        let initial_calls = Arc::new(AtomicUsize::new(0));
+        let replacement_calls = Arc::new(AtomicUsize::new(0));
+        let initial_calls_for_transport = Arc::clone(&initial_calls);
+        let replacement_calls_for_transport = Arc::clone(&replacement_calls);
+        let session = test_session(
+            Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                assert!(matches!(request, RequestEnvelope::Write(_)));
+                initial_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Err(AtmError::daemon_unavailable("test daemon cycle"))
+            }))),
+            Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                assert!(matches!(request, RequestEnvelope::Write(_)));
+                replacement_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Ok(ResponseEnvelope::Send(SendResponseEnvelope::Sent(
+                    send_outcome(),
+                )))
+            }))),
+        );
+
+        Python::attach(|py| {
+            let result = session
+                .send_tool(
+                    py,
+                    format!("{TEST_RECIPIENT}@{TEST_TEAM}"),
+                    "do not replay".to_owned(),
+                    false,
+                )
+                .expect("typed recovery result");
+            let result = result.bind(py);
+            assert!(result.is_instance_of::<AtmToolError>());
+            assert_eq!(
+                result
+                    .getattr("code")
+                    .expect("code")
+                    .extract::<String>()
+                    .unwrap(),
+                AtmErrorCode::DaemonUnavailable.as_str()
+            );
+            let recovery = result
+                .getattr("recovery")
+                .expect("recovery")
+                .extract::<String>()
+                .unwrap();
+            assert!(recovery.contains("retry this send once"));
+            assert!(recovery.contains("was not replayed"));
+        });
+
+        assert_eq!(initial_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(session.reconnect_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(replacement_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn plain_send_refreshes_once_without_replaying_a_failed_write() {
+        Python::initialize();
+        let initial_calls = Arc::new(AtomicUsize::new(0));
+        let replacement_calls = Arc::new(AtomicUsize::new(0));
+        let initial_calls_for_transport = Arc::clone(&initial_calls);
+        let replacement_calls_for_transport = Arc::clone(&replacement_calls);
+        let session = test_session(
+            Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                assert!(matches!(request, RequestEnvelope::Write(_)));
+                initial_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Err(AtmError::daemon_unavailable("test daemon cycle"))
+            }))),
+            Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                assert!(matches!(request, RequestEnvelope::Write(_)));
+                replacement_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Ok(ResponseEnvelope::Send(SendResponseEnvelope::Sent(
+                    send_outcome(),
+                )))
+            }))),
+        );
+        let recipient =
+            PyAgentAddress::new(TEST_RECIPIENT.to_string(), TEST_TEAM.to_string(), None)
+                .expect("recipient");
+
+        Python::attach(|py| {
+            let error = session
+                .send(py, recipient, "do not replay".to_owned(), false)
+                .expect_err("plain write reports the potentially ambiguous failure");
+            assert_eq!(
+                AtmToolError::from_native_error(py, &error).code,
+                AtmErrorCode::DaemonUnavailable.as_str()
+            );
+        });
+        assert_eq!(initial_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(session.reconnect_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(replacement_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn read_and_list_tools_retry_once_on_the_refreshed_fake_transport() {
+        Python::initialize();
+        for (operation, replacement_response) in [
+            ("read", ResponseEnvelope::Receive(Box::new(read_outcome()))),
+            ("list", ResponseEnvelope::List(list_outcome())),
+        ] {
+            let initial_calls = Arc::new(AtomicUsize::new(0));
+            let replacement_calls = Arc::new(AtomicUsize::new(0));
+            let initial_calls_for_transport = Arc::clone(&initial_calls);
+            let replacement_calls_for_transport = Arc::clone(&replacement_calls);
+            let initial = Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                match operation {
+                    "read" => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                    "list" => assert!(matches!(request, RequestEnvelope::List(_))),
+                    _ => unreachable!(),
+                }
+                initial_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Err(AtmError::daemon_unavailable("test daemon cycle"))
+            })));
+            let replacement = Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                match operation {
+                    "read" => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                    "list" => assert!(matches!(request, RequestEnvelope::List(_))),
+                    _ => unreachable!(),
+                }
+                replacement_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Ok(replacement_response.clone())
+            })));
+            let session = test_session(initial, replacement);
+
+            Python::attach(|py| {
+                let result = match operation {
+                    "read" => session.read_tool(py, "actionable", None, None, None, None, None),
+                    "list" => session.list_tool(py, "actionable", None, None, None, None, None),
+                    _ => unreachable!(),
+                }
+                .expect("read-only operation recovers");
+                assert!(
+                    !result.bind(py).is_instance_of::<AtmToolError>(),
+                    "{operation} returns its success projection after one retry"
+                );
+            });
+            assert_eq!(initial_calls.load(Ordering::SeqCst), 1, "{operation}");
+            assert_eq!(
+                session.reconnect_attempts.load(Ordering::SeqCst),
+                1,
+                "{operation}"
+            );
+            assert_eq!(replacement_calls.load(Ordering::SeqCst), 1, "{operation}");
+        }
+    }
+
+    #[test]
+    fn plain_python_methods_and_work_counts_share_the_recovery_policy() {
+        Python::initialize();
+        let operations: [(&str, ResponseEnvelope); 3] = [
+            ("read", ResponseEnvelope::Receive(Box::new(read_outcome()))),
+            ("list", ResponseEnvelope::List(list_outcome())),
+            (
+                "counts",
+                ResponseEnvelope::Receive(Box::new(read_outcome())),
+            ),
+        ];
+        for (operation, replacement_response) in operations {
+            let initial_calls = Arc::new(AtomicUsize::new(0));
+            let replacement_calls = Arc::new(AtomicUsize::new(0));
+            let initial_calls_for_transport = Arc::clone(&initial_calls);
+            let replacement_calls_for_transport = Arc::clone(&replacement_calls);
+            let initial = Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                match operation {
+                    "list" => assert!(matches!(request, RequestEnvelope::List(_))),
+                    _ => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                }
+                initial_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Err(AtmError::daemon_unavailable("test daemon cycle"))
+            })));
+            let replacement = Arc::new(FakeClientTransport::new(Box::new(move |request| {
+                match operation {
+                    "list" => assert!(matches!(request, RequestEnvelope::List(_))),
+                    _ => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                }
+                replacement_calls_for_transport.fetch_add(1, Ordering::SeqCst);
+                Ok(replacement_response.clone())
+            })));
+            let session = test_session(initial, replacement);
+
+            Python::attach(|py| match operation {
+                "read" => assert!(session.read(py).expect("plain read recovery").is_empty()),
+                "list" => assert_eq!(session.list(py).expect("plain list recovery"), 0),
+                "counts" => {
+                    let counts = session.mailbox_work_counts(py).expect("count recovery");
+                    assert_eq!((counts.unread, counts.pending_ack), (2, 3));
+                }
+                _ => unreachable!(),
+            });
+            assert_eq!(initial_calls.load(Ordering::SeqCst), 1, "{operation}");
+            assert_eq!(
+                session.reconnect_attempts.load(Ordering::SeqCst),
+                1,
+                "{operation}"
+            );
+            assert_eq!(replacement_calls.load(Ordering::SeqCst), 1, "{operation}");
+        }
+    }
+
+    #[test]
     fn python_send_uses_the_outer_ffi_runtime_bridge_for_the_async_client() {
         Python::initialize();
         let caller = PyAgentAddress::new(TEST_SENDER.to_string(), TEST_TEAM.to_string(), None)
@@ -1360,6 +1721,8 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(transport))),
             receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
         };
         let recipient =
             PyAgentAddress::new(TEST_RECIPIENT.to_string(), TEST_TEAM.to_string(), None)
@@ -1416,6 +1779,8 @@ mod tests {
                 })),
             )))),
             receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
         };
         let options = PyGraftSessionOptions {
             workspace_root: tempdir.path().display().to_string(),

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -323,6 +323,15 @@ impl AtmToolError {
             layer: "native_client".to_owned(),
         }
     }
+
+    fn is_daemon_unavailable(&self) -> bool {
+        self.code == "ATM_DAEMON_UNAVAILABLE"
+    }
+
+    fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
+        self.recovery = recovery.into();
+        self
+    }
 }
 
 impl PyMessage {
@@ -769,7 +778,22 @@ impl PyGraftSession {
     ) -> PyResult<Py<PyAny>> {
         match py.detach(|| self.send_outcome(to, body, requires_ack)) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => Ok(Py::new(py, AtmToolError::from_native_error(py, &error))?.into_any()),
+            Err(error) => {
+                let tool_error = AtmToolError::from_native_error(py, &error);
+                let tool_error = if tool_error.is_daemon_unavailable() {
+                    match py.detach(|| self.reconnect_client()) {
+                        Ok(()) => tool_error.with_recovery(
+                            "the native ATM session was refreshed after a transient failure; retry this send once. The failed send was not replayed to avoid duplicate delivery",
+                        ),
+                        Err(refresh_error) => tool_error.with_recovery(format!(
+                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
+                        )),
+                    }
+                } else {
+                    tool_error
+                };
+                Ok(Py::new(py, tool_error)?.into_any())
+            }
         }
     }
 
@@ -793,9 +817,31 @@ impl PyGraftSession {
             since.as_deref(),
             from_agent.as_deref(),
         )?;
-        match py.detach(|| self.read_outcome(query)) {
+        match py.detach(|| self.read_outcome(query.clone())) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => Ok(Py::new(py, AtmToolError::from_native_error(py, &error))?.into_any()),
+            Err(error) => {
+                let tool_error = AtmToolError::from_native_error(py, &error);
+                if !tool_error.is_daemon_unavailable() {
+                    return Ok(Py::new(py, tool_error)?.into_any());
+                }
+                if let Err(refresh_error) = py.detach(|| self.reconnect_client()) {
+                    return Ok(Py::new(
+                        py,
+                        tool_error.with_recovery(format!(
+                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
+                        )),
+                    )?
+                    .into_any());
+                }
+                match py.detach(|| self.read_outcome(query)) {
+                    Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
+                    Err(retry_error) => Ok(Py::new(
+                        py,
+                        AtmToolError::from_native_error(py, &retry_error),
+                    )?
+                    .into_any()),
+                }
+            }
         }
     }
 
@@ -819,9 +865,31 @@ impl PyGraftSession {
             since.as_deref(),
             from_agent.as_deref(),
         )?;
-        match py.detach(|| self.list_outcome(query)) {
+        match py.detach(|| self.list_outcome(query.clone())) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
-            Err(error) => Ok(Py::new(py, AtmToolError::from_native_error(py, &error))?.into_any()),
+            Err(error) => {
+                let tool_error = AtmToolError::from_native_error(py, &error);
+                if !tool_error.is_daemon_unavailable() {
+                    return Ok(Py::new(py, tool_error)?.into_any());
+                }
+                if let Err(refresh_error) = py.detach(|| self.reconnect_client()) {
+                    return Ok(Py::new(
+                        py,
+                        tool_error.with_recovery(format!(
+                            "the native ATM session could not reconnect; verify the managed daemon is healthy, then retry ({refresh_error})"
+                        )),
+                    )?
+                    .into_any());
+                }
+                match py.detach(|| self.list_outcome(query)) {
+                    Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
+                    Err(retry_error) => Ok(Py::new(
+                        py,
+                        AtmToolError::from_native_error(py, &retry_error),
+                    )?
+                    .into_any()),
+                }
+            }
         }
     }
 

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -503,6 +503,32 @@ impl PyGraftSession {
             .ok_or_else(|| PyRuntimeError::new_err("ATM graft session is closed"))
     }
 
+    fn reconnect_client(&self) -> PyResult<()> {
+        {
+            let client = self
+                .client
+                .lock()
+                .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?;
+            if client.is_none() {
+                return Err(PyRuntimeError::new_err("ATM graft session is closed"));
+            }
+        }
+
+        // Re-resolve the one selected daemon endpoint.  A managed restart may
+        // replace its Unix socket and invalidate a long-lived embedded host's
+        // pooled transport; this never starts a competing daemon.
+        let replacement = GraftClient::connect_existing().map_err(atm_error)?;
+        let mut client = self
+            .client
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?;
+        if client.is_none() {
+            return Err(PyRuntimeError::new_err("ATM graft session is closed"));
+        }
+        *client = Some(replacement);
+        Ok(())
+    }
+
     fn command_paths() -> PyResult<(std::path::PathBuf, std::path::PathBuf)> {
         Ok((
             atm_home().map_err(atm_error)?,
@@ -722,6 +748,14 @@ impl PyGraftSession {
     fn list(&self, py: Python<'_>) -> PyResult<usize> {
         let query = self.build_list_query("actionable", None, None, None, None, None)?;
         py.detach(|| self.list_outcome(query).map(|outcome| outcome.count))
+    }
+
+    /// Refresh the selected same-host client after a managed daemon cycle.
+    ///
+    /// This refreshes only this embedded session's transport; it never starts
+    /// or changes the operator-owned daemon lifecycle.
+    fn reconnect(&self, py: Python<'_>) -> PyResult<()> {
+        py.detach(|| self.reconnect_client())
     }
 
     /// Native-tool ingress delegates to the same canonical send implementation.
@@ -989,12 +1023,29 @@ mod tests {
             assert!(session_type.getattr("send_tool").is_ok());
             assert!(session_type.getattr("read_tool").is_ok());
             assert!(session_type.getattr("list_tool").is_ok());
+            assert!(session_type.getattr("reconnect").is_ok());
             assert!(module.getattr("AtmSendResult").is_ok());
             assert!(module.getattr("AtmReadResult").is_ok());
             assert!(module.getattr("AtmListResult").is_ok());
             assert!(module.getattr("AtmToolError").is_ok());
             assert!(session_type.getattr("acknowledge").is_err());
         });
+    }
+
+    #[test]
+    fn closed_python_session_rejects_reconnect() {
+        let caller = PyAgentAddress::new(TEST_SENDER.to_string(), TEST_TEAM.to_string(), None)
+            .expect("caller");
+        let session = PyGraftSession {
+            caller: caller.to_typed().expect("typed caller"),
+            client: Mutex::new(None),
+            receiver: Mutex::new(None),
+        };
+
+        let error = session
+            .reconnect_client()
+            .expect_err("closed sessions must not reconnect");
+        assert!(error.to_string().contains("session is closed"));
     }
 
     #[test]

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -18,7 +18,8 @@ use atm_core::graft::AtmGraftClient;
 use atm_core::home::{atm_home, command_invocation_dir};
 use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::read::{ReadOutcome, ReadQuery};
-use atm_core::send::{SendMessageSource, SendRequest};
+use atm_core::schema::AtmMessageId;
+use atm_core::send::{SendMessageSource, SendRequest, WriteOutcome};
 use atm_core::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TeamName};
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -197,12 +198,23 @@ pub struct AtmSendResult {
     outcome: String,
 }
 
-impl From<atm_core::send::SendOutcome> for AtmSendResult {
-    fn from(outcome: atm_core::send::SendOutcome) -> Self {
-        Self {
-            message_id: outcome.message_id.to_string(),
-            requires_ack: outcome.requires_ack,
-            outcome: outcome.outcome.as_str().to_owned(),
+impl From<WriteOutcome> for AtmSendResult {
+    fn from(outcome: WriteOutcome) -> Self {
+        match outcome {
+            WriteOutcome::Sent(outcome) => Self {
+                message_id: outcome.message_id.to_string(),
+                requires_ack: outcome.requires_ack,
+                outcome: outcome.outcome.as_str().to_owned(),
+            },
+            WriteOutcome::Acknowledged(outcome) => Self {
+                message_id: match outcome.reply_disposition {
+                    atm_core::ack::AckReplyDisposition::Sent {
+                        reply_message_id, ..
+                    } => reply_message_id.to_string(),
+                },
+                requires_ack: false,
+                outcome: "acknowledged".to_owned(),
+            },
         }
     }
 }
@@ -627,17 +639,26 @@ impl PyGraftSession {
 
     fn send_outcome(
         &self,
-        to: String,
+        to: Option<String>,
         body: String,
         requires_ack: bool,
+        acknowledges_message_id: Option<String>,
     ) -> PyResult<AtmSendResult> {
         let (home_dir, current_dir) = Self::command_paths()?;
         let caller_team = self.caller_team()?;
+        let acknowledgement = acknowledges_message_id
+            .as_deref()
+            .map(str::parse::<AtmMessageId>)
+            .transpose()
+            .map_err(|error| {
+                PyValueError::new_err(format!("invalid acknowledges_message_id: {error}"))
+            })?;
+        let fallback_destination = self.caller.to_string();
         let request = SendRequest::new(
             home_dir,
             current_dir,
             self.caller.agent().clone(),
-            &to,
+            to.as_deref().unwrap_or(&fallback_destination),
             caller_team.clone(),
             SendMessageSource::Inline(body),
             None,
@@ -651,11 +672,15 @@ impl PyGraftSession {
             self.caller.agent(),
             &caller_team,
         ));
+        let request = match acknowledgement {
+            Some(message_id) => request.with_acknowledges_message_id(message_id),
+            None => request,
+        };
         let client = self.client()?;
         python_extension_runtime()?
             .lock()
             .map_err(|_| PyRuntimeError::new_err("ATM Python extension runtime lock poisoned"))?
-            .block_on(client.send_message(request))
+            .block_on(client.write_message(request))
             .map(AtmSendResult::from)
             .map_err(atm_error)
     }
@@ -708,7 +733,7 @@ impl PyGraftSession {
         let to = to.to_typed()?.to_string();
         // `detach` is PyO3 0.29's replacement for `allow_threads`: all
         // runtime blocking happens without holding the Python GIL.
-        py.detach(|| self.send_outcome(to, body, requires_ack))
+        py.detach(|| self.send_outcome(Some(to), body, requires_ack, None))
     }
 
     fn read(&self, py: Python<'_>) -> PyResult<Vec<PyMessage>> {
@@ -725,15 +750,16 @@ impl PyGraftSession {
     }
 
     /// Native-tool ingress delegates to the same canonical send implementation.
-    #[pyo3(signature = (to, body, requires_ack=false))]
+    #[pyo3(signature = (to, body, requires_ack=false, acknowledges_message_id=None))]
     fn send_tool(
         &self,
         py: Python<'_>,
-        to: String,
+        to: Option<String>,
         body: String,
         requires_ack: bool,
+        acknowledges_message_id: Option<String>,
     ) -> PyResult<Py<PyAny>> {
-        match py.detach(|| self.send_outcome(to, body, requires_ack)) {
+        match py.detach(|| self.send_outcome(to, body, requires_ack, acknowledges_message_id)) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
             Err(error) => Ok(Py::new(py, AtmToolError::from_native_error(py, &error))?.into_any()),
         }
@@ -1183,9 +1209,10 @@ mod tests {
             let result = session
                 .send_tool(
                     py,
-                    format!("{TEST_RECIPIENT}@{TEST_TEAM}"),
+                    Some(format!("{TEST_RECIPIENT}@{TEST_TEAM}")),
                     "typed native failure".to_owned(),
                     false,
+                    None,
                 )
                 .expect("native tool returns a typed error object");
             let value = result.bind(py);

--- a/crates/atm-graft-python/src/tool_types.rs
+++ b/crates/atm-graft-python/src/tool_types.rs
@@ -1,0 +1,169 @@
+//! Typed Python projections of canonical ATM daemon outcomes.
+
+use atm_core::error::AtmErrorCode;
+use atm_core::list::ListOutcome;
+use atm_core::read::ReadOutcome;
+use atm_core::send::WriteOutcome;
+use pyo3::prelude::*;
+
+use super::PyMessage;
+
+/// Typed, JSON-compatible projection of the canonical send outcome.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct AtmSendResult {
+    #[pyo3(get)]
+    pub(crate) message_id: String,
+    #[pyo3(get)]
+    pub(crate) requires_ack: bool,
+    #[pyo3(get)]
+    pub(crate) outcome: String,
+}
+
+impl From<WriteOutcome> for AtmSendResult {
+    fn from(outcome: WriteOutcome) -> Self {
+        match outcome {
+            WriteOutcome::Sent(outcome) => Self {
+                message_id: outcome.message_id.to_string(),
+                requires_ack: outcome.requires_ack,
+                outcome: outcome.outcome.as_str().to_owned(),
+            },
+            WriteOutcome::Acknowledged(outcome) => Self {
+                message_id: match outcome.reply_disposition {
+                    atm_core::ack::AckReplyDisposition::Sent {
+                        reply_message_id, ..
+                    } => reply_message_id.to_string(),
+                },
+                requires_ack: false,
+                outcome: "acknowledged".to_owned(),
+            },
+        }
+    }
+}
+
+/// Typed, read-only projection of the canonical mailbox read outcome.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct AtmReadResult {
+    #[pyo3(get)]
+    pub(crate) count: usize,
+    #[pyo3(get)]
+    pub(crate) match_count: usize,
+    #[pyo3(get)]
+    pub(crate) additional_match_count: usize,
+    #[pyo3(get)]
+    pub(crate) mutation_applied: bool,
+    #[pyo3(get)]
+    pub(crate) message: Option<PyMessage>,
+}
+
+impl AtmReadResult {
+    pub(crate) fn from_outcome(outcome: ReadOutcome) -> PyResult<Self> {
+        let count = outcome.count;
+        let match_count = outcome.match_count;
+        let additional_match_count = outcome.additional_match_count;
+        let mutation_applied = outcome.mutation_applied;
+        let message = PyMessage::from_read(outcome)?.into_iter().next();
+        Ok(Self {
+            count,
+            match_count,
+            additional_match_count,
+            mutation_applied,
+            message,
+        })
+    }
+}
+
+/// One typed row in a bounded native mailbox list result.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct AtmListRow {
+    #[pyo3(get)]
+    pub(crate) message_id: Option<String>,
+    #[pyo3(get)]
+    pub(crate) summary: String,
+    #[pyo3(get)]
+    pub(crate) from_agent: String,
+    #[pyo3(get)]
+    pub(crate) timestamp: String,
+    #[pyo3(get)]
+    pub(crate) read: bool,
+    #[pyo3(get)]
+    pub(crate) pending_ack: bool,
+    #[pyo3(get)]
+    pub(crate) task_id: Option<String>,
+}
+
+impl From<atm_core::list::ListRow> for AtmListRow {
+    fn from(row: atm_core::list::ListRow) -> Self {
+        Self {
+            message_id: row.message_id.map(|id| id.to_string()),
+            summary: row.summary,
+            from_agent: row.from.to_string(),
+            timestamp: row.timestamp.to_string(),
+            read: row.read,
+            pending_ack: row.pending_ack,
+            task_id: row.task_id.map(|id| id.to_string()),
+        }
+    }
+}
+
+/// Typed, bounded projection of the canonical mailbox list outcome.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct AtmListResult {
+    #[pyo3(get)]
+    pub(crate) count: usize,
+    #[pyo3(get)]
+    pub(crate) rows: Vec<AtmListRow>,
+}
+
+impl From<ListOutcome> for AtmListResult {
+    fn from(outcome: ListOutcome) -> Self {
+        Self {
+            count: outcome.count,
+            rows: outcome.rows.into_iter().map(AtmListRow::from).collect(),
+        }
+    }
+}
+
+/// Structured native-tool error data used by Python adapters' failure envelope.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct AtmToolError {
+    #[pyo3(get)]
+    pub(crate) code: String,
+    #[pyo3(get)]
+    pub(crate) message: String,
+    #[pyo3(get)]
+    pub(crate) recovery: String,
+    #[pyo3(get)]
+    pub(crate) layer: String,
+}
+
+impl AtmToolError {
+    pub(crate) fn from_native_error(py: Python<'_>, error: &PyErr) -> Self {
+        let value = error.value(py);
+        let attribute = |name: &str| {
+            value
+                .getattr(name)
+                .ok()
+                .and_then(|attribute| attribute.extract::<String>().ok())
+        };
+        Self {
+            code: attribute("code").unwrap_or_else(|| "ATM_NATIVE_OPERATION_FAILED".to_owned()),
+            message: attribute("message").unwrap_or_else(|| error.to_string()),
+            recovery: "verify the local ATM daemon and configured identity, then retry".to_owned(),
+            layer: "native_client".to_owned(),
+        }
+    }
+
+    pub(crate) fn is_daemon_unavailable(&self) -> bool {
+        self.code == AtmErrorCode::DaemonUnavailable.as_str()
+    }
+
+    pub(crate) fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
+        self.recovery = recovery.into();
+        self
+    }
+}

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -123,7 +123,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         delivered_tx,
     });
     let session = GraftSession::activate(
-        client.clone(),
         GraftSessionOptions::new(&args.workspace_root, args.team.clone(), args.agent.clone()),
         Arc::clone(&injector) as Arc<dyn HostNudgeInjector>,
     )?;

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
 use atm_core::boundary::PostSendHookEvent;
+use atm_core::graft::AtmGraftClient;
 use atm_core::read::ReadQuery;
 use atm_core::send::{SendCommandOutcome, SendMessageSource, SendRequest};
 use atm_core::types::{AgentName, ReadSelection, TeamName};
@@ -122,7 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         delivered_tx,
     });
     let session = GraftSession::activate(
-        client,
+        client.clone(),
         GraftSessionOptions::new(&args.workspace_root, args.team.clone(), args.agent.clone()),
         Arc::clone(&injector) as Arc<dyn HostNudgeInjector>,
     )?;
@@ -171,8 +172,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let target_address = format!("{}@{}", args.agent, args.team);
     let nudge_message_id = nudge.message_id.to_string();
-    let read_outcome = session
-        .read(ReadQuery::new(
+    let read_outcome = client
+        .read_message(ReadQuery::new(
             home_dir.clone(),
             args.workspace_root.clone(),
             args.agent.parse().expect("caller"),
@@ -200,8 +201,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .into());
     }
 
-    let follow_up_outcome = session
-        .send(SendRequest::new(
+    let follow_up_outcome = client
+        .send_message(SendRequest::new(
             home_dir,
             args.workspace_root.clone(),
             args.agent.parse().expect("caller"),

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -15,7 +15,7 @@ use atm_core::graft::AtmGraftClient;
 use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::{ReadOutcome, ReadQuery};
-use atm_core::send::{SendOutcome, SendRequest};
+use atm_core::send::{SendOutcome, SendRequest, WriteOutcome};
 use atm_core::types::{AgentName, ChatId, TeamName};
 use atm_daemon_client::{resolve_daemon_local_ipc_endpoint, unexpected_response};
 use atm_http_runtime::SAME_HOST_REQUEST_DEADLINE;
@@ -258,6 +258,25 @@ impl GraftClient {
         }
     }
 
+    /// Execute the one canonical write operation, including acknowledgement writes.
+    pub async fn write_message(&self, request: SendRequest) -> Result<WriteOutcome, AtmError> {
+        let transport =
+            atm_http_runtime::selected_write_transport(&request, &self.async_transport)?;
+        match transport
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .await?
+            .into_inner()
+        {
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
+                Ok(WriteOutcome::Sent(outcome))
+            }
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
+                Ok(WriteOutcome::Acknowledged(outcome))
+            }
+            other => Err(unexpected_response("write", other)),
+        }
+    }
+
     /// Read the daemon's existing mailbox bucket counts without mutating mail.
     pub async fn mailbox_work_counts(
         &self,
@@ -280,15 +299,11 @@ impl GraftClient {
 #[async_trait::async_trait]
 impl AtmGraftClient for GraftClient {
     async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        let transport =
-            atm_http_runtime::selected_write_transport(&request, &self.async_transport)?;
-        match transport
-            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
-            .await?
-            .into_inner()
-        {
-            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => Ok(outcome),
-            other => Err(unexpected_response("send", other)),
+        match self.write_message(request).await? {
+            WriteOutcome::Sent(outcome) => Ok(outcome),
+            WriteOutcome::Acknowledged(_) => Err(AtmError::validation(
+                "send_message cannot project an acknowledgement response; use write_message",
+            )),
         }
     }
 

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -299,11 +299,15 @@ impl GraftClient {
 #[async_trait::async_trait]
 impl AtmGraftClient for GraftClient {
     async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        match self.write_message(request).await? {
-            WriteOutcome::Sent(outcome) => Ok(outcome),
-            WriteOutcome::Acknowledged(_) => Err(AtmError::validation(
-                "send_message cannot project an acknowledgement response; use write_message",
-            )),
+        let transport =
+            atm_http_runtime::selected_write_transport(&request, &self.async_transport)?;
+        match transport
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .await?
+            .into_inner()
+        {
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => Ok(outcome),
+            other => Err(unexpected_response("send", other)),
         }
     }
 

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -450,14 +450,6 @@ impl GraftSession {
         read_snapshot(&self.snapshot)
     }
 
-    pub async fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        self.client.send_message(request).await
-    }
-
-    pub async fn read(&self, query: ReadQuery) -> Result<ReadOutcome, AtmError> {
-        self.client.read_message(query).await
-    }
-
     /// # Errors
     ///
     /// Returns [`AtmError`] when the receive loop cannot join cleanly during

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -236,7 +236,6 @@ impl GraftClient {
         injector: Arc<dyn HostNudgeInjector>,
     ) -> Result<GraftSession, AtmError> {
         GraftSession::activate_with_observability(
-            self.clone(),
             options,
             injector,
             Arc::new(NoopGraftObservability),
@@ -331,7 +330,6 @@ impl AtmGraftClient for GraftClient {
 
 /// Concrete embedded graft session runtime.
 pub struct GraftSession {
-    client: Arc<dyn AtmGraftClient>,
     // Reads dominate (status projection and hook delivery) while updates only
     // replace a complete snapshot, so an RwLock permits concurrent readers
     // without exposing partial session state to a receiver callback.
@@ -367,16 +365,10 @@ impl GraftSession {
     /// Returns [`AtmError`] when configuration gating allows graft mode but
     /// receiver-loop startup fails.
     pub fn activate(
-        client: GraftClient,
         options: GraftSessionOptions,
         injector: Arc<dyn HostNudgeInjector>,
     ) -> Result<Self, AtmError> {
-        Self::activate_with_observability(
-            client,
-            options,
-            injector,
-            Arc::new(NoopGraftObservability),
-        )
+        Self::activate_with_observability(options, injector, Arc::new(NoopGraftObservability))
     }
 
     /// # Errors
@@ -384,23 +376,15 @@ impl GraftSession {
     /// Returns [`AtmError`] when configuration gating allows graft mode but
     /// receiver-loop startup fails.
     pub fn activate_with_observability(
-        client: GraftClient,
         options: GraftSessionOptions,
         injector: Arc<dyn HostNudgeInjector>,
         observability: Arc<dyn GraftObservability>,
     ) -> Result<Self, AtmError> {
         let graft_config = load_graft_config(&options.workspace_root)?;
-        Self::activate_with_graft_config(
-            Arc::new(client),
-            graft_config,
-            options,
-            injector,
-            observability,
-        )
+        Self::activate_with_graft_config(graft_config, options, injector, observability)
     }
 
     fn activate_with_graft_config(
-        client: Arc<dyn AtmGraftClient>,
         graft_config: Option<GraftConfig>,
         options: GraftSessionOptions,
         injector: Arc<dyn HostNudgeInjector>,
@@ -410,10 +394,10 @@ impl GraftSession {
         let snapshot = Arc::new(RwLock::new(initial_snapshot));
 
         let Some(graft_config) = graft_config else {
-            return inactive_session(client, snapshot, observability);
+            return inactive_session(snapshot, observability);
         };
         if !graft_config.enabled {
-            return inactive_session(client, snapshot, observability);
+            return inactive_session(snapshot, observability);
         }
 
         let endpoint_path = atm_core::graft::graft_receiver_record_path_from_root(
@@ -435,7 +419,6 @@ impl GraftSession {
             observability.as_ref(),
         )?;
         Ok(Self {
-            client,
             snapshot,
             observability,
             stop_tx: Some(stop_tx),
@@ -503,13 +486,11 @@ impl GraftSession {
 }
 
 fn inactive_session(
-    client: Arc<dyn AtmGraftClient>,
     snapshot: Arc<RwLock<SessionSnapshot>>,
     observability: Arc<dyn GraftObservability>,
 ) -> Result<GraftSession, AtmError> {
     observability.session_state_changed(&read_snapshot(&snapshot)?);
     Ok(GraftSession {
-        client,
         snapshot,
         observability,
         stop_tx: None,
@@ -567,21 +548,6 @@ impl Drop for GraftSession {
     }
 }
 
-#[async_trait::async_trait]
-impl AtmGraftClient for GraftSession {
-    async fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        self.client.send_message(request).await
-    }
-
-    async fn read_message(&self, query: ReadQuery) -> Result<ReadOutcome, AtmError> {
-        self.client.read_message(query).await
-    }
-
-    async fn list_messages(&self, query: ListQuery) -> Result<ListOutcome, AtmError> {
-        self.client.list_messages(query).await
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -606,20 +572,6 @@ mod tests {
     impl HostNudgeInjector for NoopInjector {
         fn inject_nudge(&self, _nudge: &HostNudge) -> Result<(), AtmError> {
             Ok(())
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct StubSessionClient;
-
-    #[async_trait::async_trait]
-    impl AtmGraftClient for StubSessionClient {
-        async fn send_message(&self, _request: SendRequest) -> Result<SendOutcome, AtmError> {
-            panic!("send_message should not run in inactive-session tests")
-        }
-
-        async fn read_message(&self, _query: ReadQuery) -> Result<ReadOutcome, AtmError> {
-            panic!("read_message should not run in inactive-session tests")
         }
     }
 
@@ -844,7 +796,6 @@ mod tests {
     fn session_stays_inactive_without_atm_config() {
         let paths = test_paths();
         let session = GraftSession::activate_with_graft_config(
-            Arc::new(StubSessionClient),
             None,
             session_options(&paths),
             Arc::new(NoopInjector),
@@ -862,7 +813,6 @@ mod tests {
     fn session_stays_inactive_when_graft_is_disabled() {
         let paths = test_paths();
         let session = GraftSession::activate_with_graft_config(
-            Arc::new(StubSessionClient),
             Some(GraftConfig { enabled: false }),
             session_options(&paths),
             Arc::new(NoopInjector),
@@ -894,7 +844,6 @@ mod tests {
         ]);
 
         let session = GraftSession::activate_with_graft_config(
-            Arc::new(StubSessionClient),
             load_graft_config(tempdir.path()).expect("graft config"),
             GraftSessionOptions::new(
                 tempdir.path(),

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["atm-graft>=1.4,<1.5", "PyYAML>=6"]
+dependencies = ["atm-graft>=1.4,<1.5"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "0.1.3"
+version = "0.1.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["atm-graft>=1.4,<1.5"]
+dependencies = ["atm-graft>=1.4,<1.5", "PyYAML>=6"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -10,6 +10,8 @@ import plistlib
 import sys
 from typing import Any, Mapping, Sequence
 
+import yaml
+
 
 HOOK_NAME = "hermes-atm"
 HOOK_MANIFEST = """name: hermes-atm
@@ -54,6 +56,7 @@ TOOLS_PLUGIN_NAME = "hermes-atm-native-tools"
 TOOLS_PLUGIN_MANIFEST = """name: hermes-atm-native-tools
 version: 1
 description: Native ATM mailbox tools backed by the typed atm-graft client.
+hermes_version: ">=0.20"
 kind: backend
 provides_tools:
   - atm_send
@@ -163,6 +166,50 @@ def _write_text_if_changed(path: Path, content: str) -> bool:
     return True
 
 
+def _enable_native_tools_plugin(profile_home: Path) -> bool:
+    """Add the package-owned native-tools plugin to Hermes' opt-in allow-list.
+
+    Hermes discovers user plugins from ``<HERMES_HOME>/plugins`` but does not
+    load them until their path-derived key is in ``plugins.enabled``.  The
+    installer owns both the generated plugin and this declarative enablement,
+    so a normal install followed by a gateway reset is sufficient; operators
+    never need to edit the profile configuration by hand.
+    """
+
+    config_path = profile_home / "config.yaml"
+    try:
+        existing = (
+            yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            if config_path.exists()
+            else {}
+        )
+    except (OSError, yaml.YAMLError) as error:
+        raise HermesAtmInstallError(
+            f"cannot read Hermes profile config {config_path}: {error}"
+        ) from error
+    if existing is None:
+        existing = {}
+    if not isinstance(existing, dict):
+        raise HermesAtmInstallError(f"Hermes profile config {config_path} must be a mapping")
+
+    plugins = existing.setdefault("plugins", {})
+    if not isinstance(plugins, dict):
+        raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
+    enabled = plugins.setdefault("enabled", [])
+    if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
+        raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
+    if TOOLS_PLUGIN_NAME in enabled:
+        return False
+    enabled.append(TOOLS_PLUGIN_NAME)
+    try:
+        rendered = yaml.safe_dump(existing, sort_keys=False, allow_unicode=True)
+    except yaml.YAMLError as error:
+        raise HermesAtmInstallError(
+            f"cannot serialize Hermes profile config {config_path}: {error}"
+        ) from error
+    return _write_text_if_changed(config_path, rendered)
+
+
 def install_profile(
     *,
     profile_home: Path,
@@ -207,6 +254,7 @@ def install_profile(
             ),
         )
     )
+    changed = _enable_native_tools_plugin(profile_home) or changed
     return {
         "hook_dir": str(hook_dir),
         "plugin_dir": str(plugin_dir),

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -10,9 +10,6 @@ import plistlib
 import sys
 from typing import Any, Mapping, Sequence
 
-import yaml
-
-
 HOOK_NAME = "hermes-atm"
 HOOK_MANIFEST = """name: hermes-atm
 description: Deliver ATM graft nudges through the Hermes public gateway runner API.
@@ -176,38 +173,38 @@ def _enable_native_tools_plugin(profile_home: Path) -> bool:
     never need to edit the profile configuration by hand.
     """
 
-    config_path = profile_home / "config.yaml"
     try:
-        existing = (
-            yaml.safe_load(config_path.read_text(encoding="utf-8"))
-            if config_path.exists()
-            else {}
-        )
-    except (OSError, yaml.YAMLError) as error:
+        from hermes_cli.config import load_config, save_config
+    except ImportError as error:
         raise HermesAtmInstallError(
-            f"cannot read Hermes profile config {config_path}: {error}"
+            "the active interpreter cannot import Hermes public config APIs"
         ) from error
-    if existing is None:
-        existing = {}
-    if not isinstance(existing, dict):
-        raise HermesAtmInstallError(f"Hermes profile config {config_path} must be a mapping")
 
-    plugins = existing.setdefault("plugins", {})
-    if not isinstance(plugins, dict):
-        raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
-    enabled = plugins.setdefault("enabled", [])
-    if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
-        raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
-    if TOOLS_PLUGIN_NAME in enabled:
-        return False
-    enabled.append(TOOLS_PLUGIN_NAME)
+    # Hermes' config API deliberately derives the active profile from
+    # HERMES_HOME.  Scope the override to this synchronous installer call so
+    # the caller's process environment is restored even when validation fails.
+    previous_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(profile_home)
     try:
-        rendered = yaml.safe_dump(existing, sort_keys=False, allow_unicode=True)
-    except yaml.YAMLError as error:
-        raise HermesAtmInstallError(
-            f"cannot serialize Hermes profile config {config_path}: {error}"
-        ) from error
-    return _write_text_if_changed(config_path, rendered)
+        config = load_config()
+        if not isinstance(config, dict):
+            raise HermesAtmInstallError("Hermes profile config must be a mapping")
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            raise HermesAtmInstallError("Hermes profile plugins configuration must be a mapping")
+        enabled = plugins.setdefault("enabled", [])
+        if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
+            raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
+        if TOOLS_PLUGIN_NAME in enabled:
+            return False
+        enabled.append(TOOLS_PLUGIN_NAME)
+        save_config(config, merge_existing=True)
+        return True
+    finally:
+        if previous_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = previous_home
 
 
 def install_profile(

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -207,9 +207,21 @@ def register_tools(context: Any, *, identity: str, team: str, chat_id: str) -> N
 
     tools = AtmNativeTools(identity=identity, team=team, chat_id=chat_id)
     for name, handler, description in (
-        ("atm_send", tools.atm_send, "Send an ATM mailbox message."),
-        ("atm_read", tools.atm_read, "Read one ATM mailbox message without mutating it."),
-        ("atm_list", tools.atm_list, "List ATM mailbox metadata without mutating it."),
+        (
+            "atm_send",
+            tools.atm_send,
+            "Send one ordinary ATM mailbox message; use the ATM CLI for administrative or advanced operations.",
+        ),
+        (
+            "atm_read",
+            tools.atm_read,
+            "Read one ATM mailbox message without mutating it; use the ATM CLI for administrative or advanced operations.",
+        ),
+        (
+            "atm_list",
+            tools.atm_list,
+            "List ATM mailbox metadata without mutating it; use the ATM CLI for administrative or advanced operations.",
+        ),
     ):
         context.register_tool(
             name=name,

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -28,6 +28,19 @@ def _error(*, code: str, message: str, recovery: str, layer: str) -> ToolEnvelop
     }
 
 
+def _render_for_hermes(envelope: ToolEnvelope) -> str:
+    """Serialize the typed ATM union at Hermes' string-only tool boundary.
+
+    Hermes' public ``PluginContext.register_tool`` accepts structured JSON
+    schemas, but its normal tool execution pipeline accepts string results
+    (the only structured exception is Hermes' own multimodal envelope).  Keep
+    the discriminator and detailed error payload intact as JSON text instead
+    of leaking a Python ``dict`` into that host boundary.
+    """
+
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":"))
+
+
 def _validate(model: type[Any], arguments: Mapping[str, Any]) -> Any | ToolEnvelope:
     try:
         return model.model_validate(dict(arguments))
@@ -131,45 +144,51 @@ class AtmNativeTools:
             atm_graft.PyAgentAddress(identity, team, chat_id)
         )
 
-    def atm_send(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_send(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmSendRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
-            _send_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
+                _send_result,
+            )
         )
 
-    def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmReadRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.read_tool(
-                request.selection,
-                request.message_id,
-                request.task,
-                request.contains,
-                request.since,
-                request.from_agent,
-            ),
-            _read_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.read_tool(
+                    request.selection,
+                    request.message_id,
+                    request.task,
+                    request.contains,
+                    request.since,
+                    request.from_agent,
+                ),
+                _read_result,
+            )
         )
 
-    def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
+    def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> str:
         request = _validate(atm_graft.AtmListRequest, arguments)
         if isinstance(request, dict):
-            return request
-        return _invoke(
-            lambda: self._session.list_tool(
-                request.selection,
-                request.limit,
-                request.task,
-                request.contains,
-                request.since,
-                request.from_agent,
-            ),
-            _list_result,
+            return _render_for_hermes(request)
+        return _render_for_hermes(
+            _invoke(
+                lambda: self._session.list_tool(
+                    request.selection,
+                    request.limit,
+                    request.task,
+                    request.contains,
+                    request.since,
+                    request.from_agent,
+                ),
+                _list_result,
+            )
         )
 
 

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -106,61 +106,21 @@ def _list_result(result: Any) -> dict[str, Any]:
     }
 
 
-def _is_daemon_unavailable(outcome: Any) -> bool:
-    return (
-        isinstance(outcome, atm_graft.AtmToolError)
-        and outcome.code == "ATM_DAEMON_UNAVAILABLE"
-    )
-
-
-def _invoke(
-    call: Callable[[], Any],
-    project: Callable[[Any], dict[str, Any]],
-    *,
-    reconnect: Callable[[], None],
-    retry_after_reconnect: bool,
-) -> ToolEnvelope:
-    """Run one native operation and refresh a stale client after a daemon cycle.
-
-    Read-only operations may replay once after refresh. A send does not: a
-    transport error can occur after the daemon admits a write, so replaying it
-    could create a duplicate delivery. The refresh makes the caller's next
-    explicit send use the successor daemon connection.
-    """
-
-    # Native-tool methods project canonical Rust failures as AtmToolError
-    # values rather than Python exceptions, preserving their public code.
-    outcome = call()
-    if not _is_daemon_unavailable(outcome):
-        return _native_error(outcome) if isinstance(outcome, atm_graft.AtmToolError) else {
-            "kind": "success",
-            "result": project(outcome),
-        }
-
+def _invoke(call: Callable[[], Any], project: Callable[[Any], dict[str, Any]]) -> ToolEnvelope:
     try:
-        reconnect()
-    except Exception as reconnect_error:
-        envelope = _native_error(outcome)
-        envelope["error"]["recovery"] = (
-            "the native ATM session could not reconnect; verify the managed daemon is healthy, "
-            f"then retry ({reconnect_error})"
+        # The typed graft result is projected once at this Hermes-only JSON
+        # boundary; raw JSON never crosses into or out of atm_graft.
+        outcome = call()
+    except Exception as error:  # native binding establishes the canonical code
+        return _error(
+            code="ATM_NATIVE_OPERATION_FAILED",
+            message=str(error),
+            recovery="verify the local ATM daemon and configured identity, then retry",
+            layer="native_client",
         )
-        return envelope
-
-    if retry_after_reconnect:
-        retry_outcome = call()
-        return (
-            _native_error(retry_outcome)
-            if isinstance(retry_outcome, atm_graft.AtmToolError)
-            else {"kind": "success", "result": project(retry_outcome)}
-        )
-
-    envelope = _native_error(outcome)
-    envelope["error"]["recovery"] = (
-        "the native ATM session was refreshed after a transient failure; retry this send once. "
-        "The failed send was not replayed to avoid duplicate delivery"
-    )
-    return envelope
+    if isinstance(outcome, atm_graft.AtmToolError):
+        return _native_error(outcome)
+    return {"kind": "success", "result": project(outcome)}
 
 
 class AtmNativeTools:
@@ -178,8 +138,6 @@ class AtmNativeTools:
         return _invoke(
             lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
             _send_result,
-            reconnect=self._session.reconnect,
-            retry_after_reconnect=False,
         )
 
     def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -196,8 +154,6 @@ class AtmNativeTools:
                 request.from_agent,
             ),
             _read_result,
-            reconnect=self._session.reconnect,
-            retry_after_reconnect=True,
         )
 
     def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -214,8 +170,6 @@ class AtmNativeTools:
                 request.from_agent,
             ),
             _list_result,
-            reconnect=self._session.reconnect,
-            retry_after_reconnect=True,
         )
 
 

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -176,10 +176,10 @@ class AtmNativeTools:
         if isinstance(request, dict):
             return request
         return _invoke(
-                lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
-                _send_result,
-                reconnect=self._session.reconnect,
-                retry_after_reconnect=False,
+            lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
+            _send_result,
+            reconnect=self._session.reconnect,
+            retry_after_reconnect=False,
         )
 
     def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -194,10 +194,10 @@ class AtmNativeTools:
                 request.contains,
                 request.since,
                 request.from_agent,
-                ),
-                _read_result,
-                reconnect=self._session.reconnect,
-                retry_after_reconnect=True,
+            ),
+            _read_result,
+            reconnect=self._session.reconnect,
+            retry_after_reconnect=True,
         )
 
     def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -212,10 +212,10 @@ class AtmNativeTools:
                 request.contains,
                 request.since,
                 request.from_agent,
-                ),
-                _list_result,
-                reconnect=self._session.reconnect,
-                retry_after_reconnect=True,
+            ),
+            _list_result,
+            reconnect=self._session.reconnect,
+            retry_after_reconnect=True,
         )
 
 

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -106,21 +106,61 @@ def _list_result(result: Any) -> dict[str, Any]:
     }
 
 
-def _invoke(call: Callable[[], Any], project: Callable[[Any], dict[str, Any]]) -> ToolEnvelope:
+def _is_daemon_unavailable(outcome: Any) -> bool:
+    return (
+        isinstance(outcome, atm_graft.AtmToolError)
+        and outcome.code == "ATM_DAEMON_UNAVAILABLE"
+    )
+
+
+def _invoke(
+    call: Callable[[], Any],
+    project: Callable[[Any], dict[str, Any]],
+    *,
+    reconnect: Callable[[], None],
+    retry_after_reconnect: bool,
+) -> ToolEnvelope:
+    """Run one native operation and refresh a stale client after a daemon cycle.
+
+    Read-only operations may replay once after refresh. A send does not: a
+    transport error can occur after the daemon admits a write, so replaying it
+    could create a duplicate delivery. The refresh makes the caller's next
+    explicit send use the successor daemon connection.
+    """
+
+    # Native-tool methods project canonical Rust failures as AtmToolError
+    # values rather than Python exceptions, preserving their public code.
+    outcome = call()
+    if not _is_daemon_unavailable(outcome):
+        return _native_error(outcome) if isinstance(outcome, atm_graft.AtmToolError) else {
+            "kind": "success",
+            "result": project(outcome),
+        }
+
     try:
-        # The typed graft result is projected once at this Hermes-only JSON
-        # boundary; raw JSON never crosses into or out of atm_graft.
-        outcome = call()
-    except Exception as error:  # native binding establishes the canonical code
-        return _error(
-            code="ATM_NATIVE_OPERATION_FAILED",
-            message=str(error),
-            recovery="verify the local ATM daemon and configured identity, then retry",
-            layer="native_client",
+        reconnect()
+    except Exception as reconnect_error:
+        envelope = _native_error(outcome)
+        envelope["error"]["recovery"] = (
+            "the native ATM session could not reconnect; verify the managed daemon is healthy, "
+            f"then retry ({reconnect_error})"
         )
-    if isinstance(outcome, atm_graft.AtmToolError):
-        return _native_error(outcome)
-    return {"kind": "success", "result": project(outcome)}
+        return envelope
+
+    if retry_after_reconnect:
+        retry_outcome = call()
+        return (
+            _native_error(retry_outcome)
+            if isinstance(retry_outcome, atm_graft.AtmToolError)
+            else {"kind": "success", "result": project(retry_outcome)}
+        )
+
+    envelope = _native_error(outcome)
+    envelope["error"]["recovery"] = (
+        "the native ATM session was refreshed after a transient failure; retry this send once. "
+        "The failed send was not replayed to avoid duplicate delivery"
+    )
+    return envelope
 
 
 class AtmNativeTools:
@@ -136,8 +176,10 @@ class AtmNativeTools:
         if isinstance(request, dict):
             return request
         return _invoke(
-            lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
-            _send_result,
+                lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
+                _send_result,
+                reconnect=self._session.reconnect,
+                retry_after_reconnect=False,
         )
 
     def atm_read(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -152,8 +194,10 @@ class AtmNativeTools:
                 request.contains,
                 request.since,
                 request.from_agent,
-            ),
-            _read_result,
+                ),
+                _read_result,
+                reconnect=self._session.reconnect,
+                retry_after_reconnect=True,
         )
 
     def atm_list(self, arguments: Mapping[str, Any], **_: Any) -> ToolEnvelope:
@@ -168,8 +212,10 @@ class AtmNativeTools:
                 request.contains,
                 request.since,
                 request.from_agent,
-            ),
-            _list_result,
+                ),
+                _list_result,
+                reconnect=self._session.reconnect,
+                retry_after_reconnect=True,
         )
 
 

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -150,7 +150,12 @@ class AtmNativeTools:
             return _render_for_hermes(request)
         return _render_for_hermes(
             _invoke(
-                lambda: self._session.send_tool(request.to, request.body, request.requires_ack),
+                lambda: self._session.send_tool(
+                    request.to,
+                    request.body,
+                    request.requires_ack,
+                    request.acknowledges_message_id,
+                ),
                 _send_result,
             )
         )

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -149,6 +149,9 @@ class InstallerTests(unittest.TestCase):
                 json.loads((plugin / "config.json").read_text(encoding="utf-8")),
                 json.loads((hook / "config.json").read_text(encoding="utf-8")),
             )
+            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
+            self.assertIn("hermes-atm-native-tools", profile_config)
+            self.assertIn("enabled:", profile_config)
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
@@ -160,6 +163,28 @@ class InstallerTests(unittest.TestCase):
                     workspace_root="/tmp/workspace",
                 )["changed"]
             )
+
+    def test_install_preserves_existing_plugin_allowlist_and_enables_native_tools(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules():
+            profile_home = Path(temporary) / "profile"
+            profile_home.mkdir(parents=True)
+            (profile_home / "config.yaml").write_text(
+                "plugins:\n  enabled:\n    - another-plugin\nother: value\n",
+                encoding="utf-8",
+            )
+            install_profile(
+                profile_home=profile_home,
+                profile="skillrx",
+                identity="skillrx",
+                team="hermes",
+                chat_id="100000001",
+                atm_home="/tmp/atm",
+                workspace_root="/tmp/workspace",
+            )
+            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
+            self.assertIn("- another-plugin", profile_config)
+            self.assertIn("- hermes-atm-native-tools", profile_config)
+            self.assertIn("other: value", profile_config)
 
     def test_install_rejects_a_launch_agent_for_another_interpreter(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import redirect_stdout
 from io import StringIO
 import json
+import os
 from pathlib import Path
 import plistlib
 import runpy
@@ -61,6 +62,7 @@ class GatewayModules:
         self.original_config = sys.modules.get("gateway.config")
         self.original_run = sys.modules.get("gateway.run")
         self.original_hermes_cli = sys.modules.get("hermes_cli")
+        self.original_hermes_config = sys.modules.get("hermes_cli.config")
         self.original_plugins = sys.modules.get("hermes_cli.plugins")
 
         class Platform:
@@ -78,19 +80,34 @@ class GatewayModules:
         config.Platform = Platform
         run.GatewayRunner = GatewayRunner
         hermes_cli = types.ModuleType("hermes_cli")
+        hermes_config = types.ModuleType("hermes_cli.config")
         plugins = types.ModuleType("hermes_cli.plugins")
+
+        def load_config():
+            config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+            return json.loads(config_path.read_text()) if config_path.exists() else {}
+
+        def save_config(config, *, merge_existing=False):
+            del merge_existing
+            config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
 
         class PluginContext:
             def register_tool(self, **_kwargs):
                 return None
 
         plugins.PluginContext = PluginContext
+        hermes_config.load_config = load_config
+        hermes_config.save_config = save_config
         hermes_cli.plugins = plugins
+        hermes_cli.config = hermes_config
         gateway.config = config
         sys.modules["gateway"] = gateway
         sys.modules["gateway.config"] = config
         sys.modules["gateway.run"] = run
         sys.modules["hermes_cli"] = hermes_cli
+        sys.modules["hermes_cli.config"] = hermes_config
         sys.modules["hermes_cli.plugins"] = plugins
         self.runner = GatewayRunner()
         return self
@@ -101,6 +118,7 @@ class GatewayModules:
             ("gateway.config", self.original_config),
             ("gateway.run", self.original_run),
             ("hermes_cli", self.original_hermes_cli),
+            ("hermes_cli.config", self.original_hermes_config),
             ("hermes_cli.plugins", self.original_plugins),
         ):
             if value is None:
@@ -149,9 +167,8 @@ class InstallerTests(unittest.TestCase):
                 json.loads((plugin / "config.json").read_text(encoding="utf-8")),
                 json.loads((hook / "config.json").read_text(encoding="utf-8")),
             )
-            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
-            self.assertIn("hermes-atm-native-tools", profile_config)
-            self.assertIn("enabled:", profile_config)
+            profile_config = json.loads((profile_home / "config.yaml").read_text())
+            self.assertEqual(profile_config["plugins"]["enabled"], ["hermes-atm-native-tools"])
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
@@ -169,7 +186,7 @@ class InstallerTests(unittest.TestCase):
             profile_home = Path(temporary) / "profile"
             profile_home.mkdir(parents=True)
             (profile_home / "config.yaml").write_text(
-                "plugins:\n  enabled:\n    - another-plugin\nother: value\n",
+                json.dumps({"plugins": {"enabled": ["another-plugin"]}, "other": "value"}),
                 encoding="utf-8",
             )
             install_profile(
@@ -181,10 +198,12 @@ class InstallerTests(unittest.TestCase):
                 atm_home="/tmp/atm",
                 workspace_root="/tmp/workspace",
             )
-            profile_config = (profile_home / "config.yaml").read_text(encoding="utf-8")
-            self.assertIn("- another-plugin", profile_config)
-            self.assertIn("- hermes-atm-native-tools", profile_config)
-            self.assertIn("other: value", profile_config)
+            profile_config = json.loads((profile_home / "config.yaml").read_text())
+            self.assertEqual(
+                profile_config["plugins"]["enabled"],
+                ["another-plugin", "hermes-atm-native-tools"],
+            )
+            self.assertEqual(profile_config["other"], "value")
 
     def test_install_rejects_a_launch_agent_for_another_interpreter(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -49,6 +49,9 @@ class _FakeSession:
             message_id="test", requires_ack=requires_ack, outcome="sent"
         )
 
+    def reconnect(self):
+        self.reconnect_calls = getattr(self, "reconnect_calls", 0) + 1
+
 
 class _TypedToolError:
     code = "ATM_DAEMON_UNAVAILABLE"
@@ -96,24 +99,50 @@ class NativeToolsTests(unittest.TestCase):
         self.assertEqual(rejected["error"]["layer"], "ingress_validation")
         self.assertEqual(len(self.session.calls), 1)
 
-    def test_send_projects_rust_typed_error_without_exception_attribute_rebuild(self):
+    def test_send_projects_typed_error_with_safe_retry_once_recovery(self):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         self.session.send_tool = lambda *_args: _TypedToolError()
 
         result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
 
-        self.assertEqual(
-            result,
-            {
-                "kind": "error",
-                "error": {
-                    "code": "ATM_DAEMON_UNAVAILABLE",
-                    "message": "the local daemon is unavailable",
-                    "recovery": "start the local daemon and retry",
-                    "layer": "native_client",
-                },
-            },
+        self.assertEqual(result["kind"], "error")
+        self.assertEqual(result["error"]["code"], "ATM_DAEMON_UNAVAILABLE")
+        self.assertEqual(result["error"]["message"], "the local daemon is unavailable")
+        self.assertEqual(result["error"]["layer"], "native_client")
+        self.assertIn("retry this send once", result["error"]["recovery"])
+        self.assertIn("was not replayed", result["error"]["recovery"])
+        self.assertEqual(self.session.reconnect_calls, 1)
+
+    def test_send_refreshes_connection_without_replaying_an_ambiguous_write(self):
+        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
+        self.session.send_tool = lambda *_args: _TypedToolError()
+
+        result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+
+        self.assertEqual(result["kind"], "error")
+        self.assertEqual(self.session.reconnect_calls, 1)
+        self.assertIn("was not replayed", result["error"]["recovery"])
+
+    def test_read_retries_once_after_a_refreshed_connection(self):
+        attempts = []
+
+        def call():
+            attempts.append("call")
+            if len(attempts) == 1:
+                return _TypedToolError()
+            return types.SimpleNamespace(value="recovered")
+
+        reconnects = []
+        result = native_tools._invoke(
+            call,
+            lambda outcome: {"value": outcome.value},
+            reconnect=lambda: reconnects.append("reconnected"),
+            retry_after_reconnect=True,
         )
+
+        self.assertEqual(result, {"kind": "success", "result": {"value": "recovered"}})
+        self.assertEqual(attempts, ["call", "call"])
+        self.assertEqual(reconnects, ["reconnected"])
 
     def test_registration_uses_public_plugin_context(self):
         calls = []

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import types
 import unittest
@@ -86,12 +87,14 @@ class NativeToolsTests(unittest.TestCase):
     def test_send_validates_before_the_native_client_and_preserves_requires_ack(self):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         recipient = "native-tool-recipient@hermes"
-        result = tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
+        result = json.loads(
+            tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
+        )
         self.assertEqual(result["kind"], "success")
         self.assertEqual(result["result"]["message_id"], "test")
         self.assertEqual(self.session.calls, [(recipient, "hello", True)])
 
-        rejected = tools.atm_send({"to": recipient, "body": "hello", "unexpected": 1})
+        rejected = json.loads(tools.atm_send({"to": recipient, "body": "hello", "unexpected": 1}))
         self.assertEqual(rejected["kind"], "error")
         self.assertEqual(rejected["error"]["layer"], "ingress_validation")
         self.assertEqual(len(self.session.calls), 1)
@@ -100,7 +103,9 @@ class NativeToolsTests(unittest.TestCase):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         self.session.send_tool = lambda *_args: _TypedToolError()
 
-        result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+        result = json.loads(
+            tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+        )
 
         self.assertEqual(
             result,
@@ -125,6 +130,10 @@ class NativeToolsTests(unittest.TestCase):
         native_tools.register_tools(Context(), identity="skillrx", team="hermes", chat_id="local")
         self.assertEqual([call["name"] for call in calls], ["atm_send", "atm_read", "atm_list"])
         self.assertTrue(all(call["toolset"] == "atm" for call in calls))
+        for call in calls:
+            outcome = call["handler"]({})
+            self.assertIsInstance(outcome, str)
+            self.assertEqual(json.loads(outcome)["kind"], "error")
 
 
 if __name__ == "__main__":

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -20,14 +20,15 @@ class _Model:
 
     @classmethod
     def model_validate(cls, value):
-        allowed = {"to", "body", "requires_ack"}
+        allowed = {"to", "body", "requires_ack", "acknowledges_message_id"}
         unknown = set(value) - allowed
         if unknown:
             raise _ValidationError()
         return cls(
-            to=value["to"],
+            to=value.get("to"),
             body=value["body"],
             requires_ack=value.get("requires_ack", False),
+            acknowledges_message_id=value.get("acknowledges_message_id"),
         )
 
     @classmethod
@@ -44,8 +45,8 @@ class _FakeSession:
     def __init__(self, _caller):
         self.calls = []
 
-    def send_tool(self, to, body, requires_ack):
-        self.calls.append((to, body, requires_ack))
+    def send_tool(self, to, body, requires_ack, acknowledges_message_id):
+        self.calls.append((to, body, requires_ack, acknowledges_message_id))
         return types.SimpleNamespace(
             message_id="test", requires_ack=requires_ack, outcome="sent"
         )
@@ -92,7 +93,7 @@ class NativeToolsTests(unittest.TestCase):
         )
         self.assertEqual(result["kind"], "success")
         self.assertEqual(result["result"]["message_id"], "test")
-        self.assertEqual(self.session.calls, [(recipient, "hello", True)])
+        self.assertEqual(self.session.calls, [(recipient, "hello", True, None)])
 
         rejected = json.loads(tools.atm_send({"to": recipient, "body": "hello", "unexpected": 1}))
         self.assertEqual(rejected["kind"], "error")
@@ -118,6 +119,21 @@ class NativeToolsTests(unittest.TestCase):
                     "layer": "native_client",
                 },
             },
+        )
+
+    def test_send_forwards_optional_acknowledgement_id_without_a_destination(self):
+        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
+
+        result = json.loads(
+            tools.atm_send(
+                {"body": "received", "acknowledges_message_id": "01KZSSREKYM7G39237P0YQ3CW3"}
+            )
+        )
+
+        self.assertEqual(result["kind"], "success")
+        self.assertEqual(
+            self.session.calls,
+            [(None, "received", False, "01KZSSREKYM7G39237P0YQ3CW3")],
         )
 
     def test_registration_uses_public_plugin_context(self):

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -113,16 +113,6 @@ class NativeToolsTests(unittest.TestCase):
         self.assertIn("was not replayed", result["error"]["recovery"])
         self.assertEqual(self.session.reconnect_calls, 1)
 
-    def test_send_refreshes_connection_without_replaying_an_ambiguous_write(self):
-        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
-        self.session.send_tool = lambda *_args: _TypedToolError()
-
-        result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
-
-        self.assertEqual(result["kind"], "error")
-        self.assertEqual(self.session.reconnect_calls, 1)
-        self.assertIn("was not replayed", result["error"]["recovery"])
-
     def test_read_retries_once_after_a_refreshed_connection(self):
         attempts = []
 

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -49,6 +49,7 @@ class _FakeSession:
             message_id="test", requires_ack=requires_ack, outcome="sent"
         )
 
+
 class _TypedToolError:
     code = "ATM_DAEMON_UNAVAILABLE"
     message = "the local daemon is unavailable"

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -49,10 +49,6 @@ class _FakeSession:
             message_id="test", requires_ack=requires_ack, outcome="sent"
         )
 
-    def reconnect(self):
-        self.reconnect_calls = getattr(self, "reconnect_calls", 0) + 1
-
-
 class _TypedToolError:
     code = "ATM_DAEMON_UNAVAILABLE"
     message = "the local daemon is unavailable"
@@ -99,40 +95,24 @@ class NativeToolsTests(unittest.TestCase):
         self.assertEqual(rejected["error"]["layer"], "ingress_validation")
         self.assertEqual(len(self.session.calls), 1)
 
-    def test_send_projects_typed_error_with_safe_retry_once_recovery(self):
+    def test_send_projects_rust_typed_error_without_exception_attribute_rebuild(self):
         tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
         self.session.send_tool = lambda *_args: _TypedToolError()
 
         result = tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
 
-        self.assertEqual(result["kind"], "error")
-        self.assertEqual(result["error"]["code"], "ATM_DAEMON_UNAVAILABLE")
-        self.assertEqual(result["error"]["message"], "the local daemon is unavailable")
-        self.assertEqual(result["error"]["layer"], "native_client")
-        self.assertIn("retry this send once", result["error"]["recovery"])
-        self.assertIn("was not replayed", result["error"]["recovery"])
-        self.assertEqual(self.session.reconnect_calls, 1)
-
-    def test_read_retries_once_after_a_refreshed_connection(self):
-        attempts = []
-
-        def call():
-            attempts.append("call")
-            if len(attempts) == 1:
-                return _TypedToolError()
-            return types.SimpleNamespace(value="recovered")
-
-        reconnects = []
-        result = native_tools._invoke(
-            call,
-            lambda outcome: {"value": outcome.value},
-            reconnect=lambda: reconnects.append("reconnected"),
-            retry_after_reconnect=True,
+        self.assertEqual(
+            result,
+            {
+                "kind": "error",
+                "error": {
+                    "code": "ATM_DAEMON_UNAVAILABLE",
+                    "message": "the local daemon is unavailable",
+                    "recovery": "start the local daemon and retry",
+                    "layer": "native_client",
+                },
+            },
         )
-
-        self.assertEqual(result, {"kind": "success", "result": {"value": "recovered"}})
-        self.assertEqual(attempts, ["call", "call"])
-        self.assertEqual(reconnects, ["reconnected"])
 
     def test_registration_uses_public_plugin_context(self):
         calls = []

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -113,8 +113,12 @@ Initial crate requirement IDs:
   override any of those values.
   `AtmSendRequest.requires_ack` is in scope, defaults to `false`, and maps to
   the ordinary `SendRequest` / CLI `--ack-required` send semantics. This does
-  not add a graft or Python acknowledgement operation: acknowledging received
-  pending acknowledgements remains the canonical `atm ack` CLI path.
+  not add a separate graft or Python acknowledgement tool or mode:
+  `AtmSendRequest.acknowledges_message_id` is an optional field on the same
+  native `atm_send` path. When set it acknowledges the named pending-ack
+  message through the canonical `WriteRequest` acknowledgement shape; `to`
+  is omitted and `requires_ack` is false. The `atm ack` CLI command is
+  unchanged and remains available for callers who prefer it.
 - `REQ-GRAFT-HERMES-005` Native Hermes tools use only the public installed
   `atm_graft` Python API and the public Hermes registration API. They must not
   invoke the `atm` executable, create a second daemon client/receiver,

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -158,6 +158,14 @@ Initial crate requirement IDs:
   strings/dicts must never pass through `atm_graft`, and no Python layer may
   reproduce HTTP serialization. Tests cover ingress model-validation success
   and failure for every public tool.
+- `REQ-GRAFT-HERMES-009` A long-lived Hermes native-tool session must refresh
+  its public `PyGraftSession` client after an `ATM_DAEMON_UNAVAILABLE` result
+  caused by an operator-managed daemon cycle. `atm_read` and `atm_list` may
+  replay exactly once after that refresh because they are read-only. `atm_send`
+  must refresh but must not replay automatically: it returns a structured
+  retry-once recovery action because the original write may already have been
+  accepted. Refreshing a client never starts, replaces, or otherwise controls
+  the managed daemon.
 
 AI.38 evidence note: the reference adapter calls only the injected Hermes
 `session.steer` port with a runtime session id resolved from the configured


### PR DESCRIPTION
## Summary
Fixes a production-breaking reliability gap found via live SkillRX testing: `PyGraftSession` held one long-lived `GraftClient` with its daemon endpoint resolved once at construction and never re-resolved, so native tool calls (`atm_send`/`atm_read`/`atm_list`) would permanently break after any daemon restart until the whole Hermes gateway process itself restarted. The CLI was unaffected since every invocation reconnects fresh.

Fix: rebuild/refresh the cached session on a transient native-call failure. Auto-retry only idempotent operations (`atm_read`/`atm_list`). For `atm_send` (non-idempotent, no dedup contract), return a structured recovered-connection/retry-once error rather than risk a silent double-send.

Commits: f4931501, f7be05db, 591e38d0, 683a7682

## Test plan
- [x] Focused local tests + `just lint` + `cargo test --workspace`
- [x] Live SkillRX daemon-cycle reproduction proving the fix (not stub-only)
- [ ] quality-mgr QA pass

Gates PR #852 and PR #853 (Phase AM -> develop), both currently held pending this and PR #852's own outstanding items.