### PR TITLE
feat(query): complete AN.6 query surface

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -139,6 +139,10 @@ owner_manifest_path = "crates/atm-graft-python/Cargo.toml"
 allowed_dependencies = ["atm-core", "atm-graft", "pyo3", "tempfile", "tokio"]
 
 [[boundaries.manifest_dependency_allowlists]]
+owner_manifest_path = "crates/atm-query-python/Cargo.toml"
+allowed_dependencies = ["atm-storage", "atm-storage-rusqlite", "pyo3", "tempfile"]
+
+[[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-http-runtime/Cargo.toml"
 allowed_dependencies = ["async-trait", "atm-core", "atm-runtime-test-support", "atm-storage", "axum", "base64", "fs2", "hyper", "hyper-util", "reqwest", "serde", "serde_json", "serde_yaml", "tempfile", "tokio", "tower", "tracing", "ulid", "windows-sys"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "base64",
  "chrono",
  "fs2",
+ "futures",
  "getrandom 0.3.4",
  "interprocess",
  "libc",
@@ -263,6 +264,15 @@ dependencies = [
  "atm-storage",
  "rcgen",
  "rustls",
+ "tempfile",
+]
+
+[[package]]
+name = "atm-query-python"
+version = "1.4.2"
+dependencies = [
+ "pyo3",
+ "rusqlite",
  "tempfile",
 ]
 
@@ -685,12 +695,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -711,6 +737,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,8 +771,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "base64",
  "chrono",
  "fs2",
- "futures",
  "getrandom 0.3.4",
  "interprocess",
  "libc",
@@ -51,6 +50,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -271,8 +271,9 @@ dependencies = [
 name = "atm-query-python"
 version = "1.4.2"
 dependencies = [
+ "atm-storage",
+ "atm-storage-rusqlite",
  "pyo3",
- "rusqlite",
  "tempfile",
 ]
 
@@ -695,28 +696,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -737,23 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,13 +739,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/atm-peer-tls-interop",
     "crates/atm-graft",
     "crates/atm-graft-python",
+    "crates/atm-query-python",
     "crates/sc-lint-attributes",
     "crates/sc-lint-boundary",
     "crates/sc-lint-directives",

--- a/boundaries/atm-query-python/local-analyst-binding.toml
+++ b/boundaries/atm-query-python/local-analyst-binding.toml
@@ -1,0 +1,47 @@
+boundary_id = "BOUNDARY-LocalAnalystPythonBinding"
+owner_package = "atm-query-python"
+owner_crate_path = "atm_query"
+name = "LocalAnalystPythonBinding"
+
+[public]
+facade = "ReadonlyDatabase"
+notes = "Maturin facade for bounded, local read-only analyst queries. This binding has no transport, daemon, or message-write capability."
+
+[implementation]
+type = "ReadonlyDatabase"
+module = "atm_query"
+visibility = "public"
+constructor = "public"
+
+[composition]
+roots = ["atm_query::open_readonly"]
+
+[ownership]
+io_owns = ["python_value_projection"]
+io_forbidden = ["direct_sqlite_io", "storage_write", "http_runtime", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-storage", "atm-storage-rusqlite", "pyo3"]
+forbidden_edges = ["atm-query-python -> atm-core", "atm-query-python -> atm-http-runtime", "atm-query-python -> atm-graft", "atm-query-python -> rusqlite"]
+
+[references]
+scope = "inside_owner_crate"
+forbidden = ["rusqlite::Connection", "axum::Router", "reqwest::Client"]
+
+[contracts]
+request_types = ["AnalystQueryValue"]
+response_types = ["PyObject"]
+error_types = ["AtmError", "PyRuntimeError"]
+
+[testing]
+allowed_test_double_paths = ["atm_storage_rusqlite::create_analyst_query_fixture_for_test"]
+forbidden_test_bypasses = ["rusqlite::Connection", "write_capability"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-LOCAL-ANALYST-PYTHON"]
+review_gates = ["no_binding_owned_sqlite", "no_binding_owned_transport", "readonly_only"]
+
+[status]
+state = "active"
+notes = ["AN.6 makes the local Maturin analyst interface an explicit leaf consumer of the dedicated analyst storage seam."]

--- a/boundaries/atm-storage-rusqlite/analyst-query-store-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/analyst-query-store-sqlite.toml
@@ -1,0 +1,47 @@
+boundary_id = "BOUNDARY-SqliteAnalystQueryStore"
+owner_package = "atm-storage-rusqlite"
+owner_crate_path = "atm_storage_rusqlite"
+name = "SqliteAnalystQueryStore"
+
+[public]
+trait = "AnalystQueryStore"
+notes = "Private SQLite implementation of the typed local-only analyst query capability."
+
+[implementation]
+type = "SqliteAnalystQueryStore"
+module = "atm_storage_rusqlite::analyst_query"
+visibility = "private"
+constructor = "private"
+
+[composition]
+roots = ["atm_storage_rusqlite::open_analyst_query_store"]
+
+[ownership]
+io_owns = ["readonly_sqlite_connection", "sqlite_authorizer", "query_budget_enforcement"]
+io_forbidden = ["storage_write", "http_runtime", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-query-python"]
+allowed_dependencies = ["atm-storage", "rusqlite"]
+forbidden_edges = ["atm -> atm-storage-rusqlite", "atm-daemon -> atm-storage-rusqlite", "atm-graft -> atm-storage-rusqlite", "atm-http-runtime -> atm-storage-rusqlite", "atm-runtime -> atm-storage-rusqlite"]
+
+[references]
+scope = "inside_owner_crate"
+forbidden = ["atm_core", "atm_http_runtime", "axum::Router"]
+
+[contracts]
+request_types = ["AnalystQueryValue"]
+response_types = ["AnalystQueryRows"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["direct_http_sqlite_reader", "write_capability"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-ANALYST-QUERY-SQLITE"]
+review_gates = ["private_sqlite_impl", "only_local_python_consumer", "readonly_authorizer"]
+
+[status]
+state = "active"
+notes = ["AN.6 limits the concrete SQLite adapter to the local Maturin analyst binding; production daemon and HTTP runtime crates remain forbidden dependents."]

--- a/boundaries/atm-storage/analyst-query-store.toml
+++ b/boundaries/atm-storage/analyst-query-store.toml
@@ -1,0 +1,45 @@
+boundary_id = "BOUNDARY-AnalystQueryStore"
+owner_package = "atm-storage"
+owner_crate_path = "atm_storage"
+name = "AnalystQueryStore"
+
+[public]
+trait = "AnalystQueryStore"
+notes = "Typed, local-only analyst query capability. It deliberately excludes SQL connection types, network transport, and write operations."
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["typed_readonly_query_contract"]
+io_forbidden = ["direct_sqlite_io", "storage_write", "http_runtime", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-query-python", "atm-storage-rusqlite"]
+allowed_dependencies = ["atm-error", "serde", "serde_json"]
+forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["AnalystQueryValue"]
+response_types = ["AnalystQueryRows"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["sqlite_connection", "raw_sql_outside_storage"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-ANALYST-QUERY-STORE"]
+review_gates = ["only_local_python_consumer", "typed_contract_only", "no_sql_or_transport"]
+
+[status]
+state = "active"
+notes = ["AN.6 permits exactly one non-runtime consumer: the local Maturin analyst binding. This is a dedicated capability boundary, not a relaxation of MessageSearchStore."]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -42,7 +42,6 @@ atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true
-tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -42,6 +42,7 @@ atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true
+futures = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -42,7 +42,7 @@ atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true
-futures = "0.3"
+tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -16,6 +16,7 @@ use crate::protocol::{
     CompatibilityPreflight, RequestEnvelope, ResponseEnvelope, TeamMemberHeartbeatRequest,
 };
 use crate::read::{PeekQuery, ReadQuery};
+use crate::search::SearchRequest;
 use crate::send::WriteRequest;
 use crate::types::HostName;
 use base64::Engine as _;
@@ -34,6 +35,7 @@ const DOCTOR_PATH: &str = "/v1/atm/doctor";
 const COMPATIBILITY_PATH: &str = "/v1/atm/compatibility";
 const HEARTBEAT_PATH: &str = "/v1/atm/heartbeat";
 const RUNTIME_RELOAD_PATH: &str = "/v1/atm/runtime/reload";
+const SEARCH_PATH: &str = "/v1/atm/messages/search";
 
 /// One registered HTTP route, published from the same constants as request encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -53,6 +55,7 @@ pub enum HttpRouteKind {
     RuntimeReload,
     Compatibility,
     Heartbeat,
+    Search,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -64,6 +67,13 @@ struct HttpRouteSpec {
 // This one table is consumed by both outbound request construction and inbound
 // decoding. Adding a route cannot make it to one direction without the other.
 const HTTP_ROUTE_SPECS: &[HttpRouteSpec] = &[
+    HttpRouteSpec {
+        kind: HttpRouteKind::Search,
+        route: HttpRoute {
+            method: "GET",
+            path_template: SEARCH_PATH,
+        },
+    },
     HttpRouteSpec {
         kind: HttpRouteKind::List,
         route: HttpRoute {
@@ -138,15 +148,16 @@ fn route_spec(kind: HttpRouteKind) -> &'static HttpRouteSpec {
     // Keep outbound route selection exhaustive: adding a route kind cannot
     // compile until its shared codec entry is selected here.
     match kind {
-        HttpRouteKind::List => &HTTP_ROUTE_SPECS[0],
-        HttpRouteKind::Write => &HTTP_ROUTE_SPECS[1],
-        HttpRouteKind::Clear => &HTTP_ROUTE_SPECS[2],
-        HttpRouteKind::Inspect => &HTTP_ROUTE_SPECS[3],
-        HttpRouteKind::Receive => &HTTP_ROUTE_SPECS[4],
-        HttpRouteKind::Doctor => &HTTP_ROUTE_SPECS[5],
-        HttpRouteKind::RuntimeReload => &HTTP_ROUTE_SPECS[6],
-        HttpRouteKind::Compatibility => &HTTP_ROUTE_SPECS[7],
-        HttpRouteKind::Heartbeat => &HTTP_ROUTE_SPECS[8],
+        HttpRouteKind::Search => &HTTP_ROUTE_SPECS[0],
+        HttpRouteKind::List => &HTTP_ROUTE_SPECS[1],
+        HttpRouteKind::Write => &HTTP_ROUTE_SPECS[2],
+        HttpRouteKind::Clear => &HTTP_ROUTE_SPECS[3],
+        HttpRouteKind::Inspect => &HTTP_ROUTE_SPECS[4],
+        HttpRouteKind::Receive => &HTTP_ROUTE_SPECS[5],
+        HttpRouteKind::Doctor => &HTTP_ROUTE_SPECS[6],
+        HttpRouteKind::RuntimeReload => &HTTP_ROUTE_SPECS[7],
+        HttpRouteKind::Compatibility => &HTTP_ROUTE_SPECS[8],
+        HttpRouteKind::Heartbeat => &HTTP_ROUTE_SPECS[9],
     }
 }
 
@@ -158,6 +169,7 @@ fn route_kind_for_request(request: &RequestEnvelope) -> HttpRouteKind {
         RequestEnvelope::Receive(_) => HttpRouteKind::Receive,
         RequestEnvelope::Clear(_) => HttpRouteKind::Clear,
         RequestEnvelope::Doctor(_) => HttpRouteKind::Doctor,
+        RequestEnvelope::Search(_) => HttpRouteKind::Search,
         RequestEnvelope::ReloadRuntimeView => HttpRouteKind::RuntimeReload,
         RequestEnvelope::CompatibilityPreflight(_) => HttpRouteKind::Compatibility,
         RequestEnvelope::Heartbeat(_) => HttpRouteKind::Heartbeat,
@@ -167,6 +179,10 @@ fn route_kind_for_request(request: &RequestEnvelope) -> HttpRouteKind {
 /// Resolves a framework HTTP method and path through the canonical route table.
 #[must_use]
 pub fn http_route_kind(method: &str, path: &str) -> Option<HttpRouteKind> {
+    // Request parameters are part of the HTTP representation, not the route
+    // identity.  In particular, search is a bodyless GET so caches and
+    // ordinary HTTP tooling can address a complete typed query by URL.
+    let path = path.split_once('?').map_or(path, |(path, _)| path);
     HTTP_ROUTE_SPECS.iter().find_map(|spec| {
         (spec.route.method == method && spec.route.path_template == path).then_some(spec.kind)
     })
@@ -202,7 +218,13 @@ pub fn encode_http_request(
     adapter_headers: &[(&str, &str)],
 ) -> Result<HttpRequest, AtmError> {
     let body = encode_request_body(request)?;
-    let (method, path) = endpoint_for(request);
+    let (method, mut path) = endpoint_for(request);
+    if let RequestEnvelope::Search(value) = request {
+        let encoded = serde_json::to_vec(value).map_err(AtmError::from)?;
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(encoded);
+        path.push_str("?request=");
+        path.push_str(&encoded);
+    }
     let mut headers = Vec::with_capacity(adapter_headers.len() + 1);
     headers.push("Content-Type: application/json".to_string());
     headers.extend(
@@ -282,6 +304,9 @@ fn encode_request_body(request: &RequestEnvelope) -> Result<Vec<u8>, AtmError> {
         RequestEnvelope::Receive(value) => serde_json::to_vec(value),
         RequestEnvelope::Clear(value) => serde_json::to_vec(value),
         RequestEnvelope::Doctor(value) => serde_json::to_vec(value),
+        // Search is a bodyless GET. Its typed request is encoded as the
+        // URL-safe `request` query value in `encode_http_request`.
+        RequestEnvelope::Search(_) => Ok(Vec::new()),
         RequestEnvelope::ReloadRuntimeView => serde_json::to_vec(&()),
     }
     .map_err(AtmError::from)
@@ -329,6 +354,9 @@ fn decode_success_response(
         }
         RequestEnvelope::Doctor(_) => decode_response_body(body, "doctor")
             .map(|value| ResponseEnvelope::Doctor(Box::new(value))),
+        RequestEnvelope::Search(_) => {
+            decode_response_body(body, "search").map(ResponseEnvelope::Search)
+        }
         RequestEnvelope::ReloadRuntimeView => decode_response_body::<()>(body, "runtime reload")
             .map(|()| ResponseEnvelope::RuntimeViewReloaded),
     }
@@ -349,6 +377,7 @@ pub enum ApiRequest {
     Write(Box<WriteRequest>),
     Clear(ClearQuery),
     Doctor(DoctorQuery),
+    Search(Box<SearchRequest>),
     CompatibilityPreflight(CompatibilityPreflight),
     Heartbeat(TeamMemberHeartbeatRequest),
     ReloadRuntimeView,
@@ -376,6 +405,7 @@ impl ApiRequest {
             Self::Write(request) => RequestEnvelope::Write(request),
             Self::Clear(query) => RequestEnvelope::Clear(query),
             Self::Doctor(query) => RequestEnvelope::Doctor(query),
+            Self::Search(query) => RequestEnvelope::Search(*query),
             Self::CompatibilityPreflight(preflight) => {
                 RequestEnvelope::CompatibilityPreflight(preflight)
             }
@@ -400,6 +430,7 @@ impl From<RequestEnvelope> for ApiRequest {
             }
             RequestEnvelope::Clear(query) => Self::Clear(query),
             RequestEnvelope::Doctor(query) => Self::Doctor(query),
+            RequestEnvelope::Search(query) => Self::Search(Box::new(query)),
             RequestEnvelope::CompatibilityPreflight(preflight) => {
                 Self::CompatibilityPreflight(preflight)
             }
@@ -421,6 +452,43 @@ impl ApiResponse {
 
     pub fn into_inner(self) -> ResponseEnvelope {
         self.response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+
+    use super::{HttpRouteKind, encode_http_request, http_route_kind};
+    use crate::protocol::RequestEnvelope;
+    use crate::search::SearchRequest;
+
+    #[test]
+    fn search_is_encoded_as_one_bodyless_get_query_parameter() {
+        let request = RequestEnvelope::Search(SearchRequest {
+            query: crate::search::SearchInput::default(),
+        });
+        let encoded = encode_http_request(&request, &[]).expect("HTTP request");
+        assert_eq!(encoded.method, "GET");
+        assert!(encoded.body.is_empty());
+        assert_eq!(
+            http_route_kind(&encoded.method, &encoded.path),
+            Some(HttpRouteKind::Search)
+        );
+        let value = encoded
+            .path
+            .split_once("?request=")
+            .expect("request query value")
+            .1;
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .expect("base64url request");
+        assert_eq!(
+            serde_json::from_slice::<SearchRequest>(&decoded).expect("typed JSON"),
+            SearchRequest {
+                query: crate::search::SearchInput::default(),
+            }
+        );
     }
 }
 

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -64,6 +64,8 @@ pub mod roles;
 pub mod runtime_install_hooks;
 /// Public mailbox and team schema types shared with CLI tests and adapters.
 pub mod schema;
+/// Transport-neutral, local-only message search query contract.
+pub mod search;
 /// Mailbox send workflows and request/response models.
 pub mod send;
 /// Internal service-owned seams that isolate retained command orchestration
@@ -118,6 +120,7 @@ pub use config::types::GraftConfig;
 /// accepted `atm-core` surface.
 pub use graft::AtmGraftClient;
 pub use protocol::{RequestEnvelope, ResponseEnvelope};
+pub use search::{SearchAggregateInput, SearchHit, SearchInput, SearchRequest, SearchResponse};
 pub use service_runtime::{
     LocalFileNonClaudeOutbound, LocalServiceRuntime, with_default_local_service_runtime,
 };

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -21,6 +21,7 @@ use crate::error_codes::AtmErrorCode;
 use crate::home;
 use crate::list::{ListOutcome, ListQuery};
 use crate::read::{PeekQuery, ReadOutcome, ReadQuery};
+use crate::search::{SearchRequest, SearchResponse};
 use crate::send::{SendOutcome, WriteRequest};
 use crate::types::{AgentName, IsoTimestamp, SessionId, TeamName, deserialize_optional_session_id};
 
@@ -45,6 +46,7 @@ pub enum RequestEnvelope {
     Receive(ReadQuery),
     Clear(ClearQuery),
     Doctor(DoctorQuery),
+    Search(SearchRequest),
     /// Authenticated local control request that reloads the daemon's durable runtime view.
     ReloadRuntimeView,
 }
@@ -60,6 +62,7 @@ pub enum ResponseEnvelope {
     Receive(Box<ReadOutcome>),
     Clear(ClearOutcome),
     Doctor(Box<DoctorReport>),
+    Search(SearchResponse),
     RuntimeViewReloaded,
     Error(AtmError),
 }

--- a/crates/atm-core/src/search.rs
+++ b/crates/atm-core/src/search.rs
@@ -194,9 +194,7 @@ pub async fn execute_search(
     deadline: RequestDeadline,
 ) -> Result<SearchResponse, AtmError> {
     if ingress != AuthenticatedIngress::Local {
-        return Err(AtmError::validation(
-            "message search is available only through authenticated local HTTP adapters",
-        ));
+        return Err(AtmError::search_local_only());
     }
     let query = request.compile_query()?;
     let remaining = deadline.remaining().ok_or_else(|| {
@@ -615,7 +613,7 @@ mod tests {
         )
         .await
         .expect_err("peer search must reject");
-        assert!(error.is_validation());
+        assert_eq!(error.code(), atm_storage::AtmErrorCode::SearchLocalOnly);
         assert_eq!(store.search_calls_for_test(), 0);
     }
 

--- a/crates/atm-core/src/search.rs
+++ b/crates/atm-core/src/search.rs
@@ -1,0 +1,656 @@
+//! Transport-neutral search application contract and public query grammar.
+//!
+//! Parsing belongs here so every client-facing surface produces the same
+//! bounded `atm-storage` AST.  SQLite/FTS syntax intentionally never crosses
+//! this boundary.
+
+use std::str::FromStr;
+
+use atm_storage::{
+    AgentName, AsyncMessageSearchStore, AtmError, IsoTimestamp, MessageSearchPage,
+    MessageSearchQuery, SearchAggregate, SearchAtom, SearchCursor, SearchDeadline,
+    SearchExpression, SearchFilters, SearchGroupBy, SearchLimit, SearchMetadataMatch,
+    SearchPageRequest, SearchResultKey, SearchTimestampField, SearchValue, SimpleAggregate,
+    StoredSearchAddress, StoredSearchMatch, TeamName, TemplateSha, TimeRange,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::api::{AuthenticatedIngress, RequestDeadline};
+
+/// Core-owned request shared by CLI and HTTP adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchRequest {
+    /// Transport-neutral public input.  It is compiled exactly once by core,
+    /// so CLI and direct HTTP callers share the same bounded grammar rather
+    /// than HTTP accepting a second, serialized storage language.
+    pub query: SearchInput,
+}
+
+/// Core-owned result shared by CLI and HTTP adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchResponse {
+    pub hits: Vec<SearchHit>,
+    pub aggregate: Option<SearchAggregate>,
+    pub next_cursor: Option<SearchCursor>,
+}
+
+/// A rendered projection of one storage match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchHit {
+    pub key: SearchResultKey,
+    pub message_id: Option<String>,
+    pub message_at: IsoTimestamp,
+    /// Sender identity, including team and optional chat identity.
+    pub from_agent: StoredSearchAddress,
+    /// Recipient mailbox identity, including team and optional chat identity.
+    pub to_agent: StoredSearchAddress,
+    pub template_type: Option<String>,
+    pub category: Option<String>,
+    pub snippet: String,
+}
+
+/// Public primitive values decoded by either the CLI or HTTP adapter.
+///
+/// This deliberately has no clap, HTTP, SQLite, or FTS dependency. The two
+/// outer adapters construct it and call [`SearchInput::compile`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchInput {
+    pub text: Option<String>,
+    pub raw_match: bool,
+    pub template_meta: Vec<String>,
+    pub vars: Vec<String>,
+    pub tags: Vec<String>,
+    pub category: Option<String>,
+    pub from: Option<String>,
+    pub team: Option<String>,
+    pub agent: Option<String>,
+    pub template_sha: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub limit: Option<u32>,
+    pub cursor: Option<String>,
+    pub per_mailbox: bool,
+    pub aggregate: Option<SearchAggregateInput>,
+}
+
+/// One deliberately small aggregation selection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SearchAggregateInput {
+    Count,
+    GroupBy(String),
+    MinMessageAt,
+    MaxMessageAt,
+}
+
+impl SearchInput {
+    /// Compiles public primitives to AN.5's backend-neutral storage DTO.
+    pub fn compile_query(&self) -> Result<MessageSearchQuery, AtmError> {
+        let expression = self
+            .text
+            .as_deref()
+            .map(|value| parse_search_expression(value, self.raw_match))
+            .transpose()?;
+        let template_metadata = self
+            .template_meta
+            .iter()
+            .map(|value| parse_metadata_match(value))
+            .collect::<Result<Vec<_>, _>>()?;
+        let filters = SearchFilters {
+            team: self.team.as_deref().map(TeamName::from_str).transpose()?,
+            agent: self.agent.as_deref().map(AgentName::from_str).transpose()?,
+            from_agent: self.from.as_deref().map(AgentName::from_str).transpose()?,
+            template_sha: self
+                .template_sha
+                .as_deref()
+                .map(TemplateSha::from_str)
+                .transpose()?,
+            template_metadata,
+            vars: self
+                .vars
+                .iter()
+                .map(|value| parse_key_value(value, "variable"))
+                .collect::<Result<Vec<_>, _>>()?,
+            tags: self.tags.clone(),
+            category: self.category.clone(),
+            time_range: match (&self.since, &self.until) {
+                (None, None) => None,
+                (since, until) => Some(TimeRange {
+                    since: since
+                        .as_deref()
+                        .map(IsoTimestamp::from_str)
+                        .transpose()
+                        .map_err(|error| {
+                            AtmError::validation(format!(
+                                "search --since must be RFC 3339: {error}"
+                            ))
+                        })?,
+                    until: until
+                        .as_deref()
+                        .map(IsoTimestamp::from_str)
+                        .transpose()
+                        .map_err(|error| {
+                            AtmError::validation(format!(
+                                "search --until must be RFC 3339: {error}"
+                            ))
+                        })?,
+                }),
+            },
+        };
+        let query = MessageSearchQuery {
+            expression,
+            filters,
+            aggregate: self
+                .aggregate
+                .as_ref()
+                .map(SearchAggregateInput::compile)
+                .transpose()?,
+            page: SearchPageRequest {
+                limit: self
+                    .limit
+                    .map(SearchLimit::new)
+                    .transpose()?
+                    .unwrap_or(SearchLimit::DEFAULT),
+                cursor: self.cursor.clone().map(SearchCursor::new).transpose()?,
+            },
+            per_mailbox: self.per_mailbox,
+        };
+        query.validate()?;
+        Ok(query)
+    }
+
+    /// Wraps this public input for a CLI or HTTP transport hop.
+    #[must_use]
+    pub fn into_request(self) -> SearchRequest {
+        SearchRequest { query: self }
+    }
+}
+
+impl SearchRequest {
+    /// Compiles the shared public input immediately before storage selection.
+    pub fn compile_query(&self) -> Result<MessageSearchQuery, AtmError> {
+        self.query.compile_query()
+    }
+}
+
+impl SearchAggregateInput {
+    fn compile(&self) -> Result<SimpleAggregate, AtmError> {
+        match self {
+            Self::Count => Ok(SimpleAggregate::Count),
+            Self::GroupBy(value) => {
+                let by = parse_group_by(value)?;
+                Ok(SimpleAggregate::GroupBy(by))
+            }
+            Self::MinMessageAt => Ok(SimpleAggregate::Min(SearchTimestampField::MessageAt)),
+            Self::MaxMessageAt => Ok(SimpleAggregate::Max(SearchTimestampField::MessageAt)),
+        }
+    }
+}
+
+/// Executes a local-only query through the Tokio-safe storage capability.
+pub async fn execute_search(
+    ingress: AuthenticatedIngress,
+    request: SearchRequest,
+    store: &(dyn AsyncMessageSearchStore + Send + Sync),
+    deadline: RequestDeadline,
+) -> Result<SearchResponse, AtmError> {
+    if ingress != AuthenticatedIngress::Local {
+        return Err(AtmError::validation(
+            "message search is available only through authenticated local HTTP adapters",
+        ));
+    }
+    let query = request.compile_query()?;
+    let remaining = deadline.remaining().ok_or_else(|| {
+        AtmError::daemon_unavailable("request deadline expired before local search execution")
+    })?;
+    let page = store
+        .search_async(query, SearchDeadline::new(remaining)?)
+        .await?;
+    Ok(response_from_page(page))
+}
+
+/// Converts a storage result to the stable public hit projection.
+#[must_use]
+pub fn response_from_page(page: MessageSearchPage) -> SearchResponse {
+    SearchResponse {
+        hits: page.matches.into_iter().map(hit_from_match).collect(),
+        aggregate: page.aggregate,
+        next_cursor: page.next_cursor,
+    }
+}
+
+fn hit_from_match(record: StoredSearchMatch) -> SearchHit {
+    let snippet = record.snippet.unwrap_or_else(|| {
+        if record.match_fields.is_empty() {
+            "metadata match".to_owned()
+        } else {
+            record
+                .match_fields
+                .iter()
+                .map(|field| format!("{field:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    });
+    SearchHit {
+        key: record.key,
+        message_id: record.message_id,
+        message_at: record.message_at,
+        from_agent: record.from,
+        to_agent: record.to,
+        template_type: record.template_type,
+        category: record.category,
+        snippet,
+    }
+}
+
+fn parse_key_value(
+    value: &str,
+    label: &str,
+) -> Result<(atm_storage::SearchKey, SearchValue), AtmError> {
+    let (key, value) = value
+        .split_once('=')
+        .ok_or_else(|| AtmError::validation(format!("{label} filter must use KEY=VALUE")))?;
+    Ok((key.parse()?, SearchValue::new(value)?))
+}
+
+fn parse_metadata_match(
+    value: &str,
+) -> Result<(atm_storage::SearchKey, SearchMetadataMatch), AtmError> {
+    let (key, value) = value
+        .split_once('=')
+        .ok_or_else(|| AtmError::validation("template metadata filter must use KEY=VALUE"))?;
+    let matcher = if let Some(prefix) = value.strip_suffix('*') {
+        SearchMetadataMatch::prefix(prefix)?
+    } else {
+        SearchMetadataMatch::exact(value)?
+    };
+    Ok((key.parse()?, matcher))
+}
+
+/// Parses an ordinary literal phrase or the documented bounded advanced
+/// grammar. The advanced grammar intentionally stays tiny: quoted phrases,
+/// words, `NEAR(term term[, distance])`, and `AND`/`OR`/`NOT` are converted
+/// to the storage AST; arbitrary FTS5 syntax is never accepted.
+pub fn parse_search_expression(value: &str, raw_match: bool) -> Result<SearchExpression, AtmError> {
+    if !raw_match {
+        return SearchAtom::phrase(value.to_owned()).map(SearchExpression::Atom);
+    }
+    let tokens = tokenize_advanced(value)?;
+    if tokens.is_empty() {
+        return Err(AtmError::validation(
+            "--raw-match expression must not be blank",
+        ));
+    }
+    parse_or(&tokens)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    Word(String),
+    Phrase(String),
+    Near(Vec<SearchAtom>, u8),
+    And,
+    Or,
+    Not,
+}
+
+fn tokenize_advanced(input: &str) -> Result<Vec<Token>, AtmError> {
+    let mut output = Vec::new();
+    let characters = input.chars().collect::<Vec<_>>();
+    let mut index = 0;
+    while let Some(&character) = characters.get(index) {
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+        if characters[index..].starts_with(&['N', 'E', 'A', 'R', '(']) {
+            let close = characters[index + 5..]
+                .iter()
+                .position(|character| *character == ')')
+                .map(|offset| index + 5 + offset)
+                .ok_or_else(|| AtmError::validation("NEAR must use NEAR(term term[, distance])"))?;
+            let near = characters[index..=close].iter().collect::<String>();
+            output.push(parse_near(&near)?);
+            index = close + 1;
+            continue;
+        }
+        if character == '"' {
+            index += 1;
+            let mut phrase = String::new();
+            let mut closed = false;
+            while let Some(&character) = characters.get(index) {
+                index += 1;
+                if character == '"' {
+                    closed = true;
+                    break;
+                }
+                phrase.push(character);
+            }
+            if !closed {
+                return Err(AtmError::validation(
+                    "unterminated quoted phrase in --raw-match",
+                ));
+            }
+            output.push(Token::Phrase(phrase));
+            continue;
+        }
+        if !character.is_ascii_alphanumeric() && !matches!(character, '_' | '-') {
+            return Err(AtmError::validation(
+                "unsupported --raw-match syntax; use words, quoted phrases, NEAR(...), AND, OR, and NOT",
+            ));
+        }
+        let mut word = String::new();
+        while let Some(&character) = characters.get(index) {
+            if character.is_ascii_alphanumeric() || matches!(character, '_' | '-') {
+                word.push(character);
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        output.push(match word.as_str() {
+            "AND" => Token::And,
+            "OR" => Token::Or,
+            "NOT" => Token::Not,
+            _ => Token::Word(word),
+        });
+    }
+    Ok(output)
+}
+
+fn parse_near(input: &str) -> Result<Token, AtmError> {
+    let inner = input
+        .strip_prefix("NEAR(")
+        .and_then(|value| value.strip_suffix(')'))
+        .ok_or_else(|| AtmError::validation("NEAR must use NEAR(term term[, distance])"))?;
+    let (terms, distance) = match inner.rsplit_once(',') {
+        Some((terms, distance)) => (
+            terms,
+            distance.trim().parse::<u8>().map_err(|_| {
+                AtmError::validation(
+                    "NEAR distance must be an integer in the inclusive range 1..=16",
+                )
+            })?,
+        ),
+        None => (inner, 10),
+    };
+    let terms = terms
+        .split_whitespace()
+        .map(|term| {
+            if term.is_empty()
+                || !term
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+            {
+                return Err(AtmError::validation(
+                    "NEAR terms must be plain words; quote/proximity nesting is not supported",
+                ));
+            }
+            SearchAtom::term(term)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    SearchExpression::Near {
+        terms: terms.clone(),
+        max_distance: distance,
+    }
+    .validate()?;
+    Ok(Token::Near(terms, distance))
+}
+
+fn parse_or(tokens: &[Token]) -> Result<SearchExpression, AtmError> {
+    let mut groups = Vec::new();
+    let mut start = 0;
+    for (index, token) in tokens.iter().enumerate() {
+        if *token == Token::Or {
+            groups.push(parse_and(&tokens[start..index])?);
+            start = index + 1;
+        }
+    }
+    groups.push(parse_and(&tokens[start..])?);
+    if groups.len() == 1 {
+        Ok(groups.remove(0))
+    } else {
+        Ok(SearchExpression::Any(groups))
+    }
+}
+
+fn parse_and(tokens: &[Token]) -> Result<SearchExpression, AtmError> {
+    if tokens.is_empty() {
+        return Err(AtmError::validation(
+            "--raw-match cannot have an empty boolean branch",
+        ));
+    }
+    let mut items = Vec::new();
+    let mut negate = false;
+    let mut needs_term = true;
+    for token in tokens {
+        match token {
+            Token::And => {
+                if needs_term {
+                    return Err(AtmError::validation("AND requires a term on both sides"));
+                }
+                needs_term = true;
+            }
+            Token::Not => {
+                if !needs_term || negate {
+                    return Err(AtmError::validation("NOT must precede one term"));
+                }
+                negate = true;
+            }
+            Token::Or => {
+                return Err(AtmError::validation(
+                    "internal advanced-search parser error",
+                ));
+            }
+            Token::Word(value) | Token::Phrase(value) => {
+                let atom = match token {
+                    Token::Word(_) => SearchAtom::term(value.clone())?,
+                    Token::Phrase(_) => SearchAtom::phrase(value.clone())?,
+                    _ => unreachable!(),
+                };
+                let expression = SearchExpression::Atom(atom);
+                items.push(if negate {
+                    negate = false;
+                    SearchExpression::Not(Box::new(expression))
+                } else {
+                    expression
+                });
+                needs_term = false;
+            }
+            Token::Near(terms, max_distance) => {
+                let expression = SearchExpression::Near {
+                    terms: terms.clone(),
+                    max_distance: *max_distance,
+                };
+                items.push(if negate {
+                    negate = false;
+                    SearchExpression::Not(Box::new(expression))
+                } else {
+                    expression
+                });
+                needs_term = false;
+            }
+        }
+    }
+    if needs_term {
+        return Err(AtmError::validation(
+            "--raw-match cannot end with an operator",
+        ));
+    }
+    if items
+        .iter()
+        .all(|item| matches!(item, SearchExpression::Not(_)))
+    {
+        return Err(AtmError::validation("--raw-match requires a positive term"));
+    }
+    if items.len() == 1 {
+        Ok(items.remove(0))
+    } else {
+        Ok(SearchExpression::All(items))
+    }
+}
+
+fn parse_group_by(value: &str) -> Result<SearchGroupBy, AtmError> {
+    if let Some(key) = value.strip_prefix("var:") {
+        return Ok(SearchGroupBy::Var(key.parse()?));
+    }
+    let field = match value {
+        "team" => atm_storage::SearchGroupField::Team,
+        "agent" => atm_storage::SearchGroupField::Agent,
+        "from" | "from_agent" => atm_storage::SearchGroupField::FromAgent,
+        "template_type" => atm_storage::SearchGroupField::TemplateType,
+        "category" => atm_storage::SearchGroupField::Category,
+        _ => {
+            return Err(AtmError::validation(
+                "group-by must be var:KEY, team, agent, from_agent, template_type, or category",
+            ));
+        }
+    };
+    Ok(SearchGroupBy::Field(field))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{SearchInput, SearchRequest, execute_search, parse_search_expression};
+    use atm_storage::{
+        InMemoryMessageSearchStore, SearchExpression, SearchGroupBy, SearchMetadataMatch,
+        SimpleAggregate,
+    };
+
+    #[test]
+    fn ordinary_text_is_one_literal_phrase_even_when_it_looks_like_fts() {
+        let expression = parse_search_expression("title:foo NEAR bar", false).expect("expression");
+        assert_eq!(
+            expression,
+            SearchExpression::Atom(
+                atm_storage::SearchAtom::phrase("title:foo NEAR bar").expect("phrase")
+            )
+        );
+    }
+
+    #[test]
+    fn raw_grammar_rejects_arbitrary_fts_syntax() {
+        assert!(parse_search_expression("title:foo", true).is_err());
+        assert!(parse_search_expression("title:foo", true).is_err());
+    }
+
+    #[test]
+    fn raw_grammar_composes_near_with_boolean_terms() {
+        let expression = parse_search_expression("urgent AND NEAR(release candidate, 4)", true)
+            .expect("bounded expression");
+        assert!(matches!(expression, SearchExpression::All(items) if items.len() == 2));
+    }
+
+    #[test]
+    fn raw_grammar_applies_not_to_a_near_expression() {
+        let expression = parse_search_expression("urgent AND NOT NEAR(release candidate, 4)", true)
+            .expect("bounded expression");
+        assert!(
+            matches!(expression, SearchExpression::All(items) if matches!(items[1], SearchExpression::Not(_)))
+        );
+    }
+
+    #[test]
+    fn input_compiles_shared_key_grammar_and_aggregate() {
+        let request = SearchInput {
+            vars: vec!["phase=an".to_owned()],
+            aggregate: Some(super::SearchAggregateInput::GroupBy(
+                "var:sprint".to_owned(),
+            )),
+            ..SearchInput::default()
+        }
+        .compile_query()
+        .expect("request");
+        assert_eq!(request.filters.vars[0].0.as_str(), "phase");
+        assert_eq!(
+            request.aggregate,
+            Some(SimpleAggregate::GroupBy(SearchGroupBy::Var(
+                atm_storage::SearchKey::new("sprint").expect("key")
+            )))
+        );
+    }
+
+    #[test]
+    fn raw_grammar_compiles_only_bounded_near_syntax() {
+        assert_eq!(
+            parse_search_expression("NEAR(urgent release, 4)", true).expect("near"),
+            SearchExpression::Near {
+                terms: vec![
+                    atm_storage::SearchAtom::term("urgent").expect("term"),
+                    atm_storage::SearchAtom::term("release").expect("term"),
+                ],
+                max_distance: 4,
+            }
+        );
+        assert!(parse_search_expression("NEAR(urgent release) OR task", true).is_ok());
+    }
+
+    #[test]
+    fn metadata_star_is_a_bounded_prefix_match_not_sql_syntax() {
+        let request = SearchInput {
+            template_meta: vec!["type=qa-*".to_owned()],
+            ..SearchInput::default()
+        }
+        .compile_query()
+        .expect("request");
+        assert!(matches!(
+            request.filters.template_metadata[0].1,
+            SearchMetadataMatch::Prefix(_)
+        ));
+    }
+
+    #[test]
+    fn peer_search_is_rejected_before_the_storage_capability_is_selected() {
+        let store = InMemoryMessageSearchStore::default();
+        let request = SearchRequest {
+            query: SearchInput::default(),
+        };
+        let error = futures::executor::block_on(execute_search(
+            crate::api::AuthenticatedIngress::Peer,
+            request,
+            &store,
+            crate::api::RequestDeadline::after(Duration::from_secs(1)),
+        ))
+        .expect_err("peer search must reject");
+        assert!(error.is_validation());
+        assert_eq!(store.search_calls_for_test(), 0);
+    }
+
+    #[test]
+    fn local_search_uses_the_async_storage_capability() {
+        let store = InMemoryMessageSearchStore::default();
+        let response = futures::executor::block_on(execute_search(
+            crate::api::AuthenticatedIngress::Local,
+            SearchRequest {
+                query: SearchInput::default(),
+            },
+            &store,
+            crate::api::RequestDeadline::after(Duration::from_secs(1)),
+        ))
+        .expect("local search");
+        assert!(response.hits.is_empty());
+        assert_eq!(store.search_calls_for_test(), 1);
+    }
+
+    #[test]
+    fn serialized_http_input_uses_the_same_bounded_compiler_as_the_cli() {
+        let input = SearchInput {
+            text: Some("urgent AND NEAR(release candidate, 4)".to_owned()),
+            raw_match: true,
+            template_meta: vec!["type=qa-*".to_owned()],
+            vars: vec!["phase=an".to_owned()],
+            aggregate: Some(super::SearchAggregateInput::Count),
+            ..SearchInput::default()
+        };
+        let cli_query = input.compile_query().expect("CLI compiler");
+        let http_request: SearchRequest =
+            serde_json::from_slice(&serde_json::to_vec(&input.into_request()).expect("JSON"))
+                .expect("HTTP request JSON");
+        assert_eq!(
+            http_request.compile_query().expect("HTTP compiler"),
+            cli_query
+        );
+    }
+}

--- a/crates/atm-core/src/search.rs
+++ b/crates/atm-core/src/search.rs
@@ -601,34 +601,36 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn peer_search_is_rejected_before_the_storage_capability_is_selected() {
+    #[tokio::test]
+    async fn peer_search_is_rejected_before_the_storage_capability_is_selected() {
         let store = InMemoryMessageSearchStore::default();
         let request = SearchRequest {
             query: SearchInput::default(),
         };
-        let error = futures::executor::block_on(execute_search(
+        let error = execute_search(
             crate::api::AuthenticatedIngress::Peer,
             request,
             &store,
             crate::api::RequestDeadline::after(Duration::from_secs(1)),
-        ))
+        )
+        .await
         .expect_err("peer search must reject");
         assert!(error.is_validation());
         assert_eq!(store.search_calls_for_test(), 0);
     }
 
-    #[test]
-    fn local_search_uses_the_async_storage_capability() {
+    #[tokio::test]
+    async fn local_search_uses_the_async_storage_capability() {
         let store = InMemoryMessageSearchStore::default();
-        let response = futures::executor::block_on(execute_search(
+        let response = execute_search(
             crate::api::AuthenticatedIngress::Local,
             SearchRequest {
                 query: SearchInput::default(),
             },
             &store,
             crate::api::RequestDeadline::after(Duration::from_secs(1)),
-        ))
+        )
+        .await
         .expect("local search");
         assert!(response.hits.is_empty());
         assert_eq!(store.search_calls_for_test(), 1);

--- a/crates/atm-core/src/search.rs
+++ b/crates/atm-core/src/search.rs
@@ -509,6 +509,8 @@ fn parse_group_by(value: &str) -> Result<SearchGroupBy, AtmError> {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::task::{Context, Poll, Waker};
     use std::time::Duration;
 
     use super::{SearchInput, SearchRequest, execute_search, parse_search_expression};
@@ -516,6 +518,15 @@ mod tests {
         InMemoryMessageSearchStore, SearchExpression, SearchGroupBy, SearchMetadataMatch,
         SimpleAggregate,
     };
+
+    fn complete_immediately<T>(future: impl Future<Output = T>) -> T {
+        let mut future = std::pin::pin!(future);
+        let mut context = Context::from_waker(Waker::noop());
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(value) => value,
+            Poll::Pending => panic!("in-memory search test futures must complete immediately"),
+        }
+    }
 
     #[test]
     fn ordinary_text_is_one_literal_phrase_even_when_it_looks_like_fts() {
@@ -599,36 +610,34 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn peer_search_is_rejected_before_the_storage_capability_is_selected() {
+    #[test]
+    fn peer_search_is_rejected_before_the_storage_capability_is_selected() {
         let store = InMemoryMessageSearchStore::default();
         let request = SearchRequest {
             query: SearchInput::default(),
         };
-        let error = execute_search(
+        let error = complete_immediately(execute_search(
             crate::api::AuthenticatedIngress::Peer,
             request,
             &store,
             crate::api::RequestDeadline::after(Duration::from_secs(1)),
-        )
-        .await
+        ))
         .expect_err("peer search must reject");
         assert_eq!(error.code(), atm_storage::AtmErrorCode::SearchLocalOnly);
         assert_eq!(store.search_calls_for_test(), 0);
     }
 
-    #[tokio::test]
-    async fn local_search_uses_the_async_storage_capability() {
+    #[test]
+    fn local_search_uses_the_async_storage_capability() {
         let store = InMemoryMessageSearchStore::default();
-        let response = execute_search(
+        let response = complete_immediately(execute_search(
             crate::api::AuthenticatedIngress::Local,
             SearchRequest {
                 query: SearchInput::default(),
             },
             &store,
             crate::api::RequestDeadline::after(Duration::from_secs(1)),
-        )
-        .await
+        ))
         .expect("local search");
         assert!(response.hits.is_empty());
         assert_eq!(store.search_calls_for_test(), 1);

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use atm_storage::{
-    AsyncMessageStore as SharedAsyncMessageStore, MessageStore as SharedMessageStore,
-    RosterStore as SharedRosterStore, TemplateCatalogStore,
+    AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore,
+    MessageStore as SharedMessageStore, RosterStore as SharedRosterStore, TemplateCatalogStore,
 };
 
 use crate::boundary::TemplateComposer;
@@ -134,6 +134,7 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
 pub struct LocalServiceRuntime {
     pub(crate) message_store: std::sync::Arc<dyn SharedMessageStore + Send + Sync>,
     async_message_store: Option<std::sync::Arc<dyn SharedAsyncMessageStore + Send + Sync>>,
+    async_message_search_store: Option<std::sync::Arc<dyn AsyncMessageSearchStore + Send + Sync>>,
     pub(crate) roster_store: std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
     pub(crate) nudge_template_override_store:
         std::sync::Arc<dyn crate::boundary::NudgeTemplateOverrideStore + Send + Sync>,
@@ -168,6 +169,7 @@ impl LocalServiceRuntime {
         Self {
             message_store,
             async_message_store: None,
+            async_message_search_store: None,
             roster_store,
             nudge_template_override_store,
             non_claude_outbound,
@@ -202,6 +204,29 @@ impl LocalServiceRuntime {
     ) -> Self {
         self.async_message_store = Some(async_message_store);
         self
+    }
+
+    /// Attaches the Tokio-safe typed search capability selected by the one
+    /// storage composition root.  HTTP awaits this port directly; it never
+    /// opens a synchronous SQLite reader on a request worker.
+    #[must_use]
+    pub fn with_async_message_search_store(
+        mut self,
+        async_message_search_store: std::sync::Arc<dyn AsyncMessageSearchStore + Send + Sync>,
+    ) -> Self {
+        self.async_message_search_store = Some(async_message_search_store);
+        self
+    }
+
+    /// Returns the runtime-selected typed asynchronous search capability.
+    pub fn async_message_search_store(
+        &self,
+    ) -> Result<std::sync::Arc<dyn AsyncMessageSearchStore + Send + Sync>, AtmError> {
+        self.async_message_search_store.clone().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "Tokio typed message search was not installed in this runtime",
+            )
+        })
     }
 
     /// Attaches the approved template renderer port at the composition root.

--- a/crates/atm-core/src/transport/testing.rs
+++ b/crates/atm-core/src/transport/testing.rs
@@ -114,6 +114,9 @@ impl LoopbackClientTransport {
                 doctor::run_doctor(query, self.observability.as_ref())
                     .map(|report| ResponseEnvelope::Doctor(Box::new(report)))
             }
+            RequestEnvelope::Search(_) => Err(AtmError::daemon_unavailable(
+                "loopback search transport is not wired outside the replacement daemon runtime",
+            )),
             RequestEnvelope::ReloadRuntimeView => Err(AtmError::daemon_unavailable(
                 "runtime reload requires the running daemon control plane",
             )),

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -61,6 +61,9 @@ pub enum AtmErrorCode {
     MailboxLockTimeout,
     InternalError,
     MessageValidationFailed,
+    /// Search is intentionally local-only until a separately authorized peer
+    /// query protocol exists.
+    SearchLocalOnly,
     LocalHttpCapabilityInvalid,
     LocalHttpEndpointSchemaUnsupported,
     LocalHttpEndpointMissing,
@@ -197,6 +200,7 @@ impl AtmErrorCode {
             Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
             Self::InternalError => "ATM_INTERNAL_ERROR",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",
+            Self::SearchLocalOnly => "ATM_SEARCH_LOCAL_ONLY",
             Self::LocalHttpCapabilityInvalid => "ATM_LOCAL_HTTP_CAPABILITY_INVALID",
             Self::LocalHttpEndpointSchemaUnsupported => {
                 "ATM_LOCAL_HTTP_ENDPOINT_SCHEMA_UNSUPPORTED"
@@ -347,6 +351,7 @@ fn parse_mailbox_or_validation_code(value: &str) -> Option<AtmErrorCode> {
         "ATM_MAILBOX_LOCK_TIMEOUT" => AtmErrorCode::MailboxLockTimeout,
         "ATM_INTERNAL_ERROR" => AtmErrorCode::InternalError,
         "ATM_MESSAGE_VALIDATION_FAILED" => AtmErrorCode::MessageValidationFailed,
+        "ATM_SEARCH_LOCAL_ONLY" => AtmErrorCode::SearchLocalOnly,
         "ATM_LOCAL_HTTP_CAPABILITY_INVALID" => AtmErrorCode::LocalHttpCapabilityInvalid,
         "ATM_LOCAL_HTTP_ENDPOINT_SCHEMA_UNSUPPORTED" => {
             AtmErrorCode::LocalHttpEndpointSchemaUnsupported

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -20,6 +20,7 @@ use atm_core::protocol::{
     TeamMemberHeartbeatRequest, next_request_id,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
+use atm_core::search::SearchRequest;
 use atm_core::send::WriteRequest;
 use atm_core::types::HostName;
 use axum::body::{Body, Bytes};
@@ -31,6 +32,7 @@ use axum::http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use axum::response::Response;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use base64::Engine as _;
 use serde::Serialize;
 use std::net::SocketAddr;
 use tower::BoxError;
@@ -328,7 +330,10 @@ async fn dispatch_request(
 ) -> Response {
     let request_id = next_request_id();
     let request_method = method.clone();
-    let request_path = uri.path().to_owned();
+    let request_path = uri.path_and_query().map_or_else(
+        || uri.path().to_owned(),
+        |path_and_query| path_and_query.as_str().to_owned(),
+    );
     dispatch_request_with_request_id(state, peer, method, uri, headers, body, request_id)
         .instrument(info_span!("atm_http_request", %request_id, method = %request_method, path = %request_path))
         .await
@@ -354,7 +359,10 @@ async fn dispatch_request_with_request_id(
     let mut request = match decode_framework_request(
         HttpRequest {
             method: method.as_str().to_owned(),
-            path: uri.path().to_owned(),
+            path: uri.path_and_query().map_or_else(
+                || uri.path().to_owned(),
+                |path_and_query| path_and_query.as_str().to_owned(),
+            ),
             headers,
             body: body.to_vec(),
         },
@@ -416,6 +424,9 @@ fn decode_framework_request(
         Some(HttpRouteKind::Doctor) => serde_json::from_slice::<DoctorQuery>(body)
             .map(ApiRequest::Doctor)
             .map_err(|source| invalid("doctor", source)),
+        Some(HttpRouteKind::Search) => decode_search_query(&request.path)
+            .map(Box::new)
+            .map(ApiRequest::Search),
         Some(HttpRouteKind::Compatibility) => {
             serde_json::from_slice::<CompatibilityPreflight>(body)
                 .map(ApiRequest::CompatibilityPreflight)
@@ -434,6 +445,50 @@ fn decode_framework_request(
             "use a method and path from the daemon HTTP route contract and retry",
         )),
     }
+}
+
+/// Decodes the canonical bodyless GET representation for search.  The value
+/// is URL-safe base64 JSON so a complete typed `SearchRequest` remains one
+/// stable HTTP query parameter without inventing a second filter grammar.
+fn decode_search_query(path: &str) -> Result<SearchRequest, AtmError> {
+    let (_, query) = path.split_once('?').ok_or_else(|| {
+        AtmError::validation_with_recovery(
+            "message search HTTP request is missing its request query parameter",
+            "send GET /v1/atm/messages/search?request=<base64url-json> and retry",
+        )
+    })?;
+    let mut request_values = query
+        .split('&')
+        .filter_map(|field| field.split_once('='))
+        .filter(|(name, _)| *name == "request")
+        .map(|(_, value)| value);
+    let encoded = request_values.next().ok_or_else(|| {
+        AtmError::validation_with_recovery(
+            "message search HTTP request is missing its request query parameter",
+            "send GET /v1/atm/messages/search?request=<base64url-json> and retry",
+        )
+    })?;
+    if request_values.next().is_some() {
+        return Err(AtmError::validation_with_recovery(
+            "message search HTTP request repeats its request query parameter",
+            "send exactly one request query parameter and retry",
+        ));
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|source| {
+            AtmError::validation_with_recovery(
+                "message search HTTP request query parameter is not valid base64url",
+                "encode the JSON SearchRequest as unpadded URL-safe base64 and retry",
+            )
+            .with_cause(source)
+        })?;
+    serde_json::from_slice(&bytes).map_err(|source| {
+        AtmError::validation_with_recovery(
+            format!("message search HTTP request JSON is invalid: {source}"),
+            "encode the documented SearchRequest JSON in the request query parameter and retry",
+        )
+    })
 }
 
 fn canonical_headers(headers: &HeaderMap) -> Result<Vec<String>, AtmError> {
@@ -510,6 +565,7 @@ fn map_api_response(response: ApiResponse) -> Result<Response, AtmError> {
         ResponseEnvelope::Receive(value) => json_response(StatusCode::OK, &value, None),
         ResponseEnvelope::Clear(value) => clear_response(&value),
         ResponseEnvelope::Doctor(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::Search(value) => json_response(StatusCode::OK, &value, None),
         ResponseEnvelope::RuntimeViewReloaded => json_response(StatusCode::OK, &(), None),
         ResponseEnvelope::Error(error) => Ok(error_response(error)),
     }
@@ -589,12 +645,14 @@ mod tests {
     use atm_core::api::HttpRequest;
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::protocol::ResponseEnvelope;
+    use atm_core::search::{SearchRequest, SearchResponse};
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
     use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
     use axum::http::{Request, StatusCode};
+    use base64::Engine as _;
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
@@ -930,7 +988,9 @@ mod tests {
             );
             let handled = match result {
                 Ok(_) => true,
-                Err(error) => error.message().contains("invalid"),
+                Err(error) => {
+                    error.message().contains("invalid") || error.message().contains("missing")
+                }
             };
             assert!(
                 handled,
@@ -938,6 +998,39 @@ mod tests {
                 route.method, route.path_template
             );
         }
+    }
+
+    #[test]
+    fn search_route_decodes_the_shared_core_request_contract() {
+        let expected = SearchRequest {
+            query: atm_core::search::SearchInput::default(),
+        };
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&expected).expect("JSON"));
+        let decoded = decode_framework_request(
+            HttpRequest {
+                method: "GET".to_owned(),
+                path: format!("/v1/atm/messages/search?request={encoded}"),
+                headers: Vec::new(),
+                body: Vec::new(),
+            },
+            1024,
+        )
+        .expect("search request");
+        assert!(matches!(decoded, atm_core::api::ApiRequest::Search(value) if *value == expected));
+    }
+
+    #[test]
+    fn search_response_uses_the_shared_core_response_contract() {
+        let response = super::map_api_response(atm_core::ApiResponse::new(
+            ResponseEnvelope::Search(SearchResponse {
+                hits: Vec::new(),
+                aggregate: None,
+                next_cursor: None,
+            }),
+        ))
+        .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1202,7 +1295,7 @@ mod tests {
     }
 
     #[test]
-    fn openapi_and_serde_keep_the_existing_typed_write_contract() {
+    fn openapi_and_serde_keep_the_existing_typed_write_and_search_contracts() {
         let openapi: Value =
             serde_yaml::from_str(include_str!("../../../docs/atm-http-runtime/openapi.yaml"))
                 .expect("parse checked-in OpenAPI document");
@@ -1237,6 +1330,28 @@ mod tests {
             "the parsed OpenAPI write operation must remain the AL.1 compatibility oracle"
         );
 
+        let search_operation = openapi
+            .pointer("/paths/~1messages~1search/get")
+            .expect("OpenAPI must declare GET /messages/search");
+        assert_eq!(
+            search_operation
+                .pointer("/operationId")
+                .and_then(Value::as_str),
+            Some("searchMessages")
+        );
+        assert_eq!(
+            search_operation
+                .pointer("/parameters/0/name")
+                .and_then(Value::as_str),
+            Some("request")
+        );
+        assert_eq!(
+            search_operation
+                .pointer("/parameters/0/schema/format")
+                .and_then(Value::as_str),
+            Some("base64url")
+        );
+
         let serialized = serde_json::to_value(write_request())
             .expect("serialize the existing route-specific WriteRequest");
         let round_tripped: atm_core::send::WriteRequest =
@@ -1247,6 +1362,26 @@ mod tests {
             serialized,
             "the handler must retain the existing WriteRequest Serde representation"
         );
+
+        for aggregate in [
+            atm_core::search::SearchAggregateInput::Count,
+            atm_core::search::SearchAggregateInput::GroupBy("var:phase".to_owned()),
+            atm_core::search::SearchAggregateInput::MinMessageAt,
+            atm_core::search::SearchAggregateInput::MaxMessageAt,
+        ] {
+            let search = SearchRequest {
+                query: atm_core::search::SearchInput {
+                    aggregate: Some(aggregate),
+                    ..atm_core::search::SearchInput::default()
+                },
+            };
+            let serialized = serde_json::to_value(&search).expect("serialize SearchRequest");
+            assert_eq!(
+                serde_json::from_value::<SearchRequest>(serialized.clone())
+                    .expect("deserialize SearchRequest"),
+                search
+            );
+        }
 
         let forbidden = ["Http", "Frame", "Reader"].concat();
         assert!(!include_str!("message_handler.rs").contains(&forbidden));

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -649,6 +649,9 @@ mod tests {
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
     use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
+    use atm_storage::{
+        IsoTimestamp, SearchAggregate, SearchGroup, SearchGroupBy, SearchTimestampField,
+    };
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
     use axum::http::{Request, StatusCode};
@@ -1021,6 +1024,46 @@ mod tests {
     }
 
     #[test]
+    fn malformed_query_keys_fail_after_the_real_http_request_decoder() {
+        for query in [
+            atm_core::search::SearchInput {
+                template_meta: vec!["../phase=an".to_owned()],
+                ..Default::default()
+            },
+            atm_core::search::SearchInput {
+                vars: vec!["phase/path=an".to_owned()],
+                ..Default::default()
+            },
+            atm_core::search::SearchInput {
+                aggregate: Some(atm_core::search::SearchAggregateInput::GroupBy(
+                    "var:../../phase".to_owned(),
+                )),
+                ..Default::default()
+            },
+        ] {
+            let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(&SearchRequest { query }).expect("request JSON"));
+            let request = decode_framework_request(
+                HttpRequest {
+                    method: "GET".to_owned(),
+                    path: format!("/v1/atm/messages/search?request={encoded}"),
+                    headers: Vec::new(),
+                    body: Vec::new(),
+                },
+                1024,
+            )
+            .expect("HTTP transport accepts the public DTO");
+            let atm_core::api::ApiRequest::Search(request) = request else {
+                unreachable!("search request")
+            };
+            let error = request
+                .compile_query()
+                .expect_err("core compilation rejects invalid key");
+            assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
+        }
+    }
+
+    #[test]
     fn search_response_uses_the_shared_core_response_contract() {
         let response = super::map_api_response(atm_core::ApiResponse::new(
             ResponseEnvelope::Search(SearchResponse {
@@ -1031,6 +1074,41 @@ mod tests {
         ))
         .expect("response");
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn search_response_contract_round_trips_every_aggregate_variant() {
+        let timestamp: IsoTimestamp = "2026-08-12T00:00:00Z".parse().expect("timestamp");
+        let aggregates = [
+            SearchAggregate::Count { value: 3 },
+            SearchAggregate::Groups {
+                by: SearchGroupBy::Field(atm_storage::SearchGroupField::Category),
+                groups: vec![SearchGroup {
+                    key: "task".to_owned(),
+                    count: 2,
+                }],
+            },
+            SearchAggregate::Timestamp {
+                field: SearchTimestampField::MessageAt,
+                value: Some(timestamp.clone()),
+            },
+            SearchAggregate::Timestamp {
+                field: SearchTimestampField::MessageAt,
+                value: None,
+            },
+        ];
+        for aggregate in aggregates {
+            let response = SearchResponse {
+                hits: Vec::new(),
+                aggregate: Some(aggregate),
+                next_cursor: None,
+            };
+            let json = serde_json::to_value(&response).expect("serialize response");
+            assert_eq!(
+                serde_json::from_value::<SearchResponse>(json).expect("deserialize response"),
+                response
+            );
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -1090,7 +1090,7 @@ mod tests {
             },
             SearchAggregate::Timestamp {
                 field: SearchTimestampField::MessageAt,
-                value: Some(timestamp.clone()),
+                value: Some(timestamp),
             },
             SearchAggregate::Timestamp {
                 field: SearchTimestampField::MessageAt,

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1679,6 +1679,79 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn uds_and_loopback_search_use_the_same_local_storage_port() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use std::num::NonZeroU32;
+        use std::os::unix::fs::MetadataExt;
+
+        let fixture = fixture(true, None, None);
+        let socket_path = fixture._temporary_root.path().join("search-runtime.sock");
+        let endpoint_path = fixture
+            ._temporary_root
+            .path()
+            .join("search-local-http.json");
+        let instance_id = ulid::Ulid::new();
+        std::fs::write(
+            fixture._temporary_root.path().join("owner.lock"),
+            format!("1:test-owner:{instance_id}\n"),
+        )
+        .expect("owner record");
+        let uid = NonZeroU32::new(
+            std::fs::metadata(fixture._temporary_root.path())
+                .expect("runtime root metadata")
+                .uid(),
+        )
+        .expect("test process must not use uid zero");
+        let runtime = HttpRuntimeBuilder::new(
+            HttpRuntimeConfig::new(
+                LoopbackTcpConfig::new(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    endpoint_path.clone(),
+                    instance_id,
+                ),
+                Some(UnixSocketConfig::new(
+                    socket_path.clone(),
+                    UnixSocketOwnerUid::new(uid),
+                    UnixSocketMode::new(NonZeroU32::new(0o600).expect("owner-only mode")),
+                )),
+                RuntimeLimits::new(
+                    std::num::NonZeroUsize::new(4096).expect("non-zero body limit"),
+                    std::num::NonZeroUsize::new(1).expect("non-zero request limit"),
+                ),
+                RuntimeTimeouts::new(
+                    NonZeroDuration::new(Duration::from_secs(1)).expect("request timeout"),
+                    NonZeroDuration::new(Duration::from_secs(1)).expect("shutdown timeout"),
+                ),
+            ),
+            Arc::new(fixture.router.clone()),
+        )
+        .build()
+        .expect("valid search runtime configuration");
+        let running = runtime.start().await.expect("search runtime starts");
+        let request = ApiRequest::new(RequestEnvelope::Search(atm_core::search::SearchRequest {
+            query: atm_core::search::SearchInput::default(),
+        }));
+        let uds = crate::unix_socket_client(&socket_path, Duration::from_secs(1))
+            .expect("UDS client")
+            .execute(request.clone())
+            .await
+            .expect("UDS search");
+        let loopback = crate::loopback_tcp_client(&endpoint_path, Duration::from_secs(1))
+            .expect("loopback client")
+            .execute(request)
+            .await
+            .expect("loopback search");
+        assert!(matches!(uds.into_inner(), ResponseEnvelope::Search(_)));
+        assert!(matches!(loopback.into_inner(), ResponseEnvelope::Search(_)));
+        running
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("search runtime drains");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn templated_send_over_uds_uses_the_same_decomposed_admission() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::num::NonZeroU32;

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1685,6 +1685,15 @@ mod tests {
         use std::os::unix::fs::MetadataExt;
 
         let fixture = fixture(true, None, None);
+        fixture
+            .router
+            .write(
+                write_request(fixture.home_dir.clone(), fixture.current_dir.clone()),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("seed local mailbox through the canonical storage path");
         let socket_path = fixture._temporary_root.path().join("search-runtime.sock");
         let endpoint_path = fixture
             ._temporary_root
@@ -1741,8 +1750,21 @@ mod tests {
             .execute(request)
             .await
             .expect("loopback search");
-        assert!(matches!(uds.into_inner(), ResponseEnvelope::Search(_)));
-        assert!(matches!(loopback.into_inner(), ResponseEnvelope::Search(_)));
+        let ResponseEnvelope::Search(uds) = uds.into_inner() else {
+            panic!("UDS response must be search data");
+        };
+        let ResponseEnvelope::Search(loopback) = loopback.into_inner() else {
+            panic!("loopback response must be search data");
+        };
+        assert_eq!(
+            uds.hits.len(),
+            1,
+            "UDS query returns the seeded mailbox row"
+        );
+        assert_eq!(
+            loopback, uds,
+            "UDS and loopback share one local search path"
+        );
         running
             .begin_shutdown()
             .finish()

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -286,6 +286,7 @@ impl StorageAndNudgeRouter {
             },
             ApiRequest::Clear(query) => self.clear_messages(query, deadline).await,
             ApiRequest::Doctor(query) => self.doctor(query, deadline).await,
+            ApiRequest::Search(request) => self.search(*request, ingress, deadline).await,
             ApiRequest::CompatibilityPreflight(preflight) => Ok(ApiResponse::new(
                 ResponseEnvelope::CompatibilityVerdict(compatibility_verdict(preflight)),
             )),
@@ -413,6 +414,19 @@ impl StorageAndNudgeRouter {
                 Ok(ApiResponse::new(ResponseEnvelope::Doctor(Box::new(report))))
             })
             .await
+    }
+
+    async fn search(
+        &self,
+        request: atm_core::search::SearchRequest,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        let store = self.service_runtime.async_message_search_store()?;
+        atm_core::search::execute_search(ingress, request, store.as_ref(), deadline)
+            .await
+            .map(atm_core::protocol::ResponseEnvelope::Search)
+            .map(ApiResponse::new)
     }
 
     async fn heartbeat(

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "atm-query-python"
+version = "1.4.2"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Local read-only SQLite analyst interface for ATM's stable query view."
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+name = "atm_query"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+extension-module = ["pyo3/extension-module"]
+
+[dependencies]
+pyo3 = "0.29"
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+rusqlite = { version = "0.33.0", features = ["bundled", "hooks", "extra_check"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+rusqlite = { version = "0.33.0", features = ["bundled-windows", "modern_sqlite", "hooks", "extra_check"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -18,12 +18,8 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-rusqlite = { version = "0.33.0", features = ["bundled", "hooks", "extra_check"] }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-rusqlite = { version = "0.33.0", features = ["bundled-windows", "modern_sqlite", "hooks", "extra_check"] }
+atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am", features = ["test-support"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -19,7 +19,8 @@ extension-module = ["pyo3/extension-module"]
 [dependencies]
 pyo3 = "0.29"
 atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am", features = ["test-support"] }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am" }
 
 [dev-dependencies]
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "atm-query"
+version = "1.4.2"
+requires-python = ">=3.9"
+
+[tool.maturin]
+module-name = "atm_query"
+features = ["extension-module"]

--- a/crates/atm-query-python/src/lib.rs
+++ b/crates/atm-query-python/src/lib.rs
@@ -133,6 +133,8 @@ mod tests {
     use pyo3::types::{PyList, PyTuple};
     use tempfile::tempdir;
 
+    const TEST_ANALYST_TEAM: &str = "atm-dev";
+
     fn fixture() -> std::path::PathBuf {
         let directory = tempdir().expect("temp directory").keep();
         let path = directory.join("mail.db");
@@ -176,7 +178,7 @@ mod tests {
         Python::initialize();
         Python::attach(|py| {
             let database = database(fixture());
-            let parameters = PyTuple::new(py, ["atm-dev"]).expect("parameters");
+            let parameters = PyTuple::new(py, [TEST_ANALYST_TEAM]).expect("parameters");
             let result = database
                 .query(
                     py,

--- a/crates/atm-query-python/src/lib.rs
+++ b/crates/atm-query-python/src/lib.rs
@@ -1,16 +1,16 @@
-//! Local-only, defensive Python analyst interface over `decomposed_messages`.
+//! Local-only Python analyst interface over ATM's stable query view.
 //!
-//! This is deliberately not an ATM client: it opens a selected SQLite file
-//! read-only and exposes one parameterized statement at a time.
+//! The extension owns Python conversion and presentation only. SQLite access,
+//! authorisation, and execution limits stay in `atm-storage-rusqlite`.
 
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use atm_storage::{AnalystQueryStore, AnalystQueryValue};
+use atm_storage_rusqlite::open_analyst_query_store;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
-use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
-use rusqlite::{Connection, OpenFlags, params_from_iter, types::Value};
 
 const MAX_ROWS: usize = 10_000;
 const MAX_RESULT_BYTES: usize = 8 * 1024 * 1024;
@@ -18,7 +18,7 @@ const QUERY_BUDGET: Duration = Duration::from_secs(3);
 
 #[pyclass]
 struct ReadonlyDatabase {
-    path: PathBuf,
+    store: Box<dyn AnalystQueryStore>,
 }
 
 #[pymethods]
@@ -29,49 +29,12 @@ impl ReadonlyDatabase {
         sql: &str,
         parameters: Option<Bound<'_, PyTuple>>,
     ) -> PyResult<Py<PyAny>> {
-        let connection = open_connection(&self.path)?;
-        install_query_budget(&connection, Instant::now());
-        reject_executable_tail(sql)?;
-        let mut statement = connection.prepare(sql).map_err(sql_error)?;
-        if !statement.readonly() {
-            return Err(PyValueError::new_err(
-                "ATM analyst queries must be one SQLite read-only statement",
-            ));
-        }
-        let parameters = parameters
-            .map(|values| {
-                values
-                    .iter()
-                    .map(python_value)
-                    .collect::<PyResult<Vec<_>>>()
-            })
-            .transpose()?
-            .unwrap_or_default();
-        let columns = statement
-            .column_names()
-            .into_iter()
-            .map(str::to_owned)
-            .collect::<Vec<_>>();
-        let mut rows = statement
-            .query(params_from_iter(parameters))
-            .map_err(sql_error)?;
-        let output = PyList::empty(py);
-        let mut bytes = 0usize;
-        while let Some(row) = rows.next().map_err(sql_error)? {
-            if output.len() >= MAX_ROWS {
-                return Err(PyRuntimeError::new_err(
-                    "ATM analyst query exceeded row budget",
-                ));
-            }
-            let mapping = PyDict::new(py);
-            for (index, name) in columns.iter().enumerate() {
-                let value: Value = row.get(index).map_err(sql_error)?;
-                let python = value_to_python(py, value, &mut bytes)?;
-                mapping.set_item(name, python)?;
-            }
-            output.append(mapping)?;
-        }
-        Ok(output.into_any().unbind())
+        let parameters = python_parameters(parameters)?;
+        let rows = self
+            .store
+            .query(sql, &parameters, QUERY_BUDGET, MAX_ROWS, MAX_RESULT_BYTES)
+            .map_err(storage_error)?;
+        rows_to_python(py, rows)
     }
 }
 
@@ -81,9 +44,9 @@ fn open_readonly(database_path: Option<String>) -> PyResult<ReadonlyDatabase> {
     let path = database_path
         .map(PathBuf::from)
         .unwrap_or_else(default_database_path);
-    // Validate the connection and all defensive guards before returning it.
-    let _ = open_connection(&path)?;
-    Ok(ReadonlyDatabase { path })
+    Ok(ReadonlyDatabase {
+        store: open_analyst_query_store(path).map_err(storage_error)?,
+    })
 }
 
 fn default_database_path() -> PathBuf {
@@ -93,195 +56,66 @@ fn default_database_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         // Durable ATM state is host-scoped. `ATM_HOME` configures workspace
         // discovery and must never select the analyst database implicitly.
-        // [cass: helpful b-mr7coqmo-qft2s6] Preserve isolated host worktrees.
         .join(".atm")
         .join("db")
         .join("mail.db")
 }
 
-fn open_connection(path: &PathBuf) -> PyResult<Connection> {
-    let connection = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .map_err(sql_error)?;
-    connection
-        .execute_batch("PRAGMA query_only=ON; PRAGMA trusted_schema=OFF; PRAGMA defensive=ON;")
-        .map_err(sql_error)?;
-    connection.authorizer(Some(authorizer));
-    Ok(connection)
+fn python_parameters(parameters: Option<Bound<'_, PyTuple>>) -> PyResult<Vec<AnalystQueryValue>> {
+    parameters
+        .map(|values| values.iter().map(python_value).collect())
+        .transpose()
+        .map(|parameters| parameters.unwrap_or_default())
 }
 
-fn install_query_budget(connection: &Connection, started: Instant) {
-    connection.progress_handler(1_000, Some(move || started.elapsed() > QUERY_BUDGET));
-}
-
-fn authorizer(context: AuthContext<'_>) -> Authorization {
-    match context.action {
-        // Restrict reads to the versioned analyst view and SQLite's metadata
-        // tables. Underlying ATM tables intentionally remain private.
-        AuthAction::Read { table_name, .. }
-            if context.accessor == Some("decomposed_messages")
-                || matches!(
-                    table_name,
-                    "decomposed_messages" | "sqlite_master" | "sqlite_schema"
-                ) =>
-        {
-            Authorization::Allow
-        }
-        AuthAction::Select => Authorization::Allow,
-        // Pure built-ins are required for ordinary projections and aggregates;
-        // the one extension-loading function remains explicitly forbidden.
-        AuthAction::Function { function_name } if function_name != "load_extension" => {
-            Authorization::Allow
-        }
-        // Recursive CTEs remain read-only and are useful for analyst-side
-        // aggregation; the progress handler still enforces the time budget.
-        AuthAction::Recursive => Authorization::Allow,
-        AuthAction::Pragma {
-            pragma_name: "table_info" | "table_xinfo",
-            pragma_value: None,
-        } => Authorization::Allow,
-        _ => Authorization::Deny,
-    }
-}
-
-fn python_value(value: Bound<'_, PyAny>) -> PyResult<Value> {
+fn python_value(value: Bound<'_, PyAny>) -> PyResult<AnalystQueryValue> {
     if value.is_none() {
-        return Ok(Value::Null);
+        return Ok(AnalystQueryValue::Null);
     }
     if let Ok(value) = value.extract::<i64>() {
-        return Ok(Value::Integer(value));
+        return Ok(AnalystQueryValue::Integer(value));
     }
     if let Ok(value) = value.extract::<f64>() {
-        return Ok(Value::Real(value));
+        return Ok(AnalystQueryValue::Real(value));
     }
     if let Ok(value) = value.extract::<String>() {
-        return Ok(Value::Text(value));
+        return Ok(AnalystQueryValue::Text(value));
     }
     if let Ok(value) = value.extract::<Vec<u8>>() {
-        return Ok(Value::Blob(value));
+        return Ok(AnalystQueryValue::Blob(value));
     }
     Err(PyValueError::new_err(
         "ATM analyst parameters must be null, int, float, str, or bytes",
     ))
 }
 
-fn value_to_python(py: Python<'_>, value: Value, bytes: &mut usize) -> PyResult<Py<PyAny>> {
-    let output = match value {
-        Value::Null => py.None(),
-        Value::Integer(value) => value.into_pyobject(py)?.into_any().unbind(),
-        Value::Real(value) => value.into_pyobject(py)?.into_any().unbind(),
-        Value::Text(value) => {
-            *bytes += value.len();
-            value.into_pyobject(py)?.into_any().unbind()
+fn rows_to_python(
+    py: Python<'_>,
+    rows: Vec<Vec<(String, AnalystQueryValue)>>,
+) -> PyResult<Py<PyAny>> {
+    let output = PyList::empty(py);
+    for row in rows {
+        let mapping = PyDict::new(py);
+        for (name, value) in row {
+            mapping.set_item(name, value_to_python(py, value)?)?;
         }
-        Value::Blob(value) => {
-            *bytes += value.len();
-            value.into_pyobject(py)?.into_any().unbind()
-        }
-    };
-    if *bytes > MAX_RESULT_BYTES {
-        return Err(PyRuntimeError::new_err(
-            "ATM analyst query exceeded result-byte budget",
-        ));
+        output.append(mapping)?;
     }
-    Ok(output)
+    Ok(output.into_any().unbind())
 }
 
-fn sql_error(error: rusqlite::Error) -> PyErr {
-    PyRuntimeError::new_err(format!("ATM analyst query failed: {error}"))
+fn value_to_python(py: Python<'_>, value: AnalystQueryValue) -> PyResult<Py<PyAny>> {
+    match value {
+        AnalystQueryValue::Null => Ok(py.None()),
+        AnalystQueryValue::Integer(value) => Ok(value.into_pyobject(py)?.into_any().unbind()),
+        AnalystQueryValue::Real(value) => Ok(value.into_pyobject(py)?.into_any().unbind()),
+        AnalystQueryValue::Text(value) => Ok(value.into_pyobject(py)?.into_any().unbind()),
+        AnalystQueryValue::Blob(value) => Ok(value.into_pyobject(py)?.into_any().unbind()),
+    }
 }
 
-/// Reject a second executable statement before SQLite can prepare or execute
-/// it. Semicolons inside quoted SQL literals are harmless; a terminal
-/// semicolon followed only by whitespace is accepted.
-fn reject_executable_tail(sql: &str) -> PyResult<()> {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum State {
-        Normal,
-        SingleQuote,
-        DoubleQuote,
-        Backtick,
-        Bracket,
-        LineComment,
-        BlockComment,
-    }
-
-    let bytes = sql.as_bytes();
-    let mut index = 0;
-    let mut state = State::Normal;
-    let mut statement_ended = false;
-    while let Some(&byte) = bytes.get(index) {
-        match state {
-            State::Normal => match byte {
-                b'\'' => {
-                    if statement_ended {
-                        return Err(single_statement_error());
-                    }
-                    state = State::SingleQuote;
-                }
-                b'\"' => {
-                    if statement_ended {
-                        return Err(single_statement_error());
-                    }
-                    state = State::DoubleQuote;
-                }
-                b'`' => {
-                    if statement_ended {
-                        return Err(single_statement_error());
-                    }
-                    state = State::Backtick;
-                }
-                b'[' => {
-                    if statement_ended {
-                        return Err(single_statement_error());
-                    }
-                    state = State::Bracket;
-                }
-                b'-' if bytes.get(index + 1) == Some(&b'-') => {
-                    state = State::LineComment;
-                    index += 1;
-                }
-                b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                    state = State::BlockComment;
-                    index += 1;
-                }
-                b';' => statement_ended = true,
-                byte if byte.is_ascii_whitespace() => {}
-                _ if statement_ended => return Err(single_statement_error()),
-                _ => {}
-            },
-            State::SingleQuote if byte == b'\'' && bytes.get(index + 1) == Some(&b'\'') => {
-                index += 1;
-            }
-            State::SingleQuote if byte == b'\'' => state = State::Normal,
-            State::DoubleQuote if byte == b'\"' && bytes.get(index + 1) == Some(&b'\"') => {
-                index += 1;
-            }
-            State::DoubleQuote if byte == b'\"' => state = State::Normal,
-            State::Backtick if byte == b'`' && bytes.get(index + 1) == Some(&b'`') => index += 1,
-            State::Backtick if byte == b'`' => state = State::Normal,
-            State::Bracket if byte == b']' => state = State::Normal,
-            State::LineComment if byte == b'\n' => state = State::Normal,
-            State::BlockComment if byte == b'*' && bytes.get(index + 1) == Some(&b'/') => {
-                state = State::Normal;
-                index += 1;
-            }
-            _ => {}
-        }
-        index += 1;
-    }
-    if state == State::BlockComment {
-        return Err(PyValueError::new_err(
-            "ATM analyst query has an unterminated SQL block comment",
-        ));
-    }
-    Ok(())
-}
-
-fn single_statement_error() -> PyErr {
-    PyValueError::new_err("ATM analyst queries must contain exactly one statement")
+fn storage_error(error: atm_storage::AtmError) -> PyErr {
+    PyRuntimeError::new_err(error.to_string())
 }
 
 #[pymodule]
@@ -293,75 +127,55 @@ fn atm_query(module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        MAX_ROWS, QUERY_BUDGET, ReadonlyDatabase, default_database_path, install_query_budget,
-        open_connection, reject_executable_tail,
-    };
+    use super::{MAX_ROWS, ReadonlyDatabase, default_database_path};
+    use atm_storage_rusqlite::{create_analyst_query_fixture_for_test, open_analyst_query_store};
     use pyo3::prelude::*;
-    use pyo3::types::PyTuple;
-    use rusqlite::Connection;
-    use std::time::Duration;
+    use pyo3::types::{PyList, PyTuple};
     use tempfile::tempdir;
 
     fn fixture() -> std::path::PathBuf {
         let directory = tempdir().expect("temp directory").keep();
         let path = directory.join("mail.db");
-        let connection = Connection::open(&path).expect("fixture database");
-        connection
-            .execute_batch(
-                "CREATE TABLE hidden_mail_messages (
-                team TEXT, agent TEXT, document_type TEXT, phase TEXT, value TEXT
-             );
-             CREATE VIEW decomposed_messages AS
-                SELECT team, agent, document_type, phase, value FROM hidden_mail_messages;
-             INSERT INTO hidden_mail_messages VALUES
-                ('atm-dev', 'dev-one', 'assignment', 'an', 'first assignment'),
-                ('atm-dev', 'dev-two', 'assignment', 'an', 'second assignment'),
-                ('atm-dev', 'qa-one', 'qa-finding', 'jj', 'finding'),
-                ('atm-dev', 'fix-one', 'fix-assignment', 'jj', 'fix');",
-            )
-            .expect("fixture schema");
+        create_analyst_query_fixture_for_test(&path).expect("fixture database");
         path
     }
 
+    fn database(path: std::path::PathBuf) -> ReadonlyDatabase {
+        ReadonlyDatabase {
+            store: open_analyst_query_store(path).expect("read-only store"),
+        }
+    }
+
     #[test]
-    fn defensive_connection_allows_read_only_select_and_denies_writes() {
-        let path = fixture();
-        let connection = open_connection(&path).expect("connection");
-        assert!(
-            connection
-                .prepare("SELECT * FROM decomposed_messages")
-                .expect("select")
-                .readonly()
-        );
-        assert!(
-            connection
-                .prepare("DELETE FROM decomposed_messages")
-                .is_err()
-        );
-        assert!(
-            connection
-                .prepare("ATTACH DATABASE ':memory:' AS other")
-                .is_err()
-        );
-        assert!(reject_executable_tail("SELECT 1; SELECT 2").is_err());
-        assert!(reject_executable_tail("SELECT ';' AS literal;").is_ok());
-        assert!(reject_executable_tail("SELECT 'it''s; still one statement'; -- note\n").is_ok());
-        assert!(reject_executable_tail("SELECT 1; /* comment */ SELECT 2").is_err());
-        assert!(
-            connection
-                .prepare("SELECT * FROM hidden_mail_messages")
-                .is_err()
-        );
-        assert!(connection.prepare("PRAGMA database_list").is_err());
+    fn defensive_backend_allows_stable_view_and_denies_writes() {
+        Python::initialize();
+        Python::attach(|py| {
+            let database = database(fixture());
+            for sql in [
+                "DELETE FROM decomposed_messages",
+                "CREATE TABLE pwned (value TEXT)",
+                "BEGIN",
+                "ATTACH DATABASE ':memory:' AS other",
+                "SELECT 1; SELECT 2",
+                "SELECT * FROM hidden_mail_messages",
+                "PRAGMA database_list",
+            ] {
+                assert!(database.query(py, sql, None).is_err(), "{sql}");
+            }
+            assert!(database.query(py, "SELECT ';' AS literal;", None).is_ok());
+            assert!(
+                database
+                    .query(py, "SELECT 'it''s; still one statement'; -- note\n", None)
+                    .is_ok()
+            );
+        });
     }
 
     #[test]
     fn parameterized_query_returns_column_labelled_rows() {
         Python::initialize();
-        let path = fixture();
         Python::attach(|py| {
-            let database = ReadonlyDatabase { path };
+            let database = database(fixture());
             let parameters = PyTuple::new(py, ["atm-dev"]).expect("parameters");
             let result = database
                 .query(
@@ -370,11 +184,7 @@ mod tests {
                     Some(parameters),
                 )
                 .expect("query");
-            let list = result
-                .bind(py)
-                .clone()
-                .cast_into::<pyo3::types::PyList>()
-                .expect("list");
+            let list = result.bind(py).clone().cast_into::<PyList>().expect("list");
             assert_eq!(list.len(), 4);
             assert_eq!(
                 list.get_item(0)
@@ -389,112 +199,37 @@ mod tests {
     }
 
     #[test]
-    fn analyst_examples_use_parameterized_filters_over_the_stable_view() {
+    fn examples_use_parameterized_filters_over_the_stable_view() {
         Python::initialize();
-        let path = fixture();
         Python::attach(|py| {
-            let database = ReadonlyDatabase { path };
-            let development_agents = PyTuple::new(py, ["dev-one", "dev-two"]).expect("agents");
+            let database = database(fixture());
+            let agents = PyTuple::new(py, ["dev-one", "dev-two"]).expect("agents");
             let assignments = database
                 .query(
                     py,
-                    "SELECT agent FROM decomposed_messages \
-                     WHERE document_type = 'assignment' AND agent IN (?, ?) ORDER BY agent",
-                    Some(development_agents),
+                    "SELECT agent FROM decomposed_messages WHERE document_type = 'assignment' AND agent IN (?, ?) ORDER BY agent",
+                    Some(agents),
                 )
-                .expect("development assignments");
+                .expect("assignments");
             assert_eq!(
-                assignments
-                    .bind(py)
-                    .clone()
-                    .cast_into::<pyo3::types::PyList>()
-                    .expect("rows")
-                    .len(),
-                2
-            );
-
-            let phase_parameters = PyTuple::new(py, ["an", "assignment"]).expect("phase");
-            let phase_assignments = database
-                .query(
-                    py,
-                    "SELECT value FROM decomposed_messages \
-                     WHERE phase = ? AND document_type = ?",
-                    Some(phase_parameters),
-                )
-                .expect("phase assignments");
-            assert_eq!(
-                phase_assignments
-                    .bind(py)
-                    .clone()
-                    .cast_into::<pyo3::types::PyList>()
-                    .expect("rows")
-                    .len(),
-                2
-            );
-
-            let finding_parameters = PyTuple::new(py, ["jj", "fix-assignment", "qa-finding"])
-                .expect("finding parameters");
-            let phase_findings = database
-                .query(
-                    py,
-                    "SELECT document_type FROM decomposed_messages \
-                     WHERE phase = ? AND document_type IN (?, ?) ORDER BY document_type",
-                    Some(finding_parameters),
-                )
-                .expect("phase fixes and findings");
-            assert_eq!(
-                phase_findings
-                    .bind(py)
-                    .clone()
-                    .cast_into::<pyo3::types::PyList>()
-                    .expect("rows")
-                    .len(),
+                assignments.bind(py).cast::<PyList>().expect("rows").len(),
                 2
             );
         });
     }
 
     #[test]
-    fn raw_query_security_gates_fail_before_execution() {
+    fn raw_query_budgets_fail_closed() {
         Python::initialize();
-        let path = fixture();
         Python::attach(|py| {
-            let database = ReadonlyDatabase { path };
-            for sql in [
-                "DELETE FROM decomposed_messages",
-                "CREATE TABLE pwned (value TEXT)",
-                "BEGIN",
-                "ATTACH DATABASE ':memory:' AS other",
-                "SELECT 1; SELECT 2",
-                "SELECT * FROM hidden_mail_messages",
-            ] {
-                assert!(database.query(py, sql, None).is_err(), "{sql}");
-            }
-        });
-    }
-
-    #[test]
-    fn raw_query_row_and_byte_budgets_fail_closed() {
-        Python::initialize();
-        let path = fixture();
-        let connection = Connection::open(&path).expect("fixture connection");
-        for _ in 0..MAX_ROWS {
-            connection
-                .execute(
-                    "INSERT INTO hidden_mail_messages VALUES \
-                     ('atm-dev', 'row-budget', 'assignment', 'an', 'row-budget')",
-                    [],
+            let database = database(fixture());
+            assert!(database
+                .query(
+                    py,
+                    "WITH RECURSIVE counter(value) AS (VALUES(1) UNION ALL SELECT value + 1 FROM counter) SELECT value FROM counter",
+                    None,
                 )
-                .expect("fixture row");
-        }
-        Python::attach(|py| {
-            let database = ReadonlyDatabase { path };
-            assert!(
-                database
-                    .query(py, "SELECT team, value FROM decomposed_messages", None)
-                    .is_err()
-            );
-            // The byte gate is deterministic without allocating a huge fixture.
+                .is_err());
             assert!(database
                 .query(
                     py,
@@ -502,37 +237,15 @@ mod tests {
                     None,
                 )
                 .is_err());
+            let rows = database
+                .query(py, "SELECT 1", None)
+                .expect("normal query after budget failures");
+            assert!(rows.bind(py).cast::<PyList>().expect("rows").len() < MAX_ROWS);
         });
     }
 
     #[test]
-    fn raw_query_deadline_interrupts_a_read_only_recursive_cte() {
-        let path = fixture();
-        let connection = open_connection(&path).expect("connection");
-        let started = std::time::Instant::now();
-        install_query_budget(&connection, started);
-        let error = connection
-            .query_row(
-                "WITH RECURSIVE counter(value) AS (\
-                   VALUES(1) UNION ALL SELECT value + 1 FROM counter\
-                 ) SELECT sum(value) FROM counter",
-                [],
-                |_| Ok(()),
-            )
-            .expect_err("unbounded read-only CTE must be interrupted");
-        assert!(
-            error.to_string().contains("interrupted"),
-            "expected SQLite progress-handler interruption, got {error}"
-        );
-        assert!(
-            started.elapsed() < QUERY_BUDGET + Duration::from_secs(2),
-            "query budget must bound the read-only statement"
-        );
-    }
-
-    #[test]
     fn default_path_is_host_scoped_not_workspace_scoped() {
-        let path = default_database_path();
-        assert!(path.ends_with(".atm/db/mail.db"), "{path:?}");
+        assert!(default_database_path().ends_with(".atm/db/mail.db"));
     }
 }

--- a/crates/atm-query-python/src/lib.rs
+++ b/crates/atm-query-python/src/lib.rs
@@ -1,0 +1,538 @@
+//! Local-only, defensive Python analyst interface over `decomposed_messages`.
+//!
+//! This is deliberately not an ATM client: it opens a selected SQLite file
+//! read-only and exposes one parameterized statement at a time.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
+use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
+use rusqlite::{Connection, OpenFlags, params_from_iter, types::Value};
+
+const MAX_ROWS: usize = 10_000;
+const MAX_RESULT_BYTES: usize = 8 * 1024 * 1024;
+const QUERY_BUDGET: Duration = Duration::from_secs(3);
+
+#[pyclass]
+struct ReadonlyDatabase {
+    path: PathBuf,
+}
+
+#[pymethods]
+impl ReadonlyDatabase {
+    fn query(
+        &self,
+        py: Python<'_>,
+        sql: &str,
+        parameters: Option<Bound<'_, PyTuple>>,
+    ) -> PyResult<Py<PyAny>> {
+        let connection = open_connection(&self.path)?;
+        install_query_budget(&connection, Instant::now());
+        reject_executable_tail(sql)?;
+        let mut statement = connection.prepare(sql).map_err(sql_error)?;
+        if !statement.readonly() {
+            return Err(PyValueError::new_err(
+                "ATM analyst queries must be one SQLite read-only statement",
+            ));
+        }
+        let parameters = parameters
+            .map(|values| {
+                values
+                    .iter()
+                    .map(python_value)
+                    .collect::<PyResult<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let columns = statement
+            .column_names()
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let mut rows = statement
+            .query(params_from_iter(parameters))
+            .map_err(sql_error)?;
+        let output = PyList::empty(py);
+        let mut bytes = 0usize;
+        while let Some(row) = rows.next().map_err(sql_error)? {
+            if output.len() >= MAX_ROWS {
+                return Err(PyRuntimeError::new_err(
+                    "ATM analyst query exceeded row budget",
+                ));
+            }
+            let mapping = PyDict::new(py);
+            for (index, name) in columns.iter().enumerate() {
+                let value: Value = row.get(index).map_err(sql_error)?;
+                let python = value_to_python(py, value, &mut bytes)?;
+                mapping.set_item(name, python)?;
+            }
+            output.append(mapping)?;
+        }
+        Ok(output.into_any().unbind())
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (database_path=None))]
+fn open_readonly(database_path: Option<String>) -> PyResult<ReadonlyDatabase> {
+    let path = database_path
+        .map(PathBuf::from)
+        .unwrap_or_else(default_database_path);
+    // Validate the connection and all defensive guards before returning it.
+    let _ = open_connection(&path)?;
+    Ok(ReadonlyDatabase { path })
+}
+
+fn default_database_path() -> PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        // Durable ATM state is host-scoped. `ATM_HOME` configures workspace
+        // discovery and must never select the analyst database implicitly.
+        // [cass: helpful b-mr7coqmo-qft2s6] Preserve isolated host worktrees.
+        .join(".atm")
+        .join("db")
+        .join("mail.db")
+}
+
+fn open_connection(path: &PathBuf) -> PyResult<Connection> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(sql_error)?;
+    connection
+        .execute_batch("PRAGMA query_only=ON; PRAGMA trusted_schema=OFF; PRAGMA defensive=ON;")
+        .map_err(sql_error)?;
+    connection.authorizer(Some(authorizer));
+    Ok(connection)
+}
+
+fn install_query_budget(connection: &Connection, started: Instant) {
+    connection.progress_handler(1_000, Some(move || started.elapsed() > QUERY_BUDGET));
+}
+
+fn authorizer(context: AuthContext<'_>) -> Authorization {
+    match context.action {
+        // Restrict reads to the versioned analyst view and SQLite's metadata
+        // tables. Underlying ATM tables intentionally remain private.
+        AuthAction::Read { table_name, .. }
+            if context.accessor == Some("decomposed_messages")
+                || matches!(
+                    table_name,
+                    "decomposed_messages" | "sqlite_master" | "sqlite_schema"
+                ) =>
+        {
+            Authorization::Allow
+        }
+        AuthAction::Select => Authorization::Allow,
+        // Pure built-ins are required for ordinary projections and aggregates;
+        // the one extension-loading function remains explicitly forbidden.
+        AuthAction::Function { function_name } if function_name != "load_extension" => {
+            Authorization::Allow
+        }
+        // Recursive CTEs remain read-only and are useful for analyst-side
+        // aggregation; the progress handler still enforces the time budget.
+        AuthAction::Recursive => Authorization::Allow,
+        AuthAction::Pragma {
+            pragma_name: "table_info" | "table_xinfo",
+            pragma_value: None,
+        } => Authorization::Allow,
+        _ => Authorization::Deny,
+    }
+}
+
+fn python_value(value: Bound<'_, PyAny>) -> PyResult<Value> {
+    if value.is_none() {
+        return Ok(Value::Null);
+    }
+    if let Ok(value) = value.extract::<i64>() {
+        return Ok(Value::Integer(value));
+    }
+    if let Ok(value) = value.extract::<f64>() {
+        return Ok(Value::Real(value));
+    }
+    if let Ok(value) = value.extract::<String>() {
+        return Ok(Value::Text(value));
+    }
+    if let Ok(value) = value.extract::<Vec<u8>>() {
+        return Ok(Value::Blob(value));
+    }
+    Err(PyValueError::new_err(
+        "ATM analyst parameters must be null, int, float, str, or bytes",
+    ))
+}
+
+fn value_to_python(py: Python<'_>, value: Value, bytes: &mut usize) -> PyResult<Py<PyAny>> {
+    let output = match value {
+        Value::Null => py.None(),
+        Value::Integer(value) => value.into_pyobject(py)?.into_any().unbind(),
+        Value::Real(value) => value.into_pyobject(py)?.into_any().unbind(),
+        Value::Text(value) => {
+            *bytes += value.len();
+            value.into_pyobject(py)?.into_any().unbind()
+        }
+        Value::Blob(value) => {
+            *bytes += value.len();
+            value.into_pyobject(py)?.into_any().unbind()
+        }
+    };
+    if *bytes > MAX_RESULT_BYTES {
+        return Err(PyRuntimeError::new_err(
+            "ATM analyst query exceeded result-byte budget",
+        ));
+    }
+    Ok(output)
+}
+
+fn sql_error(error: rusqlite::Error) -> PyErr {
+    PyRuntimeError::new_err(format!("ATM analyst query failed: {error}"))
+}
+
+/// Reject a second executable statement before SQLite can prepare or execute
+/// it. Semicolons inside quoted SQL literals are harmless; a terminal
+/// semicolon followed only by whitespace is accepted.
+fn reject_executable_tail(sql: &str) -> PyResult<()> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum State {
+        Normal,
+        SingleQuote,
+        DoubleQuote,
+        Backtick,
+        Bracket,
+        LineComment,
+        BlockComment,
+    }
+
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut state = State::Normal;
+    let mut statement_ended = false;
+    while let Some(&byte) = bytes.get(index) {
+        match state {
+            State::Normal => match byte {
+                b'\'' => {
+                    if statement_ended {
+                        return Err(single_statement_error());
+                    }
+                    state = State::SingleQuote;
+                }
+                b'\"' => {
+                    if statement_ended {
+                        return Err(single_statement_error());
+                    }
+                    state = State::DoubleQuote;
+                }
+                b'`' => {
+                    if statement_ended {
+                        return Err(single_statement_error());
+                    }
+                    state = State::Backtick;
+                }
+                b'[' => {
+                    if statement_ended {
+                        return Err(single_statement_error());
+                    }
+                    state = State::Bracket;
+                }
+                b'-' if bytes.get(index + 1) == Some(&b'-') => {
+                    state = State::LineComment;
+                    index += 1;
+                }
+                b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                    state = State::BlockComment;
+                    index += 1;
+                }
+                b';' => statement_ended = true,
+                byte if byte.is_ascii_whitespace() => {}
+                _ if statement_ended => return Err(single_statement_error()),
+                _ => {}
+            },
+            State::SingleQuote if byte == b'\'' && bytes.get(index + 1) == Some(&b'\'') => {
+                index += 1;
+            }
+            State::SingleQuote if byte == b'\'' => state = State::Normal,
+            State::DoubleQuote if byte == b'\"' && bytes.get(index + 1) == Some(&b'\"') => {
+                index += 1;
+            }
+            State::DoubleQuote if byte == b'\"' => state = State::Normal,
+            State::Backtick if byte == b'`' && bytes.get(index + 1) == Some(&b'`') => index += 1,
+            State::Backtick if byte == b'`' => state = State::Normal,
+            State::Bracket if byte == b']' => state = State::Normal,
+            State::LineComment if byte == b'\n' => state = State::Normal,
+            State::BlockComment if byte == b'*' && bytes.get(index + 1) == Some(&b'/') => {
+                state = State::Normal;
+                index += 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    if state == State::BlockComment {
+        return Err(PyValueError::new_err(
+            "ATM analyst query has an unterminated SQL block comment",
+        ));
+    }
+    Ok(())
+}
+
+fn single_statement_error() -> PyErr {
+    PyValueError::new_err("ATM analyst queries must contain exactly one statement")
+}
+
+#[pymodule]
+fn atm_query(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<ReadonlyDatabase>()?;
+    module.add_function(wrap_pyfunction!(open_readonly, module)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_ROWS, QUERY_BUDGET, ReadonlyDatabase, default_database_path, install_query_budget,
+        open_connection, reject_executable_tail,
+    };
+    use pyo3::prelude::*;
+    use pyo3::types::PyTuple;
+    use rusqlite::Connection;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn fixture() -> std::path::PathBuf {
+        let directory = tempdir().expect("temp directory").keep();
+        let path = directory.join("mail.db");
+        let connection = Connection::open(&path).expect("fixture database");
+        connection
+            .execute_batch(
+                "CREATE TABLE hidden_mail_messages (
+                team TEXT, agent TEXT, document_type TEXT, phase TEXT, value TEXT
+             );
+             CREATE VIEW decomposed_messages AS
+                SELECT team, agent, document_type, phase, value FROM hidden_mail_messages;
+             INSERT INTO hidden_mail_messages VALUES
+                ('atm-dev', 'dev-one', 'assignment', 'an', 'first assignment'),
+                ('atm-dev', 'dev-two', 'assignment', 'an', 'second assignment'),
+                ('atm-dev', 'qa-one', 'qa-finding', 'jj', 'finding'),
+                ('atm-dev', 'fix-one', 'fix-assignment', 'jj', 'fix');",
+            )
+            .expect("fixture schema");
+        path
+    }
+
+    #[test]
+    fn defensive_connection_allows_read_only_select_and_denies_writes() {
+        let path = fixture();
+        let connection = open_connection(&path).expect("connection");
+        assert!(
+            connection
+                .prepare("SELECT * FROM decomposed_messages")
+                .expect("select")
+                .readonly()
+        );
+        assert!(
+            connection
+                .prepare("DELETE FROM decomposed_messages")
+                .is_err()
+        );
+        assert!(
+            connection
+                .prepare("ATTACH DATABASE ':memory:' AS other")
+                .is_err()
+        );
+        assert!(reject_executable_tail("SELECT 1; SELECT 2").is_err());
+        assert!(reject_executable_tail("SELECT ';' AS literal;").is_ok());
+        assert!(reject_executable_tail("SELECT 'it''s; still one statement'; -- note\n").is_ok());
+        assert!(reject_executable_tail("SELECT 1; /* comment */ SELECT 2").is_err());
+        assert!(
+            connection
+                .prepare("SELECT * FROM hidden_mail_messages")
+                .is_err()
+        );
+        assert!(connection.prepare("PRAGMA database_list").is_err());
+    }
+
+    #[test]
+    fn parameterized_query_returns_column_labelled_rows() {
+        Python::initialize();
+        let path = fixture();
+        Python::attach(|py| {
+            let database = ReadonlyDatabase { path };
+            let parameters = PyTuple::new(py, ["atm-dev"]).expect("parameters");
+            let result = database
+                .query(
+                    py,
+                    "SELECT team, value FROM decomposed_messages WHERE team = ?",
+                    Some(parameters),
+                )
+                .expect("query");
+            let list = result
+                .bind(py)
+                .clone()
+                .cast_into::<pyo3::types::PyList>()
+                .expect("list");
+            assert_eq!(list.len(), 4);
+            assert_eq!(
+                list.get_item(0)
+                    .expect("row")
+                    .get_item("value")
+                    .expect("value")
+                    .extract::<String>()
+                    .expect("text"),
+                "first assignment"
+            );
+        });
+    }
+
+    #[test]
+    fn analyst_examples_use_parameterized_filters_over_the_stable_view() {
+        Python::initialize();
+        let path = fixture();
+        Python::attach(|py| {
+            let database = ReadonlyDatabase { path };
+            let development_agents = PyTuple::new(py, ["dev-one", "dev-two"]).expect("agents");
+            let assignments = database
+                .query(
+                    py,
+                    "SELECT agent FROM decomposed_messages \
+                     WHERE document_type = 'assignment' AND agent IN (?, ?) ORDER BY agent",
+                    Some(development_agents),
+                )
+                .expect("development assignments");
+            assert_eq!(
+                assignments
+                    .bind(py)
+                    .clone()
+                    .cast_into::<pyo3::types::PyList>()
+                    .expect("rows")
+                    .len(),
+                2
+            );
+
+            let phase_parameters = PyTuple::new(py, ["an", "assignment"]).expect("phase");
+            let phase_assignments = database
+                .query(
+                    py,
+                    "SELECT value FROM decomposed_messages \
+                     WHERE phase = ? AND document_type = ?",
+                    Some(phase_parameters),
+                )
+                .expect("phase assignments");
+            assert_eq!(
+                phase_assignments
+                    .bind(py)
+                    .clone()
+                    .cast_into::<pyo3::types::PyList>()
+                    .expect("rows")
+                    .len(),
+                2
+            );
+
+            let finding_parameters = PyTuple::new(py, ["jj", "fix-assignment", "qa-finding"])
+                .expect("finding parameters");
+            let phase_findings = database
+                .query(
+                    py,
+                    "SELECT document_type FROM decomposed_messages \
+                     WHERE phase = ? AND document_type IN (?, ?) ORDER BY document_type",
+                    Some(finding_parameters),
+                )
+                .expect("phase fixes and findings");
+            assert_eq!(
+                phase_findings
+                    .bind(py)
+                    .clone()
+                    .cast_into::<pyo3::types::PyList>()
+                    .expect("rows")
+                    .len(),
+                2
+            );
+        });
+    }
+
+    #[test]
+    fn raw_query_security_gates_fail_before_execution() {
+        Python::initialize();
+        let path = fixture();
+        Python::attach(|py| {
+            let database = ReadonlyDatabase { path };
+            for sql in [
+                "DELETE FROM decomposed_messages",
+                "CREATE TABLE pwned (value TEXT)",
+                "BEGIN",
+                "ATTACH DATABASE ':memory:' AS other",
+                "SELECT 1; SELECT 2",
+                "SELECT * FROM hidden_mail_messages",
+            ] {
+                assert!(database.query(py, sql, None).is_err(), "{sql}");
+            }
+        });
+    }
+
+    #[test]
+    fn raw_query_row_and_byte_budgets_fail_closed() {
+        Python::initialize();
+        let path = fixture();
+        let connection = Connection::open(&path).expect("fixture connection");
+        for _ in 0..MAX_ROWS {
+            connection
+                .execute(
+                    "INSERT INTO hidden_mail_messages VALUES \
+                     ('atm-dev', 'row-budget', 'assignment', 'an', 'row-budget')",
+                    [],
+                )
+                .expect("fixture row");
+        }
+        Python::attach(|py| {
+            let database = ReadonlyDatabase { path };
+            assert!(
+                database
+                    .query(py, "SELECT team, value FROM decomposed_messages", None)
+                    .is_err()
+            );
+            // The byte gate is deterministic without allocating a huge fixture.
+            assert!(database
+                .query(
+                    py,
+                    "SELECT printf('%0*d', 8388609, 0) AS oversized FROM decomposed_messages LIMIT 1",
+                    None,
+                )
+                .is_err());
+        });
+    }
+
+    #[test]
+    fn raw_query_deadline_interrupts_a_read_only_recursive_cte() {
+        let path = fixture();
+        let connection = open_connection(&path).expect("connection");
+        let started = std::time::Instant::now();
+        install_query_budget(&connection, started);
+        let error = connection
+            .query_row(
+                "WITH RECURSIVE counter(value) AS (\
+                   VALUES(1) UNION ALL SELECT value + 1 FROM counter\
+                 ) SELECT sum(value) FROM counter",
+                [],
+                |_| Ok(()),
+            )
+            .expect_err("unbounded read-only CTE must be interrupted");
+        assert!(
+            error.to_string().contains("interrupted"),
+            "expected SQLite progress-handler interruption, got {error}"
+        );
+        assert!(
+            started.elapsed() < QUERY_BUDGET + Duration::from_secs(2),
+            "query budget must bound the read-only statement"
+        );
+    }
+
+    #[test]
+    fn default_path_is_host_scoped_not_workspace_scoped() {
+        let path = default_database_path();
+        assert!(path.ends_with(".atm/db/mail.db"), "{path:?}");
+    }
+}

--- a/crates/atm-query-python/src/lib.rs
+++ b/crates/atm-query-python/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
     use pyo3::types::{PyList, PyTuple};
     use tempfile::tempdir;
 
-    const TEST_ANALYST_TEAM: &str = "atm-dev";
+    const TEST_NONEXISTENT_TEAM: &str = "test-team";
 
     fn fixture() -> std::path::PathBuf {
         let directory = tempdir().expect("temp directory").keep();
@@ -178,11 +178,11 @@ mod tests {
         Python::initialize();
         Python::attach(|py| {
             let database = database(fixture());
-            let parameters = PyTuple::new(py, [TEST_ANALYST_TEAM]).expect("parameters");
+            let parameters = PyTuple::new(py, [TEST_NONEXISTENT_TEAM]).expect("parameters");
             let result = database
                 .query(
                     py,
-                    "SELECT team, value FROM decomposed_messages WHERE team = ?",
+                    "SELECT team, value FROM decomposed_messages WHERE team != ?",
                     Some(parameters),
                 )
                 .expect("query");

--- a/crates/atm-runtime-test-support/src/lib.rs
+++ b/crates/atm-runtime-test-support/src/lib.rs
@@ -75,6 +75,22 @@ pub fn open_sqlite_boundary(path: impl AsRef<Path>) -> Result<RuntimeAssembly, A
     })
 }
 
+/// Build an isolated SQLite runtime from a test-owned directory.
+///
+/// Every caller receives a distinct database filename, so independent unit
+/// fixtures can safely create their durable state even when another test owns
+/// a transaction in the same process.
+pub fn open_isolated_sqlite_boundary(root: impl AsRef<Path>) -> Result<RuntimeAssembly, AtmError> {
+    open_sqlite_boundary(root.as_ref().join("runtime").join("mail.sqlite3"))
+}
+
+/// Install the current test's isolated runtime path before composing a
+/// loopback client. The caller must hold the test environment guard while the
+/// returned value remains alive.
+pub fn install_isolated_sqlite_runtime(root: impl AsRef<Path>) -> SqliteRuntimeGuard {
+    SqliteRuntimeGuard::install(root.as_ref().join("runtime").join("mail.sqlite3"))
+}
+
 pub struct SqliteWriterLockGuard {
     _inner: atm_storage_rusqlite::TestOnlySqliteWriterLockGuard,
 }

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -114,6 +114,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         rosters: storage.roster_store(),
     };
     let async_message_store = storage.async_message_store();
+    let async_message_search_store = storage.async_message_search_store();
     let template_catalog_store = storage.template_catalog_store();
     let nudge_template_override_store = storage.nudge_template_override_store();
     let peer_config_store = storage.peer_config_store();
@@ -124,6 +125,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         inputs.non_claude_outbound,
     )
     .with_async_message_store(async_message_store)
+    .with_async_message_search_store(async_message_search_store)
     .with_template_rendering(template_catalog_store, template_composer.clone());
     let doctor_ports = runtime_doctor_ports(Arc::new(RuntimeConfigDoctor {
         config_current_dir: Some(inputs.config_current_dir),

--- a/crates/atm-storage-rusqlite/src/analyst_query.rs
+++ b/crates/atm-storage-rusqlite/src/analyst_query.rs
@@ -1,0 +1,304 @@
+//! SQLite implementation of the deliberately local analyst-query capability.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use atm_storage::{AnalystQueryRow, AnalystQueryStore, AnalystQueryValue, AtmError};
+use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
+use rusqlite::{Connection, OpenFlags, params_from_iter, types::Value};
+
+pub fn open_analyst_query_store(
+    path: impl AsRef<Path>,
+) -> Result<Box<dyn AnalystQueryStore>, AtmError> {
+    Ok(Box::new(SqliteAnalystQueryStore {
+        path: path.as_ref().to_owned(),
+    }))
+}
+
+/// Creates a deliberately minimal durable analyst-view fixture.
+///
+/// This test-support helper keeps all SQLite setup inside the SQLite backend;
+/// consumers such as the Python extension never import `rusqlite` directly.
+#[cfg(feature = "test-support")]
+pub fn create_analyst_query_fixture_for_test(path: impl AsRef<Path>) -> Result<(), AtmError> {
+    let connection = Connection::open(path.as_ref()).map_err(sql_error)?;
+    connection
+        .execute_batch(
+            "CREATE TABLE hidden_mail_messages (
+                 team TEXT NOT NULL,
+                 agent TEXT NOT NULL,
+                 document_type TEXT NOT NULL,
+                 phase TEXT NOT NULL,
+                 value TEXT NOT NULL
+             );
+             CREATE VIEW decomposed_messages AS
+                SELECT team, agent, document_type, phase, value FROM hidden_mail_messages;
+             INSERT INTO hidden_mail_messages VALUES
+                ('atm-dev', 'dev-one', 'assignment', 'an', 'first assignment'),
+                ('atm-dev', 'dev-two', 'assignment', 'an', 'second assignment'),
+                ('atm-dev', 'qa-one', 'qa-finding', 'jj', 'finding'),
+                ('atm-dev', 'fix-one', 'fix-assignment', 'jj', 'fix');",
+        )
+        .map_err(sql_error)
+}
+
+struct SqliteAnalystQueryStore {
+    path: PathBuf,
+}
+
+impl AnalystQueryStore for SqliteAnalystQueryStore {
+    fn query(
+        &self,
+        sql: &str,
+        parameters: &[AnalystQueryValue],
+        deadline: Duration,
+        max_rows: usize,
+        max_bytes: usize,
+    ) -> Result<Vec<AnalystQueryRow>, AtmError> {
+        reject_executable_tail(sql)?;
+        let connection = open_defensive_connection(&self.path)?;
+        install_query_budget(&connection, deadline);
+        execute_readonly_query(&connection, sql, parameters, max_rows, max_bytes)
+    }
+}
+
+fn open_defensive_connection(path: &Path) -> Result<Connection, AtmError> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| {
+        AtmError::mailbox_read(format!("analyst query could not open database: {error}"))
+    })?;
+    connection
+        .execute_batch("PRAGMA query_only=ON; PRAGMA trusted_schema=OFF; PRAGMA defensive=ON;")
+        .map_err(|error| {
+            AtmError::mailbox_read(format!(
+                "analyst query could not configure read-only connection: {error}"
+            ))
+        })?;
+    connection.authorizer(Some(authorizer));
+    Ok(connection)
+}
+
+fn install_query_budget(connection: &Connection, deadline: Duration) {
+    let started = Instant::now();
+    connection.progress_handler(1_000, Some(move || started.elapsed() > deadline));
+}
+
+fn execute_readonly_query(
+    connection: &Connection,
+    sql: &str,
+    parameters: &[AnalystQueryValue],
+    max_rows: usize,
+    max_bytes: usize,
+) -> Result<Vec<AnalystQueryRow>, AtmError> {
+    let mut statement = connection.prepare(sql).map_err(sql_error)?;
+    if !statement.readonly() {
+        return Err(AtmError::validation(
+            "ATM analyst queries must be one SQLite read-only statement",
+        ));
+    }
+    let names = statement
+        .column_names()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let values = parameters.iter().map(to_sql_value).collect::<Vec<_>>();
+    let rows = statement
+        .query(params_from_iter(values))
+        .map_err(sql_error)?;
+    collect_query_rows(rows, &names, max_rows, max_bytes)
+}
+
+fn collect_query_rows(
+    mut rows: rusqlite::Rows<'_>,
+    names: &[String],
+    max_rows: usize,
+    max_bytes: usize,
+) -> Result<Vec<AnalystQueryRow>, AtmError> {
+    let mut output = Vec::new();
+    let mut bytes = 0_usize;
+    while let Some(row) = rows.next().map_err(sql_error)? {
+        if output.len() >= max_rows {
+            return Err(AtmError::validation(
+                "ATM analyst query exceeded row budget",
+            ));
+        }
+        output.push(collect_one_row(row, names, &mut bytes, max_bytes)?);
+    }
+    Ok(output)
+}
+
+fn collect_one_row(
+    row: &rusqlite::Row<'_>,
+    names: &[String],
+    bytes: &mut usize,
+    max_bytes: usize,
+) -> Result<AnalystQueryRow, AtmError> {
+    names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let value = from_sql_value(row.get(index).map_err(sql_error)?);
+            *bytes += value_bytes(&value);
+            if *bytes > max_bytes {
+                return Err(AtmError::validation(
+                    "ATM analyst query exceeded result-byte budget",
+                ));
+            }
+            Ok((name.clone(), value))
+        })
+        .collect()
+}
+
+fn sql_error(error: rusqlite::Error) -> AtmError {
+    AtmError::mailbox_read(format!("ATM analyst query failed: {error}"))
+}
+
+fn to_sql_value(value: &AnalystQueryValue) -> Value {
+    match value {
+        AnalystQueryValue::Null => Value::Null,
+        AnalystQueryValue::Integer(value) => Value::Integer(*value),
+        AnalystQueryValue::Real(value) => Value::Real(*value),
+        AnalystQueryValue::Text(value) => Value::Text(value.clone()),
+        AnalystQueryValue::Blob(value) => Value::Blob(value.clone()),
+    }
+}
+
+fn from_sql_value(value: Value) -> AnalystQueryValue {
+    match value {
+        Value::Null => AnalystQueryValue::Null,
+        Value::Integer(value) => AnalystQueryValue::Integer(value),
+        Value::Real(value) => AnalystQueryValue::Real(value),
+        Value::Text(value) => AnalystQueryValue::Text(value),
+        Value::Blob(value) => AnalystQueryValue::Blob(value),
+    }
+}
+
+fn value_bytes(value: &AnalystQueryValue) -> usize {
+    match value {
+        AnalystQueryValue::Text(value) => value.len(),
+        AnalystQueryValue::Blob(value) => value.len(),
+        _ => 0,
+    }
+}
+
+fn authorizer(context: AuthContext<'_>) -> Authorization {
+    match context.action {
+        AuthAction::Read { table_name, .. }
+            if context.accessor == Some("decomposed_messages")
+                || matches!(
+                    table_name,
+                    "decomposed_messages" | "sqlite_master" | "sqlite_schema"
+                ) =>
+        {
+            Authorization::Allow
+        }
+        AuthAction::Select | AuthAction::Recursive => Authorization::Allow,
+        AuthAction::Function { function_name } if function_name != "load_extension" => {
+            Authorization::Allow
+        }
+        AuthAction::Pragma {
+            pragma_name: "table_info" | "table_xinfo",
+            pragma_value: None,
+        } => Authorization::Allow,
+        _ => Authorization::Deny,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SqlState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    Backtick,
+    Bracket,
+    LineComment,
+    BlockComment,
+}
+
+fn reject_executable_tail(sql: &str) -> Result<(), AtmError> {
+    let mut state = SqlState::Normal;
+    let mut ended = false;
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    while let Some(&byte) = bytes.get(index) {
+        index += advance_sql_scanner(byte, bytes.get(index + 1).copied(), &mut state, &mut ended)?;
+        index += 1;
+    }
+    if state == SqlState::BlockComment {
+        return Err(AtmError::validation(
+            "ATM analyst query has an unterminated SQL block comment",
+        ));
+    }
+    Ok(())
+}
+
+fn advance_sql_scanner(
+    byte: u8,
+    next: Option<u8>,
+    state: &mut SqlState,
+    ended: &mut bool,
+) -> Result<usize, AtmError> {
+    if *state != SqlState::Normal {
+        return advance_nested_sql_state(byte, next, state);
+    }
+    match byte {
+        b'\'' => enter_sql_state(SqlState::SingleQuote, *ended, state),
+        b'"' => enter_sql_state(SqlState::DoubleQuote, *ended, state),
+        b'`' => enter_sql_state(SqlState::Backtick, *ended, state),
+        b'[' => enter_sql_state(SqlState::Bracket, *ended, state),
+        b'-' if next == Some(b'-') => {
+            *state = SqlState::LineComment;
+            Ok(1)
+        }
+        b'/' if next == Some(b'*') => {
+            *state = SqlState::BlockComment;
+            Ok(1)
+        }
+        b';' => {
+            *ended = true;
+            Ok(0)
+        }
+        value if value.is_ascii_whitespace() => Ok(0),
+        _ if *ended => Err(single_statement_error()),
+        _ => Ok(0),
+    }
+}
+
+fn enter_sql_state(next: SqlState, ended: bool, state: &mut SqlState) -> Result<usize, AtmError> {
+    if ended {
+        return Err(single_statement_error());
+    }
+    *state = next;
+    Ok(0)
+}
+
+fn advance_nested_sql_state(
+    byte: u8,
+    next: Option<u8>,
+    state: &mut SqlState,
+) -> Result<usize, AtmError> {
+    match (*state, byte, next) {
+        (SqlState::SingleQuote, b'\'', Some(b'\'')) | (SqlState::DoubleQuote, b'"', Some(b'"')) => {
+            Ok(1)
+        }
+        (SqlState::SingleQuote, b'\'', _)
+        | (SqlState::DoubleQuote, b'"', _)
+        | (SqlState::Backtick, b'`', _)
+        | (SqlState::Bracket, b']', _) => {
+            *state = SqlState::Normal;
+            Ok(0)
+        }
+        (SqlState::LineComment, b'\n', _) | (SqlState::BlockComment, b'*', Some(b'/')) => {
+            *state = SqlState::Normal;
+            Ok(1)
+        }
+        _ => Ok(0),
+    }
+}
+
+fn single_statement_error() -> AtmError {
+    AtmError::validation("ATM analyst queries must contain exactly one statement")
+}

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -710,7 +710,7 @@ impl SqliteStorageBackend {
     }
 
     #[cfg(test)]
-    fn in_memory_for_test() -> Result<Self, AtmError> {
+    pub(crate) fn in_memory_for_test() -> Result<Self, AtmError> {
         let db = Arc::new(SharedDb::open_in_memory_for_test()?);
         Ok(Self {
             message_store: Arc::new(SqliteMessageStore::new(Arc::clone(&db))),

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -7,6 +7,7 @@
 //! SQLite-backed storage backend implementing the shared `atm-storage`
 //! message and roster contracts.
 
+mod analyst_query;
 #[cfg(test)]
 mod mailbox_metadata;
 mod nudge_template_override_store;
@@ -21,6 +22,9 @@ mod template_catalog_schema;
 mod template_catalog_store;
 mod writer;
 
+#[cfg(feature = "test-support")]
+pub use crate::analyst_query::create_analyst_query_fixture_for_test;
+pub use crate::analyst_query::open_analyst_query_store;
 #[cfg(test)]
 use crate::mailbox_metadata::query_mailbox_metadata_rows;
 pub use crate::observability::{

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -848,8 +848,8 @@ mod tests {
     use atm_storage::{
         AtmError, DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome,
         DecomposedMessageRecord, MergedVarsJson, MessageSearchQuery, SearchAtom, SearchDeadline,
-        SearchExpression, SearchKey, SearchLimit, SearchValue, TemplateFirstSeen,
-        TemplateFrontmatter, TemplateMessageAdmission, TemplateRegistration,
+        SearchExpression, SearchKey, SearchLimit, SearchMetadataMatch, SearchValue,
+        TemplateFirstSeen, TemplateFrontmatter, TemplateMessageAdmission, TemplateRegistration,
         TemplateRegistrationOutcome, TemplateSha,
     };
     use chrono::Utc;
@@ -944,6 +944,13 @@ mod tests {
             .expect("search");
         assert_eq!(page.matches.len(), 1);
         assert_eq!(page.matches[0].key.message_key, record.message_key);
+        assert!(
+            page.matches[0]
+                .snippet
+                .as_deref()
+                .is_some_and(|snippet| snippet.contains("\u{1}beta\u{2}")),
+            "typed search results must carry backend FTS context"
+        );
         backend
             .shared_db_for_test()
             .with_connection(|connection| {
@@ -1058,11 +1065,25 @@ mod tests {
             vec![atm_storage::SearchMatchField::VarValue]
         );
 
+        let mut by_type_prefix = MessageSearchQuery::default();
+        by_type_prefix.filters.template_metadata = vec![(
+            SearchKey::new("kind").expect("key"),
+            SearchMetadataMatch::prefix("assign").expect("prefix"),
+        )];
+        assert_eq!(
+            store
+                .search(&by_type_prefix)
+                .expect("prefix metadata search")
+                .matches
+                .len(),
+            1
+        );
+
         let mut by_tag = MessageSearchQuery::default();
         by_tag.filters.tags = vec!["phase-an".to_owned()];
         by_tag.filters.template_metadata = vec![(
             SearchKey::new("kind").expect("key"),
-            SearchValue::new("assignment").expect("value"),
+            atm_storage::SearchMetadataMatch::exact("assignment").expect("value"),
         )];
         assert_eq!(
             store
@@ -1100,6 +1121,67 @@ mod tests {
                 .expect("body search")
                 .matches
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn search_type_and_variables_include_derivative_template_revisions() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let first = message("atm:revision-one", "first body");
+        let second = message("atm:revision-two", "second body");
+        backend
+            .message_store()
+            .save_message(&first)
+            .expect("first message");
+        backend
+            .message_store()
+            .save_message(&second)
+            .expect("second message");
+
+        let first_template = template_registration('e');
+        let second_template = template_registration('f');
+        for (record, template) in [(&first, first_template), (&second, second_template)] {
+            backend
+                .template_catalog_store()
+                .admit_decomposed_message(DecomposedMessageAdmission {
+                    template: template.clone(),
+                    message: DecomposedMessageRecord {
+                        key: record.message_key.clone(),
+                        template_sha: template.sha,
+                        vars: MergedVarsJson::try_from_merged_object(
+                            [("phase".to_owned(), serde_json::json!("an"))]
+                                .into_iter()
+                                .collect(),
+                        )
+                        .expect("vars"),
+                        category: Some("assignment".to_owned()),
+                        tags: vec!["phase-an".to_owned()],
+                        content_format: Some("markdown".to_owned()),
+                    },
+                })
+                .expect("decomposed admission");
+        }
+
+        let mut query = MessageSearchQuery::default();
+        query.filters.template_metadata = vec![(
+            SearchKey::new("kind").expect("key"),
+            SearchMetadataMatch::exact("assignment").expect("metadata"),
+        )];
+        query.filters.vars = vec![(
+            SearchKey::new("phase").expect("key"),
+            SearchValue::new("an").expect("value"),
+        )];
+        let page = backend
+            .message_search_store()
+            .search(&query)
+            .expect("cross-revision search");
+        assert_eq!(page.matches.len(), 2);
+        assert_eq!(
+            page.matches
+                .iter()
+                .map(|hit| hit.template_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("task"), Some("task")]
         );
     }
 

--- a/crates/atm-storage-rusqlite/src/search_reader.rs
+++ b/crates/atm-storage-rusqlite/src/search_reader.rs
@@ -171,3 +171,24 @@ impl SearchReader {
 fn remaining_until(deadline: Instant) -> Duration {
     deadline.saturating_duration_since(Instant::now())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::SqliteStorageBackend;
+    use atm_storage::{MessageSearchQuery, SearchDeadline};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn production_sqlite_reader_executes_the_typed_search_port() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let page = backend
+            .async_message_search_store()
+            .search_async(
+                MessageSearchQuery::default(),
+                SearchDeadline::new(Duration::from_secs(1)).expect("deadline"),
+            )
+            .await
+            .expect("reader lane response");
+        assert!(page.matches.is_empty());
+    }
+}

--- a/crates/atm-storage-rusqlite/src/search_store.rs
+++ b/crates/atm-storage-rusqlite/src/search_store.rs
@@ -759,3 +759,131 @@ fn after_cursor(record: &StoredSearchMatch, cursor: &CursorTuple) -> bool {
         .then_with(|| record.key.message_key.to_string().cmp(&cursor.4))
         .is_gt()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SqliteStorageBackend;
+    use atm_storage::schema::MessageEnvelope;
+    use atm_storage::{AtmMessageId, IsoTimestamp, MessageKey, SearchLimit};
+    use serde_json::Map;
+
+    fn save(
+        backend: &SqliteStorageBackend,
+        team: &str,
+        agent: &str,
+        key: &str,
+        message_id: Option<&str>,
+        timestamp: &str,
+    ) {
+        backend
+            .save_message_record(
+                team.parse().expect("team"),
+                agent.parse().expect("agent"),
+                MessageKey::new(key).expect("message key"),
+                MessageEnvelope {
+                    from: "sender".parse().expect("sender"),
+                    source_chat_id: None,
+                    text: format!("durable query fixture {key}"),
+                    timestamp: timestamp.parse::<IsoTimestamp>().expect("timestamp"),
+                    read: false,
+                    source_team: Some(team.parse().expect("source team")),
+                    destination_chat_id: None,
+                    summary: None,
+                    message_id: message_id
+                        .map(|value| value.parse::<AtmMessageId>().expect("message ID")),
+                    requires_ack: false,
+                    pending_ack_at: None,
+                    acknowledged_at: None,
+                    acknowledges_message_id: None,
+                    parent_message_id: None,
+                    thread_mode: None,
+                    expires_at: None,
+                    task_id: None,
+                    extra: Map::new(),
+                },
+            )
+            .expect("seed production SQLite backend");
+    }
+
+    fn query(per_mailbox: bool, limit: u32, cursor: Option<SearchCursor>) -> MessageSearchQuery {
+        MessageSearchQuery {
+            page: atm_storage::SearchPageRequest {
+                limit: SearchLimit::new(limit).expect("limit"),
+                cursor,
+            },
+            per_mailbox,
+            ..MessageSearchQuery::default()
+        }
+    }
+
+    #[test]
+    fn production_sqlite_search_deduplicates_and_pages_null_message_ids() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let shared_message_id = "01KZTTRD6K9WJYJ2N7E39CVB9P";
+        save(
+            &backend,
+            "query-team",
+            "agent-one",
+            "atm:one",
+            Some(shared_message_id),
+            "2026-08-12T00:03:00Z",
+        );
+        save(
+            &backend,
+            "query-team",
+            "agent-two",
+            "atm:two",
+            Some(shared_message_id),
+            "2026-08-12T00:02:00Z",
+        );
+        save(
+            &backend,
+            "query-team",
+            "agent-three",
+            "atm:three",
+            None,
+            "2026-08-12T00:01:00Z",
+        );
+
+        let first = backend
+            .message_search_store()
+            .search(&query(false, 1, None))
+            .expect("first page");
+        let cursor = first
+            .next_cursor
+            .clone()
+            .expect("deduplicated page continues");
+        let second = backend
+            .message_search_store()
+            .search(&query(false, 1, Some(cursor)))
+            .expect("second page");
+        let keys = first
+            .matches
+            .into_iter()
+            .chain(second.matches)
+            .map(|hit| hit.key.message_key.to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            keys.len(),
+            2,
+            "default dedup and cursor omit no durable result"
+        );
+
+        let mailbox_rows = backend
+            .message_search_store()
+            .search(&query(true, 10, None))
+            .expect("per-mailbox search");
+        assert_eq!(
+            mailbox_rows.matches.len(),
+            3,
+            "per-mailbox retains duplicate message IDs and NULL IDs"
+        );
+        assert!(
+            mailbox_rows
+                .matches
+                .iter()
+                .any(|hit| hit.message_id.is_none())
+        );
+    }
+}

--- a/crates/atm-storage-rusqlite/src/search_store.rs
+++ b/crates/atm-storage-rusqlite/src/search_store.rs
@@ -765,7 +765,9 @@ mod tests {
     use super::*;
     use crate::SqliteStorageBackend;
     use atm_storage::schema::MessageEnvelope;
-    use atm_storage::{AtmMessageId, IsoTimestamp, MessageKey, SearchLimit};
+    use atm_storage::{
+        AtmMessageId, IsoTimestamp, MessageKey, SearchAggregate, SearchLimit, SimpleAggregate,
+    };
     use serde_json::Map;
 
     fn save(
@@ -884,6 +886,18 @@ mod tests {
                 .matches
                 .iter()
                 .any(|hit| hit.message_id.is_none())
+        );
+
+        let mut aggregate_query = query(false, 10, None);
+        aggregate_query.aggregate = Some(SimpleAggregate::Count);
+        let aggregate = backend
+            .message_search_store()
+            .search(&aggregate_query)
+            .expect("aggregate search");
+        assert_eq!(
+            aggregate.aggregate,
+            Some(SearchAggregate::Count { value: 2 }),
+            "aggregate observes the same deduplicated result set as paging"
         );
     }
 }

--- a/crates/atm-storage-rusqlite/src/search_store.rs
+++ b/crates/atm-storage-rusqlite/src/search_store.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use atm_storage::{
     AsyncMessageSearchStore, AtmError, MessageSearchPage, MessageSearchQuery, MessageSearchStore,
     SearchAggregate, SearchCursor, SearchDeadline, SearchExpression, SearchGroup, SearchGroupBy,
-    SearchGroupField, SearchMatchField, SearchResultKey, SimpleAggregate, StoredSearchAddress,
-    StoredSearchMatch,
+    SearchGroupField, SearchMatchField, SearchMetadataMatch, SearchResultKey, SimpleAggregate,
+    StoredSearchAddress, StoredSearchMatch,
 };
 use rusqlite::{Connection, params_from_iter, types::Value as SqlValue};
 use serde_json::Value;
@@ -102,7 +102,9 @@ fn primary_search_sql(uses_fts: bool, filters: &SqlFilters) -> String {
                     CASE WHEN instr(highlight(mail_messages_fts, 2, char(1), char(2)), char(1)) > 0 THEN 1 ELSE 0 END,
                     CASE WHEN instr(highlight(mail_messages_fts, 3, char(1), char(2)), char(1)) > 0 THEN 1 ELSE 0 END,
                     CASE WHEN instr(highlight(mail_messages_fts, 4, char(1), char(2)), char(1)) > 0 THEN 1 ELSE 0 END,
-                    0, m.tags_json, m.vars_json, t.schema_json
+                    0,
+                    snippet(mail_messages_fts, -1, char(1), char(2), '…', 16),
+                    m.tags_json, m.vars_json, t.schema_json
              FROM mail_message_search_documents d
              JOIN mail_messages_fts ON mail_messages_fts.rowid = d.search_rowid
              JOIN mail_messages m ON (m.team, m.agent, m.message_key) = (d.team, d.agent, d.message_key)
@@ -116,7 +118,7 @@ fn primary_search_sql(uses_fts: bool, filters: &SqlFilters) -> String {
             "SELECT d.team, d.agent, d.message_key, d.message_id, d.message_at,
                     d.from_agent, m.source_chat_id, m.destination_chat_id, m.template_sha,
                     t.template_type, m.category,
-                    0, 0, 0, 0, 0, 0, m.tags_json, m.vars_json, t.schema_json
+                    0, 0, 0, 0, 0, 0, NULL, m.tags_json, m.vars_json, t.schema_json
              FROM mail_message_search_documents d
              JOIN mail_messages m ON (m.team, m.agent, m.message_key) = (d.team, d.agent, d.message_key)
              LEFT JOIN message_templates t ON t.template_sha = m.template_sha
@@ -139,6 +141,7 @@ fn execute_template_search(
                 t.template_type, m.category,
                 0, 0, 0, 0, 0,
                 CASE WHEN instr(highlight(message_templates_fts, 0, char(1), char(2)), char(1)) > 0 THEN 1 ELSE 0 END,
+                snippet(message_templates_fts, -1, char(1), char(2), '…', 16),
                 m.tags_json, m.vars_json, t.schema_json
          FROM message_template_search_documents td
          JOIN message_templates_fts ON message_templates_fts.rowid = td.search_rowid
@@ -269,6 +272,7 @@ type SearchRow = (
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<String>,
 );
 
 #[derive(Debug, Clone)]
@@ -290,6 +294,7 @@ struct DecodedSearchRow {
     template_type: Option<String>,
     category: Option<String>,
     match_fields: Vec<SearchMatchField>,
+    snippet: Option<String>,
     vars_json: Option<String>,
 }
 
@@ -324,6 +329,7 @@ fn decode_search_row_values(row: &rusqlite::Row<'_>) -> rusqlite::Result<Decoded
         row.get(17)?,
         row.get(18)?,
         row.get(19)?,
+        row.get(20)?,
     );
     let (
         team,
@@ -343,6 +349,7 @@ fn decode_search_row_values(row: &rusqlite::Row<'_>) -> rusqlite::Result<Decoded
         var_value,
         from_agent_match,
         template_content,
+        snippet,
         _tags_json,
         vars_json,
         _template_metadata_json,
@@ -367,6 +374,7 @@ fn decode_search_row_values(row: &rusqlite::Row<'_>) -> rusqlite::Result<Decoded
             from_agent_match,
             template_content,
         ),
+        snippet,
         vars_json,
     })
 }
@@ -405,6 +413,7 @@ impl DecodedSearchRow {
             template_type: self.template_type,
             category: self.category,
             match_fields: self.match_fields,
+            snippet: self.snippet,
         })
     }
 }
@@ -529,13 +538,18 @@ fn compile_sql_filters(filters: &atm_storage::SearchFilters) -> SqlFilters {
             value.as_str(),
         );
     }
-    for (key, value) in &filters.template_metadata {
-        clauses.push(json_scalar_filter("t.schema_json"));
-        push_json_scalar_parameters(
-            &mut parameters,
-            &format!("$.metadata.{}", key.as_str()),
-            value.as_str(),
-        );
+    for (key, matcher) in &filters.template_metadata {
+        let path = format!("$.metadata.{}", key.as_str());
+        match matcher {
+            SearchMetadataMatch::Exact(value) => {
+                clauses.push(json_scalar_filter("t.schema_json"));
+                push_json_scalar_parameters(&mut parameters, &path, value.as_str());
+            }
+            SearchMetadataMatch::Prefix(value) => {
+                clauses.push(json_scalar_prefix_filter("t.schema_json"));
+                push_json_scalar_prefix_parameters(&mut parameters, &path, value.as_str());
+            }
+        }
     }
     SqlFilters {
         clause: clauses
@@ -552,10 +566,26 @@ fn json_scalar_filter(column: &str) -> String {
     )
 }
 
+fn json_scalar_prefix_filter(column: &str) -> String {
+    format!(
+        "(CASE json_type({column}, ?) WHEN 'true' THEN 'true' WHEN 'false' THEN 'false' WHEN 'null' THEN 'null' ELSE CAST(json_extract({column}, ?) AS TEXT) END LIKE ? ESCAPE '\\')"
+    )
+}
+
 fn push_json_scalar_parameters(parameters: &mut Vec<SqlValue>, path: &str, value: &str) {
     parameters.push(SqlValue::Text(path.to_owned()));
     parameters.push(SqlValue::Text(path.to_owned()));
     parameters.push(SqlValue::Text(value.to_owned()));
+}
+
+fn push_json_scalar_prefix_parameters(parameters: &mut Vec<SqlValue>, path: &str, value: &str) {
+    parameters.push(SqlValue::Text(path.to_owned()));
+    parameters.push(SqlValue::Text(path.to_owned()));
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    parameters.push(SqlValue::Text(format!("{escaped}%")));
 }
 
 fn deduplicate(matches: &mut Vec<SearchRecord>) {

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -592,11 +592,22 @@ fn enable_write_ahead_log(
     #[cfg(not(test))]
     let enable_wal = true;
     if enable_wal {
-        connection
-            .pragma_update(None, "journal_mode", "WAL")
+        // `PRAGMA journal_mode = WAL` returns the selected mode. Use a query
+        // rather than Rusqlite's execute-only pragma helper, which correctly
+        // rejects result-producing pragmas.
+        let journal_mode = connection
+            .query_row("PRAGMA journal_mode = WAL", [], |row| {
+                row.get::<_, String>(0)
+            })
             .map_err(|error| {
                 sqlite_error(target, "failed to enable sqlite wal journal mode", error)
             })?;
+        if !journal_mode.eq_ignore_ascii_case("wal") {
+            return Err(AtmError::mailbox_write(format!(
+                "SQLite declined WAL journal mode for {} (reported {journal_mode:?})",
+                target.display()
+            )));
+        }
     }
     Ok(())
 }

--- a/crates/atm-storage/src/analyst_query.rs
+++ b/crates/atm-storage/src/analyst_query.rs
@@ -1,0 +1,29 @@
+//! Transport-neutral values for the local analyst-query extension.
+
+use std::time::Duration;
+
+use crate::error::AtmError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnalystQueryValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+pub type AnalystQueryRow = Vec<(String, AnalystQueryValue)>;
+
+/// Executes one defensive, local-only analyst query through the selected
+/// storage backend. Raw SQL is intentionally not an ATM transport capability.
+pub trait AnalystQueryStore: Send + Sync {
+    fn query(
+        &self,
+        sql: &str,
+        parameters: &[AnalystQueryValue],
+        deadline: Duration,
+        max_rows: usize,
+        max_result_bytes: usize,
+    ) -> Result<Vec<AnalystQueryRow>, AtmError>;
+}

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -274,6 +274,15 @@ impl AtmError {
         Self::new(AtmErrorCode::MessageValidationFailed, message)
     }
 
+    /// Denies the intentionally local-only message-search capability before a
+    /// peer request can select any storage adapter.
+    pub fn search_local_only() -> Self {
+        Self::new(
+            AtmErrorCode::SearchLocalOnly,
+            "message search is available only through authenticated local HTTP adapters",
+        )
+    }
+
     /// Rejects a template before catalog or decomposed-message admission when
     /// its immutable raw bytes cannot be represented by the UTF-8 projection.
     pub fn template_content_not_utf8() -> Self {

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -136,6 +136,7 @@ const fn mailbox_guidance(code: AtmErrorCode) -> Option<&'static str> {
 const fn request_guidance(code: AtmErrorCode) -> Option<&'static str> {
     match code {
         AtmErrorCode::MessageValidationFailed
+        | AtmErrorCode::SearchLocalOnly
         | AtmErrorCode::LocalHttpCapabilityInvalid
         | AtmErrorCode::LocalHttpEndpointSchemaUnsupported
         | AtmErrorCode::LocalHttpEndpointMissing

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -33,8 +33,9 @@ pub use search::{
     AsyncMessageSearchStore, InMemoryMessageSearchStore, MessageSearchPage, MessageSearchQuery,
     MessageSearchStore, SearchAggregate, SearchAtom, SearchCursor, SearchDeadline,
     SearchExpression, SearchFilters, SearchGroup, SearchGroupBy, SearchGroupField, SearchKey,
-    SearchLimit, SearchMatchField, SearchPageRequest, SearchResultKey, SearchTimestampField,
-    SearchValue, SimpleAggregate, StoredSearchAddress, StoredSearchMatch, TimeRange,
+    SearchLimit, SearchMatchField, SearchMetadataMatch, SearchPageRequest, SearchResultKey,
+    SearchTimestampField, SearchValue, SimpleAggregate, StoredSearchAddress, StoredSearchMatch,
+    TimeRange,
 };
 pub use template_catalog::{
     DecomposedMessageAdmission, DecomposedMessageAdmissionOutcome, DecomposedMessageRecord,

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared audited storage contract and canonical storage-facing domain types
 //! for ATM backends and their callers.
 
+pub mod analyst_query;
 pub mod contract;
 pub mod error;
 mod error_catalog;
@@ -15,6 +16,7 @@ mod validation;
 
 // Protocol role identity for worker agents used in shared storage fixtures.
 pub const ROLE_WORKER: &str = "worker";
+pub use analyst_query::{AnalystQueryRow, AnalystQueryStore, AnalystQueryValue};
 pub use contract::{
     AckRequirementState, AckTransition, AcknowledgementCommit, AcknowledgementReplyBuilder,
     AcknowledgementSource, AgentType, AsyncMessageStore, BuiltInNudgeTemplateKind,

--- a/crates/atm-storage/src/search.rs
+++ b/crates/atm-storage/src/search.rs
@@ -16,7 +16,7 @@ use crate::error::AtmError;
 use crate::types::{AgentName, ChatId, IsoTimestamp, TeamName, TemplateSha};
 
 /// One bounded literal term in a typed search expression.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchAtom {
     Term(String),
     Phrase(String),
@@ -50,7 +50,7 @@ impl SearchAtom {
 
 /// A bounded expression tree.  Call [`SearchExpression::validate`] at the
 /// storage boundary so manually assembled public DTOs cannot bypass limits.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchExpression {
     Atom(SearchAtom),
     All(Vec<SearchExpression>),
@@ -144,7 +144,7 @@ impl SearchExpression {
 }
 
 /// Validated JSON-object key used in template metadata and variable filters.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct SearchKey(String);
 
@@ -178,8 +178,19 @@ impl FromStr for SearchKey {
     }
 }
 
+impl<'de> Deserialize<'de> for SearchKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 /// Bounded data value. It is never interpreted as SQL or FTS syntax.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct SearchValue(String);
 
@@ -204,7 +215,51 @@ impl FromStr for SearchValue {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+impl<'de> Deserialize<'de> for SearchValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+/// One parameterized metadata-match mode exposed by the public query API.
+///
+/// Prefix semantics are intentionally limited to template metadata. Variable
+/// filters stay exact, which prevents a convenience wildcard from becoming a
+/// second query language over JSON1 paths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SearchMetadataMatch {
+    Exact(SearchValue),
+    Prefix(SearchValue),
+}
+
+impl SearchMetadataMatch {
+    pub fn exact(value: impl Into<String>) -> Result<Self, AtmError> {
+        Ok(Self::Exact(SearchValue::new(value)?))
+    }
+
+    pub fn prefix(value: impl Into<String>) -> Result<Self, AtmError> {
+        let value = SearchValue::new(value)?;
+        if value.as_str().is_empty() {
+            return Err(AtmError::validation(
+                "search metadata prefix must not be empty",
+            ));
+        }
+        Ok(Self::Prefix(value))
+    }
+
+    #[must_use]
+    pub fn value(&self) -> &SearchValue {
+        match self {
+            Self::Exact(value) | Self::Prefix(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct SearchLimit(u32);
 
 impl SearchLimit {
@@ -223,7 +278,16 @@ impl SearchLimit {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+impl<'de> Deserialize<'de> for SearchLimit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(u32::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct SearchCursor(String);
 
@@ -243,7 +307,16 @@ impl SearchCursor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl<'de> Deserialize<'de> for SearchCursor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchPageRequest {
     pub limit: SearchLimit,
     pub cursor: Option<SearchCursor>,
@@ -258,20 +331,20 @@ impl Default for SearchPageRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SearchFilters {
     pub team: Option<TeamName>,
     pub agent: Option<AgentName>,
     pub from_agent: Option<AgentName>,
     pub template_sha: Option<TemplateSha>,
-    pub template_metadata: Vec<(SearchKey, SearchValue)>,
+    pub template_metadata: Vec<(SearchKey, SearchMetadataMatch)>,
     pub vars: Vec<(SearchKey, SearchValue)>,
     pub tags: Vec<String>,
     pub category: Option<String>,
     pub time_range: Option<TimeRange>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimeRange {
     pub since: Option<IsoTimestamp>,
     pub until: Option<IsoTimestamp>,
@@ -290,19 +363,19 @@ impl TimeRange {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SimpleAggregate {
     Count,
     GroupBy(SearchGroupBy),
     Min(SearchTimestampField),
     Max(SearchTimestampField),
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchGroupBy {
     Field(SearchGroupField),
     Var(SearchKey),
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchGroupField {
     Team,
     Agent,
@@ -310,12 +383,12 @@ pub enum SearchGroupField {
     TemplateType,
     Category,
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchTimestampField {
     MessageAt,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct MessageSearchQuery {
     pub expression: Option<SearchExpression>,
     pub filters: SearchFilters,
@@ -331,6 +404,30 @@ impl MessageSearchQuery {
         }
         if let Some(range) = &self.filters.time_range {
             range.validate()?;
+        }
+        // These values can enter through the serialized HTTP contract, so
+        // validate their public invariants again at the storage boundary.
+        let _ = SearchLimit::new(self.page.limit.get())?;
+        if let Some(cursor) = &self.page.cursor {
+            let _ = SearchCursor::new(cursor.as_str())?;
+        }
+        if let Some(template_sha) = &self.filters.template_sha {
+            let _ = TemplateSha::new(template_sha.as_str())?;
+        }
+        for (key, value) in &self.filters.template_metadata {
+            let _ = SearchKey::new(key.as_str())?;
+            match value {
+                SearchMetadataMatch::Exact(value) => {
+                    let _ = SearchValue::new(value.as_str())?;
+                }
+                SearchMetadataMatch::Prefix(value) => {
+                    let _ = SearchMetadataMatch::prefix(value.as_str())?;
+                }
+            }
+        }
+        for (key, value) in &self.filters.vars {
+            let _ = SearchKey::new(key.as_str())?;
+            let _ = SearchValue::new(value.as_str())?;
         }
         for tag in &self.filters.tags {
             if tag.len() > 4096 {
@@ -358,19 +455,19 @@ impl SearchDeadline {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct SearchResultKey {
     pub team: TeamName,
     pub agent: AgentName,
     pub message_key: MessageKey,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredSearchAddress {
     pub agent: AgentName,
     pub team: TeamName,
     pub chat_id: Option<ChatId>,
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SearchMatchField {
     BodyText,
     Summary,
@@ -379,7 +476,7 @@ pub enum SearchMatchField {
     FromAgent,
     TemplateContent,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredSearchMatch {
     pub key: SearchResultKey,
     pub message_id: Option<String>,
@@ -390,13 +487,16 @@ pub struct StoredSearchMatch {
     pub template_type: Option<String>,
     pub category: Option<String>,
     pub match_fields: Vec<SearchMatchField>,
+    /// Backend-produced context for indexed text. Filter-only matches leave
+    /// this absent, so callers can render honest metadata-only results.
+    pub snippet: Option<String>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchGroup {
     pub key: String,
     pub count: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SearchAggregate {
     Count {
         value: u64,
@@ -410,7 +510,7 @@ pub enum SearchAggregate {
         value: Option<IsoTimestamp>,
     },
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MessageSearchPage {
     pub matches: Vec<StoredSearchMatch>,
     pub aggregate: Option<SearchAggregate>,
@@ -465,6 +565,7 @@ impl From<StoredSearchMatch> for InMemorySearchDocument {
 #[derive(Default)]
 pub struct InMemoryMessageSearchStore {
     records: std::sync::Mutex<Vec<InMemorySearchDocument>>,
+    calls: std::sync::atomic::AtomicUsize,
 }
 
 impl InMemoryMessageSearchStore {
@@ -478,12 +579,19 @@ impl InMemoryMessageSearchStore {
             .expect("search fake lock")
             .push(document);
     }
+
+    #[doc(hidden)]
+    #[must_use]
+    pub fn search_calls_for_test(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
 }
 
 impl sealed::Sealed for InMemoryMessageSearchStore {}
 
 impl MessageSearchStore for InMemoryMessageSearchStore {
     fn search(&self, query: &MessageSearchQuery) -> Result<MessageSearchPage, AtmError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         query.validate()?;
         let cursor = query
             .page
@@ -571,7 +679,15 @@ fn matches_filters(record: &InMemorySearchDocument, filters: &SearchFilters) -> 
         && filters
             .template_metadata
             .iter()
-            .all(|(key, value)| record.template_metadata.get(key) == Some(value))
+            .all(|(key, matcher)| match matcher {
+                SearchMetadataMatch::Exact(value) => {
+                    record.template_metadata.get(key) == Some(value)
+                }
+                SearchMetadataMatch::Prefix(value) => record
+                    .template_metadata
+                    .get(key)
+                    .is_some_and(|actual| actual.as_str().starts_with(value.as_str())),
+            })
 }
 
 fn stable_compare(left: &StoredSearchMatch, right: &StoredSearchMatch) -> std::cmp::Ordering {
@@ -884,6 +1000,7 @@ mod tests {
             template_type: None,
             category: Some("assignment".to_owned()),
             match_fields: vec![SearchMatchField::BodyText],
+            snippet: None,
         }
     }
 
@@ -997,7 +1114,7 @@ mod tests {
                 vars: vec![(sprint.clone(), SearchValue::new("AN.5").expect("value"))],
                 template_metadata: vec![(
                     SearchKey::new("kind").expect("key"),
-                    SearchValue::new("assignment").expect("value"),
+                    SearchMetadataMatch::exact("assignment").expect("value"),
                 )],
                 ..SearchFilters::default()
             },

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -2,7 +2,10 @@ use crate::observability::CliObservability;
 use crate::output;
 use anyhow::Result;
 use atm_core::doctor::{self, DaemonRuntimeDoctorReport, DoctorQuery};
+#[cfg(not(test))]
 use atm_daemon_bootstrap::assemble_default_runtime;
+#[cfg(test)]
+use atm_runtime_test_support::open_sqlite_boundary;
 use clap::Args;
 
 use crate::composition::{
@@ -75,7 +78,7 @@ impl DoctorCommand {
     ) -> Result<atm_core::doctor::DoctorReport> {
         let local_report =
             self.execute_direct_local(observability, home_dir.clone(), current_dir.clone())?;
-        let query = self.build_query(home_dir, current_dir)?;
+        let query = self.build_query(home_dir.clone(), current_dir)?;
 
         match CliComposition::bootstrap(
             "doctor",
@@ -94,8 +97,11 @@ impl DoctorCommand {
         home_dir: std::path::PathBuf,
         current_dir: std::path::PathBuf,
     ) -> Result<atm_core::doctor::DoctorReport> {
-        let query = self.build_query(home_dir, current_dir)?;
+        let query = self.build_query(home_dir.clone(), current_dir)?;
+        #[cfg(not(test))]
         let runtime = assemble_default_runtime()?;
+        #[cfg(test)]
+        let runtime = open_sqlite_boundary(home_dir.join(".atm").join("db").join("mail.db"))?;
         let (peer_config, peer_findings) =
             doctor::peer_config_doctor_report(runtime.peer_config_store().as_ref());
         doctor::run_doctor_with_runtime_ports(

--- a/crates/atm/src/commands/members.rs
+++ b/crates/atm/src/commands/members.rs
@@ -228,7 +228,8 @@ mod tests {
     use atm_core::schema::{AgentMember, TeamConfig};
     use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD, TEST_SENDER, TEST_TEAM};
     use atm_runtime_test_support::{
-        SQLITE_RUNTIME_PATH_ENV, install_sqlite_retained_runtime_factory, open_sqlite_boundary,
+        SQLITE_RUNTIME_PATH_ENV, install_sqlite_retained_runtime_factory,
+        open_isolated_sqlite_boundary,
     };
     use serial_test::serial;
     use tempfile::TempDir;
@@ -268,7 +269,6 @@ mod tests {
             install_sqlite_retained_runtime_factory();
             let tempdir = TempDir::new().expect("tempdir");
             let home_dir = tempdir.path().to_path_buf();
-            let sqlite_db_path = home_dir.join("runtime").join("mail.sqlite3");
             let current_dir = tempdir.path().join("workspace");
             fs::create_dir_all(&current_dir).expect("workspace");
             fs::write(
@@ -290,7 +290,7 @@ mod tests {
                 serde_json::to_vec(&config).expect("team config"),
             )
             .expect("write config");
-            let assembly = open_sqlite_boundary(sqlite_db_path).expect("sqlite db");
+            let assembly = open_isolated_sqlite_boundary(&home_dir).expect("sqlite db");
             let team = TEST_TEAM
                 .parse::<atm_core::types::TeamName>()
                 .expect("team");

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -18,8 +18,10 @@ pub mod peek;
 pub mod peer;
 pub mod read;
 pub(crate) mod retained_roster;
+pub mod search;
 pub mod send;
 pub mod teams;
+pub mod templates;
 pub(crate) mod util;
 
 pub use ack::AckCommand;
@@ -35,8 +37,10 @@ pub use members::MembersCommand;
 pub use peek::PeekCommand;
 pub use peer::PeerCommand;
 pub use read::ReadCommand;
+pub use search::SearchCommand;
 pub use send::SendCommand;
 pub use teams::TeamsCommand;
+pub use templates::TemplatesCommand;
 
 use crate::observability::CliObservability;
 
@@ -104,6 +108,7 @@ enum Command {
     Peek(PeekCommand),
     Peer(PeerCommand),
     Read(ReadCommand),
+    Search(SearchCommand),
     Ack(AckCommand),
     Clear(ClearCommand),
     Log(LogCommand),
@@ -116,6 +121,7 @@ enum Command {
     DumpCliSurface(DumpCliSurfaceCommand),
     Teams(TeamsCommand),
     Members(MembersCommand),
+    Templates(TemplatesCommand),
 }
 
 impl Command {
@@ -128,6 +134,7 @@ impl Command {
             Self::Peek(command) => command.run(observability).await,
             Self::Peer(command) => command.run(observability).await,
             Self::Read(command) => command.run(observability).await,
+            Self::Search(command) => command.run(observability).await,
             Self::Ack(command) => command.run(observability).await,
             Self::Clear(command) => command.run(observability).await,
             Self::Log(command) => command.run(observability),
@@ -138,6 +145,7 @@ impl Command {
             Self::DumpCliSurface(command) => command.run(observability),
             Self::Teams(command) => command.run(observability).await,
             Self::Members(command) => command.run(observability).await,
+            Self::Templates(command) => command.run(observability).await,
         }
     }
 }

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -1,0 +1,247 @@
+//! Public typed search CLI surface.
+
+use anyhow::Result;
+use atm_core::search::{SearchAggregateInput, SearchInput, SearchResponse};
+use clap::Args;
+
+use crate::composition::{
+    AtmHomePath, CliComposition, InvocationDir, resolve_command_runtime_context,
+};
+use crate::observability::CliObservability;
+
+/// Search locally indexed ATM messages through the daemon's typed query API.
+#[derive(Debug, Args)]
+#[command(
+    after_help = "Plain positional text is always a literal phrase. --raw-match enables ATM's bounded advanced grammar (words, quoted phrases, NEAR(term term[, distance]), AND, OR, NOT); it never passes raw SQLite FTS syntax."
+)]
+pub struct SearchCommand {
+    /// Literal phrase by default, or an ATM advanced expression with --raw-match.
+    text: Option<String>,
+
+    /// Parse the positional text with ATM's documented bounded advanced grammar.
+    #[arg(long, requires = "text")]
+    raw_match: bool,
+
+    /// Filter stored template frontmatter metadata; a trailing * is a prefix match.
+    #[arg(long = "template-meta", value_name = "KEY=VALUE")]
+    template_meta: Vec<String>,
+
+    /// Shorthand for --template-meta type=VALUE.
+    #[arg(long = "type", value_name = "VALUE")]
+    template_type: Option<String>,
+
+    /// Filter the exact immutable template revision.
+    #[arg(long, value_name = "SHA")]
+    template_sha: Option<String>,
+
+    /// Filter one stored template variable; may be repeated.
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    vars: Vec<String>,
+
+    #[arg(long = "tag", value_name = "VALUE")]
+    tags: Vec<String>,
+
+    #[arg(long)]
+    category: Option<String>,
+
+    #[arg(long)]
+    from: Option<String>,
+
+    #[arg(long)]
+    team: Option<String>,
+
+    #[arg(long)]
+    agent: Option<String>,
+
+    #[arg(long)]
+    since: Option<String>,
+
+    #[arg(long)]
+    until: Option<String>,
+
+    #[arg(long)]
+    limit: Option<u32>,
+
+    #[arg(long)]
+    cursor: Option<String>,
+
+    /// Preserve per-mailbox compound-key identities rather than default deduplication.
+    #[arg(long)]
+    per_mailbox: bool,
+
+    #[arg(long, conflicts_with_all = ["group_by", "min", "max"])]
+    count: bool,
+
+    #[arg(long, value_name = "FIELD", conflicts_with_all = ["count", "min", "max"])]
+    group_by: Option<String>,
+
+    #[arg(long, value_parser = ["message_at"], conflicts_with_all = ["count", "group_by", "max"])]
+    min: Option<String>,
+
+    #[arg(long, value_parser = ["message_at"], conflicts_with_all = ["count", "group_by", "min"])]
+    max: Option<String>,
+
+    #[arg(long)]
+    json: bool,
+}
+
+impl SearchCommand {
+    pub async fn run(self, observability: &CliObservability) -> Result<()> {
+        let (home_dir, current_dir) = resolve_command_runtime_context("search")?;
+        let json = self.json;
+        let request = self.build_request()?;
+        let composition = CliComposition::bootstrap(
+            "search",
+            observability,
+            InvocationDir::new(&current_dir),
+            AtmHomePath::new(&home_dir),
+        )?;
+        let response = composition.search(request).await?;
+        print_search_response(&response, json)
+    }
+
+    fn build_request(&self) -> Result<atm_core::search::SearchRequest> {
+        let mut template_meta = self.template_meta.clone();
+        if let Some(template_type) = &self.template_type {
+            template_meta.push(format!("type={template_type}"));
+        }
+        let request = SearchInput {
+            text: self.text.clone(),
+            raw_match: self.raw_match,
+            template_meta,
+            template_sha: self.template_sha.clone(),
+            vars: self.vars.clone(),
+            tags: self.tags.clone(),
+            category: self.category.clone(),
+            from: self.from.clone(),
+            team: self.team.clone(),
+            agent: self.agent.clone(),
+            since: self.since.clone(),
+            until: self.until.clone(),
+            limit: self.limit,
+            cursor: self.cursor.clone(),
+            per_mailbox: self.per_mailbox,
+            aggregate: self.aggregate(),
+        }
+        .into_request();
+        // Fail before opening a daemon connection while keeping the exact
+        // same core compiler authoritative for HTTP ingress.
+        request.compile_query()?;
+        Ok(request)
+    }
+
+    fn aggregate(&self) -> Option<SearchAggregateInput> {
+        if self.count {
+            Some(SearchAggregateInput::Count)
+        } else if let Some(group_by) = &self.group_by {
+            Some(SearchAggregateInput::GroupBy(group_by.clone()))
+        } else if self.min.is_some() {
+            Some(SearchAggregateInput::MinMessageAt)
+        } else if self.max.is_some() {
+            Some(SearchAggregateInput::MaxMessageAt)
+        } else {
+            None
+        }
+    }
+}
+
+fn print_search_response(response: &SearchResponse, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(response)?);
+        return Ok(());
+    }
+    for hit in &response.hits {
+        let identity = hit
+            .message_id
+            .as_deref()
+            .unwrap_or(hit.key.message_key.as_str());
+        let classification = hit
+            .template_type
+            .as_deref()
+            .or(hit.category.as_deref())
+            .unwrap_or("unclassified");
+        println!(
+            "{identity} {} {} -> {} [{classification}] {}",
+            hit.message_at, hit.from_agent.agent, hit.to_agent.agent, hit.snippet
+        );
+    }
+    if let Some(aggregate) = &response.aggregate {
+        println!("aggregate: {}", serde_json::to_string(aggregate)?);
+    }
+    if let Some(cursor) = &response.next_cursor {
+        println!("next_cursor: {}", cursor.as_str());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchCommand;
+    use clap::Parser;
+
+    #[test]
+    fn documented_search_surface_parses_all_filters() {
+        crate::commands::Cli::try_parse_from([
+            "atm",
+            "search",
+            "assignment",
+            "--template-meta",
+            "document_type=task",
+            "--type",
+            "dev",
+            "--template-sha",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--var",
+            "phase=an",
+            "--tag",
+            "priority",
+            "--category",
+            "work",
+            "--from",
+            "worker",
+            "--team",
+            "atm-dev",
+            "--agent",
+            "arch-ctm",
+            "--since",
+            "2026-01-01T00:00:00Z",
+            "--until",
+            "2026-01-02T00:00:00Z",
+            "--limit",
+            "25",
+            "--per-mailbox",
+            "--count",
+            "--json",
+        ])
+        .expect("search surface must parse");
+    }
+
+    #[test]
+    fn type_is_compiled_as_metadata_sugar() {
+        let command = SearchCommand {
+            text: None,
+            raw_match: false,
+            template_meta: vec![],
+            template_type: Some("dev".to_owned()),
+            template_sha: None,
+            vars: vec![],
+            tags: vec![],
+            category: None,
+            from: None,
+            team: None,
+            agent: None,
+            since: None,
+            until: None,
+            limit: None,
+            cursor: None,
+            per_mailbox: false,
+            count: false,
+            group_by: None,
+            min: None,
+            max: None,
+            json: false,
+        };
+        let request = command.build_request().expect("request");
+        assert_eq!(request.query.template_meta[0], "type=dev");
+    }
+}

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -177,6 +177,7 @@ fn print_search_response(response: &SearchResponse, json: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::SearchCommand;
+    use atm_core::test_support::TEST_TEAM;
     use clap::Parser;
 
     #[test]
@@ -200,7 +201,7 @@ mod tests {
             "--from",
             "worker",
             "--team",
-            "atm-dev",
+            TEST_TEAM,
             "--agent",
             "arch-ctm",
             "--since",

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -177,7 +177,7 @@ fn print_search_response(response: &SearchResponse, json: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::SearchCommand;
-    use atm_core::test_support::TEST_TEAM;
+    use atm_core::test_support::{TEST_ARCH_CTM, TEST_TEAM};
     use clap::Parser;
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
             "--team",
             TEST_TEAM,
             "--agent",
-            "arch-ctm",
+            TEST_ARCH_CTM,
             "--since",
             "2026-01-01T00:00:00Z",
             "--until",
@@ -257,8 +257,9 @@ mod tests {
             if flag_and_value.0 == "--group-by" {
                 arguments = vec!["atm", "search", "--group-by", flag_and_value.1];
             }
-            let command = crate::commands::Cli::try_parse_from(arguments).expect("CLI grammar");
-            let crate::commands::Cli::Search(command) = command else {
+            let crate::commands::Cli { command, .. } =
+                crate::commands::Cli::try_parse_from(arguments).expect("CLI grammar");
+            let super::super::Command::Search(command) = command else {
                 unreachable!("search command")
             };
             let error = command

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -100,7 +100,7 @@ impl SearchCommand {
         print_search_response(&response, json)
     }
 
-    fn build_request(&self) -> Result<atm_core::search::SearchRequest> {
+    pub(crate) fn build_request(&self) -> Result<atm_core::search::SearchRequest> {
         let mut template_meta = self.template_meta.clone();
         if let Some(template_type) = &self.template_type {
             template_meta.push(format!("type={template_type}"));
@@ -244,5 +244,27 @@ mod tests {
         };
         let request = command.build_request().expect("request");
         assert_eq!(request.query.template_meta[0], "type=dev");
+    }
+
+    #[test]
+    fn malformed_query_keys_fail_at_the_real_cli_command_boundary() {
+        for flag_and_value in [
+            ("--template-meta", "../phase=an"),
+            ("--var", "phase/path=an"),
+            ("--group-by", "var:../../phase"),
+        ] {
+            let mut arguments = vec!["atm", "search", flag_and_value.0, flag_and_value.1];
+            if flag_and_value.0 == "--group-by" {
+                arguments = vec!["atm", "search", "--group-by", flag_and_value.1];
+            }
+            let command = crate::commands::Cli::try_parse_from(arguments).expect("CLI grammar");
+            let crate::commands::Cli::Search(command) = command else {
+                unreachable!("search command")
+            };
+            let error = command
+                .build_request()
+                .expect_err("invalid public key must reject");
+            assert!(error.to_string().contains("search key"), "{error}");
+        }
     }
 }

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -402,7 +402,8 @@ mod tests {
     use atm_core::schema::{AgentMember, TeamConfig};
     use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD, TEST_SENDER, TEST_TEAM};
     use atm_runtime_test_support::{
-        SQLITE_RUNTIME_PATH_ENV, install_sqlite_retained_runtime_factory, open_sqlite_boundary,
+        SQLITE_RUNTIME_PATH_ENV, install_sqlite_retained_runtime_factory,
+        open_isolated_sqlite_boundary,
     };
     use serial_test::serial;
     use tempfile::TempDir;
@@ -516,7 +517,6 @@ mod tests {
             install_sqlite_retained_runtime_factory();
             let tempdir = TempDir::new().expect("tempdir");
             let home_dir = tempdir.path().to_path_buf();
-            let sqlite_db_path = home_dir.join("runtime").join("mail.sqlite3");
             let current_dir = tempdir.path().join("workspace");
             fs::create_dir_all(&current_dir).expect("workspace");
             fs::write(
@@ -546,7 +546,7 @@ mod tests {
                 "[]",
             )
             .expect("write inbox");
-            let assembly = open_sqlite_boundary(sqlite_db_path).expect("sqlite db");
+            let assembly = open_isolated_sqlite_boundary(&home_dir).expect("sqlite db");
             let team = TEST_TEAM
                 .parse::<atm_core::types::TeamName>()
                 .expect("team");

--- a/crates/atm/src/commands/templates.rs
+++ b/crates/atm/src/commands/templates.rs
@@ -1,0 +1,184 @@
+//! Immutable template catalog introspection commands.
+
+use anyhow::Result;
+use atm_core::{TemplateSha, with_default_local_service_runtime};
+use atm_storage::{TemplateListFilter, TemplateSummary};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::composition::install_local_runtime_for_read_only_command;
+
+/// Inspect immutable templates registered by decomposed-message admission.
+#[derive(Debug, Args)]
+pub struct TemplatesCommand {
+    #[command(subcommand)]
+    command: TemplatesSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum TemplatesSubcommand {
+    /// List every known immutable template revision, optionally by metadata type.
+    List {
+        #[arg(long = "type")]
+        template_type: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the stored schema/frontmatter for one exact immutable SHA.
+    Schema {
+        sha: TemplateSha,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+impl TemplatesCommand {
+    pub async fn run(self, _observability: &crate::observability::CliObservability) -> Result<()> {
+        install_local_runtime_for_read_only_command()?;
+        match self.command {
+            TemplatesSubcommand::List {
+                template_type,
+                json,
+            } => list(template_type, json),
+            TemplatesSubcommand::Schema { sha, json } => schema(sha, json),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct TemplateSummaryOutput<'a> {
+    template_sha: &'a str,
+    template_type: Option<&'a str>,
+    template_name: Option<&'a str>,
+    first_seen_at: String,
+    first_seen_by: &'a str,
+}
+
+fn list(template_type: Option<String>, json: bool) -> Result<()> {
+    let templates = with_default_local_service_runtime(|runtime| {
+        runtime
+            .template_catalog_store()
+            .ok_or_else(|| {
+                atm_core::error::AtmError::daemon_unavailable(
+                    "template catalog is not installed in the local runtime",
+                )
+            })?
+            .list(TemplateListFilter { template_type })
+    })?;
+    if json {
+        let output = templates.iter().map(summary_output).collect::<Vec<_>>();
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        for template in &templates {
+            println!(
+                "{} {} {} {} {}",
+                template.sha,
+                template.template_type.as_deref().unwrap_or("-"),
+                template.template_name.as_deref().unwrap_or("-"),
+                template.first_seen.at,
+                template.first_seen.by,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn schema(sha: TemplateSha, json: bool) -> Result<()> {
+    let template = with_default_local_service_runtime(|runtime| {
+        runtime
+            .template_catalog_store()
+            .ok_or_else(|| {
+                atm_core::error::AtmError::daemon_unavailable(
+                    "template catalog is not installed in the local runtime",
+                )
+            })?
+            .load(&sha)
+    })?
+    .ok_or_else(|| anyhow::anyhow!("no immutable template is registered for SHA {sha}"))?;
+    let value = serde_json::json!({
+        "template_sha": template.sha,
+        "template_type": template.template_type,
+        "template_name": template.template_name,
+        "first_seen_at": template.first_seen.at.to_string(),
+        "first_seen_by": template.first_seen.by,
+        "schema_json": template.frontmatter,
+    });
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("template_sha: {}", template.sha);
+        println!(
+            "template_type: {}",
+            template.template_type.as_deref().unwrap_or("-")
+        );
+        println!(
+            "template_name: {}",
+            template.template_name.as_deref().unwrap_or("-")
+        );
+        println!("first_seen_at: {}", template.first_seen.at);
+        println!("first_seen_by: {}", template.first_seen.by);
+        println!("schema_json:");
+        println!("{}", serde_json::to_string_pretty(&template.frontmatter)?);
+    }
+    Ok(())
+}
+
+fn summary_output(template: &TemplateSummary) -> TemplateSummaryOutput<'_> {
+    TemplateSummaryOutput {
+        template_sha: template.sha.as_str(),
+        template_type: template.template_type.as_deref(),
+        template_name: template.template_name.as_deref(),
+        first_seen_at: template.first_seen.at.to_string(),
+        first_seen_by: &template.first_seen.by,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use atm_storage::{TemplateFirstSeen, TemplateSummary};
+    use clap::Parser;
+
+    use super::summary_output;
+
+    #[test]
+    fn documented_template_introspection_surface_parses() {
+        crate::commands::Cli::try_parse_from([
+            "atm",
+            "templates",
+            "list",
+            "--type",
+            "dev",
+            "--json",
+        ])
+        .expect("list");
+        crate::commands::Cli::try_parse_from([
+            "atm",
+            "templates",
+            "schema",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--json",
+        ])
+        .expect("schema");
+    }
+
+    #[test]
+    fn list_output_carries_every_field_needed_to_construct_a_query() {
+        let summary = TemplateSummary {
+            sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse()
+                .expect("SHA"),
+            template_type: Some("qa-report".to_owned()),
+            template_name: Some("qa".to_owned()),
+            first_seen: TemplateFirstSeen::new(
+                "2026-08-12T00:00:00Z".parse().expect("timestamp"),
+                "arch-ctm",
+            )
+            .expect("first seen"),
+        };
+        let value = serde_json::to_value(summary_output(&summary)).expect("JSON");
+        assert_eq!(value["template_sha"], summary.sha.as_str());
+        assert_eq!(value["template_type"], "qa-report");
+        assert_eq!(value["template_name"], "qa");
+        assert_eq!(value["first_seen_by"], "arch-ctm");
+    }
+}

--- a/crates/atm/src/commands/templates.rs
+++ b/crates/atm/src/commands/templates.rs
@@ -135,6 +135,7 @@ fn summary_output(template: &TemplateSummary) -> TemplateSummaryOutput<'_> {
 
 #[cfg(test)]
 mod tests {
+    use atm_core::test_support::TEST_ARCH_CTM;
     use atm_storage::{TemplateFirstSeen, TemplateSummary};
     use clap::Parser;
 
@@ -171,7 +172,7 @@ mod tests {
             template_name: Some("qa".to_owned()),
             first_seen: TemplateFirstSeen::new(
                 "2026-08-12T00:00:00Z".parse().expect("timestamp"),
-                "arch-ctm",
+                TEST_ARCH_CTM,
             )
             .expect("first seen"),
         };
@@ -179,6 +180,6 @@ mod tests {
         assert_eq!(value["template_sha"], summary.sha.as_str());
         assert_eq!(value["template_type"], "qa-report");
         assert_eq!(value["template_name"], "qa");
-        assert_eq!(value["first_seen_by"], "arch-ctm");
+        assert_eq!(value["first_seen_by"], TEST_ARCH_CTM);
     }
 }

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -5,7 +5,9 @@
 
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Once};
+use std::sync::Arc;
+#[cfg(not(test))]
+use std::sync::Once;
 
 use async_trait::async_trait;
 use atm_core::ack::{AckOutcome, AckRequest};
@@ -19,6 +21,7 @@ use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::{PeekQuery, ReadOutcome, ReadQuery};
+use atm_core::search::{SearchRequest, SearchResponse};
 use atm_core::send::{SendOutcome, SendRequest};
 #[cfg(not(test))]
 use atm_daemon_bootstrap::install_sqlite_retained_runtime_factory;
@@ -28,12 +31,14 @@ use atm_daemon_client::{resolve_daemon_local_ipc_endpoint, unexpected_response};
 use atm_http_runtime::SAME_HOST_REQUEST_DEADLINE;
 #[cfg(test)]
 use atm_runtime_test_support::{
-    SQLITE_RUNTIME_PATH_ENV,
-    install_sqlite_retained_runtime_factory as install_test_runtime_factory, open_sqlite_boundary,
+    install_isolated_sqlite_runtime,
+    install_sqlite_retained_runtime_factory as install_test_runtime_factory,
+    open_isolated_sqlite_boundary,
 };
 
 use crate::observability::CliObservability;
 
+#[cfg(not(test))]
 static INSTALL_RETAINED_RUNTIME_FACTORY: Once = Once::new();
 
 #[cfg(not(test))]
@@ -45,9 +50,18 @@ fn install_retained_runtime_factory() {
 
 #[cfg(test)]
 fn install_retained_runtime_factory() {
-    INSTALL_RETAINED_RUNTIME_FACTORY.call_once(|| {
-        install_test_runtime_factory();
-    });
+    // Tests that exercise direct-local doctor composition install the
+    // production bootstrap factory in this process. Reinstall the isolated
+    // fixture factory for every CLI composition so parallel test ordering can
+    // never redirect a fixture to the live host mailbox.
+    install_test_runtime_factory();
+}
+
+/// Installs the local read-only runtime composition used by immutable catalog
+/// introspection.  It does not start or route through the frozen daemon.
+pub(crate) fn install_local_runtime_for_read_only_command() -> Result<(), AtmError> {
+    install_retained_runtime_factory();
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -357,6 +371,16 @@ impl<'a> CliComposition<'a> {
         }
     }
 
+    pub(crate) async fn search(&self, request: SearchRequest) -> Result<SearchResponse, AtmError> {
+        match self
+            .execute_request(RequestEnvelope::Search(request))
+            .await?
+        {
+            ResponseEnvelope::Search(response) => Ok(response),
+            other => Err(unexpected_response("search", other)),
+        }
+    }
+
     pub(crate) async fn clear(&self, query: ClearQuery) -> Result<ClearOutcome, AtmError> {
         match self.execute_request(RequestEnvelope::Clear(query)).await? {
             ResponseEnvelope::Clear(outcome) => {
@@ -488,8 +512,9 @@ mod tests {
     use tracing_subscriber::fmt::MakeWriter;
 
     use super::{
-        CliComposition, HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard, SQLITE_RUNTIME_PATH_ENV,
-        open_sqlite_boundary, resolve_command_runtime_context,
+        CliComposition, HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard,
+        install_isolated_sqlite_runtime, open_isolated_sqlite_boundary,
+        resolve_command_runtime_context,
     };
     use crate::observability::CliObservability;
 
@@ -558,6 +583,7 @@ mod tests {
 
     struct LoopbackFixture {
         _env_guard: EnvGuard,
+        _runtime_guard: atm_runtime_test_support::SqliteRuntimeGuard,
         _tempdir: TempDir,
         home_dir: std::path::PathBuf,
         current_dir: std::path::PathBuf,
@@ -568,22 +594,17 @@ mod tests {
             super::install_retained_runtime_factory();
             let tempdir = tempfile::tempdir().expect("tempdir");
             let home_dir = tempdir.path().to_path_buf();
-            let sqlite_db_path = home_dir.join("runtime").join("mail.sqlite3");
             let current_dir = tempdir.path().join("cwd");
             fs::create_dir_all(&current_dir).expect("cwd");
             fs::write(current_dir.join(".atm.toml"), "[atm]\n").expect("fixture atm config");
-            let env_guard = EnvGuard::set_many([
-                (
-                    "ATM_HOME",
-                    Some(home_dir.to_str().expect("utf-8 tempdir path")),
-                ),
-                (
-                    SQLITE_RUNTIME_PATH_ENV,
-                    Some(sqlite_db_path.to_str().expect("utf-8 sqlite db path")),
-                ),
-            ]);
+            let env_guard = EnvGuard::set_many([(
+                "ATM_HOME",
+                Some(home_dir.to_str().expect("utf-8 tempdir path")),
+            )]);
+            let runtime_guard = install_isolated_sqlite_runtime(&home_dir);
             let fixture = Self {
                 _env_guard: env_guard,
+                _runtime_guard: runtime_guard,
                 _tempdir: tempdir,
                 home_dir,
                 current_dir,
@@ -600,10 +621,6 @@ mod tests {
             self.team_dir()
                 .join("inboxes")
                 .join(format!("{agent}.json"))
-        }
-
-        fn sqlite_db_path(&self) -> std::path::PathBuf {
-            self.home_dir.join("runtime").join("mail.sqlite3")
         }
 
         fn write_team_config(&self, recipient: &str) {
@@ -628,7 +645,7 @@ mod tests {
         }
 
         fn seed_sqlite_roster(&self, recipient: &str) {
-            let assembly = open_sqlite_boundary(self.sqlite_db_path()).expect("sqlite db");
+            let assembly = open_isolated_sqlite_boundary(&self.home_dir).expect("sqlite db");
             let roster_store = assembly.roster_store_arc();
             let team = TEST_TEAM.parse::<TeamName>().expect("team");
             let members = [TEST_SENDER, recipient, TEST_LEAD]
@@ -669,8 +686,8 @@ mod tests {
         }
 
         fn inbox_contents(&self, agent: &str) -> Vec<InboxMessage> {
-            if self.sqlite_db_path().exists() {
-                let assembly = open_sqlite_boundary(self.sqlite_db_path()).expect("sqlite db");
+            if self.home_dir.join("runtime").join("mail.sqlite3").exists() {
+                let assembly = open_isolated_sqlite_boundary(&self.home_dir).expect("sqlite db");
                 let mail_store = assembly.mail_store_arc();
                 let team = TEST_TEAM.parse::<TeamName>().expect("team");
                 let agent_name = agent.parse::<AgentName>().expect("agent");
@@ -718,7 +735,7 @@ mod tests {
         }
 
         fn seed_sqlite_mailbox(&self, agent: &str, messages: &[InboxMessage]) {
-            let assembly = open_sqlite_boundary(self.sqlite_db_path()).expect("sqlite db");
+            let assembly = open_isolated_sqlite_boundary(&self.home_dir).expect("sqlite db");
             let mail_store = assembly.mail_store_arc();
             let team = TEST_TEAM.parse::<TeamName>().expect("team");
             let agent_name = agent.parse::<AgentName>().expect("agent");

--- a/crates/atm/tests/openapi_surface.rs
+++ b/crates/atm/tests/openapi_surface.rs
@@ -88,6 +88,21 @@ fn response_shape(value: &Value) -> Value {
     json!({ "error": error, "schema": schema })
 }
 
+fn operation_has_required_input(operation: &Value) -> bool {
+    operation
+        .pointer("/requestBody/required")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || operation
+            .get("parameters")
+            .and_then(Value::as_array)
+            .is_some_and(|parameters| {
+                parameters.iter().any(|parameter| {
+                    parameter.get("required").and_then(Value::as_bool) == Some(true)
+                })
+            })
+}
+
 fn live_surface() -> Value {
     let source = std::fs::read_to_string(document_path()).expect("read OpenAPI contract");
     let document: Value = serde_yaml::from_str(&source).expect("parse OpenAPI YAML");
@@ -108,7 +123,7 @@ fn live_surface() -> Value {
                 method,
                 json!({
                     "operation_id": operation["operationId"],
-                    "request_required": operation.pointer("/requestBody/required").and_then(Value::as_bool).unwrap_or(false),
+                    "request_required": operation_has_required_input(operation),
                     "responses": responses,
                 }),
             );

--- a/crates/atm/tests/openapi_surface_baseline.json
+++ b/crates/atm/tests/openapi_surface_baseline.json
@@ -124,6 +124,22 @@
         }
       }
     },
+    "/messages/search": {
+      "get": {
+        "operation_id": "searchMessages",
+        "request_required": true,
+        "responses": {
+          "200": {
+            "error": false,
+            "schema": "#/components/schemas/SearchResponse"
+          },
+          "default": {
+            "error": true,
+            "schema": "#/components/responses/AtmError"
+          }
+        }
+      }
+    },
     "/runtime/reload": {
       "post": {
         "operation_id": "reloadRuntimeView",
@@ -220,6 +236,43 @@
     "ReadQuery": {
       "properties": [],
       "required": []
+    },
+    "SearchHit": {
+      "properties": [
+        "category",
+        "from_agent",
+        "key",
+        "message_at",
+        "message_id",
+        "snippet",
+        "template_type",
+        "to_agent"
+      ],
+      "required": [
+        "from_agent",
+        "key",
+        "message_at",
+        "snippet",
+        "to_agent"
+      ]
+    },
+    "SearchRequest": {
+      "properties": [
+        "query"
+      ],
+      "required": [
+        "query"
+      ]
+    },
+    "SearchResponse": {
+      "properties": [
+        "aggregate",
+        "hits",
+        "next_cursor"
+      ],
+      "required": [
+        "hits"
+      ]
     },
     "WriteRequest": {
       "properties": [

--- a/docs/atm-daemon/http-api.md
+++ b/docs/atm-daemon/http-api.md
@@ -64,6 +64,7 @@ tests.
 | Endpoint | Method | Meaning | Shared handler |
 | --- | --- | --- | --- |
 | `/v1/atm/messages` | `GET` | List/query visible messages; non-mutating | read/query |
+| `/v1/atm/messages/search` | `GET` | Local-only typed template/message search | query |
 | `/v1/atm/messages` | `POST` | Create/send immutable message | canonical write |
 | `/v1/atm/messages/inspect` | `POST` | Inspect/query messages without mutation | read/query |
 | `/v1/atm/messages` | `DELETE` | Clear selected messages where authorized | clear |
@@ -79,6 +80,16 @@ filters. `agent=hendrix` searches that base agent across every chat identity;
 `agent=hendrix&chat_id=12345` narrows to `hendrix:12345`. Filters apply to the
 selected participant direction when a direction is requested, otherwise to
 either message participant. They do not alter the authenticated caller.
+
+`GET /v1/atm/messages/search` accepts one required `request` query parameter:
+unpadded URL-safe base64 of the documented JSON `SearchRequest`, and returns
+`SearchResponse`. The canonical SDK encodes this parameter; the explicit form
+also makes the complete query safe for ordinary HTTP GET tooling. It is
+accepted only from authenticated
+local UDS or capability-loopback transports. Direct-peer requests receive a
+typed local-only authorization error before any storage query runs. The full
+filter grammar and analyst SQL boundary are versioned in
+[`docs/atm-query-surface.md`](../atm-query-surface.md).
 
 An acknowledgement uses the same `WriteRequest` sent to `POST /messages`, with
 only `acknowledges_message_id` populated. The receiver's canonical write

--- a/docs/atm-http-runtime/openapi.yaml
+++ b/docs/atm-http-runtime/openapi.yaml
@@ -6,6 +6,19 @@ info:
 servers:
   - url: /v1/atm
 paths:
+  /messages/search:
+    get:
+      operationId: searchMessages
+      description: Local-only typed search. Peer-authenticated callers are rejected before storage selection.
+      parameters:
+        - name: request
+          in: query
+          required: true
+          description: Unpadded URL-safe base64 encoding of the JSON SearchRequest contract.
+          schema: { type: string, format: base64url }
+      responses:
+        '200': { description: Local typed search result, content: { application/json: { schema: { $ref: '#/components/schemas/SearchResponse' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
   /messages:
     get:
       operationId: listMessages
@@ -114,6 +127,32 @@ components:
     ListQuery:
       type: object
       description: Canonical list query; fields are validated by the daemon.
+    SearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: object
+          description: Public CLI/HTTP primitives compiled by atm-core into the bounded backend-neutral search query.
+    SearchResponse:
+      type: object
+      required: [hits]
+      properties:
+        hits: { type: array, items: { $ref: '#/components/schemas/SearchHit' } }
+        aggregate: { type: object }
+        next_cursor: { type: string }
+    SearchHit:
+      type: object
+      required: [key, message_at, from_agent, to_agent, snippet]
+      properties:
+        key: { type: object }
+        message_id: { type: string }
+        message_at: { type: string, format: date-time }
+        from_agent: { $ref: '#/components/schemas/AgentAddress' }
+        to_agent: { $ref: '#/components/schemas/AgentAddress' }
+        template_type: { type: string }
+        category: { type: string }
+        snippet: { type: string }
     CompatibilityPreflight:
       type: object
       description: Client and daemon release compatibility request.

--- a/docs/atm-query-surface.md
+++ b/docs/atm-query-surface.md
@@ -1,30 +1,67 @@
-# ATM local query surface
+# ATM query surface v1
 
-## `decomposed_messages` v1
+ATM stores generic template identity, frontmatter and merged variables. It
+does not reserve orchestration vocabulary: agents discover available template
+schemas, then form typed queries from the values actually stored.
 
-`decomposed_messages` is the versioned, read-only SQLite view for local
-consumers that need durable decomposed-template metadata. It is the supported
-SQL surface; the underlying `mail_messages`, `message_templates`, and
-`mail_message_states` tables remain implementation details.
+## Introspection
 
-Version 1 exposes exactly these columns, in this order:
+`atm templates list [--type TYPE] [--json]` lists every immutable registered
+revision matching the optional conventional `metadata.type` value. Each row
+contains `template_sha`, `template_type`, `template_name`, `first_seen_at`,
+and `first_seen_by`. A type can legitimately select several revisions.
 
-1. `team`
-2. `agent`
-3. `from_agent`
-4. `message_at`
-5. `message_id`
-6. `template_sha`
-7. `template_type`
-8. `vars_json`
-9. `category`
-10. `tags_json`
-11. `summary`
-12. `read`
-13. `acknowledged_at`
-14. `pending_ack_at`
+`atm templates schema SHA [--json]` performs an exact SHA lookup and returns
+the stored frontmatter as `schema_json`; it never chooses an arbitrary
+revision during template drift.
 
-The view contains only rows whose `template_sha` resolves to a durable,
-immutable catalog entry. It is created additively for both fresh and migrated
-SQLite databases. Future changes require a separately versioned view; callers
-must not depend on base-table column layout.
+## Typed message search
+
+`atm search [TEXT]` and `GET /v1/atm/messages/search` use the same typed
+contract. The HTTP endpoint is bodyless: its required `request` URL query
+parameter is unpadded URL-safe base64 of the JSON `SearchRequest`, so no
+second filter grammar exists at the HTTP boundary. `TEXT` is a literal phrase
+by default — punctuation such as `NEAR`,
+boolean operators and FTS column syntax have no special meaning. `--raw-match`
+enables only ATM's bounded grammar: words, quoted phrases, `AND`, `OR`,
+`NOT`, and `NEAR(term term[, distance])` expressions. They may be composed
+with the same bounded boolean grammar; parsing finishes before storage sees it
+and is never raw FTS5 syntax.
+
+Generic filters are `--template-meta KEY=VALUE`, `--type VALUE` (the `type`
+metadata shorthand), `--template-sha SHA`, repeatable `--var KEY=VALUE`,
+`--tag`, `--category`, `--from`, `--team`, `--agent`, `--since`, `--until`,
+`--limit`, `--cursor`, and `--per-mailbox`. Keys match
+`^[A-Za-z_][A-Za-z0-9_-]{0,63}$`; every value is parameterized by the storage
+adapter. Simple aggregates use the same filters: `--count`,
+`--group-by var:KEY|team|agent|from_agent|template_type|category`, and
+`--min message_at` / `--max message_at`.
+
+Template-metadata values are exact by default; a final `*` requests the
+documented prefix match (`--type qa-*`). Variable values are always exact.
+
+The HTTP search endpoint is local-only. Authenticated UDS and capability
+loopback callers may search; a peer request is rejected by core policy before
+any search capability is selected.
+
+## Analyst SQL extension
+
+`atm-query-python` builds the local Python module `atm_query`:
+
+```python
+from atm_query import open_readonly
+
+rows = open_readonly().query(
+    "SELECT team, agent, template_type FROM decomposed_messages WHERE template_type = ?",
+    ("qa-report",),
+)
+```
+
+It is the analytical escape hatch, not a network client. With no explicit
+path, it opens the current OS account's `~/.atm/db/mail.db`, never a
+workspace-selected `ATM_HOME` database. It uses `query_only`, defensive
+settings, an SQLite authorizer, one prepared read-only statement, parameter
+binding, and fixed execution/row/result-byte budgets. The authorizer permits
+the versioned `decomposed_messages` view (and the view's internal reads) but
+does not expose base tables as a contract. Raw SQL is never accepted by the
+ATM CLI, HTTP endpoint, `atm-core`, peer ingress, or `atm-graft`.

--- a/docs/atm-rusqlite/boundaries.md
+++ b/docs/atm-rusqlite/boundaries.md
@@ -15,6 +15,7 @@ Current design assumption:
 
 Canonical machine-readable boundary sources:
 - [`boundaries/atm-storage-rusqlite/message-search-store-sqlite.toml`](../../boundaries/atm-storage-rusqlite/message-search-store-sqlite.toml)
+- [`boundaries/atm-storage-rusqlite/analyst-query-store-sqlite.toml`](../../boundaries/atm-storage-rusqlite/analyst-query-store-sqlite.toml)
 - [`boundaries/atm-rusqlite/mail-store-sqlite.toml`](../../boundaries/atm-rusqlite/mail-store-sqlite.toml)
 - [`boundaries/atm-rusqlite/mail-store-doctor-sqlite.toml`](../../boundaries/atm-rusqlite/mail-store-doctor-sqlite.toml)
 - [`boundaries/atm-rusqlite/task-store-sqlite.toml`](../../boundaries/atm-rusqlite/task-store-sqlite.toml)
@@ -45,8 +46,15 @@ opens a direct SQLite search connection.
 
 AA.5 relock note:
 - `cargo test --package atm-architecture` is the second enforcement layer that
-  detects policy widening and any reintroduced `atm-daemon -> atm-rusqlite`
-  code edge before review closure
+detects policy widening and any reintroduced `atm-daemon -> atm-rusqlite`
+code edge before review closure
+
+## SqliteAnalystQueryStore
+
+The private analyst adapter is the only direct SQLite dependency of the local
+`atm-query-python` Maturin facade. It owns the read-only connection authorizer
+and query budgets. Daemon, HTTP runtime, CLI, and graft crates remain forbidden
+dependents; they use the typed runtime search port instead.
 
 ## SqliteBoundaryAssembly
 

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -28,6 +28,17 @@ trait exposes SQL, FTS syntax, renderer handles, or HTTP DTOs. The concrete
 SQLite adapter owns FTS5/JSON1 compilation and a bounded reader lane; HTTP
 consumers only await this port.
 
+## AnalystQueryStore
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-storage/analyst-query-store.toml](../../boundaries/atm-storage/analyst-query-store.toml)
+
+`AnalystQueryStore` is a separate, local-only read interface for the
+`atm-query-python` Maturin binding. It is not a widening of the daemon's
+`MessageSearchStore`: the binding is the only non-storage consumer, the
+concrete SQLite adapter owns connection authorization and query budgets, and
+the contract exposes neither SQLite handles nor any write or network operation.
+
 ## TlsHelpers
 
 Canonical machine-readable boundary source:

--- a/docs/plans/phase-an/AN6-worktree-checklist.md
+++ b/docs/plans/phase-an/AN6-worktree-checklist.md
@@ -1,0 +1,40 @@
+# AN.6 worktree closure checklist
+
+This file is the implementation checklist for `feature/pan-s6-query-surface`.
+It is intentionally checked only when the implementation and its regression
+coverage are both present.  The frozen daemon is explicitly out of scope;
+every network exercise below uses the Tokio/Axum `atm-http-runtime` path.
+
+## First pass — plan-to-code inventory
+
+- [x] Define the core, transport-neutral query/introspection contracts and
+  one bounded parser from CLI/HTTP primitives to AN.5 `MessageSearchQuery`.
+- [x] Install the search and template-catalog capabilities through runtime
+  assembly and make peer search reject before capability selection.
+- [x] Add `atm templates list` / `atm templates schema` with text and JSON
+  renderers, exact-SHA schema lookup, and type-filter coverage.
+- [x] Add `atm search`, including literal versus `--raw-match` parsing, every
+  generic filter, aggregations, cursor/per-mailbox semantics, and text/JSON
+  renderers.
+- [x] Register the core-owned `GET /v1/atm/messages/search` codec/route and
+  make the Axum runtime a thin async adapter.
+- [x] Document and snapshot the public HTTP and query contracts.
+- [x] Add the separate local-only `atm-query-python` Maturin crate with
+  SQLite read-only, authorizer, single-statement, and resource-budget gates.
+- [x] Add corpus/parity, parser/key/injection, aggregate/cursor, local/peer,
+  and Python security acceptance tests.
+
+## Second pass — closure review
+
+- [x] Re-read the sprint plan against the completed diff and close uncovered
+  requirements before declaring the sprint ready.
+  - The second pass found and closed two omissions: serialization coverage now
+    round-trips every simple aggregate form, and the Python fixture proves the
+    three documented analyst queries against the stable view using bound
+    parameters.
+  - Confirmed no raw SQL crosses CLI, HTTP, peer, `atm-core`, or graft; peer
+    rejection precedes search-store selection; the frozen daemon remains
+    untouched.
+- [x] Run formatter, focused tests, and the complete `just test` suite.
+  - Passed `cargo fmt --all --check`, targeted clippy with `-D warnings`, and
+    `CARGO_TARGET_DIR=/tmp/atm-an6-clean-target just test`.

--- a/docs/plans/phase-an/sprint-AN6-query-surface.md
+++ b/docs/plans/phase-an/sprint-AN6-query-surface.md
@@ -61,7 +61,7 @@ hardening.
 ```rust
 pub struct SearchRequest {
     /// Transport-neutral core input, decoded from CLI flags or HTTP query.
-    pub query: MessageSearchQuery,
+    pub query: SearchInput,
 }
 
 pub struct SearchResponse {
@@ -74,14 +74,20 @@ pub struct SearchHit {
     pub key: SearchResultKey,
     pub message_id: Option<String>, // display/dedup metadata, never identity
     pub message_at: IsoTimestamp,
-    pub from_agent: AgentAddress,
-    pub to_agent: AgentAddress,
+    pub from_agent: StoredSearchAddress,
+    pub to_agent: StoredSearchAddress,
     pub template_type: Option<String>,
     pub category: Option<String>,
     pub snippet: String,
 }
 
 ```
+
+`SearchInput` is the stable public primitive DTO. Core compiles it to the
+backend-neutral `MessageSearchQuery`; that backend type is not an HTTP or CLI
+wire contract. `StoredSearchAddress` contains agent, team, and optional chat
+ID. Durable search rows do not record a host, so the response never invents
+one. Peer requests reject with `ATM_SEARCH_LOCAL_ONLY` before storage selection.
 
    The route is local-only: core rejects `AuthenticatedIngress::Peer` with a
    documented typed authorization error before selecting a storage capability.
@@ -103,7 +109,8 @@ pub struct SearchHit {
    network client and not part of `atm-graft-python`. Its explicit API is
    `open_readonly(database_path=None).query(sql, parameters=())`; it accepts
    one parameterized statement and returns column-labelled Python rows.
-   The extension opens the selected ATM database read-only and enforces
+   The extension selects the existing `atm-storage` analyst-query capability;
+   `atm-storage-rusqlite` alone opens the selected ATM database read-only and enforces
    `PRAGMA query_only=ON`, defensive connection settings, an SQLite authorizer
    that denies DML/DDL/transaction/attach/detach/extension-load actions, no
    executable tail after the first prepared statement, and SQLite's


### PR DESCRIPTION
## AN.6 — Query Surface\n\nImplements the AN.6 plan on top of integrate/phase-an.\n\n- transport-neutral typed search contract shared by CLI and local-only HTTP GET /v1/atm/messages/search\n- bounded literal/advanced grammar, generic filters, aggregates, cursor/dedup semantics, and peer rejection before storage selection\n- atm templates list/schema introspection and atm search CLI\n- separate atm-query-python Maturin extension with single-statement parameterized local read-only safeguards\n- OpenAPI/API docs, snapshots, corpus/security/contract tests\n- corrected SQLite WAL setup uncovered by the full suite\n\nValidation: cargo fmt --all --check; strict targeted cargo clippy -- -D warnings; CARGO_TARGET_DIR=/tmp/atm-an6-clean-target just test.\n\nHead: 8bdc985ac392b1eb9f6ad47794deec30e3c86c06