### PR TITLE
fix(hermes-atm): docs, ARCH-003, and boundary hardening (FIX-HERMES-TOOLREG-2)

### DIFF
--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -53,7 +53,10 @@ the nudge will fail closed because it cannot find or contact the receiver.
 
 5. Run the package installer with the launch agent's Python. The command
    validates the public Hermes capability and interpreter match before it writes
-   the standard generated hook:
+   the standard generated hook and the package-owned native-tools plugin. It
+   also declaratively adds `hermes-atm-native-tools` to the profile's
+   `config.yaml` `plugins.enabled` list; do not make that configuration edit by
+   hand:
 
    ```sh
    python -m hermes_atm install \
@@ -72,6 +75,18 @@ the nudge will fail closed because it cannot find or contact the receiver.
 7. From the same profile identity, send a localhost message to the profile and
    require an autonomous reply. Only that reply proves the full path: ATM send,
    receiver, Hermes queue injection, and agent context processing.
+
+## Native ATM tools
+
+The same installer registers exactly three native Hermes tools through the
+public plugin API: `atm_send`, `atm_read`, and `atm_list`. They use the typed
+`atm-graft` client and the installed profile's identity, team, and workspace;
+tool arguments cannot override those profile settings. `atm_read` is read-only
+and `atm_list` returns bounded metadata. Administrative and advanced CLI
+operations remain `atm` CLI operations.
+
+For the reproducible native-tool proof, see [NATIVE_TOOLS_PROOF.md](NATIVE_TOOLS_PROOF.md).
+The implementation checklist and validation record are in [TASKLIST.md](TASKLIST.md).
 
 Do not edit `hooks/hermes-atm/handler.py`, `HOOK.yaml`, or `config.json` after
 installation. To change package behavior, publish a new wheel, reinstall it,

--- a/crates/hermes-atm/TASKLIST.md
+++ b/crates/hermes-atm/TASKLIST.md
@@ -1,0 +1,26 @@
+# hermes-atm installation and proof checklist
+
+Use this checklist for every profile installation. Keep profile-specific values,
+especially a chat identifier, in local configuration only.
+
+- [ ] Install a Hermes Agent release that exposes the public gateway and plugin
+  seams required by `hermes-atm`.
+- [ ] Configure the gateway LaunchAgent environment with `ATM_HOME`,
+  `ATM_IDENTITY`, `ATM_TEAM`, `ATM_CHAT_ID`, and `ATM_WORKSPACE_ROOT`.
+- [ ] Install matching released `atm-graft` and `hermes-atm` wheels into the
+  Python interpreter selected by that LaunchAgent.
+- [ ] Publish the matching ATM roster member with `harness hermes`, the
+  profile home directory, and the exact workspace root.
+- [ ] Run `python -m hermes_atm install` using the same Python interpreter.
+  The installer owns the generated hook, native-tools plugin, and
+  `plugins.enabled` configuration entry.
+- [ ] Reset the gateway; do not hand-edit generated package files.
+- [ ] Prove a localhost ATM send reaches the profile as a nudge and produces
+  an autonomous reply.
+- [ ] Prove the registered `atm_send`, `atm_read`, and `atm_list` tools return
+  their structured JSON envelopes. See [NATIVE_TOOLS_PROOF.md](NATIVE_TOOLS_PROOF.md)
+  for the detailed native-tool proof procedure.
+
+After a package update, repeat the wheel install, package installer, gateway
+reset, and proof steps. Never patch an installed wheel or generated hook to
+make a proof pass.

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from importlib import import_module
 import json
 import os
 from pathlib import Path
@@ -124,37 +125,44 @@ def _config_apis() -> tuple[Any, Any]:
     return load_config, save_config
 
 
+def _require_public_capability(
+    module_name: str,
+    class_name: str,
+    member_name: str,
+    *,
+    member_must_be_callable: bool = True,
+) -> Any:
+    """Load one documented Hermes capability with consistent fail-closed errors."""
+
+    qualified_class = f"{module_name}.{class_name}"
+    qualified_member = f"{qualified_class}.{member_name}"
+    try:
+        module = import_module(module_name)
+    except ImportError as error:
+        raise HermesAtmInstallError(
+            f"the active interpreter cannot import {qualified_class}"
+        ) from error
+    capability = getattr(module, class_name, None)
+    if capability is None:
+        raise HermesAtmInstallError(
+            f"the active interpreter cannot import {qualified_class}"
+        )
+    member = getattr(capability, member_name, None)
+    if member is None or (member_must_be_callable and not callable(member)):
+        raise HermesAtmInstallError(
+            f"Hermes gateway does not expose public {qualified_member}"
+        )
+    return capability
+
+
 def validate_host_capability(*, launch_agent_plist: Path | None = None) -> None:
     """Fail before profile mutation unless this interpreter is a supported host."""
 
-    try:
-        from gateway.run import GatewayRunner
-    except ImportError as error:
-        raise HermesAtmInstallError(
-            "the active interpreter cannot import gateway.run.GatewayRunner"
-        ) from error
-    if not callable(getattr(GatewayRunner, "inject_internal_message", None)):
-        raise HermesAtmInstallError(
-            "Hermes gateway does not expose public GatewayRunner.inject_internal_message"
-        )
-    try:
-        from gateway.config import Platform
-    except ImportError as error:
-        raise HermesAtmInstallError(
-            "the active interpreter cannot import gateway.config.Platform"
-        ) from error
-    if not hasattr(Platform, "TELEGRAM"):
-        raise HermesAtmInstallError("Hermes gateway does not expose Platform.TELEGRAM")
-    try:
-        from hermes_cli.plugins import PluginContext
-    except ImportError as error:
-        raise HermesAtmInstallError(
-            "the active interpreter cannot import hermes_cli.plugins.PluginContext"
-        ) from error
-    if not callable(getattr(PluginContext, "register_tool", None)):
-        raise HermesAtmInstallError(
-            "Hermes plugin context does not expose public PluginContext.register_tool"
-        )
+    _require_public_capability("gateway.run", "GatewayRunner", "inject_internal_message")
+    _require_public_capability(
+        "gateway.config", "Platform", "TELEGRAM", member_must_be_callable=False
+    )
+    _require_public_capability("hermes_cli.plugins", "PluginContext", "register_tool")
     _config_apis()
     if launch_agent_plist is not None:
         configured = Path(_read_launch_agent_python(launch_agent_plist)).resolve()

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -32,15 +32,18 @@ The installer writes the receiver hook and the package-owned native-tools plugin
 Do not hand-edit those generated files; rerun this command after package changes.
 See the distribution README for the complete, safe install and proof sequence.
 """
-HOOK_HANDLER = """from pathlib import Path
-import sys
+PYTHON_SITE_PACKAGES_BOOTSTRAP = """import sys
 import sysconfig
 
-# Hermes loads hook modules dynamically. Ensure that loader can resolve the
+# Hermes loads extension modules dynamically. Ensure that loader can resolve
 # packages installed into the interpreter that owns this gateway process.
 _site_packages = sysconfig.get_paths()["purelib"]
 if _site_packages not in sys.path:
     sys.path.insert(0, _site_packages)
+"""
+
+HOOK_HANDLER = f"""from pathlib import Path
+{PYTHON_SITE_PACKAGES_BOOTSTRAP}
 
 from hermes_atm.hook import handle as _handle
 
@@ -60,16 +63,11 @@ provides_tools:
   - atm_read
   - atm_list
 """
-TOOLS_PLUGIN_HANDLER = """from __future__ import annotations
+TOOLS_PLUGIN_HANDLER = f"""from __future__ import annotations
 
 import json
 from pathlib import Path
-import sys
-import sysconfig
-
-_site_packages = sysconfig.get_paths()["purelib"]
-if _site_packages not in sys.path:
-    sys.path.insert(0, _site_packages)
+{PYTHON_SITE_PACKAGES_BOOTSTRAP}
 
 from hermes_atm.native_tools import register_tools
 
@@ -114,6 +112,18 @@ def _read_launch_agent_python(path: Path) -> str:
     return arguments[0]
 
 
+def _config_apis() -> tuple[Any, Any]:
+    """Return Hermes' public config APIs or fail before profile mutation."""
+
+    try:
+        from hermes_cli.config import load_config, save_config
+    except ImportError as error:
+        raise HermesAtmInstallError(
+            "the active interpreter cannot import Hermes public config APIs"
+        ) from error
+    return load_config, save_config
+
+
 def validate_host_capability(*, launch_agent_plist: Path | None = None) -> None:
     """Fail before profile mutation unless this interpreter is a supported host."""
 
@@ -145,6 +155,7 @@ def validate_host_capability(*, launch_agent_plist: Path | None = None) -> None:
         raise HermesAtmInstallError(
             "Hermes plugin context does not expose public PluginContext.register_tool"
         )
+    _config_apis()
     if launch_agent_plist is not None:
         configured = Path(_read_launch_agent_python(launch_agent_plist)).resolve()
         active = Path(sys.executable).resolve()
@@ -173,12 +184,7 @@ def _enable_native_tools_plugin(profile_home: Path) -> bool:
     never need to edit the profile configuration by hand.
     """
 
-    try:
-        from hermes_cli.config import load_config, save_config
-    except ImportError as error:
-        raise HermesAtmInstallError(
-            "the active interpreter cannot import Hermes public config APIs"
-        ) from error
+    load_config, save_config = _config_apis()
 
     # Hermes' config API deliberately derives the active profile from
     # HERMES_HOME.  Scope the override to this synchronous installer call so

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -43,6 +43,11 @@ graft.PyGraftSession = _PyGraftSession
 from hermes_atm import HermesAtmInstallError, install_profile
 from hermes_atm.installer import main
 
+TEST_PROFILE = "test-profile"
+TEST_IDENTITY = "test-agent"
+TEST_TEAM = "test-team"
+TEST_CHAT_ID = "100000001"
+
 
 class FakeSession:
     def __init__(self, _caller):
@@ -57,6 +62,9 @@ class FakeSession:
 
 
 class GatewayModules:
+    def __init__(self, *, include_config: bool = True):
+        self.include_config = include_config
+
     def __enter__(self):
         self.original_gateway = sys.modules.get("gateway")
         self.original_config = sys.modules.get("gateway.config")
@@ -98,16 +106,21 @@ class GatewayModules:
                 return None
 
         plugins.PluginContext = PluginContext
-        hermes_config.load_config = load_config
-        hermes_config.save_config = save_config
+        if self.include_config:
+            hermes_config.load_config = load_config
+            hermes_config.save_config = save_config
         hermes_cli.plugins = plugins
-        hermes_cli.config = hermes_config
+        if self.include_config:
+            hermes_cli.config = hermes_config
         gateway.config = config
         sys.modules["gateway"] = gateway
         sys.modules["gateway.config"] = config
         sys.modules["gateway.run"] = run
         sys.modules["hermes_cli"] = hermes_cli
-        sys.modules["hermes_cli.config"] = hermes_config
+        if self.include_config:
+            sys.modules["hermes_cli.config"] = hermes_config
+        else:
+            sys.modules.pop("hermes_cli.config", None)
         sys.modules["hermes_cli.plugins"] = plugins
         self.runner = GatewayRunner()
         return self
@@ -130,13 +143,13 @@ class GatewayModules:
 class InstallerTests(unittest.TestCase):
     def test_install_writes_standard_hook_and_is_idempotent(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():
-            profile_home = Path(temporary) / "skillrx"
+            profile_home = Path(temporary) / TEST_PROFILE
             result = install_profile(
                 profile_home=profile_home,
-                profile="skillrx",
-                identity="skillrx",
-                team="hermes",
-                chat_id="100000001",
+                profile=TEST_PROFILE,
+                identity=TEST_IDENTITY,
+                team=TEST_TEAM,
+                chat_id=TEST_CHAT_ID,
                 atm_home="/tmp/atm",
                 workspace_root="/tmp/workspace",
             )
@@ -146,11 +159,11 @@ class InstallerTests(unittest.TestCase):
                 json.loads((hook / "config.json").read_text(encoding="utf-8")),
                 {
                     "schema_version": 1,
-                    "profile": "skillrx",
+                    "profile": TEST_PROFILE,
                     "atm_home": "/tmp/atm",
-                    "identity": "skillrx",
-                    "team": "hermes",
-                    "chat_id": "100000001",
+                    "identity": TEST_IDENTITY,
+                    "team": TEST_TEAM,
+                    "chat_id": TEST_CHAT_ID,
                     "workspace_root": "/tmp/workspace",
                 },
             )
@@ -172,10 +185,10 @@ class InstallerTests(unittest.TestCase):
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
-                    profile="skillrx",
-                    identity="skillrx",
-                    team="hermes",
-                    chat_id="100000001",
+                    profile=TEST_PROFILE,
+                    identity=TEST_IDENTITY,
+                    team=TEST_TEAM,
+                    chat_id=TEST_CHAT_ID,
                     atm_home="/tmp/atm",
                     workspace_root="/tmp/workspace",
                 )["changed"]
@@ -191,10 +204,10 @@ class InstallerTests(unittest.TestCase):
             )
             install_profile(
                 profile_home=profile_home,
-                profile="skillrx",
-                identity="skillrx",
-                team="hermes",
-                chat_id="100000001",
+                profile=TEST_PROFILE,
+                identity=TEST_IDENTITY,
+                team=TEST_TEAM,
+                chat_id=TEST_CHAT_ID,
                 atm_home="/tmp/atm",
                 workspace_root="/tmp/workspace",
             )
@@ -214,15 +227,31 @@ class InstallerTests(unittest.TestCase):
             with self.assertRaisesRegex(HermesAtmInstallError, "launch agent uses"):
                 install_profile(
                     profile_home=root / "profile",
-                    profile="skillrx",
-                    identity="skillrx",
-                    team="hermes",
-                    chat_id="100000001",
+                    profile=TEST_PROFILE,
+                    identity=TEST_IDENTITY,
+                    team=TEST_TEAM,
+                    chat_id=TEST_CHAT_ID,
                     atm_home="/tmp/atm",
                     workspace_root="/tmp/workspace",
                     launch_agent_plist=plist,
                 )
             self.assertFalse((root / "profile" / "hooks").exists())
+
+    def test_missing_config_api_fails_before_writing_hook_or_plugin(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules(include_config=False):
+            profile_home = Path(temporary) / "profile"
+            with self.assertRaisesRegex(HermesAtmInstallError, "public config APIs"):
+                install_profile(
+                    profile_home=profile_home,
+                    profile=TEST_PROFILE,
+                    identity=TEST_IDENTITY,
+                    team=TEST_TEAM,
+                    chat_id=TEST_CHAT_ID,
+                    atm_home="/tmp/atm",
+                    workspace_root="/tmp/workspace",
+                )
+            self.assertFalse((profile_home / "hooks").exists())
+            self.assertFalse((profile_home / "plugins").exists())
 
     def test_generated_hook_imports_from_the_gateway_interpreter_site_packages(self):
         """Reproduce Hermes' dynamic loader without package source-path help."""
@@ -231,10 +260,10 @@ class InstallerTests(unittest.TestCase):
             profile_home = Path(temporary) / "profile"
             install_profile(
                 profile_home=profile_home,
-                profile="skillrx",
-                identity="skillrx",
-                team="hermes",
-                chat_id="100000001",
+                profile=TEST_PROFILE,
+                identity=TEST_IDENTITY,
+                team=TEST_TEAM,
+                chat_id=TEST_CHAT_ID,
                 atm_home="/tmp/atm",
                 workspace_root="/tmp/workspace",
             )
@@ -266,13 +295,13 @@ class InstallerTests(unittest.TestCase):
                     [
                         "install",
                         "--profile",
-                        "skillrx",
+                        TEST_PROFILE,
                         "--profile-home",
                         str(Path(temporary) / "profile"),
                         "--identity",
-                        "skillrx",
+                        TEST_IDENTITY,
                         "--team",
-                        "hermes",
+                        TEST_TEAM,
                         "--chat-id",
                         "local-secret-chat-id",
                         "--atm-home",
@@ -308,10 +337,10 @@ class InstallerTests(unittest.TestCase):
                     root = Path(temporary)
                     install_profile(
                         profile_home=root,
-                        profile="skillrx",
-                        identity="skillrx",
-                        team="hermes",
-                        chat_id="100000001",
+                        profile=TEST_PROFILE,
+                        identity=TEST_IDENTITY,
+                        team=TEST_TEAM,
+                        chat_id=TEST_CHAT_ID,
                         atm_home="/tmp/atm",
                         workspace_root="/tmp/workspace",
                     )

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -93,7 +93,7 @@ class NativeToolsTests(unittest.TestCase):
         tools = native_tools.AtmNativeTools(
             identity=TEST_IDENTITY, team=TEST_TEAM, chat_id=TEST_CHAT_ID
         )
-        recipient = "native-tool-recipient@hermes"
+        recipient = "native-tool-recipient@test-team"
         result = json.loads(
             tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
         )
@@ -113,7 +113,7 @@ class NativeToolsTests(unittest.TestCase):
         self.session.send_tool = lambda *_args: _TypedToolError()
 
         result = json.loads(
-            tools.atm_send({"to": "native-tool-recipient@hermes", "body": "hello"})
+            tools.atm_send({"to": "native-tool-recipient@test-team", "body": "hello"})
         )
 
         self.assertEqual(

--- a/crates/hermes-atm/tests/test_native_tools.py
+++ b/crates/hermes-atm/tests/test_native_tools.py
@@ -13,6 +13,10 @@ if "atm_graft" not in sys.modules:
 
 from hermes_atm import native_tools
 
+TEST_IDENTITY = "test-agent"
+TEST_TEAM = "test-team"
+TEST_CHAT_ID = "local"
+
 
 class _Model:
     def __init__(self, **values):
@@ -86,7 +90,9 @@ class NativeToolsTests(unittest.TestCase):
         native_tools.atm_graft = self.original
 
     def test_send_validates_before_the_native_client_and_preserves_requires_ack(self):
-        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
+        tools = native_tools.AtmNativeTools(
+            identity=TEST_IDENTITY, team=TEST_TEAM, chat_id=TEST_CHAT_ID
+        )
         recipient = "native-tool-recipient@hermes"
         result = json.loads(
             tools.atm_send({"to": recipient, "body": "hello", "requires_ack": True})
@@ -101,7 +107,9 @@ class NativeToolsTests(unittest.TestCase):
         self.assertEqual(len(self.session.calls), 1)
 
     def test_send_projects_rust_typed_error_without_exception_attribute_rebuild(self):
-        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
+        tools = native_tools.AtmNativeTools(
+            identity=TEST_IDENTITY, team=TEST_TEAM, chat_id=TEST_CHAT_ID
+        )
         self.session.send_tool = lambda *_args: _TypedToolError()
 
         result = json.loads(
@@ -122,7 +130,9 @@ class NativeToolsTests(unittest.TestCase):
         )
 
     def test_send_forwards_optional_acknowledgement_id_without_a_destination(self):
-        tools = native_tools.AtmNativeTools(identity="skillrx", team="hermes", chat_id="local")
+        tools = native_tools.AtmNativeTools(
+            identity=TEST_IDENTITY, team=TEST_TEAM, chat_id=TEST_CHAT_ID
+        )
 
         result = json.loads(
             tools.atm_send(
@@ -143,7 +153,9 @@ class NativeToolsTests(unittest.TestCase):
             def register_tool(self, **kwargs):
                 calls.append(kwargs)
 
-        native_tools.register_tools(Context(), identity="skillrx", team="hermes", chat_id="local")
+        native_tools.register_tools(
+            Context(), identity=TEST_IDENTITY, team=TEST_TEAM, chat_id=TEST_CHAT_ID
+        )
         self.assertEqual([call["name"] for call in calls], ["atm_send", "atm_read", "atm_list"])
         self.assertTrue(all(call["toolset"] == "atm" for call in calls))
         for call in calls:

--- a/crates/hermes-atm/tests/test_runtime.py
+++ b/crates/hermes-atm/tests/test_runtime.py
@@ -9,6 +9,10 @@ from hermes_atm import HermesAtmRuntime, HermesAtmRuntimeError
 
 
 TEST_SOURCE = "coordinator@test-team"
+TEST_PROFILE = "test-profile"
+TEST_IDENTITY = "test-agent"
+TEST_TEAM = "test-team"
+TEST_CHAT_ID = "100000001"
 
 
 class FakeSession:
@@ -48,11 +52,11 @@ class RuntimeTests(unittest.TestCase):
                 inject_internal_message=FakeInjector(),
                 loop=asyncio.new_event_loop(),
                 platform="telegram",
-                profile="skillrx",
+                profile=TEST_PROFILE,
                 environment={
                     "ATM_HOME": "/tmp/atm",
-                    "ATM_IDENTITY": "skillrx",
-                    "ATM_TEAM": "hermes",
+                    "ATM_IDENTITY": TEST_IDENTITY,
+                    "ATM_TEAM": TEST_TEAM,
                 },
             )
 
@@ -82,12 +86,12 @@ class RuntimeTests(unittest.TestCase):
                     inject_internal_message=injector,
                     loop=loop,
                     platform="telegram",
-                    profile="skillrx",
+                    profile=TEST_PROFILE,
                     environment={
                         "ATM_HOME": "/tmp/atm",
-                        "ATM_IDENTITY": "skillrx",
-                        "ATM_TEAM": "hermes",
-                        "ATM_CHAT_ID": "100000001",
+                        "ATM_IDENTITY": TEST_IDENTITY,
+                        "ATM_TEAM": TEST_TEAM,
+                        "ATM_CHAT_ID": TEST_CHAT_ID,
                     },
                 )
                 session.callback(FakeNudge())
@@ -95,9 +99,9 @@ class RuntimeTests(unittest.TestCase):
                 await asyncio.sleep(0)
                 self.assertEqual(len(injector.calls), 1)
                 call = injector.calls[0]
-                self.assertEqual(call["profile"], "skillrx")
+                self.assertEqual(call["profile"], TEST_PROFILE)
                 self.assertEqual(call["platform"], "telegram")
-                self.assertEqual(call["chat_id"], "100000001")
+                self.assertEqual(call["chat_id"], TEST_CHAT_ID)
                 self.assertEqual(
                     call["text"],
                     f'<atm from="{TEST_SOURCE}"><action>read atm</action></atm>',
@@ -131,15 +135,15 @@ class RuntimeTests(unittest.TestCase):
                 injector = FakeInjector()
                 environment = {
                     "ATM_HOME": "/tmp/atm",
-                    "ATM_IDENTITY": "skillrx",
-                    "ATM_TEAM": "hermes",
-                    "ATM_CHAT_ID": "100000001",
+                    "ATM_IDENTITY": TEST_IDENTITY,
+                    "ATM_TEAM": TEST_TEAM,
+                    "ATM_CHAT_ID": TEST_CHAT_ID,
                 }
                 first = HermesAtmRuntime.from_components(
                     inject_internal_message=injector,
                     loop=asyncio.get_running_loop(),
                     platform="telegram",
-                    profile="skillrx",
+                    profile=TEST_PROFILE,
                     environment=environment,
                 )
                 second = HermesAtmRuntime.from_components(
@@ -157,8 +161,8 @@ class RuntimeTests(unittest.TestCase):
                     [(call["profile"], call["chat_id"], call["text"]) for call in injector.calls],
                     [
                         (
-                            "skillrx",
-                            "100000001",
+                            TEST_PROFILE,
+                            TEST_CHAT_ID,
                             f'<atm from="{TEST_SOURCE}"><action>read atm</action></atm>',
                         ),
                         ("other-profile", "12345", "second"),
@@ -204,12 +208,12 @@ class RuntimeTests(unittest.TestCase):
                 )
                 runtime = HermesAtmRuntime.from_gateway_runner(
                     runner,
-                    profile="skillrx",
+                    profile=TEST_PROFILE,
                     environment={
                         "ATM_HOME": "/tmp/atm",
-                        "ATM_IDENTITY": "skillrx",
-                        "ATM_TEAM": "hermes",
-                        "ATM_CHAT_ID": "100000001",
+                        "ATM_IDENTITY": TEST_IDENTITY,
+                        "ATM_TEAM": TEST_TEAM,
+                        "ATM_CHAT_ID": TEST_CHAT_ID,
                     },
                 )
                 sessions[0].callback(FakeNudge())
@@ -217,7 +221,7 @@ class RuntimeTests(unittest.TestCase):
                 await asyncio.sleep(0)
                 self.assertEqual(len(injector.calls), 1)
                 self.assertIs(injector.calls[0]["platform"], FakePlatform.TELEGRAM)
-                self.assertEqual(injector.calls[0]["profile"], "skillrx")
+                self.assertEqual(injector.calls[0]["profile"], TEST_PROFILE)
                 runtime.close()
             finally:
                 module.atm_graft.PyGraftSession = original_session
@@ -258,12 +262,12 @@ class RuntimeTests(unittest.TestCase):
                 runner = types.SimpleNamespace(inject_internal_message=FakeInjector())
                 runtime = HermesAtmRuntime.from_gateway_runner(
                     runner,
-                    profile="skillrx",
+                    profile=TEST_PROFILE,
                     environment={
                         "ATM_HOME": "/tmp/atm",
-                        "ATM_IDENTITY": "skillrx",
-                        "ATM_TEAM": "hermes",
-                        "ATM_CHAT_ID": "100000001",
+                        "ATM_IDENTITY": TEST_IDENTITY,
+                        "ATM_TEAM": TEST_TEAM,
+                        "ATM_CHAT_ID": TEST_CHAT_ID,
                     },
                 )
                 self.assertIs(runtime.loop, asyncio.get_running_loop())

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -5,6 +5,13 @@ Hermes receives ATM wake-up nudges through the independently installable
 client and one receiver capability only; it contains no Hermes, Telegram, or
 gateway-session policy.
 
+`hermes-atm` also installs the initial native mailbox tools through Hermes'
+public plugin seam: `atm_send`, `atm_read`, and `atm_list`. They use the same
+typed public `atm_graft` API as the adapter and return the documented JSON
+success/error union. The installed profile configuration, not tool arguments,
+owns identity, team, home, and workspace root. Native `atm_read` is strictly
+read-only; acknowledgements remain an optional field on native `atm_send`.
+
 ## Production composition seam
 
 `hermes_atm.HermesAtmRuntime` is the sole production composition seam. At

--- a/scripts/phase-ai/run-hermes-graft-smoke.py
+++ b/scripts/phase-ai/run-hermes-graft-smoke.py
@@ -25,7 +25,7 @@ import uuid
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--sender", default="hendrix")
-    parser.add_argument("--agent", default=os.environ.get("ATM_IDENTITY", "skillrx"))
+    parser.add_argument("--agent", default=os.environ.get("ATM_IDENTITY"))
     parser.add_argument("--team", default=os.environ.get("ATM_TEAM", "hermes"))
     parser.add_argument("--chat-id", default=None)
     parser.add_argument(
@@ -97,6 +97,8 @@ def main() -> None:
             "atm_graft is not installed; run maturin develop for "
             "crates/atm-graft-python first"
         ) from error
+    if not args.agent:
+        raise SystemExit("--agent or ATM_IDENTITY is required")
     if args.agent == args.sender:
         raise SystemExit("--agent and --sender must identify different registered agents")
     if args.timeout <= 0:


### PR DESCRIPTION
## Context

PR #852 was auto-merged/closed by GitHub as a side effect of merging PR #854 (whose branch had absorbed PR #852's head commit `8517e80d` via an earlier merge-forward) -- **before** FIX-HERMES-TOOLREG-2's fixes existed and **without** quality-mgr's QA-2 approval. This PR carries those fixes, now as a clean diff against the already-merged baseline.

## Summary
- Doc gaps: README.md and docs/atm-graft/hermes-agent-use-case.md now document the native-tools plugin, config.yaml mutation, and the 3 registered tools; NATIVE_TOOLS_PROOF.md/TASKLIST.md linked from README.
- ARCH-003: removed the hardcoded skillrx/hermes reserved-role literal from test_installer.py.
- RBQA-F001: moved the hermes_cli.config host-capability check into validate_host_capability()'s up-front gate (fail-before-mutation).
- RBQA-F002/F003: consolidated 2 DRY duplications in generated-file templates.

Commit: 7def5d5e

## Test plan
- [x] Local validation (arch-ctm): full workspace tests, strict clippy, fmt, lint, 16-test hermes bridge suite
- [ ] quality-mgr QA pass (this content was never independently reviewed due to the auto-merge)