### PR TITLE
AN.4: Render-on-Read — read paths, export, determinism

### DIFF
--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::address::AgentAddress;
+use crate::boundary;
 use crate::error::AtmError;
 use crate::mailbox::source::resolve_target;
 use crate::observability::ObservabilityPort;
@@ -192,6 +193,12 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         contains_needle,
     )?;
     sort_and_limit_selected(&mut selected, query.limit);
+
+    for message in &mut selected {
+        let key = boundary::MessageKey::new(message.source_path.to_string_lossy().into_owned())?;
+        message.envelope =
+            runtime.render_message_body(&key, message.envelope.message_id, &message.envelope)?;
+    }
 
     let rows = selected
         .iter()

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -194,11 +194,7 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     )?;
     sort_and_limit_selected(&mut selected, query.limit);
 
-    for message in &mut selected {
-        let key = boundary::MessageKey::new(message.source_path.to_string_lossy().into_owned())?;
-        message.envelope =
-            runtime.render_message_body(&key, message.envelope.message_id, &message.envelope)?;
-    }
+    render_selected_messages(runtime, &mut selected)?;
 
     let rows = selected
         .iter()
@@ -216,6 +212,18 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         rows,
         bucket_counts,
     })
+}
+
+fn render_selected_messages<R: RetainedMailboxRuntime>(
+    runtime: &R,
+    selected: &mut [ClassifiedMessage],
+) -> Result<(), AtmError> {
+    for message in selected {
+        let key = boundary::MessageKey::new(message.source_path.to_string_lossy().into_owned())?;
+        message.envelope =
+            runtime.render_message_body(&key, message.envelope.message_id, &message.envelope)?;
+    }
+    Ok(())
 }
 
 fn metadata_limit_for_list(query: &ListQuery, storage_counts_available: bool) -> Option<usize> {

--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -36,8 +36,9 @@ pub fn write_messages(
     path: &Path,
     messages: &[InboxMessage],
     export_policy: SharedAppendPolicy,
+    render: &dyn Fn(&InboxMessage) -> Result<InboxMessage, AtmError>,
 ) -> Result<(), AtmError> {
-    write_message_iter(path, messages.iter(), export_policy)
+    write_message_iter_with_renderer(path, messages.iter(), export_policy, render)
 }
 
 #[cfg(test)]
@@ -49,10 +50,24 @@ pub fn write_message_iter<'a, I>(
 where
     I: IntoIterator<Item = &'a InboxMessage>,
 {
+    write_message_iter_with_renderer(path, messages, export_policy, &identity)
+}
+
+#[cfg(test)]
+fn write_message_iter_with_renderer<'a, I>(
+    path: &Path,
+    messages: I,
+    export_policy: SharedAppendPolicy,
+    render: &dyn Fn(&InboxMessage) -> Result<InboxMessage, AtmError>,
+) -> Result<(), AtmError>
+where
+    I: IntoIterator<Item = &'a InboxMessage>,
+{
     let iterator = messages.into_iter();
     let mut encoded = Vec::<Value>::new();
     for message in iterator {
-        encoded.push(to_shared_inbox_value_with_policy(message, export_policy)?);
+        let rendered = render(message)?;
+        encoded.push(to_shared_inbox_value_with_policy(&rendered, export_policy)?);
     }
     let mut bytes = serde_json::to_vec(&encoded)?;
     bytes.push(b'\n');
@@ -64,6 +79,11 @@ where
         "mailbox file",
         "Check that the mailbox directory is writable, has available disk space, and resides on a healthy filesystem before retrying the ATM command.",
     )
+}
+
+#[cfg(test)]
+fn identity(message: &InboxMessage) -> Result<InboxMessage, AtmError> {
+    Ok(message.clone())
 }
 
 #[cfg_attr(

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -50,7 +50,25 @@ fn write_compat_mailbox_projection_with_policy(
     messages: &[InboxMessage],
     export_policy: SharedAppendPolicy,
 ) -> Result<(), AtmError> {
-    atomic::write_messages(path, messages, export_policy)
+    write_compat_mailbox_projection_with_renderer(path, messages, export_policy, &identity)
+}
+
+/// Render each envelope before the atomic writer applies Claude's export-size
+/// policy. The renderer is injected by the core/runtime boundary so this
+/// compatibility writer never reaches into a storage or composition adapter.
+#[cfg(test)]
+pub(crate) fn write_compat_mailbox_projection_with_renderer(
+    path: &Path,
+    messages: &[InboxMessage],
+    export_policy: SharedAppendPolicy,
+    render: &dyn Fn(&InboxMessage) -> Result<InboxMessage, AtmError>,
+) -> Result<(), AtmError> {
+    atomic::write_messages(path, messages, export_policy, render)
+}
+
+#[cfg(test)]
+fn identity(message: &InboxMessage) -> Result<InboxMessage, AtmError> {
+    Ok(message.clone())
 }
 
 #[cfg(test)]
@@ -90,8 +108,11 @@ pub(crate) fn inbox_file_format(path: &Path) -> InboxFileFormat {
 mod tests {
     use tempfile::tempdir;
 
-    use super::write_compat_mailbox_projection;
+    use super::{
+        identity, write_compat_mailbox_projection, write_compat_mailbox_projection_with_renderer,
+    };
     use crate::mailbox::load_compat_mailbox_messages;
+    use crate::schema::inbox_message::SharedAppendPolicy;
     use crate::schema::{AtmMessageId, InboxMessage};
     use crate::test_support::{TEST_QA, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp};
@@ -155,6 +176,53 @@ mod tests {
             encoded[0]["summary"],
             serde_json::Value::String("stub summary".into())
         );
+    }
+
+    #[test]
+    fn jsonl_export_stubs_rendered_and_plain_oversized_bodies_identically() {
+        let tempdir = tempdir().expect("tempdir");
+        let rendered_path = tempdir.path().join("rendered.json");
+        let plain_path = tempdir.path().join("plain.json");
+        let message = sample_message(TEST_SENDER, "stored decomposition");
+        let message_id = message.message_id.expect("message id");
+        let policy = SharedAppendPolicy {
+            atm_authored_body_export_max_bytes: crate::config::types::ByteCount::new(8),
+        };
+        let rendered_body = "rendered body that exceeds the export cap".to_string();
+
+        write_compat_mailbox_projection_with_renderer(
+            &rendered_path,
+            std::slice::from_ref(&message),
+            policy,
+            &|stored| {
+                let mut rendered = stored.clone();
+                rendered.text = rendered_body.clone();
+                Ok(rendered)
+            },
+        )
+        .expect("rendered export");
+
+        let mut plain = message.clone();
+        plain.text = rendered_body;
+        write_compat_mailbox_projection_with_renderer(
+            &plain_path,
+            std::slice::from_ref(&plain),
+            policy,
+            &identity,
+        )
+        .expect("plain export");
+
+        let rendered_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(rendered_path).expect("rendered JSON"))
+                .expect("rendered array");
+        let plain_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(plain_path).expect("plain JSON"))
+                .expect("plain array");
+        let expected_stub =
+            serde_json::Value::String(format!("atm read --message-id {message_id}"));
+        assert_eq!(rendered_json[0]["text"], expected_stub);
+        assert_eq!(plain_json[0]["text"], expected_stub);
+        assert_eq!(rendered_json[0], plain_json[0]);
     }
 
     fn sample_message(from: &str, text: &str) -> InboxMessage {

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -40,7 +40,7 @@ pub(crate) fn write_compat_mailbox_projection(
     messages: &[InboxMessage],
 ) -> Result<(), AtmError> {
     let export_policy = export_policy_for_path(path)?;
-    write_compat_mailbox_projection_with_policy(path, messages, export_policy)
+    write_compat_mailbox_projection_with_policy(path, messages, export_policy, &identity)
 }
 
 /// Repair/rebuild only — not reachable from normal runtime send or ack paths.
@@ -49,20 +49,10 @@ fn write_compat_mailbox_projection_with_policy(
     path: &Path,
     messages: &[InboxMessage],
     export_policy: SharedAppendPolicy,
-) -> Result<(), AtmError> {
-    write_compat_mailbox_projection_with_renderer(path, messages, export_policy, &identity)
-}
-
-/// Render each envelope before the atomic writer applies Claude's export-size
-/// policy. The renderer is injected by the core/runtime boundary so this
-/// compatibility writer never reaches into a storage or composition adapter.
-#[cfg(test)]
-pub(crate) fn write_compat_mailbox_projection_with_renderer(
-    path: &Path,
-    messages: &[InboxMessage],
-    export_policy: SharedAppendPolicy,
     render: &dyn Fn(&InboxMessage) -> Result<InboxMessage, AtmError>,
 ) -> Result<(), AtmError> {
+    // The injected renderer runs before atomic serialization and therefore
+    // before schema stub sizing decisions are made for the Claude export.
     atomic::write_messages(path, messages, export_policy, render)
 }
 
@@ -109,7 +99,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        identity, write_compat_mailbox_projection, write_compat_mailbox_projection_with_renderer,
+        identity, write_compat_mailbox_projection, write_compat_mailbox_projection_with_policy,
     };
     use crate::mailbox::load_compat_mailbox_messages;
     use crate::schema::inbox_message::SharedAppendPolicy;
@@ -190,7 +180,7 @@ mod tests {
         };
         let rendered_body = "rendered body that exceeds the export cap".to_string();
 
-        write_compat_mailbox_projection_with_renderer(
+        write_compat_mailbox_projection_with_policy(
             &rendered_path,
             std::slice::from_ref(&message),
             policy,
@@ -204,7 +194,7 @@ mod tests {
 
         let mut plain = message.clone();
         plain.text = rendered_body;
-        write_compat_mailbox_projection_with_renderer(
+        write_compat_mailbox_projection_with_policy(
             &plain_path,
             std::slice::from_ref(&plain),
             policy,

--- a/crates/atm-core/src/read/metadata_selection.rs
+++ b/crates/atm-core/src/read/metadata_selection.rs
@@ -228,6 +228,8 @@ pub(crate) fn load_durable_metadata_message<R: RetainedMailboxRuntime>(
     } else {
         record.envelope
     };
+    let envelope =
+        runtime.render_message_body(&metadata_row.message_key, envelope.message_id, &envelope)?;
     Ok(ClassifiedMessage {
         source_index: selected_message.source_index,
         source_path: selected_message.source_path.clone(),
@@ -267,7 +269,9 @@ fn load_durable_message_text<R: RetainedMailboxRuntime>(
     } else {
         record.envelope
     };
-    Ok(envelope.text)
+    Ok(runtime
+        .render_message_body(&metadata_row.message_key, envelope.message_id, &envelope)?
+        .text)
 }
 
 fn load_logical_current_record<R: RetainedMailboxRuntime>(

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod filters;
 pub(crate) mod metadata_selection;
+pub(crate) mod render;
 mod request;
 pub(crate) mod seen_state;
 pub(crate) mod state;

--- a/crates/atm-core/src/read/render.rs
+++ b/crates/atm-core/src/read/render.rs
@@ -1,0 +1,182 @@
+//! Core-owned render-on-read policy for decomposed mailbox records.
+//!
+//! The storage layer supplies immutable bytes and merged variables while the
+//! composition root supplies the renderer port. Keeping this operation here
+//! prevents read surfaces from depending on SQLite or the sc-compose adapter.
+
+use atm_storage::{MergedVarsJson, StoredTemplate, TemplateCatalogStore};
+
+use crate::boundary::{RenderedBody, TemplateComposer, TemplateSource};
+use crate::error::AtmError;
+use crate::schema::{AtmMessageId, InboxMessage};
+
+/// Render one stored template without making filesystem or resolver calls.
+///
+/// This is intentionally a pure function of the immutable catalog row and the
+/// already-merged variables captured at admission time.
+pub fn render_decomposed(
+    composer: &dyn TemplateComposer,
+    template: &StoredTemplate,
+    vars: &MergedVarsJson,
+) -> Result<RenderedBody, AtmError> {
+    let source = TemplateSource {
+        raw_file_bytes: template.content_bytes.clone(),
+    };
+    composer.render_without_includes(&source, vars.as_map())
+}
+
+/// Render a durable envelope when its message key has decomposition columns.
+///
+/// The returned envelope is suitable for every presentation surface. For a
+/// decomposed row its summary is refreshed from the rendered prefix so list
+/// and peek snippets never rely on the nullable storage body column.
+pub(crate) fn render_message_body(
+    catalog: &dyn TemplateCatalogStore,
+    composer: Option<&dyn TemplateComposer>,
+    key: &crate::boundary::MessageKey,
+    message_id: Option<AtmMessageId>,
+    envelope: &InboxMessage,
+) -> Result<InboxMessage, AtmError> {
+    let Some(decomposed) = catalog.load_decomposed_message(key)? else {
+        return Ok(envelope.clone());
+    };
+    let message_label = message_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "<none>".to_string());
+    let template_sha = decomposed.template_sha.clone();
+    let composer = composer.ok_or_else(|| {
+        AtmError::mailbox_read(format!(
+            "decomposed message_id {message_label} template_sha {template_sha} cannot be rendered because no TemplateComposer is installed"
+        ))
+    })?;
+    let template = catalog.load(&template_sha)?.ok_or_else(|| {
+        AtmError::mailbox_read(format!(
+            "decomposed message_id {message_label} template_sha {template_sha} is missing; re-register the same template SHA"
+        ))
+    })?;
+    let rendered = render_decomposed(composer, &template, &decomposed.vars).map_err(|error| {
+        // Preserve the renderer's stable typed code (notably
+        // DECOMPOSED_TEMPLATE_INCLUDE_FORBIDDEN) while adding the durable
+        // identifiers needed to diagnose a corrupt row.
+        AtmError::new(
+            error.code(),
+            format!(
+                "decomposed message_id {message_label} template_sha {template_sha}: {}",
+                error.detail()
+            ),
+        )
+        .with_cause(error.message())
+    })?;
+    let mut envelope = envelope.clone();
+    envelope.text = rendered.text;
+    envelope.summary = Some(rendered_prefix(&envelope.text));
+    Ok(envelope)
+}
+
+fn rendered_prefix(text: &str) -> String {
+    text.chars().take(160).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use atm_storage::{TemplateFrontmatter, TemplateSha};
+    use serde_json::{Map, Value};
+
+    use super::{render_decomposed, rendered_prefix};
+    use crate::boundary::sealed;
+    use crate::boundary::{
+        RenderedBody, TemplateComposer, TemplateInspection, TemplateRoot, TemplateSource,
+    };
+
+    struct FixtureComposer {
+        includes: bool,
+    }
+
+    impl sealed::Sealed for FixtureComposer {}
+
+    impl TemplateComposer for FixtureComposer {
+        fn inspect(
+            &self,
+            _raw_file_bytes: &[u8],
+        ) -> Result<TemplateInspection, crate::error::AtmError> {
+            Ok(TemplateInspection {
+                sha: TemplateSha::new("a".repeat(64)).expect("fixture SHA"),
+                frontmatter: TemplateFrontmatter::default(),
+                include_references: Vec::new(),
+            })
+        }
+
+        fn render_within_root(
+            &self,
+            _template: &TemplateSource,
+            _vars: &Map<String, Value>,
+            _root: &TemplateRoot,
+        ) -> Result<RenderedBody, crate::error::AtmError> {
+            unreachable!("render-on-read never uses a loader-backed operation")
+        }
+
+        fn render_without_includes(
+            &self,
+            _source: &TemplateSource,
+            _vars: &Map<String, Value>,
+        ) -> Result<RenderedBody, crate::error::AtmError> {
+            if self.includes {
+                return Err(crate::error::AtmError::decomposed_template_include_forbidden());
+            }
+            Ok(RenderedBody {
+                text: "stable rendered body".to_string(),
+            })
+        }
+    }
+
+    fn template() -> atm_storage::StoredTemplate {
+        atm_storage::StoredTemplate {
+            sha: TemplateSha::new("a".repeat(64)).expect("fixture SHA"),
+            template_type: None,
+            template_name: None,
+            content_bytes: b"stable source".to_vec(),
+            content_text: "stable source".to_string(),
+            frontmatter: TemplateFrontmatter::default(),
+            first_seen: atm_storage::TemplateFirstSeen::new(
+                crate::types::IsoTimestamp::now(),
+                "test",
+            )
+            .expect("first seen"),
+        }
+    }
+
+    #[test]
+    fn rendered_prefix_is_character_bounded() {
+        assert_eq!(rendered_prefix(&"é".repeat(161)).chars().count(), 160);
+    }
+
+    #[test]
+    fn decomposed_render_is_stable_and_uses_the_no_include_port() {
+        let vars = atm_storage::MergedVarsJson::try_from_merged_object(Map::from_iter([(
+            "name".to_string(),
+            Value::String("cipher".to_string()),
+        )]))
+        .expect("merged vars");
+        let composer = FixtureComposer { includes: false };
+        let template = template();
+        let first = render_decomposed(&composer, &template, &vars).expect("render");
+        let second = render_decomposed(&composer, &template, &vars).expect("repeat render");
+        assert_eq!(first, second);
+        assert_eq!(first.text, "stable rendered body");
+    }
+
+    #[test]
+    fn include_rejection_keeps_the_typed_error_contract() {
+        let composer = FixtureComposer { includes: true };
+        let error = render_decomposed(
+            &composer,
+            &template(),
+            &atm_storage::MergedVarsJson::default(),
+        )
+        .expect_err("include-bearing stored source");
+        assert_eq!(
+            error.code(),
+            crate::error_codes::AtmErrorCode::DecomposedTemplateIncludeForbidden
+        );
+    }
+}

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -106,7 +106,16 @@ async fn load_store_backed_mailbox_projection_async(
             .cmp(&right.envelope.timestamp)
             .then_with(|| left.message_key.as_ref().cmp(right.message_key.as_ref()))
     });
-    Ok(records.into_iter().map(|record| record.envelope).collect())
+    records
+        .into_iter()
+        .map(|record| {
+            runtime.render_message_body(
+                &record.message_key,
+                record.envelope.message_id,
+                &record.envelope,
+            )
+        })
+        .collect()
 }
 
 /// Tokio-owned durable admission for ordinary immutable messages.
@@ -182,7 +191,12 @@ fn load_store_backed_mailbox_projection(
         else {
             continue;
         };
-        messages.push(record.envelope);
+        let envelope = runtime.render_message_body(
+            &record.message_key,
+            record.envelope.message_id,
+            &record.envelope,
+        )?;
+        messages.push(envelope);
     }
     Ok(messages)
 }

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, RwLock};
 
 use atm_storage::{
     AsyncMessageStore as SharedAsyncMessageStore, MessageStore as SharedMessageStore,
-    RosterStore as SharedRosterStore,
+    RosterStore as SharedRosterStore, TemplateCatalogStore,
 };
 
 use crate::config::{self, AtmConfig};
@@ -138,6 +138,9 @@ pub struct LocalServiceRuntime {
         std::sync::Arc<dyn crate::boundary::NudgeTemplateOverrideStore + Send + Sync>,
     pub(crate) non_claude_outbound:
         std::sync::Arc<dyn crate::boundary::NonClaudeOutbound + Send + Sync>,
+    pub(crate) template_catalog_store:
+        Option<std::sync::Arc<dyn TemplateCatalogStore + Send + Sync>>,
+    pub(crate) template_composer: Option<std::sync::Arc<dyn crate::boundary::TemplateComposer>>,
     /// Immutable roster snapshots used by daemon-owned admission.
     ///
     /// A daemon reload clears this cache before publishing its replacement
@@ -163,9 +166,25 @@ impl LocalServiceRuntime {
             roster_store,
             nudge_template_override_store,
             non_claude_outbound,
+            template_catalog_store: None,
+            template_composer: None,
             roster_cache: Arc::new(RosterSnapshotCache::default()),
             workspace_config_access: WorkspaceConfigAccess::Client,
         }
+    }
+
+    /// Installs the storage catalog and the composition-root renderer port
+    /// used by render-on-read. The core remains independent of the concrete
+    /// adapter; tests may leave this seam unset for plain-text mailboxes.
+    #[must_use]
+    pub fn with_template_rendering(
+        mut self,
+        template_catalog_store: std::sync::Arc<dyn TemplateCatalogStore + Send + Sync>,
+        template_composer: Option<std::sync::Arc<dyn crate::boundary::TemplateComposer>>,
+    ) -> Self {
+        self.template_catalog_store = Some(template_catalog_store);
+        self.template_composer = template_composer;
+        self
     }
 
     /// Attaches the Tokio-safe durable-admission boundary selected by the

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -115,6 +115,18 @@ pub(crate) trait RetainedMailboxRuntime {
         agent: &AgentName,
         message_key: &boundary::MessageKey,
     ) -> Result<Option<boundary::Message>, AtmError>;
+    /// Resolves a decomposed body through the core renderer port when the
+    /// runtime has one installed. Compatibility test runtimes retain plain
+    /// envelopes through the default implementation.
+    fn render_message_body(
+        &self,
+        message_key: &boundary::MessageKey,
+        message_id: Option<crate::schema::AtmMessageId>,
+        envelope: &crate::schema::InboxMessage,
+    ) -> Result<crate::schema::InboxMessage, AtmError> {
+        let _ = (message_key, message_id);
+        Ok(envelope.clone())
+    }
     /// Atomically admits a new immutable record or returns the existing record
     /// for duplicate classification. The default retains compatibility for
     /// narrow test runtimes; the production SQLite runtime overrides it to
@@ -198,6 +210,24 @@ impl RetainedMailboxRuntime for LocalServiceRuntime {
             .load_message(message_key)?
             .filter(|message| &message.team == team && &message.agent == agent)
             .map(shared_message_to_record))
+    }
+
+    fn render_message_body(
+        &self,
+        message_key: &boundary::MessageKey,
+        message_id: Option<crate::schema::AtmMessageId>,
+        envelope: &crate::schema::InboxMessage,
+    ) -> Result<crate::schema::InboxMessage, AtmError> {
+        let Some(catalog) = self.template_catalog_store.as_deref() else {
+            return Ok(envelope.clone());
+        };
+        crate::read::render::render_message_body(
+            catalog,
+            self.template_composer.as_deref(),
+            message_key,
+            message_id,
+            envelope,
+        )
     }
 
     fn admit_message_record(

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -114,6 +114,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         rosters: storage.roster_store(),
     };
     let async_message_store = storage.async_message_store();
+    let template_catalog_store = storage.template_catalog_store();
     let nudge_template_override_store = storage.nudge_template_override_store();
     let peer_config_store = storage.peer_config_store();
     let service_runtime = LocalServiceRuntime::new_with_delivery_boundaries(
@@ -122,7 +123,8 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         Arc::clone(&nudge_template_override_store),
         inputs.non_claude_outbound,
     )
-    .with_async_message_store(async_message_store);
+    .with_async_message_store(async_message_store)
+    .with_template_rendering(template_catalog_store, template_composer.clone());
     let doctor_ports = runtime_doctor_ports(Arc::new(RuntimeConfigDoctor {
         config_current_dir: Some(inputs.config_current_dir),
     }));

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -836,6 +836,15 @@ mod tests {
                 template: TemplateRegistrationOutcome::AlreadyRegistered
             }
         );
+        let decomposed = catalog
+            .load_decomposed_message(&message.message_key)
+            .expect("load decomposition")
+            .expect("decomposed row exists");
+        assert_eq!(decomposed.key, message.message_key);
+        assert_eq!(decomposed.template_sha, template.sha);
+        assert_eq!(decomposed.category.as_deref(), Some("assignment"));
+        assert_eq!(decomposed.tags, vec!["phase-an"]);
+        assert_eq!(decomposed.content_format.as_deref(), Some("markdown"));
         backend
             .shared_db_for_test()
             .with_connection(|connection| {

--- a/crates/atm-storage-rusqlite/src/template_catalog_store.rs
+++ b/crates/atm-storage-rusqlite/src/template_catalog_store.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use atm_storage::{
-    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, StoredTemplate,
-    TemplateCatalogStore, TemplateFirstSeen, TemplateListFilter, TemplateRegistration,
-    TemplateRegistrationOutcome, TemplateSummary,
+    DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, DecomposedMessageRecord,
+    MergedVarsJson, StoredTemplate, TemplateCatalogStore, TemplateFirstSeen, TemplateListFilter,
+    TemplateRegistration, TemplateRegistrationOutcome, TemplateSummary,
 };
 use rusqlite::{OptionalExtension, params};
 
@@ -62,6 +62,48 @@ impl TemplateCatalogStore for SqliteTemplateCatalogStore {
                 .optional()
                 .map_err(|error| self.db.error("failed to load immutable template", error))?
                 .map(decode_stored_template)
+                .transpose()
+        })
+    }
+
+    fn load_decomposed_message(
+        &self,
+        key: &atm_storage::contract::MessageKey,
+    ) -> Result<Option<DecomposedMessageRecord>, atm_storage::AtmError> {
+        self.db.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT template_sha, vars_json, category, tags_json, content_format
+                     FROM mail_messages
+                     WHERE message_key = ?1 AND template_sha IS NOT NULL",
+                    params![key.as_str()],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, String>(3)?,
+                            row.get::<_, Option<String>>(4)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|error| self.db.error("failed to load decomposed message", error))?
+                .map(
+                    |(template_sha, vars_json, category, tags_json, content_format)| {
+                        let vars = deserialize_json(&vars_json, "decomposed message vars")?;
+                        let vars = MergedVarsJson::try_from_merged_object(vars)?;
+                        let tags = deserialize_json(&tags_json, "decomposed message tags")?;
+                        Ok(DecomposedMessageRecord {
+                            key: key.clone(),
+                            template_sha: template_sha.parse()?,
+                            vars,
+                            category,
+                            tags,
+                            content_format,
+                        })
+                    },
+                )
                 .transpose()
         })
     }

--- a/crates/atm-storage/src/template_catalog.rs
+++ b/crates/atm-storage/src/template_catalog.rs
@@ -219,6 +219,18 @@ pub trait TemplateCatalogStore: crate::contract::sealed::Sealed + Send + Sync {
         request: TemplateRegistration,
     ) -> Result<TemplateRegistrationOutcome, AtmError>;
     fn load(&self, sha: &TemplateSha) -> Result<Option<StoredTemplate>, AtmError>;
+    /// Loads the immutable decomposition columns for one canonical message.
+    ///
+    /// The default keeps narrow legacy doubles source-compatible; concrete
+    /// stores that persist decomposition metadata must override it. Read
+    /// surfaces use this capability to render on demand rather than treating
+    /// the nullable `message_text` column as the body of truth.
+    fn load_decomposed_message(
+        &self,
+        _key: &MessageKey,
+    ) -> Result<Option<DecomposedMessageRecord>, AtmError> {
+        Ok(None)
+    }
     fn list(&self, filter: TemplateListFilter) -> Result<Vec<TemplateSummary>, AtmError>;
     fn admit_decomposed_message(
         &self,
@@ -236,7 +248,7 @@ pub(crate) struct InMemoryTemplateCatalogStore {
 #[derive(Default)]
 struct InMemoryTemplateCatalogState {
     templates: BTreeMap<TemplateSha, StoredTemplate>,
-    decomposed_messages: BTreeMap<MessageKey, TemplateSha>,
+    decomposed_messages: BTreeMap<MessageKey, DecomposedMessageRecord>,
     fail_next_admission: bool,
 }
 
@@ -315,6 +327,19 @@ impl TemplateCatalogStore for InMemoryTemplateCatalogStore {
             .collect())
     }
 
+    fn load_decomposed_message(
+        &self,
+        key: &MessageKey,
+    ) -> Result<Option<DecomposedMessageRecord>, AtmError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AtmError::mailbox_read("in-memory template catalog lock poisoned"))?
+            .decomposed_messages
+            .get(key)
+            .cloned())
+    }
+
     fn admit_decomposed_message(
         &self,
         admission: DecomposedMessageAdmission,
@@ -358,7 +383,7 @@ impl TemplateCatalogStore for InMemoryTemplateCatalogStore {
         };
         state
             .decomposed_messages
-            .insert(admission.message.key, admission.message.template_sha);
+            .insert(admission.message.key.clone(), admission.message);
         Ok(DecomposedMessageAdmissionOutcome::Inserted {
             template: template_outcome,
         })

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -81,6 +81,10 @@ Error codes should describe the failure class, not a specific prose message.
   content that has no strict UTF-8 projection; replace the source with UTF-8
   text and retry. This is checked before either a catalog row or a decomposed
   message row can become durable.
+- `DECOMPOSED_TEMPLATE_INCLUDE_FORBIDDEN` — a stored decomposed template was
+  inspected during render-on-read and still declares an include, import, or
+  from-import. Re-register the same SHA from a dependency-free source; ATM
+  rejects the render before any resolver or loader can run.
 
 #### 5.3.1 `ATM_MAILBOX_LOCK_TIMEOUT`
 


### PR DESCRIPTION
## Summary
- Storage-neutral decomposed lookup
- Core `render_decomposed` / no-include policy with typed corruption context
- Render-on-read across `atm read`, `atm peek`, `atm list`, `contains`, and the Claude JSONL export — inserted before existing stubbing
- Runtime composition wiring
- SQLite lookup tests + docs

## Test plan
- [x] `cargo fmt --check`
- [x] focused and full `just test` suites (workspace fixture diagnostics remain pre-existing)
- [x] clippy / lint checks (cargo-deny wrapper `--config` arg rejected — environment/tooling issue, not a code defect; flagged for quality-mgr to confirm)
- [ ] quality-mgr QA-1

Sprint doc: docs/plans/phase-an/sprint-AN4-render-on-read.md