### PR TITLE
test: restore AN6 parameter selectivity coverage

### DIFF
--- a/.triage/phase-an/findings/AN6-TESTQUALITY-001.ttl
+++ b/.triage/phase-an/findings/AN6-TESTQUALITY-001.ttl
@@ -15,9 +15,11 @@
   triage:severity "minor" ;
   triage:repeatable false ;
   triage:sweepScope "branch" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady false ;
   triage:triagedAt "2026-08-12T11:38:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-13T23:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "Cipher-311d" ;
   triage:foundIn triage:AN.6 ;
   triage:foundAt "2026-08-12T11:38:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AN6-TESTQUALITY-001/1> ;
@@ -28,10 +30,12 @@
   triage:file "crates/atm-query-python/src/lib.rs" ;
   triage:line 180 ;
   triage:snippet "team != question-mark predicate matches all fixture rows regardless of bound value -- equality-selectivity coverage lost" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-08-13T23:20:00Z"^^xsd:dateTime ;
+  triage:closedBy "Cipher-311d" ;
   triage:branch "feature/pan-s6-query-surface" ;
-  triage:headSha "3c62c2bb389061ee820c99aa5971300dd05f7cb2" ;
+  triage:headSha "64133471d9cee5b076f86aa855ac60bc02a2e506" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pan-s6-query-surface> .
 
 <urn:atm:triage:worktree/feature-pan-s6-query-surface>

--- a/crates/atm-query-python/src/lib.rs
+++ b/crates/atm-query-python/src/lib.rs
@@ -136,7 +136,8 @@ mod tests {
     use pyo3::types::{PyDict, PyList, PyTuple};
     use tempfile::tempdir;
 
-    const TEST_NONEXISTENT_TEAM: &str = "test-team";
+    const SELECTIVE_TEAM: &str = "fixture-team";
+    const UNMATCHED_TEAM: &str = "fixture-no-match";
 
     fn fixture() -> std::path::PathBuf {
         let directory = tempdir().expect("temp directory").keep();
@@ -248,16 +249,16 @@ mod tests {
         Python::initialize();
         Python::attach(|py| {
             let database = database(fixture());
-            let parameters = PyTuple::new(py, [TEST_NONEXISTENT_TEAM]).expect("parameters");
+            let parameters = PyTuple::new(py, [SELECTIVE_TEAM]).expect("parameters");
             let result = database
                 .query(
                     py,
-                    "SELECT team, value FROM decomposed_messages WHERE team != ?",
+                    "SELECT team, value FROM decomposed_messages WHERE team = ?",
                     Some(parameters),
                 )
                 .expect("query");
             let list = result.bind(py).clone().cast_into::<PyList>().expect("list");
-            assert_eq!(list.len(), 4);
+            assert_eq!(list.len(), 1);
             assert_eq!(
                 list.get_item(0)
                     .expect("row")
@@ -265,7 +266,23 @@ mod tests {
                     .expect("value")
                     .extract::<String>()
                     .expect("text"),
-                "first assignment"
+                "fixture assignment"
+            );
+
+            let wrong_parameters = PyTuple::new(py, [UNMATCHED_TEAM]).expect("parameters");
+            let wrong_result = database
+                .query(
+                    py,
+                    "SELECT team, value FROM decomposed_messages WHERE team = ?",
+                    Some(wrong_parameters),
+                )
+                .expect("query with a non-matching bound team");
+            assert!(
+                wrong_result
+                    .bind(py)
+                    .cast::<PyList>()
+                    .expect("list")
+                    .is_empty()
             );
         });
     }

--- a/crates/atm-storage-rusqlite/src/analyst_query.rs
+++ b/crates/atm-storage-rusqlite/src/analyst_query.rs
@@ -49,7 +49,8 @@ pub fn create_analyst_query_fixture_for_test(path: impl AsRef<Path>) -> Result<(
                 ('atm-dev', 'dev-one', 'assignment', 'an', 'first assignment'),
                 ('atm-dev', 'dev-two', 'assignment', 'an', 'second assignment'),
                 ('atm-dev', 'qa-one', 'qa-finding', 'jj', 'finding'),
-                ('atm-dev', 'fix-one', 'fix-assignment', 'jj', 'fix');"#,
+                ('atm-dev', 'fix-one', 'fix-assignment', 'jj', 'fix'),
+                ('fixture-team', 'fixture-one', 'assignment', 'an', 'fixture assignment');"#,
         )
         .map_err(sql_error)
 }


### PR DESCRIPTION
Fixes AN6-TESTQUALITY-001.

The analyst-query test now uses equality binding against a distinct fixture-team row and asserts a wrong bound value returns no rows, restoring selectivity coverage without reintroducing forbidden identity literals.

Validation: just test PASS; PATH=/tmp/cargo-deny-0199/bin:$PATH just lint PASS (28/28); focused atm-query-python and atm-storage-rusqlite tests PASS.