### PR TITLE
AN.7: compose passthrough and path telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,13 @@ jobs:
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -m pip install 'pydantic>=2.12,<3'
 
+      - name: Install sc-compose CLI for passthrough parity tests
+        # The AN.7 process-level tests compare the ATM command with the
+        # pinned upstream CLI on every platform, so the test lane needs the
+        # same source revision already used by just-lint.
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
+
       - name: Cache cargo registry
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/cache@v4

--- a/crates/atm-core/src/boundary/template_composer.rs
+++ b/crates/atm-core/src/boundary/template_composer.rs
@@ -46,6 +46,24 @@ pub trait TemplateComposer: sealed::Sealed + Send + Sync {
         root: &TemplateRoot,
     ) -> Result<RenderedBody, AtmError>;
 
+    /// Compose a caller-owned file through the adapter's native composition
+    /// pipeline.  The default keeps older adapters source-compatible by using
+    /// the already-inspected root render seam; the production adapter
+    /// overrides this to preserve sc-compose's validation and diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when validation, include confinement, or rendering
+    /// fails.
+    fn compose_file(
+        &self,
+        template: &TemplateSource,
+        vars: &Map<String, Value>,
+        root: &TemplateRoot,
+    ) -> Result<RenderedBody, AtmError> {
+        self.render_within_root(template, vars, root)
+    }
+
     /// Render a stored source only after parser-backed dependency rejection.
     ///
     /// # Errors

--- a/crates/atm-core/src/send/async_persistence.rs
+++ b/crates/atm-core/src/send/async_persistence.rs
@@ -6,16 +6,17 @@ use super::*;
 
 /// Prepares the canonical write after its one asynchronous durable admission.
 pub(super) async fn prepare_persisted_write_async(
-    request: SendRequest,
+    mut request: SendRequest,
     observability: &(dyn ObservabilityPort + Send + Sync),
     runtime: &LocalServiceRuntime,
     acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
 ) -> Result<PreparedWrite, AtmError> {
-    let context = prepare_send_context(runtime, &request)?;
+    let mut context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
     let requires_ack = request_requires_ack(&request, &task_id);
     let verified_template = verify_template_request(runtime, &request)?;
     let body = resolve_async_body(&request, &context, verified_template.as_ref())?;
+    super::annotate_path_only_body(&mut request, &mut context, &body);
     let summary = summary::build_summary(&body, request.summary_override.clone());
     let message_id = request.origin_message_id.unwrap_or_default();
     let timestamp = request.origin_timestamp.unwrap_or_else(IsoTimestamp::now);

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -651,13 +651,13 @@ fn request_requires_ack(request: &SendRequest, task_id: &Option<TaskId>) -> bool
 fn prepare_persisted_write<
     R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
 >(
-    request: SendRequest,
+    mut request: SendRequest,
     observability: &dyn ObservabilityPort,
     runtime: &R,
     acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
     delivery_mode: DeliveryExecutionMode,
 ) -> Result<PreparedWrite, AtmError> {
-    let context = prepare_send_context(runtime, &request)?;
+    let mut context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
     let requires_ack = request_requires_ack(&request, &task_id);
     let body = resolve_message_body(
@@ -667,6 +667,7 @@ fn prepare_persisted_write<
         &context.recipient.team,
         request.max_message_bytes,
     )?;
+    annotate_path_only_body(&mut request, &mut context, &body);
     let summary = summary::build_summary(&body, request.summary_override.clone());
     let message_id = request.origin_message_id.unwrap_or_default();
     let timestamp = request.origin_timestamp.unwrap_or_else(IsoTimestamp::now);
@@ -805,10 +806,99 @@ fn finalize_send_outcome<
         observability,
         command_outcome.as_str(),
         &outcome,
-        task_id,
+        task_id.clone(),
         &context.canonical_sender,
     );
+    if looks_like_path_only_body(body, &request.current_dir, &request.home_dir) {
+        emit_path_body_detection_event(observability, &outcome, task_id, context);
+    }
     Ok(outcome)
+}
+
+/// Detect the migration pattern where a rendered file path is sent instead
+/// of the file's content. This is deliberately advisory: the message is
+/// admitted and retained while telemetry guides callers toward `--template`.
+pub(crate) fn looks_like_path_only_body(
+    body: &str,
+    current_dir: &std::path::Path,
+    home_dir: &std::path::Path,
+) -> bool {
+    if body.len() >= 512 || body.is_empty() || body.trim() != body {
+        return false;
+    }
+    if body.contains(['\n', '\r']) {
+        return false;
+    }
+    let candidate = std::path::Path::new(body);
+    let resolved = if body == "~" || body.starts_with("~/") {
+        Some(if body == "~" {
+            home_dir.to_path_buf()
+        } else {
+            home_dir.join(body.trim_start_matches("~/"))
+        })
+    } else if candidate.is_absolute() {
+        Some(candidate.to_path_buf())
+    } else {
+        let from_current = current_dir.join(candidate);
+        let from_home = home_dir.join(candidate);
+        if from_current.is_file() {
+            Some(from_current)
+        } else if from_home.is_file() {
+            Some(from_home)
+        } else {
+            None
+        }
+    };
+    let Some(resolved) = resolved else {
+        return false;
+    };
+    // Whitespace is valid in an existing filename, but an unresolvable path
+    // containing prose must never become a false positive.
+    if body.chars().any(char::is_whitespace) && !resolved.is_file() {
+        return false;
+    }
+    true
+}
+
+fn annotate_path_only_body(
+    request: &mut SendRequest,
+    context: &mut SendExecutionContext,
+    body: &str,
+) {
+    if !looks_like_path_only_body(body, &request.current_dir, &request.home_dir) {
+        return;
+    }
+    // Detection is an admission fact, so it wins over an optional caller
+    // label; otherwise explicit labels could hide the migration telemetry.
+    request.classification.content_format = Some("path-ref".to_owned());
+    context.warnings.push(WarningEntry::new(
+        "message body looks like a file path; send file content with `atm send --template <path> --vars <file>` (path retained for compatibility)",
+        Some("use `atm compose --template <path>` to preview rendered content"),
+    ));
+}
+
+fn emit_path_body_detection_event(
+    observability: &dyn ObservabilityPort,
+    outcome: &SendOutcome,
+    task_id: Option<TaskId>,
+    context: &SendExecutionContext,
+) {
+    if let Err(error) = observability.emit(CommandEvent {
+        command: "send",
+        action: action_name("path_body_detected"),
+        outcome: outcome_label("warn"),
+        team: outcome.team.clone(),
+        agent: outcome.agent.clone(),
+        sender: context.canonical_sender.clone(),
+        message_id: Some(outcome.message_id),
+        requires_ack: outcome.requires_ack,
+        dry_run: outcome.dry_run,
+        task_id,
+        error_code: None,
+        error_message: Some("content_format=path-ref".to_owned()),
+    }) {
+        warn!(%error, command = "send", action = "path_body_detected", "failed to emit path-body detection event");
+    }
 }
 
 #[expect(
@@ -986,3 +1076,59 @@ fn emit_send_command_event(
 mod post_write_tests;
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod path_body_tests {
+    use super::looks_like_path_only_body;
+
+    #[test]
+    fn detects_existing_relative_and_absolute_files() {
+        let root = tempfile::tempdir().expect("temporary workspace");
+        let home = tempfile::tempdir().expect("temporary home");
+        let relative = root.path().join("rendered.xml");
+        std::fs::write(&relative, "<message />").expect("fixture");
+
+        assert!(looks_like_path_only_body(
+            "rendered.xml",
+            root.path(),
+            home.path()
+        ));
+        assert!(looks_like_path_only_body(
+            &relative.display().to_string(),
+            root.path(),
+            home.path()
+        ));
+    }
+
+    #[test]
+    fn detects_home_shorthand_but_not_prose_containing_a_path() {
+        let root = tempfile::tempdir().expect("temporary workspace");
+        let home = tempfile::tempdir().expect("temporary home");
+        assert!(looks_like_path_only_body(
+            "~/report.xml",
+            root.path(),
+            home.path()
+        ));
+        assert!(!looks_like_path_only_body(
+            "Please see /tmp/report.xml for details.",
+            root.path(),
+            home.path()
+        ));
+    }
+
+    #[test]
+    fn rejects_multiline_and_oversized_bodies() {
+        let root = tempfile::tempdir().expect("temporary workspace");
+        let home = tempfile::tempdir().expect("temporary home");
+        assert!(!looks_like_path_only_body(
+            "/tmp/report.xml\n",
+            root.path(),
+            home.path()
+        ));
+        assert!(!looks_like_path_only_body(
+            &"/".repeat(512),
+            root.path(),
+            home.path()
+        ));
+    }
+}

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -27,11 +27,11 @@ use crate::observability::{
 use crate::process::process_is_alive;
 use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::{AckIntentFields, AtmMessageId, InboxMessage, ThreadMode};
-use crate::send::{SendCommandOutcome, SendMessageSource, SendRequest};
+use crate::send::{SendCommandOutcome, SendMessageSource, SendOutcome, SendRequest};
 use crate::service_runtime::RetainedServiceRuntime;
 use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
-use crate::types::{AgentName, IsoTimestamp, TeamName};
+use crate::types::{AgentName, CommandAction, IsoTimestamp, TeamName};
 
 pub(super) fn message(
     from: &str,
@@ -400,6 +400,49 @@ fn send_runtime_with_missing_atm_roster_member() -> TestRuntime {
 pub(super) struct RecordingObservability {
     // Mutex records concurrent delivery-policy events for deterministic assertions.
     events: Mutex<Vec<CommandEvent>>,
+}
+
+#[test]
+fn path_body_detection_emits_structured_warning_event() {
+    let observability = RecordingObservability::default();
+    let tempdir = tempdir().expect("tempdir");
+    let context = SendExecutionContext {
+        recipient: ResolvedRecipient {
+            agent: AgentName::from_validated("recipient"),
+            team: TeamName::from_validated(TEST_TEAM),
+        },
+        canonical_sender: AgentName::from_validated(TEST_SENDER),
+        inbox_path: tempdir.path().join("recipient.jsonl"),
+        delivery_snapshot: delivery_snapshot(DeliveryHarnessPath::NonClaude),
+        delivery_family: DeliveryEventFamily::NewMessage,
+        warnings: Vec::new(),
+    };
+    let outcome = SendOutcome {
+        action: CommandAction::Send,
+        team: TeamName::from_validated(TEST_TEAM),
+        agent: AgentName::from_validated("recipient"),
+        sender: AgentName::from_validated(TEST_SENDER),
+        outcome: SendCommandOutcome::Sent,
+        message_id: AtmMessageId::new(),
+        requires_ack: false,
+        task_id: None,
+        summary: Some("path reference".to_owned()),
+        message: None,
+        warnings: Vec::new(),
+        dry_run: false,
+    };
+
+    super::emit_path_body_detection_event(&observability, &outcome, None, &context);
+
+    let events = observability.events.lock().expect("events lock");
+    assert!(events.iter().any(|event| {
+        event.action.as_str() == "path_body_detected"
+            && event.outcome.as_str() == "warn"
+            && event
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("content_format=path-ref"))
+    }));
 }
 
 impl crate::boundary::sealed::Sealed for RecordingObservability {}

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -89,10 +89,14 @@ pub fn assemble_host_runtime(
     assemble_host_runtime_with_template_composer(
         config_current_dir,
         non_claude_outbound,
-        Some(Arc::new(
-            atm_template_sc_compose::ScComposeTemplateComposer::new(),
-        )),
+        Some(template_composer()),
     )
+}
+
+/// Construct the approved renderer adapter for callers that only need local
+/// composition (for example `atm compose`) and must not touch mailbox state.
+pub fn template_composer() -> Arc<dyn TemplateComposer> {
+    Arc::new(atm_template_sc_compose::ScComposeTemplateComposer::new())
 }
 
 /// Assemble the host-scoped runtime with the sole bootstrap-owned template

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -118,6 +118,60 @@ impl TemplateComposer for ScComposeTemplateComposer {
         Ok(RenderedBody { text })
     }
 
+    fn compose_file(
+        &self,
+        template: &TemplateSource,
+        vars: &Map<String, Value>,
+        root: &TemplateRoot,
+    ) -> Result<RenderedBody, AtmError> {
+        let source_path = template
+            .canonical_file_path
+            .as_deref()
+            .ok_or_else(|| AtmError::config("composition requires a canonical source-file path"))?;
+        let current_bytes = std::fs::read(source_path).map_err(|error| {
+            Self::render_error("template source could not be read for composition", error)
+        })?;
+        if current_bytes != template.raw_file_bytes {
+            return Err(AtmError::config(format!(
+                "template source changed after it was loaded: '{}' no longer matches the verified raw bytes",
+                source_path.display()
+            )));
+        }
+
+        let vars_input = vars
+            .iter()
+            .map(|(name, value)| {
+                let name = sc_composer::VariableName::new(name.clone()).map_err(|error| {
+                    AtmError::validation(format!("invalid template variable '{name}': {error}"))
+                })?;
+                Ok((name, value.clone()))
+            })
+            .collect::<Result<std::collections::BTreeMap<_, _>, AtmError>>()?;
+        let request = sc_composer::ComposeRequest {
+            runtime: None,
+            mode: sc_composer::ComposeMode::File {
+                template_path: source_path.to_path_buf(),
+            },
+            root: sc_composer::ConfiningRoot::from_path_buf(root.canonical_path.clone()),
+            vars_input,
+            vars_env: std::collections::BTreeMap::new(),
+            vars_defaults: std::collections::BTreeMap::new(),
+            guidance_block: None,
+            user_prompt: None,
+            policy: sc_composer::ComposePolicy {
+                allowed_roots: vec![sc_composer::ConfiningRoot::from_path_buf(
+                    root.canonical_path.clone(),
+                )],
+                ..sc_composer::ComposePolicy::default()
+            },
+        };
+        sc_composer::compose(&request)
+            .map(|result| RenderedBody {
+                text: result.rendered_text,
+            })
+            .map_err(|error| Self::render_error("template composition failed", error))
+    }
+
     fn render_without_includes(
         &self,
         source: &TemplateSource,
@@ -277,6 +331,33 @@ mod tests {
         fs::remove_dir_all(&root).expect("remove isolated template root");
 
         assert_eq!(result.expect("in-root render").text, "hello Rand");
+    }
+
+    #[test]
+    fn production_adapter_compose_matches_sc_compose_file_mode() {
+        let root = temporary_root("compose-file");
+        let template_path = root.join("notice.j2");
+        let raw = "---\nrequired_variables:\n  - name\n---\nHello {{ name }}!\n";
+        fs::write(&template_path, raw).expect("write template");
+        let source = TemplateSource::file_backed(
+            raw.as_bytes().to_vec(),
+            fs::canonicalize(&template_path).expect("canonical template"),
+        );
+        let mut vars = Map::new();
+        vars.insert("name".to_owned(), Value::String("Rand".to_owned()));
+        let composer = ScComposeTemplateComposer::new();
+        let canonical_root = fs::canonicalize(&root).expect("canonical root");
+        let rendered = composer
+            .compose_file(
+                &source,
+                &vars,
+                &TemplateRoot {
+                    canonical_path: canonical_root,
+                },
+            )
+            .expect("compose through adapter");
+
+        assert_eq!(rendered.text, "Hello Rand!");
     }
 
     #[test]

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -66,12 +66,18 @@ impl ScComposeTemplateComposer {
             .map_err(|_| AtmError::template_content_not_utf8())
     }
 
-    fn render_error(operation: &str, cause: impl std::fmt::Display) -> AtmError {
+    fn render_error(_operation: &str, cause: impl std::fmt::Display) -> AtmError {
         // The caller's AN.3 error mapper assigns the public send-specific code
         // (for example TEMPLATE_INCLUDE_UNRESOLVED) exactly once while this
         // boundary retains the upstream diagnostic as the machine-preserved
         // cause. [cass: helpful starter-rust-errors]
-        AtmError::config(operation).with_cause(cause)
+        // Preserve the upstream diagnostic as the primary message as well as
+        // the machine-preserved cause.  The standalone sc-compose CLI prints
+        // this diagnostic verbatim; keeping it at the ATM boundary makes
+        // validation failures actionable and lets callers compare the two
+        // process-level surfaces without losing the adapter context.
+        let diagnostic = cause.to_string();
+        AtmError::config(diagnostic.clone()).with_cause(diagnostic)
     }
 }
 

--- a/crates/atm/src/commands/compose.rs
+++ b/crates/atm/src/commands/compose.rs
@@ -87,9 +87,14 @@ impl ComposeCommand {
                 }))?
             );
         } else {
-            // Do not add a newline: callers compare this output byte-for-byte
-            // with `sc-compose render`.
+            // sc-compose's stdout contract terminates a rendered document
+            // with one newline even when the source template has none.  Do
+            // the same without adding a second newline to templates that
+            // already carry their final line ending.
             print!("{rendered}");
+            if !rendered.ends_with('\n') {
+                println!();
+            }
         }
         Ok(())
     }

--- a/crates/atm/src/commands/compose.rs
+++ b/crates/atm/src/commands/compose.rs
@@ -1,0 +1,176 @@
+//! Local template composition without mailbox or daemon interaction.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use atm_core::boundary::{TemplateRoot, TemplateSource};
+use atm_core::send::input;
+use clap::Args;
+use serde_json::{Map, Value};
+
+use crate::commands::send::{capture_environment_values, parse_assignment_values};
+use crate::composition::resolve_command_runtime_context;
+
+/// Render a template through the core renderer port and print the exact body.
+#[derive(Debug, Args)]
+#[command(
+    after_help = "Composition is local and never reads or writes the mailbox. Use `atm send <agent> --template <path> --vars <file>` to deliver the same template after previewing it."
+)]
+pub struct ComposeCommand {
+    /// Template file to validate and render.
+    #[arg(long, value_name = "PATH", required = true)]
+    template: PathBuf,
+
+    /// JSON object providing template variables; `-` reads stdin.
+    #[arg(long, value_name = "FILE|-")]
+    vars: Option<String>,
+
+    /// One template variable; may be repeated.
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    var: Vec<String>,
+
+    /// Capture environment variables with this prefix.
+    #[arg(long = "env-prefix", value_name = "PREFIX")]
+    env_prefix: Option<String>,
+
+    /// Validate and render without any side effects (the default operation is
+    /// already side-effect free; the flag makes scripts self-documenting).
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Emit a structured result instead of the byte-identical rendered body.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ComposeCommand {
+    /// Execute local composition through the bootstrap-owned renderer port.
+    pub fn run(self) -> Result<()> {
+        let (_home_dir, current_dir) = resolve_command_runtime_context("compose")?;
+        let source = load_template_source(
+            &self.template,
+            &current_dir,
+            self.vars.as_deref(),
+            &self.var,
+            self.env_prefix.as_deref(),
+        )?;
+        let root = TemplateRoot {
+            canonical_path: source
+                .source
+                .canonical_file_path
+                .as_deref()
+                .and_then(Path::parent)
+                .ok_or_else(|| anyhow::anyhow!("template path has no parent directory"))?
+                .to_path_buf(),
+        };
+        let composer = atm_daemon_bootstrap::template_composer();
+        let rendered = composer
+            .compose_file(&source.source, &source.vars, &root)
+            .map_err(anyhow::Error::from)?;
+        let max_bytes = atm_core::load_atm_config(&current_dir)?
+            .map(|config| {
+                config.max_message_bytes.as_usize().ok_or_else(|| {
+                    anyhow::anyhow!("configured max_message_bytes does not fit this platform")
+                })
+            })
+            .transpose()?
+            .unwrap_or(input::default_message_max_bytes());
+        let rendered = input::validate_message_text_with_limit(rendered.text, max_bytes)?;
+
+        if self.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "template": source.display_path,
+                    "dry_run": self.dry_run,
+                    "body": rendered,
+                }))?
+            );
+        } else {
+            // Do not add a newline: callers compare this output byte-for-byte
+            // with `sc-compose render`.
+            print!("{rendered}");
+        }
+        Ok(())
+    }
+}
+
+struct LoadedTemplate {
+    source: TemplateSource,
+    vars: Map<String, Value>,
+    display_path: String,
+}
+
+fn load_template_source(
+    template: &Path,
+    current_dir: &Path,
+    vars_path: Option<&str>,
+    explicit: &[String],
+    env_prefix: Option<&str>,
+) -> Result<LoadedTemplate> {
+    let template_path = if template.is_absolute() {
+        template.to_path_buf()
+    } else {
+        current_dir.join(template)
+    };
+    let canonical_path = std::fs::canonicalize(&template_path)
+        .map_err(|error| anyhow::anyhow!("template could not be resolved: {error}"))?;
+    let raw_file_bytes = std::fs::read(&canonical_path)
+        .map_err(|error| anyhow::anyhow!("template could not be read: {error}"))?;
+    let mut vars = capture_environment_values(env_prefix)?;
+    vars.extend(read_vars_file(vars_path, current_dir)?);
+    vars.extend(parse_assignment_values(explicit)?);
+    Ok(LoadedTemplate {
+        source: TemplateSource::file_backed(raw_file_bytes, canonical_path.clone()),
+        vars,
+        display_path: canonical_path.display().to_string(),
+    })
+}
+
+fn read_vars_file(source: Option<&str>, current_dir: &Path) -> Result<Map<String, Value>> {
+    let Some(source) = source else {
+        return Ok(Map::new());
+    };
+    let contents = if source == "-" {
+        use std::io::Read as _;
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input)?;
+        input
+    } else {
+        let path = Path::new(source);
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            current_dir.join(path)
+        };
+        std::fs::read_to_string(path)?
+    };
+    let value: Value = serde_json::from_str(&contents)?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("--vars must contain a JSON object"))
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    #[test]
+    fn compose_help_surface_accepts_documented_flags() {
+        crate::commands::Cli::try_parse_from([
+            "atm",
+            "compose",
+            "--template",
+            "notice.j2",
+            "--vars",
+            "vars.json",
+            "--var",
+            "name=Rand",
+            "--env-prefix",
+            "ATM_TEMPLATE_",
+            "--dry-run",
+        ])
+        .expect("documented compose command must parse");
+    }
+}

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod ack;
 pub mod api;
 pub(crate) mod caller_context;
 pub mod clear;
+pub mod compose;
 pub mod doctor;
 pub mod help;
 pub(crate) mod internal_nudge;
@@ -24,6 +25,7 @@ pub(crate) mod util;
 pub use ack::AckCommand;
 pub use api::ApiCommand;
 pub use clear::ClearCommand;
+pub use compose::ComposeCommand;
 pub use doctor::DoctorCommand;
 pub use help::HelpCommand;
 pub(crate) use internal_nudge::InternalNudgeCommand;
@@ -97,6 +99,7 @@ impl Cli {
 enum Command {
     Api(ApiCommand),
     Send(SendCommand),
+    Compose(ComposeCommand),
     List(ListCommand),
     Peek(PeekCommand),
     Peer(PeerCommand),
@@ -120,6 +123,7 @@ impl Command {
         match self {
             Self::Api(command) => command.run(observability),
             Self::Send(command) => command.run(observability).await,
+            Self::Compose(command) => command.run(),
             Self::List(command) => command.run(observability).await,
             Self::Peek(command) => command.run(observability).await,
             Self::Peer(command) => command.run(observability).await,

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -21,7 +21,7 @@ use crate::output;
 
 #[derive(Debug, Args)]
 #[command(
-    after_help = "Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = \"name-or-*\" and command = [\"argv\", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr."
+    after_help = "Path-only bodies are admitted for compatibility but recorded as content_format=path-ref and warned on stderr; use `atm send --template <path> --vars <file>` to send rendered content, and `atm compose --template <path>` to preview it. Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = \"name-or-*\" and command = [\"argv\", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr."
 )]
 /// Send one ATM mailbox message.
 pub struct SendCommand {
@@ -362,7 +362,7 @@ impl SendCommand {
     }
 }
 
-fn parse_assignment_values(
+pub(crate) fn parse_assignment_values(
     values: &[String],
 ) -> Result<serde_json::Map<String, serde_json::Value>> {
     let mut parsed = serde_json::Map::new();
@@ -386,7 +386,7 @@ fn parse_assignment_values(
     Ok(parsed)
 }
 
-fn capture_environment_values(
+pub(crate) fn capture_environment_values(
     prefix: Option<&str>,
 ) -> Result<serde_json::Map<String, serde_json::Value>> {
     let Some(prefix) = prefix else {

--- a/crates/atm/tests/compose_passthrough.rs
+++ b/crates/atm/tests/compose_passthrough.rs
@@ -1,0 +1,127 @@
+//! Process-level parity checks for the local compose passthrough.
+//!
+//! The AN.1 fixture is intentionally used here instead of an ad-hoc template:
+//! this protects the public command from drifting away from the template
+//! contract that the later decomposed-message sprints consume.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("agent-team-mail crate has a workspace root")
+        .to_path_buf()
+}
+
+fn fixture_template() -> PathBuf {
+    workspace_root().join("docs/plans/phase-an/fixtures/task-assignment.xml.j2")
+}
+
+fn fixture_vars() -> PathBuf {
+    workspace_root().join("docs/plans/phase-an/fixtures/task-vars.json")
+}
+
+fn run_sc_compose(args: &[&str]) -> Output {
+    Command::new("sc-compose")
+        .current_dir(workspace_root())
+        .args(args)
+        .output()
+        .expect("CI installs the pinned sc-compose CLI before running passthrough tests")
+}
+
+fn run_atm(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_atm"))
+        .current_dir(workspace_root())
+        .args(args)
+        .output()
+        .expect("run the built atm binary")
+}
+
+#[test]
+fn compose_matches_sc_compose_fixture_stdout_byte_for_byte() {
+    let template = fixture_template();
+    let vars = fixture_vars();
+    let template = template.to_str().expect("fixture path is UTF-8");
+    let vars = vars.to_str().expect("fixture path is UTF-8");
+    let direct = run_sc_compose(&[
+        "render",
+        "--root",
+        ".",
+        "--file",
+        template,
+        "--var-file",
+        vars,
+    ]);
+    let passthrough = run_atm(&["compose", "--template", template, "--vars", vars]);
+
+    assert!(
+        direct.status.success(),
+        "direct sc-compose render failed: {}",
+        String::from_utf8_lossy(&direct.stderr)
+    );
+    assert!(
+        passthrough.status.success(),
+        "atm compose failed: {}",
+        String::from_utf8_lossy(&passthrough.stderr)
+    );
+    assert_eq!(
+        passthrough.stdout, direct.stdout,
+        "atm compose must preserve the direct sc-compose stdout bytes"
+    );
+}
+
+#[test]
+fn compose_matches_validation_failure_status_and_diagnostic() {
+    let template = fixture_template();
+    let template = template.to_str().expect("fixture path is UTF-8");
+    let direct = run_sc_compose(&["render", "--root", ".", "--file", template]);
+    let passthrough = run_atm(&["compose", "--template", template]);
+
+    assert_eq!(
+        passthrough.status.code(),
+        direct.status.code(),
+        "validation failure must retain sc-compose's exit code"
+    );
+    assert!(
+        passthrough.stdout.is_empty(),
+        "failed composition has no body"
+    );
+    assert!(
+        direct
+            .stderr
+            .windows(b"ERR_VAL_MISSING_REQUIRED".len())
+            .any(|w| { w == b"ERR_VAL_MISSING_REQUIRED" })
+    );
+    assert!(
+        String::from_utf8_lossy(&passthrough.stderr).contains("ERR_VAL_MISSING_REQUIRED"),
+        "ATM must retain the upstream validation diagnostic: {}",
+        String::from_utf8_lossy(&passthrough.stderr)
+    );
+}
+
+#[test]
+fn team_protocol_worked_example_executes_against_checked_in_fixture() {
+    let root = workspace_root();
+    let docs = std::fs::read_to_string(root.join("docs/team-protocol.md"))
+        .expect("team protocol documentation must be readable");
+    let template = "docs/plans/phase-an/fixtures/task-assignment.xml.j2";
+    let vars = "docs/plans/phase-an/fixtures/task-vars.json";
+    assert!(docs.contains(&format!("atm compose --template {template}")));
+    assert!(docs.contains(&format!("atm send teammate@atm-dev --template {template}")));
+    assert!(docs.contains(&format!("--vars {vars}")));
+    assert!(root.join(template).is_file());
+    assert!(root.join(vars).is_file());
+
+    // Execute the preview command verbatim.  The send line is deliberately
+    // asserted above rather than fired by a test: it is a mailbox mutation,
+    // while compose is the side-effect-free half of the worked example.
+    let output = run_atm(&["compose", "--template", template, "--vars", vars]);
+    assert!(
+        output.status.success(),
+        "documented fixture preview failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!output.stdout.is_empty());
+}

--- a/crates/atm/tests/compose_passthrough.rs
+++ b/crates/atm/tests/compose_passthrough.rs
@@ -88,16 +88,19 @@ fn compose_matches_validation_failure_status_and_diagnostic() {
         passthrough.stdout.is_empty(),
         "failed composition has no body"
     );
+    let direct_stderr = String::from_utf8_lossy(&direct.stderr);
+    let atm_stderr = String::from_utf8_lossy(&passthrough.stderr);
+    let direct_diag = direct_stderr
+        .lines()
+        .find(|line| line.contains("ERR_VAL_MISSING_REQUIRED"))
+        .expect("direct sc-compose must report the validation diagnostic");
+    let atm_diag = atm_stderr
+        .lines()
+        .find(|line| line.contains("ERR_VAL_MISSING_REQUIRED"))
+        .expect("ATM must retain the upstream validation diagnostic");
     assert!(
-        direct
-            .stderr
-            .windows(b"ERR_VAL_MISSING_REQUIRED".len())
-            .any(|w| { w == b"ERR_VAL_MISSING_REQUIRED" })
-    );
-    assert!(
-        String::from_utf8_lossy(&passthrough.stderr).contains("ERR_VAL_MISSING_REQUIRED"),
-        "ATM must retain the upstream validation diagnostic: {}",
-        String::from_utf8_lossy(&passthrough.stderr)
+        direct_diag.ends_with(atm_diag),
+        "ATM diagnostic must preserve the direct sc-compose detail:\n direct: {direct_diag}\n    atm: {atm_diag}"
     );
 }
 

--- a/docs/plans/phase-an/fixtures/README.md
+++ b/docs/plans/phase-an/fixtures/README.md
@@ -7,6 +7,7 @@ retain the original no-final-newline form where present.
 | Captured fixture | Source at capture | SHA-256 |
 | --- | --- | --- |
 | `task-assignment.xml.j2` | `.claude/skills/codex-orchestration/dev-template.xml.j2` | `b15098d1637765acd5adef8fd5aa1e60245073db0932bc8cf3a500cdb385e523` |
+| `task-vars.json` | AN.7 executable team-protocol example | `0fc8f4790494bb7e88a15e23ace2189f5a15cf29aa639f613011750df59eb948` |
 | `qa-report.xml.j2` | `.claude/skills/codex-orchestration/qa-template.xml.j2` | `1f67d3b34851ca9b9a12499ca504089eddb1489c7f8e7e1cbb9f3225b74a37e2` |
 | `claude_inbox_tmpfile_parser.py` | `scripts/claude_inbox_send.py` | `31d52f507e4a9596cb3961cc6bde0f7f8e023f7e50ac2a2d950fa2c7e6db0a91` |
 

--- a/docs/plans/phase-an/fixtures/task-vars.json
+++ b/docs/plans/phase-an/fixtures/task-vars.json
@@ -1,0 +1,12 @@
+{
+  "task_id": "AN7-DOC-FIXTURE",
+  "sprint": "AN.7",
+  "sprint_doc": "docs/plans/phase-an/sprint-AN7-compose-guidance.md",
+  "description": "Exercise the content-first team protocol example.",
+  "worktree_path": "/tmp/atm-an7-doc-fixture",
+  "branch": "feature/an7-doc-fixture",
+  "pr_target": "integrate/phase-an",
+  "deliverables": "- Render the fixture through atm compose.",
+  "acceptance_criteria": "- The composed body is delivered as content, never as a local path.",
+  "references": "- docs/team-protocol.md"
+}

--- a/docs/team-protocol.md
+++ b/docs/team-protocol.md
@@ -69,11 +69,11 @@ explicit send inputs instead:
 ```sh
 # Preview the exact body without touching the mailbox.
 atm compose --template docs/plans/phase-an/fixtures/task-assignment.xml.j2 \
-  --vars task-vars.json
+  --vars docs/plans/phase-an/fixtures/task-vars.json
 
 # Deliver the same resolved body through the normal send-admission path.
 atm send teammate@atm-dev --template docs/plans/phase-an/fixtures/task-assignment.xml.j2 \
-  --vars task-vars.json
+  --vars docs/plans/phase-an/fixtures/task-vars.json
 ```
 
 `atm compose` is local and side-effect free; it is the recommended preview and

--- a/docs/team-protocol.md
+++ b/docs/team-protocol.md
@@ -59,6 +59,28 @@ messages that actually entered the pending-ack queue because the sender set
 - Sending a status update without clear completion or next action.
 - Letting a message sit without response while processing internally.
 
+## Send Content, Not Paths
+
+The message body is the content that the receiver should act on. Do not render
+to a temporary file and send the file path; that leaves the receiver with a
+path it cannot reliably resolve. Keep the template and variables as the
+explicit send inputs instead:
+
+```sh
+# Preview the exact body without touching the mailbox.
+atm compose --template docs/plans/phase-an/fixtures/task-assignment.xml.j2 \
+  --vars task-vars.json
+
+# Deliver the same resolved body through the normal send-admission path.
+atm send teammate@atm-dev --template docs/plans/phase-an/fixtures/task-assignment.xml.j2 \
+  --vars task-vars.json
+```
+
+`atm compose` is local and side-effect free; it is the recommended preview and
+validation step. `atm send --template` captures the same template bytes and
+variable inputs before the daemon hop, so the receiver gets rendered content,
+not a sender-local path.
+
 ## Notes
 
 - If blocked, send an immediate ack plus blocker status.


### PR DESCRIPTION
## Summary
- AN.7 compose passthrough + path telemetry per docs/plans/phase-an/sprint-AN7-compose-guidance.md (dev completion reported by Cipher-311d)

## Test plan
- QA dispatch pending (quality-mgr independent verification per session standing policy)