### PR TITLE
docs+fix(am): AL9 evidence reconciliation and phase-ending review cleanup

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -120,15 +120,15 @@ allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstr
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs2", "getrandom", "interprocess", "libc", "parking_lot", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "getrandom", "interprocess", "libc", "parking_lot", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
-allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "fs2", "serde_json", "tempfile", "tokio", "ulid"]
+allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "fs4", "serde_json", "tempfile", "tokio", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-client/Cargo.toml"
-allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-storage", "fs2", "interprocess", "serde_json", "tempfile", "tokio", "tracing"]
+allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-storage", "fs4", "interprocess", "serde_json", "tempfile", "tokio", "tracing"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-graft/Cargo.toml"
@@ -140,7 +140,7 @@ allowed_dependencies = ["atm-core", "atm-graft", "pyo3", "tempfile", "tokio"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-http-runtime/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-core", "atm-runtime-test-support", "atm-storage", "axum", "base64", "fs2", "hyper", "hyper-util", "reqwest", "serde", "serde_json", "serde_yaml", "tempfile", "tokio", "tower", "tracing", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-core", "atm-runtime-test-support", "atm-storage", "axum", "base64", "fs4", "hyper", "hyper-util", "reqwest", "serde", "serde_json", "serde_yaml", "tempfile", "tokio", "tower", "tracing", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-runtime/Cargo.toml"

--- a/.triage/phase-al/findings/ATM-QA-004-AL9.ttl
+++ b/.triage/phase-al/findings/ATM-QA-004-AL9.ttl
@@ -15,7 +15,10 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Reconciled by arch-ctm's FIX-AL9-AM-RECONCILIATION-1 (docs/al9-am-evidence-reconciliation PR #861, commit 4c0c1d68). CLI-local-write and graft-outbound-write rows in AL9-physical-proof-matrix.md now read Satisfied, citing am6-closure-proof.md's dynamic-evidence table (120-case M5<->M4 crosshost smoke, real message IDs) and two live ATM message receipts documenting a post-daemon-cycle native atm_send retry success plus ack pending-state clearance. quality-mgr independently confirmed the smoke-report artifact exists on disk with the exact case count claimed, and independently confirmed the two cited ATM message IDs (01KZSSSG878QYFGBJVDWTJHXKG, 01KZSVA533HB2XG0YN2X4NB97G) are genuine by querying the raw mail.db directly (not visible via atm read due to mailbox-scoping, since they're addressed to arch-ctm). Windows physical proof row honestly reframed as an explicit Phase AP deferral (VPN/DNS reachability constraint), not a false completion claim. Independently re-confirmed by 4 reviewers this round (req-qa, arch-qa, ruthless-boundary-qa, and quality-mgr's own checks) at commit 2cdedd4d." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-07T19:30:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AL9 ;
@@ -29,8 +32,8 @@
   triage:file "docs/plans/phase-al/AL9-physical-proof-matrix.md" ;
   triage:line 39 ;
   triage:snippet "CLI local write selection: Static/source proof; final-candidate runtime row pending (owner team-lead, trigger: frozen final candidate SHA)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "fc73d4ec" ;
   triage:occursIn <urn:atm:triage:worktree/pal-s9/9b4c4799> .
@@ -40,8 +43,8 @@
   triage:file "docs/plans/phase-al/AL9-physical-proof-matrix.md" ;
   triage:line 40 ;
   triage:snippet "Graft outbound write selection: Static/source proof; final-candidate runtime row pending (owner team-lead, trigger: frozen final candidate SHA)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-al" ;
   triage:headSha "fc73d4ec" ;
   triage:occursIn <urn:atm:triage:worktree/pal-s9/9b4c4799> .

--- a/.triage/phase-am/findings/AM-PHASEEND2-PLANDOC-STALE-001.ttl
+++ b/.triage/phase-am/findings/AM-PHASEEND2-PLANDOC-STALE-001.ttl
@@ -15,7 +15,10 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "single-branch" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Fixed by arch-ctm's FIX-AL9-AM-RECONCILIATION-1 (docs/al9-am-evidence-reconciliation PR #861, commit 4c0c1d68). docs/project-plan.md sections 43 and 44 both changed from [PLAN HARDENING] to [COMPLETE]. Independently re-confirmed by 4 reviewers this round (req-qa, arch-qa, ruthless-boundary-qa, and quality-mgr's own grep) at commit 2cdedd4d; no remaining [PLAN HARDENING] tags in the document." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T04:55:00Z"^^xsd:dateTime ;
   triage:foundIn triage:QA-AM-PHASEEND-2 ;
@@ -29,8 +32,8 @@
   triage:file "docs/project-plan.md" ;
   triage:line 1124 ;
   triage:snippet "## 43. Phase AL — Build the Minimal Tokio HTTP Runtime [PLAN HARDENING]" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-am" ;
   triage:headSha "96299ad8b587b0ba314a6fc46db731d4b56c812c" ;
   triage:occursIn <urn:atm:triage:worktree/planstale/w1> .
@@ -40,8 +43,8 @@
   triage:file "docs/project-plan.md" ;
   triage:line 1194 ;
   triage:snippet "## 44. Phase AM — Deletion-Only Transport Cleanup [PLAN HARDENING]" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-am" ;
   triage:headSha "96299ad8b587b0ba314a6fc46db731d4b56c812c" ;
   triage:occursIn <urn:atm:triage:worktree/planstale/w1> .

--- a/.triage/phase-am/findings/AM-PHASEEND3-LIBRS-LINECAP-001.ttl
+++ b/.triage/phase-am/findings/AM-PHASEEND3-LIBRS-LINECAP-001.ttl
@@ -15,7 +15,10 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "single-branch" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closedAt "2026-08-12T06:35:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Fixed by arch-ctm's follow-up commit 8c458345 (docs/al9-am-evidence-reconciliation PR #861). Extracted PyGraftSession's query-builder methods into a new crates/atm-graft-python/src/query.rs (142 lines), wired via mod query; at lib.rs:27. lib.rs non-test code reduced from 1033 to 897 lines, under the RULE-003 1000-line cap with margin. Independently re-confirmed by 3 reviewers this round (arch-qa, req-qa, rust-qa-agent) via direct grep/wc-l recount, not a visual estimate; req-qa additionally confirmed no lint-exclusion loophole was used (the file is not in .just/lint-config.toml's exclusions list)." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:QA-AM-PHASEEND-3 ;
@@ -28,8 +31,8 @@
   triage:file "crates/atm-graft-python/src/lib.rs" ;
   triage:line 1033 ;
   triage:snippet "non-test code spans lines 1-1033; #[cfg(test)] mod tests begins at line 1034" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "docs/al9-am-evidence-reconciliation" ;
   triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
   triage:occursIn <urn:atm:triage:worktree/phaseend3/w1> .

--- a/.triage/phase-am/findings/AM-PHASEEND3-LIBRS-LINECAP-001.ttl
+++ b/.triage/phase-am/findings/AM-PHASEEND3-LIBRS-LINECAP-001.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/AM-PHASEEND3-LIBRS-LINECAP-001>
+  a triage:Finding ;
+  triage:findingId "AM-PHASEEND3-LIBRS-LINECAP-001" ;
+  triage:title "crates/atm-graft-python/src/lib.rs grew to 1033 non-test lines during FIX-AM-PHASEEND2-CLEANUP-1, breaching RULE-003's 1000-line cap" ;
+  triage:description "arch-qa's RULE-003 recheck (explicitly requested for this round given the file was already close to the cap after an earlier extraction into tool_types.rs) found that crates/atm-graft-python/src/lib.rs now spans lines 1-1033 of non-test code (the #[cfg(test)] mod tests block begins at line 1034/1035), 33 lines over the 1000-line non-test-code cap. quality-mgr independently confirmed via grep + wc -l. This growth was introduced by this exact fix round's RBP-F002 remediation (consolidating all PyAgentAddress/PyGraftSessionOptions/PyNudge/query-builder/reconnect FFI validation failures through the single structured AtmGraftError path via atm_error()), which added code without a corresponding extraction. Suggested remediation (from arch-qa): extract a cohesive slice -- e.g. PyGraftSession's read/list query-builder methods (build_read_query/build_list_query/read_raw/read_outcome/list_outcome) or the reconnect/DaemonRecovery machinery -- into a new session.rs or query.rs submodule under atm-graft-python/src/, matching the precedent set by the earlier tool_types.rs extraction." ;
+  triage:phaseId "phase-am" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "structural" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-branch" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:QA-AM-PHASEEND-3 ;
+  triage:foundAt "2026-08-12T06:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AM-PHASEEND3-LIBRS-LINECAP-001/o1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/AM-PHASEEND3-LIBRS-LINECAP-001/o1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-graft-python/src/lib.rs" ;
+  triage:line 1033 ;
+  triage:snippet "non-test code spans lines 1-1033; #[cfg(test)] mod tests begins at line 1034" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "docs/al9-am-evidence-reconciliation" ;
+  triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
+  triage:occursIn <urn:atm:triage:worktree/phaseend3/w1> .
+
+<urn:atm:triage:worktree/phaseend3/w1>
+  a triage:WorktreeSnapshot ;
+  triage:path "docs/al9-am-evidence-reconciliation" ;
+  triage:branch "docs/al9-am-evidence-reconciliation" ;
+  triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
+  triage:orderIndex 0 .

--- a/.triage/phase-am/findings/AM-PHASEEND3-REQUESTID-PROPAGATION-001.ttl
+++ b/.triage/phase-am/findings/AM-PHASEEND3-REQUESTID-PROPAGATION-001.ttl
@@ -1,0 +1,54 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/AM-PHASEEND3-REQUESTID-PROPAGATION-001>
+  a triage:Finding ;
+  triage:findingId "AM-PHASEEND3-REQUESTID-PROPAGATION-001" ;
+  triage:title "Cross-host request-ID correlation (RSH-001) only wires the ingress half; the in-process ACK-relay forward to a direct peer still mints an uncorrelated new ID" ;
+  triage:description "Originally raised as RSH-001 in QA-AM-PHASEEND-2: cross-host request IDs minted at HTTP ingress were never propagated onto forwarded/direct-peer requests, so a single logical delivery had no shared correlation ID across daemons' logs. FIX-AM-PHASEEND2-CLEANUP-1 (commit 2cdedd4d) implemented request-ID minting/attachment on outbound calls (client.rs's execute_envelope_with_deadline via the X-ATM-Request-Id header) and extraction/logging on inbound HTTP ingress (message_handler.rs's post_messages/dispatch_request). This closes the single client->server RPC correlation case, but does not close the original finding: HttpRuntimeClient::execute_envelope_with_deadline (client.rs:667) unconditionally calls next_request_id() with no parameter to accept an inherited ID, and there is no request_id field anywhere on ApiRequest/RequestEnvelope (atm-core/src/api.rs) to carry one through. dispatch_resolved_peer_ack (storage_and_nudge_router.rs:193-218), the exact in-process ACK-relay-to-a-direct-peer path the original finding named, is invoked after a local admitted write completes and opens a fresh client.execute(...) call that mints a brand-new, uncorrelated request ID rather than reusing the ID already assigned to the triggering inbound request. A cross-host ACK relay therefore still produces two uncorrelated request IDs in the logs. Independently confirmed by 3 sources this round: req-qa, rust-qa-agent, and quality-mgr's own direct code read (which resolved a contradiction against rust-service-hardening-agent's incorrect PASS verdict, which had only verified the ingress-mint and ingress-log halves in isolation without checking whether the ID survives an ingress-to-forward hop)." ;
+  triage:phaseId "phase-am" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "observability" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-branch" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:QA-AM-PHASEEND-3 ;
+  triage:foundAt "2026-08-12T06:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AM-PHASEEND3-REQUESTID-PROPAGATION-001/o1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AM-PHASEEND3-REQUESTID-PROPAGATION-001/o2> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/AM-PHASEEND3-REQUESTID-PROPAGATION-001/o1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-http-runtime/src/client.rs" ;
+  triage:line 667 ;
+  triage:snippet "let request_id = next_request_id();" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "docs/al9-am-evidence-reconciliation" ;
+  triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
+  triage:occursIn <urn:atm:triage:worktree/phaseend3/w2> .
+
+<urn:atm:triage:occurrence/AM-PHASEEND3-REQUESTID-PROPAGATION-001/o2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-http-runtime/src/storage_and_nudge_router.rs" ;
+  triage:line 209 ;
+  triage:snippet "client.execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request)))).await?" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "docs/al9-am-evidence-reconciliation" ;
+  triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
+  triage:occursIn <urn:atm:triage:worktree/phaseend3/w2> .
+
+<urn:atm:triage:worktree/phaseend3/w2>
+  a triage:WorktreeSnapshot ;
+  triage:path "docs/al9-am-evidence-reconciliation" ;
+  triage:branch "docs/al9-am-evidence-reconciliation" ;
+  triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
+  triage:orderIndex 0 .

--- a/.triage/phase-am/findings/AM-PHASEEND3-REQUESTID-PROPAGATION-001.ttl
+++ b/.triage/phase-am/findings/AM-PHASEEND3-REQUESTID-PROPAGATION-001.ttl
@@ -15,7 +15,10 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "single-branch" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closedAt "2026-08-12T06:35:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Fixed by arch-ctm's follow-up commit 8c458345 (docs/al9-am-evidence-reconciliation PR #861). dispatch_resolved_peer_ack now takes a request_id: RequestId parameter and calls client.execute_with_request_id(request, request_id) instead of the old bare client.execute(...). execute_envelope_with_deadline's signature changed to accept request_id: Option<RequestId>, using .unwrap_or_else(next_request_id) only when None is supplied. Full chain traced end-to-end by 3 independent reviewers this round (arch-qa, req-qa, rust-qa-agent) plus quality-mgr's own read: message_handler.rs's post_messages/dispatch_request resolve the ingress RequestId from the X-ATM-Request-Id header (or mint one only if absent) and thread it through write_with_request_id/dispatch_with_request_id -> StorageAndNudgeRouter::write_with_request_id -> dispatch_resolved_peer_ack -> execute_with_request_id -> execute_envelope_with_deadline, which reuses the supplied id rather than reminting. A new dedicated behavioral test (client.rs, caller_supplied_request_id_is_forwarded_without_reminting) asserts a caller-supplied RequestId(73) reaches the outbound header unchanged. Full workspace fmt/clippy/test suite passes clean." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T06:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:QA-AM-PHASEEND-3 ;
@@ -29,8 +32,8 @@
   triage:file "crates/atm-http-runtime/src/client.rs" ;
   triage:line 667 ;
   triage:snippet "let request_id = next_request_id();" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "docs/al9-am-evidence-reconciliation" ;
   triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
   triage:occursIn <urn:atm:triage:worktree/phaseend3/w2> .
@@ -40,8 +43,8 @@
   triage:file "crates/atm-http-runtime/src/storage_and_nudge_router.rs" ;
   triage:line 209 ;
   triage:snippet "client.execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request)))).await?" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "docs/al9-am-evidence-reconciliation" ;
   triage:headSha "2cdedd4d7ebfc139e640c4a79fd917d4d1104072" ;
   triage:occursIn <urn:atm:triage:worktree/phaseend3/w2> .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "atm-storage",
  "base64",
  "chrono",
- "fs2",
+ "fs4",
  "getrandom 0.3.4",
  "interprocess",
  "libc",
@@ -168,7 +168,7 @@ dependencies = [
  "atm-runtime",
  "atm-storage",
  "atm-storage-rusqlite",
- "fs2",
+ "fs4",
  "serde_json",
  "tempfile",
  "tokio",
@@ -182,7 +182,7 @@ dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
  "atm-storage",
- "fs2",
+ "fs4",
  "interprocess",
  "serde_json",
  "tempfile",
@@ -233,7 +233,7 @@ dependencies = [
  "atm-storage",
  "axum",
  "base64",
- "fs2",
+ "fs4",
  "hyper",
  "hyper-util",
  "reqwest",
@@ -658,13 +658,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2441,28 +2441,6 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "gra
 
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon"]
-allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-http-runtime", "tokio", "fs2", "ulid"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-http-runtime", "tokio", "fs4", "ulid"]
 forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
 
 [references]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1867,6 +1867,7 @@ fn al4_shared_client_keeps_one_async_client_boundary_without_legacy_framing() {
     let graft = read_source(&root.join("crates/atm-graft/src/lib.rs"));
     let cli = read_source(&root.join("crates/atm/src/composition.rs"));
     let python = read_source(&root.join("crates/atm-graft-python/src/lib.rs"));
+    let python_query = read_source(&root.join("crates/atm-graft-python/src/query.rs"));
     let daemon_client = read_source(&root.join("crates/atm-daemon-client/src/lib.rs"));
 
     assert_eq!(
@@ -1909,9 +1910,9 @@ fn al4_shared_client_keeps_one_async_client_boundary_without_legacy_framing() {
         "library and CLI layers must not bridge async work synchronously"
     );
     assert_eq!(
-        python.matches(".block_on(").count(),
+        python.matches(".block_on(").count() + python_query.matches(".block_on(").count(),
         3,
-        "the three Python-exposed graft operations may bridge only at the shared outer PyO3 runtime boundary"
+        "the three Python-exposed graft operations may bridge only at the shared outer PyO3 runtime boundary across the FFI modules"
     );
     assert_eq!(
         daemon_client.matches(".block_on(").count(),

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -34,7 +34,7 @@ ulid.workspace = true
 base64.workspace = true
 getrandom.workspace = true
 semver.workspace = true
-fs2 = "0.4"
+fs4 = "0.13"
 async-trait.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -13,7 +13,7 @@ use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
@@ -328,11 +328,11 @@ impl ReceiverOwnershipGuard {
                 )
             })?;
         match lock_file.try_lock_exclusive() {
-            Ok(()) => {
+            Ok(true) => {
                 tracing::info!(record_path = %record_path.display(), action = "receiver_ownership", outcome = "acquired", "graft receiver ownership acquired");
                 Ok(Self { lock_file })
             }
-            Err(source) if is_lock_contention(&source) => {
+            Ok(false) => {
                 tracing::warn!(record_path = %record_path.display(), action = "receiver_ownership", outcome = "conflict", "graft receiver ownership already active");
                 Err(AtmError::new(
                     AtmErrorCode::GraftReceiverAlreadyActive,
@@ -594,11 +594,6 @@ fn prepare_receiver_record_parent(record_path: &Path) -> Result<(), AtmError> {
 
 fn receiver_ownership_lock_path(record_path: &Path) -> PathBuf {
     record_path.with_extension("lock")
-}
-
-fn is_lock_contention(error: &std::io::Error) -> bool {
-    error.kind() == std::io::ErrorKind::WouldBlock
-        || cfg!(windows) && matches!(error.raw_os_error(), Some(32 | 33))
 }
 
 fn graft_receiver_identity(record_path: &Path) -> String {

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -26,7 +26,7 @@ use atm_runtime_test_support::{
 };
 use chrono::Utc;
 #[cfg(unix)]
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 use tempfile::TempDir;
 
 // Test-side ceiling guard only; production lock timeout defaults to 5s per

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -24,7 +24,7 @@ atm-runtime = { path = "../atm-runtime", version = "1.4.2-beta-am" }
 atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
 atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am" }
 tokio.workspace = true
-fs2 = "0.4"
+fs4 = "0.13"
 serde_json.workspace = true
 ulid.workspace = true
 

--- a/crates/atm-daemon-bootstrap/src/owner_gate.rs
+++ b/crates/atm-daemon-bootstrap/src/owner_gate.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use atm_core::error::AtmError;
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 use ulid::Ulid;
 
 #[derive(Debug)]
@@ -40,12 +40,17 @@ impl DaemonOwnerGuard {
             .map_err(|source| {
                 AtmError::daemon_unavailable("failed to open daemon owner lock").with_cause(source)
             })?;
-        lock_file.try_lock_exclusive().map_err(|source| {
+        if !lock_file.try_lock_exclusive().map_err(|source| {
             AtmError::daemon_serving_state_rejected(format!(
-                "an ATM daemon already owns {}: {source}",
+                "failed to acquire ATM daemon owner lock at {}: {source}",
                 lock_path.display()
             ))
-        })?;
+        })? {
+            return Err(AtmError::daemon_serving_state_rejected(format!(
+                "an ATM daemon already owns {}",
+                lock_path.display()
+            )));
+        }
         let instance_id = Ulid::new();
         let token = Ulid::new();
         let record = format!("{}:{token}:{instance_id}\n", std::process::id());

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
 atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2-beta-am" }
 atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
-fs2 = "0.4"
+fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
 tracing = "0.1"

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -12,7 +12,7 @@ use std::{fmt, thread};
 use atm_core::caller_context::{CallerContext, CallerContextOverrides, resolve_cli_caller_context};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
 use atm_storage::{AgentName, AtmError, AtmErrorCode, TeamName};
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 #[cfg(unix)]
 use interprocess::local_socket::Stream as LocalSocketStream;
 #[cfg(unix)]
@@ -967,8 +967,8 @@ impl LaunchGateGuard {
             })?;
 
         match file.try_lock_exclusive() {
-            Ok(()) => Ok(Some(Self { file })),
-            Err(error) if is_launch_gate_contention_error(&error) => Ok(None),
+            Ok(true) => Ok(Some(Self { file })),
+            Ok(false) => Ok(None),
             Err(source) => Err(AtmError::daemon_unavailable_with_cause(
                 format!(
                     "failed to acquire daemon launch gate at {}",

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -24,6 +24,7 @@ use atm_core::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TeamName};
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
+mod query;
 mod tool_types;
 
 pub use tool_types::{AtmListResult, AtmListRow, AtmReadResult, AtmSendResult, AtmToolError};
@@ -490,110 +491,6 @@ impl PyGraftSession {
         }
     }
 
-    fn build_read_query(&self, seen_state_update: bool) -> PyResult<ReadQuery> {
-        let (home_dir, current_dir) = Self::command_paths()?;
-        let team = self.caller_team()?;
-        let query = ReadQuery::new(
-            home_dir,
-            current_dir,
-            self.caller.agent().clone(),
-            None,
-            team.clone(),
-            ReadSelection::All,
-            false,
-            seen_state_update,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .map_err(atm_error)?;
-        Ok(query
-            .with_caller_chat_id(self.caller.chat_id().cloned())
-            .with_activity_observation(activity_observation_for_resolved_caller(
-                self.caller.agent(),
-                &team,
-            )))
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn build_tool_read_query(
-        &self,
-        selection: &str,
-        message_id: Option<&str>,
-        task: Option<&str>,
-        contains: Option<&str>,
-        since: Option<&str>,
-        from_agent: Option<&str>,
-    ) -> PyResult<ReadQuery> {
-        let (home_dir, current_dir) = Self::command_paths()?;
-        let team = self.caller_team()?;
-        let timestamp = since
-            .map(str::parse::<IsoTimestamp>)
-            .transpose()
-            .map_err(|error| {
-                atm_error(AtmError::validation(format!(
-                    "invalid since timestamp: {error}"
-                )))
-            })?;
-        ReadQuery::new(
-            home_dir,
-            current_dir,
-            self.caller.agent().clone(),
-            None,
-            team,
-            Self::read_selection(selection)?,
-            false,
-            false,
-            message_id,
-            from_agent,
-            timestamp,
-            task,
-            contains,
-            None,
-        )
-        .map_err(atm_error)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn build_list_query(
-        &self,
-        selection: &str,
-        limit: Option<usize>,
-        task: Option<&str>,
-        contains: Option<&str>,
-        since: Option<&str>,
-        from_agent: Option<&str>,
-    ) -> PyResult<ListQuery> {
-        let (home_dir, current_dir) = Self::command_paths()?;
-        let team = self.caller_team()?;
-        let timestamp = since
-            .map(str::parse::<IsoTimestamp>)
-            .transpose()
-            .map_err(|error| {
-                atm_error(AtmError::validation(format!(
-                    "invalid since timestamp: {error}"
-                )))
-            })?;
-        ListQuery::new(
-            home_dir,
-            current_dir,
-            self.caller.agent().clone(),
-            None,
-            team,
-            Self::read_selection(selection)?,
-            false,
-            limit,
-            from_agent,
-            timestamp,
-            task,
-            contains,
-        )
-        .map_err(atm_error)
-    }
-
     fn send_outcome(
         &self,
         to: Option<String>,
@@ -651,39 +548,6 @@ impl PyGraftSession {
             })?
             .block_on(client.write_message(request))
             .map(AtmSendResult::from)
-            .map_err(atm_error)
-    }
-
-    fn read_raw(&self, query: ReadQuery) -> PyResult<ReadOutcome> {
-        let client = self.client()?;
-        python_extension_runtime()?
-            .lock()
-            .map_err(|_| {
-                atm_error(AtmError::new(
-                    AtmErrorCode::InternalError,
-                    "ATM Python extension runtime lock poisoned",
-                ))
-            })?
-            .block_on(client.read_message(query))
-            .map_err(atm_error)
-    }
-
-    fn read_outcome(&self, query: ReadQuery) -> PyResult<AtmReadResult> {
-        self.read_raw(query).and_then(AtmReadResult::from_outcome)
-    }
-
-    fn list_outcome(&self, query: ListQuery) -> PyResult<AtmListResult> {
-        let client = self.client()?;
-        python_extension_runtime()?
-            .lock()
-            .map_err(|_| {
-                atm_error(AtmError::new(
-                    AtmErrorCode::InternalError,
-                    "ATM Python extension runtime lock poisoned",
-                ))
-            })?
-            .block_on(client.list_messages(query))
-            .map(AtmListResult::from)
             .map_err(atm_error)
     }
 

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -21,7 +21,7 @@ use atm_core::read::{ReadOutcome, ReadQuery};
 use atm_core::schema::AtmMessageId;
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TeamName};
-use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
+use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
 mod tool_types;
@@ -29,6 +29,8 @@ mod tool_types;
 pub use tool_types::{AtmListResult, AtmListRow, AtmReadResult, AtmSendResult, AtmToolError};
 
 fn python_extension_runtime() -> PyResult<&'static Mutex<tokio::runtime::Runtime>> {
+    // Python calls may arrive from arbitrary host threads. Serialize the one
+    // current-thread runtime instead of creating a competing runtime per call.
     static RUNTIME: OnceLock<Mutex<tokio::runtime::Runtime>> = OnceLock::new();
     if let Some(runtime) = RUNTIME.get() {
         return Ok(runtime);
@@ -39,9 +41,13 @@ fn python_extension_runtime() -> PyResult<&'static Mutex<tokio::runtime::Runtime
         .build()
         .map(Mutex::new)
         .map_err(|error| {
-            PyRuntimeError::new_err(format!(
-                "failed to create the ATM Python extension runtime: {error}"
-            ))
+            atm_error(
+                AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "failed to create the ATM Python extension runtime",
+                )
+                .with_cause(error),
+            )
         })?;
     Ok(RUNTIME.get_or_init(|| runtime))
 }
@@ -114,7 +120,7 @@ impl PyAgentAddress {
         let team = address
             .team()
             .cloned()
-            .ok_or_else(|| PyValueError::new_err("ATM address requires a team"))?;
+            .ok_or_else(|| atm_error(AtmError::validation("ATM address requires a team")))?;
         Ok(Self {
             agent: address.agent().to_string(),
             chat_id: address.chat_id().map(ToString::to_string),
@@ -137,7 +143,9 @@ pub struct PyGraftSessionOptions {
 impl PyGraftSessionOptions {
     fn to_typed(&self) -> PyResult<GraftSessionOptions> {
         if self.workspace_root.trim().is_empty() {
-            return Err(PyValueError::new_err("workspace_root must not be blank"));
+            return Err(atm_error(AtmError::validation(
+                "workspace_root must not be blank",
+            )));
         }
         Ok(GraftSessionOptions::new(
             &self.workspace_root,
@@ -283,9 +291,13 @@ impl PyNudge {
     fn new(message_id: String, source: PyAgentAddress, body: String) -> PyResult<Self> {
         message_id
             .parse::<atm_core::schema::AtmMessageId>()
-            .map_err(|error| PyValueError::new_err(format!("invalid message id: {error}")))?;
+            .map_err(|error| {
+                atm_error(AtmError::validation(format!("invalid message id: {error}")))
+            })?;
         if body.trim().is_empty() {
-            return Err(PyValueError::new_err("nudge body must not be blank"));
+            return Err(atm_error(AtmError::validation(
+                "nudge body must not be blank",
+            )));
         }
         Ok(Self {
             message_id,
@@ -386,19 +398,28 @@ impl PyGraftSession {
     fn client(&self) -> PyResult<GraftClient> {
         self.client
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM graft session lock poisoned",
+                ))
+            })?
             .clone()
-            .ok_or_else(|| PyRuntimeError::new_err("ATM graft session is closed"))
+            .ok_or_else(|| atm_error(AtmError::daemon_unavailable("ATM graft session is closed")))
     }
 
     fn reconnect_client(&self) -> PyResult<()> {
         {
-            let client = self
-                .client
-                .lock()
-                .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?;
+            let client = self.client.lock().map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM graft session lock poisoned",
+                ))
+            })?;
             if client.is_none() {
-                return Err(PyRuntimeError::new_err("ATM graft session is closed"));
+                return Err(atm_error(AtmError::daemon_unavailable(
+                    "ATM graft session is closed",
+                )));
             }
         }
 
@@ -411,7 +432,12 @@ impl PyGraftSession {
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.reconnect_replacement
                 .lock()
-                .map_err(|_| PyRuntimeError::new_err("ATM graft reconnect lock poisoned"))?
+                .map_err(|_| {
+                    atm_error(AtmError::new(
+                        AtmErrorCode::InternalError,
+                        "ATM graft reconnect lock poisoned",
+                    ))
+                })?
                 .clone()
                 .map(Ok)
                 .unwrap_or_else(|| {
@@ -422,12 +448,16 @@ impl PyGraftSession {
         };
         #[cfg(not(test))]
         let replacement = GraftClient::connect_existing().map_err(atm_error)?;
-        let mut client = self
-            .client
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?;
+        let mut client = self.client.lock().map_err(|_| {
+            atm_error(AtmError::new(
+                AtmErrorCode::InternalError,
+                "ATM graft session lock poisoned",
+            ))
+        })?;
         if client.is_none() {
-            return Err(PyRuntimeError::new_err("ATM graft session is closed"));
+            return Err(atm_error(AtmError::daemon_unavailable(
+                "ATM graft session is closed",
+            )));
         }
         *client = Some(replacement);
         Ok(())
@@ -441,10 +471,11 @@ impl PyGraftSession {
     }
 
     fn caller_team(&self) -> PyResult<TeamName> {
-        self.caller
-            .team()
-            .cloned()
-            .ok_or_else(|| PyRuntimeError::new_err("ATM graft caller identity requires a team"))
+        self.caller.team().cloned().ok_or_else(|| {
+            atm_error(AtmError::validation(
+                "ATM graft caller identity requires a team",
+            ))
+        })
     }
 
     fn read_selection(selection: &str) -> PyResult<ReadSelection> {
@@ -453,9 +484,9 @@ impl PyGraftSession {
             "all" => Ok(ReadSelection::All),
             "unread" => Ok(ReadSelection::Unread),
             "pending_ack" => Ok(ReadSelection::PendingAck),
-            _ => Err(PyValueError::new_err(
+            _ => Err(atm_error(AtmError::validation(
                 "selection must be actionable, all, unread, or pending_ack",
-            )),
+            ))),
         }
     }
 
@@ -502,7 +533,11 @@ impl PyGraftSession {
         let timestamp = since
             .map(str::parse::<IsoTimestamp>)
             .transpose()
-            .map_err(|error| PyValueError::new_err(format!("invalid since timestamp: {error}")))?;
+            .map_err(|error| {
+                atm_error(AtmError::validation(format!(
+                    "invalid since timestamp: {error}"
+                )))
+            })?;
         ReadQuery::new(
             home_dir,
             current_dir,
@@ -537,7 +572,11 @@ impl PyGraftSession {
         let timestamp = since
             .map(str::parse::<IsoTimestamp>)
             .transpose()
-            .map_err(|error| PyValueError::new_err(format!("invalid since timestamp: {error}")))?;
+            .map_err(|error| {
+                atm_error(AtmError::validation(format!(
+                    "invalid since timestamp: {error}"
+                )))
+            })?;
         ListQuery::new(
             home_dir,
             current_dir,
@@ -563,9 +602,9 @@ impl PyGraftSession {
         acknowledges_message_id: Option<String>,
     ) -> PyResult<AtmSendResult> {
         if to.is_none() && acknowledges_message_id.is_none() {
-            return Err(PyValueError::new_err(
+            return Err(atm_error(AtmError::validation(
                 "ATM send requires either a destination or acknowledges_message_id",
-            ));
+            )));
         }
         let (home_dir, current_dir) = Self::command_paths()?;
         let caller_team = self.caller_team()?;
@@ -574,7 +613,9 @@ impl PyGraftSession {
             .map(str::parse::<AtmMessageId>)
             .transpose()
             .map_err(|error| {
-                PyValueError::new_err(format!("invalid acknowledges_message_id: {error}"))
+                atm_error(AtmError::validation(format!(
+                    "invalid acknowledges_message_id: {error}"
+                )))
             })?;
         let fallback_destination = self.caller.to_string();
         let request = SendRequest::new(
@@ -602,7 +643,12 @@ impl PyGraftSession {
         let client = self.client()?;
         python_extension_runtime()?
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM Python extension runtime lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
             .block_on(client.write_message(request))
             .map(AtmSendResult::from)
             .map_err(atm_error)
@@ -612,7 +658,12 @@ impl PyGraftSession {
         let client = self.client()?;
         python_extension_runtime()?
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM Python extension runtime lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
             .block_on(client.read_message(query))
             .map_err(atm_error)
     }
@@ -625,7 +676,12 @@ impl PyGraftSession {
         let client = self.client()?;
         python_extension_runtime()?
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM Python extension runtime lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
             .block_on(client.list_messages(query))
             .map(AtmListResult::from)
             .map_err(atm_error)
@@ -887,14 +943,17 @@ impl PyGraftSession {
         on_nudge: Py<PyAny>,
     ) -> PyResult<()> {
         let client = self.client()?;
-        let mut receiver = self
-            .receiver
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft receiver lock poisoned"))?;
+        let mut receiver = self.receiver.lock().map_err(|_| {
+            atm_error(AtmError::new(
+                AtmErrorCode::InternalError,
+                "ATM graft receiver lock poisoned",
+            ))
+        })?;
         if receiver.is_some() {
-            return Err(PyRuntimeError::new_err(
+            return Err(atm_error(AtmError::new(
+                AtmErrorCode::GraftReceiverAlreadyActive,
                 "ATM graft receiver is already active",
-            ));
+            )));
         }
         let session = client
             .activate_session(
@@ -909,13 +968,19 @@ impl PyGraftSession {
     }
 
     fn snapshot(&self) -> PyResult<PyGraftSessionSnapshot> {
-        let receiver = self
-            .receiver
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft receiver lock poisoned"))?;
+        let receiver = self.receiver.lock().map_err(|_| {
+            atm_error(AtmError::new(
+                AtmErrorCode::InternalError,
+                "ATM graft receiver lock poisoned",
+            ))
+        })?;
         receiver
             .as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("ATM graft receiver is not active"))?
+            .ok_or_else(|| {
+                atm_error(AtmError::daemon_unavailable(
+                    "ATM graft receiver is not active",
+                ))
+            })?
             .snapshot()
             .map(PyGraftSessionSnapshot::from)
             .map_err(atm_error)
@@ -925,14 +990,24 @@ impl PyGraftSession {
         let receiver = self
             .receiver
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft receiver lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM graft receiver lock poisoned",
+                ))
+            })?
             .take();
         if let Some(receiver) = receiver {
             receiver.close().map_err(atm_error)?;
         }
         self.client
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("ATM graft session lock poisoned"))?
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM graft session lock poisoned",
+                ))
+            })?
             .take();
         Ok(())
     }
@@ -1426,7 +1501,7 @@ mod tests {
                     .expect("typed error code")
                     .extract::<String>()
                     .expect("string code"),
-                "ATM_NATIVE_OPERATION_FAILED"
+                "ATM_DAEMON_UNAVAILABLE"
             );
             assert_eq!(
                 value
@@ -1757,7 +1832,7 @@ mod tests {
             let error = session
                 .activate_receiver(options, callback)
                 .expect_err("second activation must be rejected at the Python API boundary");
-            assert!(error.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py));
+            assert!(error.is_instance_of::<AtmGraftError>(py));
             assert!(error.to_string().contains("already active"));
         });
     }

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -1,0 +1,142 @@
+//! Query construction and read-only execution for the Python graft session.
+
+use super::*;
+
+impl PyGraftSession {
+    pub(super) fn build_read_query(&self, seen_state_update: bool) -> PyResult<ReadQuery> {
+        let (home_dir, current_dir) = Self::command_paths()?;
+        let team = self.caller_team()?;
+        let query = ReadQuery::new(
+            home_dir,
+            current_dir,
+            self.caller.agent().clone(),
+            None,
+            team.clone(),
+            ReadSelection::All,
+            false,
+            seen_state_update,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .map_err(atm_error)?;
+        Ok(query
+            .with_caller_chat_id(self.caller.chat_id().cloned())
+            .with_activity_observation(activity_observation_for_resolved_caller(
+                self.caller.agent(),
+                &team,
+            )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn build_tool_read_query(
+        &self,
+        selection: &str,
+        message_id: Option<&str>,
+        task: Option<&str>,
+        contains: Option<&str>,
+        since: Option<&str>,
+        from_agent: Option<&str>,
+    ) -> PyResult<ReadQuery> {
+        let (home_dir, current_dir) = Self::command_paths()?;
+        let team = self.caller_team()?;
+        let timestamp = since
+            .map(str::parse::<IsoTimestamp>)
+            .transpose()
+            .map_err(|error| {
+                atm_error(AtmError::validation(format!(
+                    "invalid since timestamp: {error}"
+                )))
+            })?;
+        ReadQuery::new(
+            home_dir,
+            current_dir,
+            self.caller.agent().clone(),
+            None,
+            team,
+            Self::read_selection(selection)?,
+            false,
+            false,
+            message_id,
+            from_agent,
+            timestamp,
+            task,
+            contains,
+            None,
+        )
+        .map_err(atm_error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn build_list_query(
+        &self,
+        selection: &str,
+        limit: Option<usize>,
+        task: Option<&str>,
+        contains: Option<&str>,
+        since: Option<&str>,
+        from_agent: Option<&str>,
+    ) -> PyResult<ListQuery> {
+        let (home_dir, current_dir) = Self::command_paths()?;
+        let team = self.caller_team()?;
+        let timestamp = since
+            .map(str::parse::<IsoTimestamp>)
+            .transpose()
+            .map_err(|error| {
+                atm_error(AtmError::validation(format!(
+                    "invalid since timestamp: {error}"
+                )))
+            })?;
+        ListQuery::new(
+            home_dir,
+            current_dir,
+            self.caller.agent().clone(),
+            None,
+            team,
+            Self::read_selection(selection)?,
+            false,
+            limit,
+            from_agent,
+            timestamp,
+            task,
+            contains,
+        )
+        .map_err(atm_error)
+    }
+
+    pub(super) fn read_raw(&self, query: ReadQuery) -> PyResult<ReadOutcome> {
+        let client = self.client()?;
+        python_extension_runtime()?
+            .lock()
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
+            .block_on(client.read_message(query))
+            .map_err(atm_error)
+    }
+
+    pub(super) fn read_outcome(&self, query: ReadQuery) -> PyResult<AtmReadResult> {
+        self.read_raw(query).and_then(AtmReadResult::from_outcome)
+    }
+
+    pub(super) fn list_outcome(&self, query: ListQuery) -> PyResult<AtmListResult> {
+        let client = self.client()?;
+        python_extension_runtime()?
+            .lock()
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
+            .block_on(client.list_messages(query))
+            .map(AtmListResult::from)
+            .map_err(atm_error)
+    }
+}

--- a/crates/atm-graft-python/src/tool_types.rs
+++ b/crates/atm-graft-python/src/tool_types.rs
@@ -151,7 +151,8 @@ impl AtmToolError {
                 .and_then(|attribute| attribute.extract::<String>().ok())
         };
         Self {
-            code: attribute("code").unwrap_or_else(|| "ATM_NATIVE_OPERATION_FAILED".to_owned()),
+            code: attribute("code")
+                .unwrap_or_else(|| AtmErrorCode::InternalError.as_str().to_owned()),
             message: attribute("message").unwrap_or_else(|| error.to_string()),
             recovery: "verify the local ATM daemon and configured identity, then retry".to_owned(),
             layer: "native_client".to_owned(),
@@ -165,5 +166,26 @@ impl AtmToolError {
     pub(crate) fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
         self.recovery = recovery.into();
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use atm_core::error::AtmErrorCode;
+    use pyo3::exceptions::PyException;
+    use pyo3::prelude::*;
+
+    use super::AtmToolError;
+
+    #[test]
+    fn unstructured_python_errors_use_the_canonical_internal_error_code() {
+        Python::initialize();
+        Python::attach(|py| {
+            let error = PyErr::new::<PyException, _>("unstructured extension failure");
+            let result = AtmToolError::from_native_error(py, &error);
+
+            assert_eq!(result.code, AtmErrorCode::InternalError.as_str());
+            assert_eq!(result.layer, "native_client");
+        });
     }
 }

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "ATM_HOME is not set"))?,
     );
 
-    let client = GraftClient::connect()?;
+    let client = GraftClient::connect_existing()?;
     let (delivered_tx, delivered_rx) = mpsc::channel();
     let injector = Arc::new(RecordingInjector {
         nudges: Mutex::new(Vec::new()),

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -179,15 +179,6 @@ impl fmt::Debug for GraftClient {
 }
 
 impl GraftClient {
-    /// # Errors
-    ///
-    /// Returns [`AtmError`] when the selected daemon endpoint cannot be
-    /// resolved. The managed Tokio/Axum daemon is owned by `/daemon-switch`;
-    /// embedding a graft client never starts a second daemon.
-    pub fn connect() -> Result<Self, AtmError> {
-        Self::connect_existing()
-    }
-
     /// Connect only to the daemon selected and already running for this host.
     ///
     /// This deliberately never resolves a daemon executable or invokes the

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -21,7 +21,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tower.workspace = true
 async-trait.workspace = true
-fs2 = "0.4"
+fs4 = "0.13"
 tracing.workspace = true
 ulid.workspace = true
 

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -20,7 +20,7 @@ use atm_core::api::{
 use atm_core::boundary;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
-use atm_core::protocol::RequestEnvelope;
+use atm_core::protocol::{RequestEnvelope, next_request_id};
 use atm_core::schema::AtmMessageId;
 use atm_core::send::SendRequest;
 use atm_core::types::{HostName, IsoTimestamp};
@@ -34,6 +34,7 @@ use reqwest::header::{HeaderName, HeaderValue};
 /// every replacement daemon owns this protocol port on its active IPv4
 /// interfaces.
 pub const DIRECT_PEER_TCP_PORT: u16 = 43_101;
+const REQUEST_ID_HEADER: &str = "X-ATM-Request-Id";
 
 /// One bounded budget for the selected write connector.
 ///
@@ -663,7 +664,9 @@ impl<Connector> HttpRuntimeClient<Connector> {
     where
         Connector: HttpRuntimeConnector,
     {
-        let encoded = encode_http_request(&request, &[])?;
+        let request_id = next_request_id();
+        let request_id_value = request_id.to_string();
+        let encoded = encode_http_request(&request, &[(REQUEST_ID_HEADER, &request_id_value)])?;
         let remaining = deadline.remaining().ok_or_else(|| {
             AtmError::new(
                 AtmErrorCode::WaitTimeout,
@@ -833,6 +836,19 @@ mod tests {
             assert_eq!(requests[0].method, "POST", "{connector_kind} connector");
             assert_eq!(
                 requests[0].path, "/v1/atm/messages",
+                "{connector_kind} connector"
+            );
+            let request_id_header = requests[0]
+                .headers
+                .iter()
+                .find(|header| header.starts_with("X-ATM-Request-Id: "))
+                .expect("outbound requests carry their correlation request ID");
+            assert!(
+                request_id_header
+                    .strip_prefix("X-ATM-Request-Id: ")
+                    .expect("request ID header prefix")
+                    .parse::<u64>()
+                    .is_ok(),
                 "{connector_kind} connector"
             );
             assert!(

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -20,7 +20,7 @@ use atm_core::api::{
 use atm_core::boundary;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
-use atm_core::protocol::{RequestEnvelope, next_request_id};
+use atm_core::protocol::{RequestEnvelope, RequestId, next_request_id};
 use atm_core::schema::AtmMessageId;
 use atm_core::send::SendRequest;
 use atm_core::types::{HostName, IsoTimestamp};
@@ -133,6 +133,18 @@ pub fn direct_peer_tcp_client(
     port: NonZeroU16,
     request_timeout: Duration,
 ) -> Result<Arc<dyn DaemonApiClient + Send + Sync>, AtmError> {
+    Ok(Arc::new(direct_peer_write_client(
+        host,
+        port,
+        request_timeout,
+    )?))
+}
+
+pub(crate) fn direct_peer_write_client(
+    host: HostName,
+    port: NonZeroU16,
+    request_timeout: Duration,
+) -> Result<DirectPeerWriteClient, AtmError> {
     if request_timeout.is_zero() {
         return Err(AtmError::config(
             "direct peer HTTP client request timeout must be greater than zero",
@@ -140,7 +152,7 @@ pub fn direct_peer_tcp_client(
     }
     let connector = DirectPeerTcpConnector::new(host, port)?;
     let client = Arc::new(HttpRuntimeClient::new(Arc::new(connector), request_timeout));
-    Ok(Arc::new(DirectPeerWriteClient { client }))
+    Ok(DirectPeerWriteClient { client })
 }
 
 /// Selects the one physical connector for a canonical write before encoding.
@@ -228,7 +240,7 @@ struct DirectPeerTcpConnector {
 /// write.  Supplying a caller-originated provenance pair is supported for
 /// handoff from an origin writer; otherwise the first peer boundary creates
 /// the immutable pair once.
-struct DirectPeerWriteClient {
+pub(crate) struct DirectPeerWriteClient {
     client: Arc<HttpRuntimeClient<DirectPeerTcpConnector>>,
 }
 
@@ -237,6 +249,25 @@ impl boundary::sealed::Sealed for DirectPeerWriteClient {}
 #[async_trait]
 impl DaemonApiClient for DirectPeerWriteClient {
     async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        self.execute_with_optional_request_id(request, None).await
+    }
+}
+
+impl DirectPeerWriteClient {
+    pub(crate) async fn execute_with_request_id(
+        &self,
+        request: ApiRequest,
+        request_id: RequestId,
+    ) -> Result<ApiResponse, AtmError> {
+        self.execute_with_optional_request_id(request, Some(request_id))
+            .await
+    }
+
+    async fn execute_with_optional_request_id(
+        &self,
+        request: ApiRequest,
+        request_id: Option<RequestId>,
+    ) -> Result<ApiResponse, AtmError> {
         let RequestEnvelope::Write(write) = request.into_inner() else {
             return Err(AtmError::validation(
                 "direct peer HTTP transport accepts canonical write requests only",
@@ -266,6 +297,7 @@ impl DaemonApiClient for DirectPeerWriteClient {
                 RequestEnvelope::Write(Box::new(write)),
                 RequestEnvelope::Write(Box::new(peer_response_shape)),
                 RequestDeadline::after(self.client.request_timeout),
+                request_id,
             )
             .await
     }
@@ -643,7 +675,7 @@ impl<Connector> HttpRuntimeClient<Connector> {
         Connector: HttpRuntimeConnector,
     {
         let request = request.into_inner();
-        self.execute_envelope_with_deadline(request.clone(), request, deadline)
+        self.execute_envelope_with_deadline(request.clone(), request, deadline, None)
             .await
     }
 
@@ -660,11 +692,12 @@ impl<Connector> HttpRuntimeClient<Connector> {
         request: RequestEnvelope,
         response_shape: RequestEnvelope,
         deadline: RequestDeadline,
+        request_id: Option<RequestId>,
     ) -> Result<ApiResponse, AtmError>
     where
         Connector: HttpRuntimeConnector,
     {
-        let request_id = next_request_id();
+        let request_id = request_id.unwrap_or_else(next_request_id);
         let request_id_value = request_id.to_string();
         let encoded = encode_http_request(&request, &[(REQUEST_ID_HEADER, &request_id_value)])?;
         let remaining = deadline.remaining().ok_or_else(|| {
@@ -856,6 +889,36 @@ mod tests {
                 "{connector_kind} connector"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn caller_supplied_request_id_is_forwarded_without_reminting() {
+        let connector = Arc::new(RecordingConnector::default());
+        connector
+            .responses
+            .lock()
+            .expect("responses")
+            .push_back(Ok(sent_response()));
+        let client = HttpRuntimeClient::new(connector.clone(), Duration::from_secs(1));
+        let request = write_request();
+
+        client
+            .execute_envelope_with_deadline(
+                request.clone(),
+                request,
+                RequestDeadline::after(Duration::from_secs(1)),
+                Some(atm_core::protocol::RequestId::new(73).expect("non-zero request ID")),
+            )
+            .await
+            .expect("caller-provided request ID is accepted");
+
+        let requests = connector.requests.lock().expect("requests");
+        assert!(
+            requests[0]
+                .headers
+                .iter()
+                .any(|header| header == "X-ATM-Request-Id: 73")
+        );
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -46,6 +46,7 @@ use crate::{RuntimeLimits, RuntimeTimeouts};
 /// This remains private to the HTTP boundary solely to reject stale callers;
 /// connectors establish provenance independently after authentication.
 const RETIRED_PEER_PROVENANCE_HEADER: &str = "X-ATM-Peer-Source-Host";
+const REQUEST_ID_HEADER: &str = "X-ATM-Request-Id";
 
 /// Async replacement-owned application operation for the canonical write
 /// route. Implementations may isolate synchronous storage or hook adapters in
@@ -282,7 +283,7 @@ async fn post_messages(
     headers: HeaderMap,
     request: Result<Json<WriteRequest>, JsonRejection>,
 ) -> Response {
-    let request_id = next_request_id();
+    let request_id = request_id_from_headers(&headers).unwrap_or_else(next_request_id);
     post_messages_with_request_id(state, peer, headers, request, request_id)
         .instrument(info_span!("atm_http_request", %request_id, method = "POST", path = canonical_write_path()))
         .await
@@ -326,7 +327,7 @@ async fn dispatch_request(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    let request_id = next_request_id();
+    let request_id = request_id_from_headers(&headers).unwrap_or_else(next_request_id);
     let request_method = method.clone();
     let request_path = uri.path().to_owned();
     dispatch_request_with_request_id(state, peer, method, uri, headers, body, request_id)
@@ -456,6 +457,19 @@ fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
         )));
     }
     Ok(())
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<RequestId> {
+    let values = headers.get_all(REQUEST_ID_HEADER);
+    let mut values = values.iter();
+    let value = values.next()?.to_str().ok()?;
+    if values.next().is_some() {
+        return None;
+    }
+    value
+        .parse::<u64>()
+        .ok()
+        .and_then(|value| RequestId::new(value).ok())
 }
 
 async fn overload_response(_: BoxError) -> Response {
@@ -594,14 +608,15 @@ mod tests {
     use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
-    use axum::http::{Request, StatusCode};
+    use axum::http::{HeaderMap, HeaderValue, Request, StatusCode};
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
     use super::{
-        AuthenticatedConnector, CanonicalWriteHandler, RETIRED_PEER_PROVENANCE_HEADER,
-        canonical_api_router, canonical_message_router, canonical_write_path,
-        decode_framework_request, json_response, map_write_response,
+        AuthenticatedConnector, CanonicalWriteHandler, REQUEST_ID_HEADER,
+        RETIRED_PEER_PROVENANCE_HEADER, canonical_api_router, canonical_message_router,
+        canonical_write_path, decode_framework_request, json_response, map_write_response,
+        request_id_from_headers,
     };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
@@ -744,6 +759,22 @@ mod tests {
             NonZeroDuration::new(request).expect("non-zero request timeout"),
             NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
         )
+    }
+
+    #[test]
+    fn request_id_header_preserves_a_valid_peer_correlation_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert(REQUEST_ID_HEADER, HeaderValue::from_static("42"));
+
+        assert_eq!(
+            request_id_from_headers(&headers)
+                .expect("valid header")
+                .into_inner(),
+            42
+        );
+
+        headers.append(REQUEST_ID_HEADER, HeaderValue::from_static("43"));
+        assert!(request_id_from_headers(&headers).is_none());
     }
 
     fn write_request() -> atm_core::send::WriteRequest {

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -66,6 +66,21 @@ pub trait CanonicalWriteHandler: atm_core::boundary::sealed::Sealed + Send + Syn
         deadline: RequestDeadline,
     ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>>;
 
+    /// Writes with the correlation ID established at HTTP ingress.
+    ///
+    /// Focused write-only handlers retain the compatibility implementation;
+    /// the production router overrides this to preserve the ID across a
+    /// directly forwarded peer acknowledgement.
+    fn write_with_request_id(
+        &self,
+        request: WriteRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+        _request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        self.write(request, ingress, deadline)
+    }
+
     /// Dispatches a route decoded by the core-owned HTTP codec.
     ///
     /// Existing focused write implementations retain the default, which keeps
@@ -86,6 +101,22 @@ pub trait CanonicalWriteHandler: atm_core::boundary::sealed::Sealed + Send + Syn
                     request.into_inner()
                 )))
             }),
+        }
+    }
+
+    /// Dispatches with the correlation ID established at HTTP ingress.
+    fn dispatch_with_request_id(
+        &self,
+        request: ApiRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+        request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        match request {
+            ApiRequest::Write(request) => {
+                self.write_with_request_id(*request, ingress, deadline, request_id)
+            }
+            request => self.dispatch(request, ingress, deadline),
         }
     }
 }
@@ -313,7 +344,10 @@ async fn post_messages_with_request_id(
     };
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    let response = state.handler.write(request, ingress, deadline).await;
+    let response = state
+        .handler
+        .write_with_request_id(request, ingress, deadline, request_id)
+        .await;
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
@@ -374,7 +408,7 @@ async fn dispatch_request_with_request_id(
     let deadline = RequestDeadline::after(state.request_timeout);
     state
         .handler
-        .dispatch(request, ingress, deadline)
+        .dispatch_with_request_id(request, ingress, deadline, request_id)
         .await
         .and_then(map_api_response)
         .unwrap_or_else(error_response)

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -20,7 +20,8 @@ use atm_core::error::AtmError;
 use atm_core::list::ListQuery;
 use atm_core::observability::ObservabilityPort;
 use atm_core::protocol::{
-    CompatibilityVerdict, ReleaseVersion, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
+    CompatibilityVerdict, ReleaseVersion, RequestEnvelope, RequestId, ResponseEnvelope,
+    SendResponseEnvelope,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::send::{WarningEntry, WriteOutcome, prepare_write_with_async_runtime};
@@ -197,6 +198,7 @@ impl StorageAndNudgeRouter {
         message_id: atm_core::schema::AtmMessageId,
         timestamp: atm_core::types::IsoTimestamp,
         deadline: RequestDeadline,
+        request_id: RequestId,
     ) -> Result<(), AtmError> {
         let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
             return Ok(());
@@ -206,10 +208,17 @@ impl StorageAndNudgeRouter {
                 "request deadline expired before cross-host acknowledgement delivery",
             )
         })?;
-        let client = crate::direct_peer_tcp_client(host.clone(), self.direct_peer_port, remaining)?;
+        let client = crate::client::direct_peer_write_client(
+            host.clone(),
+            self.direct_peer_port,
+            remaining,
+        )?;
         let request = request.clone().with_origin_metadata(message_id, timestamp);
         match client
-            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .execute_with_request_id(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(request))),
+                request_id,
+            )
             .await?
             .into_inner()
         {
@@ -466,9 +475,24 @@ impl atm_core::boundary::sealed::Sealed for StorageAndNudgeRouter {}
 impl CanonicalWriteHandler for StorageAndNudgeRouter {
     fn write(
         &self,
+        request: atm_core::send::WriteRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        self.write_with_request_id(
+            request,
+            ingress,
+            deadline,
+            atm_core::protocol::next_request_id(),
+        )
+    }
+
+    fn write_with_request_id(
+        &self,
         mut request: atm_core::send::WriteRequest,
         ingress: AuthenticatedIngress,
         deadline: RequestDeadline,
+        request_id: RequestId,
     ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
         Box::pin(async move {
             if deadline.expired() {
@@ -490,6 +514,7 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                     committed.message_id,
                     committed.persisted_timestamp,
                     deadline,
+                    request_id,
                 )
                 .await?;
             }
@@ -510,9 +535,27 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
         ingress: AuthenticatedIngress,
         deadline: RequestDeadline,
     ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
+        self.dispatch_with_request_id(
+            request,
+            ingress,
+            deadline,
+            atm_core::protocol::next_request_id(),
+        )
+    }
+
+    fn dispatch_with_request_id(
+        &self,
+        request: ApiRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+        request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<ApiResponse, AtmError>> + Send + '_>> {
         Box::pin(async move {
             match request {
-                ApiRequest::Write(request) => self.write(*request, ingress, deadline).await,
+                ApiRequest::Write(request) => {
+                    self.write_with_request_id(*request, ingress, deadline, request_id)
+                        .await
+                }
                 request => self.dispatch_non_write(request, ingress, deadline).await,
             }
         })

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -883,7 +883,10 @@ mod tests {
     }
 
     fn router(fixture: &Fixture, connector: AuthenticatedConnector) -> axum::Router {
-        router_with_timeout(fixture, connector, Duration::from_secs(1))
+        // Ordinary route tests are not deadline tests. Give their SQLite
+        // admission and advisory hook enough headroom on slower CI hosts;
+        // tests of deadline behavior select their one-second budget below.
+        router_with_timeout(fixture, connector, Duration::from_secs(10))
     }
 
     fn router_with_timeout(

--- a/crates/atm-http-runtime/src/unix_socket.rs
+++ b/crates/atm-http-runtime/src/unix_socket.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use atm_core::error::AtmError;
 #[cfg(unix)]
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 #[cfg(unix)]
 use tokio::net::UnixListener;
 
@@ -122,12 +122,17 @@ impl UnixSocketStartupLock {
             AtmError::daemon_unavailable("failed to protect Unix HTTP socket startup lock")
                 .with_cause(source)
         })?;
-        file.try_lock_exclusive().map_err(|source| {
+        if !file.try_lock_exclusive().map_err(|source| {
             AtmError::daemon_serving_state_rejected(format!(
-                "another daemon is starting the Unix HTTP socket `{}`: {source}",
+                "failed to acquire Unix HTTP socket startup lock `{}`: {source}",
                 socket.path.display()
             ))
-        })?;
+        })? {
+            return Err(AtmError::daemon_serving_state_rejected(format!(
+                "another daemon is starting the Unix HTTP socket `{}`",
+                socket.path.display()
+            )));
+        }
         Ok(Self { file })
     }
 }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -85,8 +85,9 @@ pub fn hold_sqlite_writer_lock_for_test(
 #[doc(hidden)]
 #[cfg(any(test, feature = "test-support"))]
 pub fn install_message_write_failure_for_test(path: impl AsRef<Path>) -> Result<(), AtmError> {
-    let connection = Connection::open(path.as_ref()).map_err(|_error| {
+    let connection = Connection::open(path.as_ref()).map_err(|error| {
         AtmError::daemon_unavailable("failed to open sqlite storage-failure test connection")
+            .with_cause(error)
     })?;
     connection
         .execute_batch(
@@ -98,8 +99,9 @@ pub fn install_message_write_failure_for_test(path: impl AsRef<Path>) -> Result<
             END;
             "#,
         )
-        .map_err(|_error| {
+        .map_err(|error| {
             AtmError::daemon_unavailable("failed to install sqlite storage-failure test trigger")
+                .with_cause(error)
         })
 }
 

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -126,7 +126,7 @@ def _invoke(call: Callable[[], Any], project: Callable[[Any], dict[str, Any]]) -
         outcome = call()
     except Exception as error:  # native binding establishes the canonical code
         return _error(
-            code="ATM_NATIVE_OPERATION_FAILED",
+            code="ATM_INTERNAL_ERROR",
             message=str(error),
             recovery="verify the local ATM daemon and configured identity, then retry",
             layer="native_client",

--- a/docs/plans/phase-al/AL9-physical-proof-matrix.md
+++ b/docs/plans/phase-al/AL9-physical-proof-matrix.md
@@ -1,7 +1,10 @@
 # AL.9 physical-proof matrix
 
-**Status:** partial local source-and-runtime proof only; this is not an
-activation record and does not authorize Phase AM.
+**Status:** reconciled physical-proof record for the AL.9/AM transition. The
+CLI, graft, and M5<->M4 cross-host runtime rows below have retained physical
+evidence. Windows local proof is retained; the unavailable Windows<->M4 live
+cross-host lane is an explicit Phase AP environment deferral, not an ATM
+transport failure.
 
 **Proof subject:** `9ceb7bee4676cc09cb9b4bfacd56e1fcf3da8612` on
 `feature/pal-s9-physical-proof-ledger-freeze`, with AL.8 composition input
@@ -36,11 +39,11 @@ alone changes physical setup; `HttpRuntimeClient` owns the one encoder,
 | New-write-only hook semantics | `axum_route_idempotent_duplicate_skips_the_second_received_hook` and `axum_route_hook_failure_returns_durable_success_with_warning` | Pass when run locally | None beyond the full physical adapter rows. |
 | Unix UDS write | `uds_runtime_reaches_the_canonical_storage_and_received_hook_path`; `unix_socket_uses_the_shared_client_router_and_owner_only_endpoint` | Pass when run locally on Unix | Authorized host activation still required. |
 | Loopback TCP write | `loopback_shared_client_uses_the_active_record_and_canonical_handler`; `loopback_and_uds_return_identical_canonical_json` | Pass when run locally | Authorized host activation plus an actual Windows run. |
-| CLI local write selection | `atm-architecture::al9_cli_and_graft_send_use_the_selected_runtime_client` requires `preferred_local_client` plus awaited `async_transport.execute(Write)` and rejects compatibility dispatch from the send segment | Static/source proof; final-candidate runtime row pending | Owner: `team-lead`. Trigger: the frozen final `integrate/phase-al` candidate, before a `develop` proposal. Record a switched-host CLI send/read/ack artifact; static proof is not a substitute. |
-| Graft outbound write selection | The architecture test locks `GraftClient::connect` and `AtmGraftClient::send_message` to the shared client. The registered runtime command is `just smoke graft-hermes`: it first requires `atm doctor --json` to prove the selected matched pair ready, then runs the installed `atm-graft` Python session's real `send`/nudge/read/ack round trip and writes a self-contained smoke report. It never starts or terminates a daemon. | Runtime command registered; final-candidate runtime row pending | Owner: `team-lead`. Trigger: the frozen final `integrate/phase-al` candidate, before a `develop` proposal. The release operator runs `/daemon-switch`, verifies doctor, then runs `just smoke graft-hermes` from the configured profile with distinct registered sender/recipient identities. Retain the generated `site/reports/smoke/.../graft-hermes/` artifact. |
+| CLI local write selection | `atm-architecture::al9_cli_and_graft_send_use_the_selected_runtime_client` requires `preferred_local_client` plus awaited `async_transport.execute(Write)` and rejects compatibility dispatch from the send segment. The later matched-pair M5<->M4 artifact records 120 CLI send/read/ack content cases in both directions, with distinct registered `rand-m5`/`arch-ctm` identities and M4's explicit `/opt/homebrew/bin/atm` path: [`am6-closure-proof.md`](../phase-am/am6-closure-proof.md#dynamic-evidence), `site/reports/smoke/macos/rand-m5.local/20260811T001934627915Z-pid86365-crosshost-send/`. | **Satisfied** — switched-host CLI proof retained. | No additional AL.9 CLI write gate. |
+| Graft outbound write selection | The architecture test locks `GraftClient::connect` and `AtmGraftClient::send_message` to the shared client. The registered runtime command remains `just smoke graft-hermes`, but the literal command name was not used. Its required live Python-graft send/ack intent is nevertheless covered by the installed `hermes-atm` native-tools proof: SkillRX reported a post-daemon-cycle native `atm_send` retry success with durable message ID `01KZSSREKYM7G39237P0YQ3CW3` in ATM message [`01KZSSSG878QYFGBJVDWTJHXKG`](../../atm-dev/01KZSSSG878QYFGBJVDWTJHXKG), then reported the same native `atm_send` acknowledgement path's pending state cleared in [`01KZSVA533HB2XG0YN2X4NB97G`](../../atm-dev/01KZSVA533HB2XG0YN2X4NB97G). This is live installed `hermes-atm` over the shipped Python `atm_graft` session, not a hand-edited harness. | **Satisfied by equivalent live Python-graft evidence** — the prescribed smoke script itself was not run. | Retain the two ATM message IDs as the proof receipt; no claim is made that `just smoke graft-hermes` produced a report artifact. |
 | Direct failure creates no retry/replay | `client::tests::direct_connector_failure_performs_exactly_one_exchange` | Pass when run locally | One physical refused-connection run can supplement this, but must not manufacture replay state. |
-| M5 direct cross-host write | `DirectPeerTcpConfig`, `direct_peer_tcp_client`, and `direct_peer_listener_uses_the_canonical_router_and_normalizes_provenance` | **Final-candidate physical proof pending; no AL.7 reuse is claimed** | Owner: `team-lead`; M5 execution operator: `arch-ctm`. Trigger: the frozen final `integrate/phase-al` candidate, before a `develop` proposal. In a fresh M5 proof worktree, configure receiver `ATM_HTTP_DIRECT_PEER_BIND=<private-m5-ip>:<port>` and `ATM_HTTP_DIRECT_PEER_SOURCE_HOST=<sender-host>`, then sender `ATM_HTTP_DIRECT_PEER_PORT=<port>`. Curl a normal `WriteRequest` JSON to `POST /v1/atm/messages`; record source SHA/diff, HTTP response, persisted message, and exactly-one received-hook evidence. This is a temporary plaintext, unauthenticated evidence adapter only—not production activation. |
-| Windows physical proof | No current-runtime artifact exists | **Pending** | A real Windows runner must exercise the loopback row and benchmark; historical Phase AI output is baseline-only. |
+| M5 direct cross-host write | `DirectPeerTcpConfig`, `direct_peer_tcp_client`, and `direct_peer_listener_uses_the_canonical_router_and_normalizes_provenance`. The matched M5<->M4 release-pair smoke exercised both direct directions and acknowledgement/content checks for 120 cases: [`am6-closure-proof.md`](../phase-am/am6-closure-proof.md#dynamic-evidence), `site/reports/smoke/macos/rand-m5.local/20260811T001934627915Z-pid86365-crosshost-send/`. | **Satisfied** — real M5<->M4 direct cross-host write proof retained; no AL.7/TLS reuse is claimed. | No additional AL.9 direct-write gate. TLS remains separately out of scope. |
+| Windows physical proof | Windows local daemon, test suite, and FastPC4 loopback-TCP benchmark proof pass; see [`release-highlights-phase-am.md`](../../release-highlights-phase-am.md#platform-and-cross-host-status). | **Explicitly deferred to Phase AP** — not a code or transport failure. | Windows<->M4 live cross-host proof awaits the documented VPN/DNS reachability constraint; Phase AP begins with that outbound-initiated proof. |
 
 ## Explicit negative claims
 
@@ -63,8 +66,7 @@ cargo test -p atm-http-runtime --lib
 cargo test -p atm-architecture al9_cli_and_graft_send_use_the_selected_runtime_client -- --nocapture
 ```
 
-The individual test names, rather than a generic test count, are the durable
-route-to-hook evidence. A passing command is necessary but insufficient for
-the unexecuted Windows, graft, benchmark, M5, and activation rows. The M5 row
-requires the documented fresh-worktree rerun; it does not claim that the run
-has already occurred.
+The individual test names, rather than a generic test count, are durable
+route-to-hook evidence. The reconciled CLI, graft, and M5 rows above add their
+specific physical receipts; the Windows live cross-host row remains an explicit
+Phase AP environment deferral.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1121,7 +1121,7 @@ merged forward into it; do not wait for parent QA approval. Merge the current
 parent branch into the child before every child dev/fix round. A child PR may
 not complete or merge its target before its parent PR merges.
 
-## 43. Phase AL — Build the Minimal Tokio HTTP Runtime [PLAN HARDENING]
+## 43. Phase AL — Build the Minimal Tokio HTTP Runtime [COMPLETE]
 
 Status summary:
 - Phase AL replaces ATM's hand-written synchronous HTTP framing and
@@ -1191,7 +1191,7 @@ Acceptance:
 - Phase AL acceptance is defined by the authoritative plan's sprint
   validations and the runtime boundary checklist's required evidence set.
 
-## 44. Phase AM — Deletion-Only Transport Cleanup [PLAN HARDENING]
+## 44. Phase AM — Deletion-Only Transport Cleanup [COMPLETE]
 
 Status summary:
 - Phase AM is deletion-only: it removes the legacy transport machinery made

--- a/docs/release-highlights-phase-am.md
+++ b/docs/release-highlights-phase-am.md
@@ -37,7 +37,7 @@ loopback TCP, or storage-admission costs behind one aggregate number.
 is installable into the Hermes Python environment, registers a profile-aware
 graft receiver, and delivers a meaningful ATM nudge through the existing
 Telegram session and agent loop. The integration supports the native tool
-direction (`atm_read` and `atm_send`) rather than requiring agents to shell
+direction (`atm_send`, `atm_read`, and `atm_list`) rather than requiring agents to shell
 out for ordinary tool calls.
 
 The release closure includes the Hermes package/PyPI lane as a Phase AM


### PR DESCRIPTION
## Summary

Resolves the blocking (ATM-QA-004-AL9) and remaining important/minor findings from QA-AM-PHASEEND-2, the second Phase AM phase-ending review. This is the last item gating PR #853 (Phase AM -> develop).

- **ATM-QA-004-AL9** (blocking): reconciled `AL9-physical-proof-matrix.md`'s pending rows against `am6-closure-proof.md`'s dynamic evidence (CLI/M5 rows), a live production graft-outbound proof (ATM message IDs verified against mail.db by quality-mgr), and `release-highlights-phase-am.md`'s explicit Windows-deferral-to-Phase-AP framing.
- **AM-PHASEEND2-PLANDOC-STALE-001**: `project-plan.md` sections 43/44 updated `[PLAN HARDENING]` -> `[COMPLETE]`.
- **RSH-001**: request-ID propagation across HTTP ingress and direct-peer client path.
- **RBP-F001/F002**: canonical native error envelope unification (`AtmToolError`/FFI validation shapes).
- **RBQA-AM2-F001**: consolidated `GraftClient::connect()`/`connect_existing()` duplication.
- **RBQA-AM2-F002**: release-highlights doc corrected to list all 3 native tools (was undercounting at 2).
- **RSH-002**: `fs2` -> `fs4` migration.
- **RBP-F003**: rationale comment added.
- **QA-001**: SQLite error causes preserved instead of collapsed.
- **RSH-003**: explicitly scoped forward-looking, no code change (per team-lead's own framing in the dispatch).

Commit: `2cdedd4d`

## Test plan
- [x] `just lint`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`
- [x] `just test` (494 Python tests)
- [x] `just test-hermes-graft-bridge` (isolated wheel install, 16 tests)
- [x] quality-mgr independently spot-checked the AL9/docs reconciliation piece directly against mail.db and on-disk artifacts
- [ ] Final quality-mgr reissue of QA-AM-PHASEEND-2