### PR TITLE
fix(phase-an): close AN.6 query-surface findings (AN6-QUERYFIX-1)

### DIFF
--- a/.triage/phase-an/findings/AN6-CONTRACT-001.ttl
+++ b/.triage/phase-an/findings/AN6-CONTRACT-001.ttl
@@ -15,21 +15,26 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "branch" ;
-  triage:status "open" ;
+  triage:status "closed" ;
+  triage:resolution "fixed" ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): the maintained sprint contract and core types are aligned on SearchInput, StoredSearchAddress, and ATM_SEARCH_LOCAL_ONLY. Existing seeded UDS/loopback search parity, typed local-only rejection, and response aggregate coverage are retained; this round adds a response snapshot with sender/recipient team and chat-id dimensions, proving those fields survive the HTTP contract serialization boundary." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:foundIn triage:AN.6 ;
   triage:foundAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AN6-CONTRACT-001/1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AN6-CONTRACT-001/1>
   a triage:Occurrence ;
   triage:file "crates/atm-http-runtime/src/search.rs" ;
   triage:line 1 ;
   triage:snippet "SearchRequest/SearchHit type divergence from sprint doc; missing UDS/loopback integration test" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): HTTP search contract response snapshot now covers address dimensions in addition to all SearchAggregate variants." ;
   triage:branch "feature/pan-s6-query-surface" ;
   triage:headSha "8bdc985ac392b1eb9f6ad47794deec30e3c86c06" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pan-s6-query-surface> .

--- a/.triage/phase-an/findings/AN6-KEYBOUNDARY-001.ttl
+++ b/.triage/phase-an/findings/AN6-KEYBOUNDARY-001.ttl
@@ -15,21 +15,26 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "branch" ;
-  triage:status "open" ;
+  triage:status "closed" ;
+  triage:resolution "fixed" ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): malformed metadata, variable, and group-by keys are exercised through the real CLI and HTTP decoding paths; both compile through the same core validator and assert the stable MessageValidationFailed code. The HTTP path also remains covered by the existing transport decoder test." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:foundIn triage:AN.6 ;
   triage:foundAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AN6-KEYBOUNDARY-001/1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AN6-KEYBOUNDARY-001/1>
   a triage:Occurrence ;
   triage:file "crates/atm-core/src/search/mod.rs" ;
   triage:line 1 ;
   triage:snippet "SearchKey rejection tested in isolation only, not end-to-end over CLI+HTTP" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): CLI boundary test now asserts the shared typed validation code instead of only matching display text." ;
   triage:branch "feature/pan-s6-query-surface" ;
   triage:headSha "8bdc985ac392b1eb9f6ad47794deec30e3c86c06" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pan-s6-query-surface> .

--- a/.triage/phase-an/findings/AN6-TESTGAP-001.ttl
+++ b/.triage/phase-an/findings/AN6-TESTGAP-001.ttl
@@ -15,21 +15,26 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "branch" ;
-  triage:status "open" ;
+  triage:status "closed" ;
+  triage:resolution "fixed" ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): production SQLite coverage now includes the shipped reader lane, null-message-id dedup/cursor behavior, real category/tag filters, free-text FTS filtering, and category aggregation. These tests execute against SqliteStorageBackend rather than only the AN.5 in-memory fake." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:foundIn triage:AN.6 ;
   triage:foundAt "2026-08-12T10:09:50Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AN6-TESTGAP-001/1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AN6-TESTGAP-001/1>
   a triage:Occurrence ;
   triage:file "crates/atm-storage-rusqlite/src/search_store.rs" ;
   triage:line 1 ;
   triage:snippet "SqliteMessageSearchStore / search_reader.rs -- zero tests against production backend" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-13T08:20:34Z"^^xsd:dateTime ;
+  triage:closedNote "AN6-QUERYFIX-1 (36a75f3de): search_store.rs now has production-backend filter/aggregate coverage in addition to pagination/dedup, and search_reader.rs has a production reader-lane test." ;
   triage:branch "feature/pan-s6-query-surface" ;
   triage:headSha "8bdc985ac392b1eb9f6ad47794deec30e3c86c06" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pan-s6-query-surface> .

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -650,7 +650,8 @@ mod tests {
     use atm_core::types::CommandAction;
     use atm_core::{ApiResponse, AuthenticatedIngress, RequestDeadline};
     use atm_storage::{
-        IsoTimestamp, SearchAggregate, SearchGroup, SearchGroupBy, SearchTimestampField,
+        ChatId, IsoTimestamp, MessageKey, SearchAggregate, SearchGroup, SearchGroupBy,
+        SearchResultKey, SearchTimestampField, StoredSearchAddress,
     };
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
@@ -1109,6 +1110,55 @@ mod tests {
                 response
             );
         }
+    }
+
+    #[test]
+    fn search_response_contract_preserves_address_dimensions() {
+        let team: atm_storage::TeamName = "query-team".parse().expect("team");
+        let sender: atm_storage::AgentName = "sender".parse().expect("sender");
+        let recipient: atm_storage::AgentName = "recipient".parse().expect("recipient");
+        let sender_chat: ChatId = "1001".parse().expect("sender chat id");
+        let recipient_chat: ChatId = "1002".parse().expect("recipient chat id");
+        let message_at: IsoTimestamp = "2026-08-12T00:00:00Z".parse().expect("timestamp");
+        let response = SearchResponse {
+            hits: vec![atm_core::search::SearchHit {
+                key: SearchResultKey {
+                    team: team.clone(),
+                    agent: recipient.clone(),
+                    message_key: MessageKey::new("atm:address-contract").expect("message key"),
+                },
+                message_id: Some("01KZTTRD6K9WJYJ2N7E39CVB9P".to_owned()),
+                message_at,
+                from_agent: StoredSearchAddress {
+                    agent: sender,
+                    team: team.clone(),
+                    chat_id: Some(sender_chat.clone()),
+                },
+                to_agent: StoredSearchAddress {
+                    agent: recipient,
+                    team,
+                    chat_id: Some(recipient_chat.clone()),
+                },
+                template_type: Some("dev-task".to_owned()),
+                category: Some("workflow".to_owned()),
+                snippet: "address contract".to_owned(),
+            }],
+            aggregate: None,
+            next_cursor: None,
+        };
+        let json = serde_json::to_value(&response).expect("serialize response");
+        assert_eq!(
+            json["hits"][0]["from_agent"]["chat_id"],
+            serde_json::json!(sender_chat)
+        );
+        assert_eq!(
+            json["hits"][0]["to_agent"]["chat_id"],
+            serde_json::json!(recipient_chat)
+        );
+        assert_eq!(
+            serde_json::from_value::<SearchResponse>(json).expect("deserialize response"),
+            response
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-storage-rusqlite/src/search_store.rs
+++ b/crates/atm-storage-rusqlite/src/search_store.rs
@@ -766,7 +766,8 @@ mod tests {
     use crate::SqliteStorageBackend;
     use atm_storage::schema::MessageEnvelope;
     use atm_storage::{
-        AtmMessageId, IsoTimestamp, MessageKey, SearchAggregate, SearchLimit, SimpleAggregate,
+        AtmMessageId, IsoTimestamp, MessageKey, SearchAggregate, SearchAtom, SearchExpression,
+        SearchGroupBy, SearchGroupField, SearchLimit, SimpleAggregate,
     };
     use serde_json::Map;
 
@@ -777,6 +778,18 @@ mod tests {
         key: &str,
         message_id: Option<&str>,
         timestamp: &str,
+    ) {
+        save_with_extra(backend, team, agent, key, message_id, timestamp, Map::new());
+    }
+
+    fn save_with_extra(
+        backend: &SqliteStorageBackend,
+        team: &str,
+        agent: &str,
+        key: &str,
+        message_id: Option<&str>,
+        timestamp: &str,
+        extra: Map<String, serde_json::Value>,
     ) {
         backend
             .save_message_record(
@@ -802,7 +815,7 @@ mod tests {
                     thread_mode: None,
                     expires_at: None,
                     task_id: None,
-                    extra: Map::new(),
+                    extra,
                 },
             )
             .expect("seed production SQLite backend");
@@ -898,6 +911,101 @@ mod tests {
             aggregate.aggregate,
             Some(SearchAggregate::Count { value: 2 }),
             "aggregate observes the same deduplicated result set as paging"
+        );
+    }
+
+    #[test]
+    fn production_sqlite_search_applies_filters_and_aggregates() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let mut assignment = Map::new();
+        assignment.insert(
+            "category".to_owned(),
+            serde_json::Value::String("assignment".to_owned()),
+        );
+        assignment.insert("tags".to_owned(), serde_json::json!(["phase-an", "urgent"]));
+        save_with_extra(
+            &backend,
+            "query-team",
+            "agent-one",
+            "atm:assignment",
+            Some("01KZTTRD6K9WJYJ2N7E39CVB9P"),
+            "2026-08-12T00:03:00Z",
+            assignment,
+        );
+        let mut completion = Map::new();
+        completion.insert(
+            "category".to_owned(),
+            serde_json::Value::String("completion".to_owned()),
+        );
+        completion.insert("tags".to_owned(), serde_json::json!(["phase-an"]));
+        save_with_extra(
+            &backend,
+            "query-team",
+            "agent-two",
+            "atm:completion",
+            Some("01KZTTRD6K9WJYJ2N7E39CVB9Q"),
+            "2026-08-12T00:02:00Z",
+            completion,
+        );
+        save(
+            &backend,
+            "other-team",
+            "agent-three",
+            "atm:other",
+            None,
+            "2026-08-12T00:01:00Z",
+        );
+
+        let mut filtered = MessageSearchQuery::default();
+        filtered.filters.team = Some("query-team".parse().expect("team"));
+        filtered.filters.category = Some("assignment".to_owned());
+        filtered.filters.tags = vec!["phase-an".to_owned(), "urgent".to_owned()];
+        filtered.expression = Some(SearchExpression::Atom(
+            SearchAtom::phrase("durable query fixture").expect("phrase"),
+        ));
+        let page = backend
+            .message_search_store()
+            .search(&filtered)
+            .expect("filtered production search");
+        assert_eq!(page.matches.len(), 1);
+        assert_eq!(page.matches[0].key.message_key.as_str(), "atm:assignment");
+
+        let mut grouped = MessageSearchQuery::default();
+        grouped.filters.team = Some("query-team".parse().expect("team"));
+        grouped.aggregate = Some(SimpleAggregate::GroupBy(SearchGroupBy::Field(
+            SearchGroupField::Category,
+        )));
+        let grouped_page = backend
+            .message_search_store()
+            .search(&grouped)
+            .expect("grouped production search");
+        assert_eq!(
+            grouped_page.aggregate,
+            Some(SearchAggregate::Groups {
+                by: SearchGroupBy::Field(SearchGroupField::Category),
+                groups: vec![
+                    atm_storage::SearchGroup {
+                        key: "assignment".to_owned(),
+                        count: 1,
+                    },
+                    atm_storage::SearchGroup {
+                        key: "completion".to_owned(),
+                        count: 1,
+                    },
+                ],
+            })
+        );
+
+        let mut by_tag = MessageSearchQuery::default();
+        by_tag.filters.tags = vec!["urgent".to_owned()];
+        let tag_page = backend
+            .message_search_store()
+            .search(&by_tag)
+            .expect("tag and variable production search");
+        assert_eq!(tag_page.matches.len(), 1);
+        assert_eq!(
+            tag_page.matches[0].key.message_key.as_str(),
+            "atm:assignment"
         );
     }
 }

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -264,8 +264,15 @@ mod tests {
             };
             let error = command
                 .build_request()
-                .expect_err("invalid public key must reject");
-            assert!(error.to_string().contains("search key"), "{error}");
+                .expect_err("invalid public key must reject at the core boundary");
+            let typed = error
+                .downcast_ref::<atm_storage::AtmError>()
+                .expect("CLI must preserve the typed core validation error");
+            assert_eq!(
+                typed.code(),
+                atm_storage::AtmErrorCode::MessageValidationFailed,
+                "CLI query-key rejection must use the shared validation code"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Closes AN6-CONTRACT-001, AN6-KEYBOUNDARY-001, AN6-TESTGAP-001 from the AN.6 query-surface QA round
- Adds HTTP response address-dimension snapshot, production SQLite filter/aggregate coverage, typed CLI validation assertion

## Test plan
- `cargo test -p atm-http-runtime -p atm-storage-rusqlite -p agent-team-mail` — 158 + 97 + 49 tests pass
- targeted clippy with `-D warnings` pass
- `just lint` all green (pre-existing unrelated cargo-deny CLI-invocation mismatch noted, not introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)