### PR TITLE
fix: close 7 open AN.11/AN.13 legacy findings

### DIFF
--- a/crates/atm/tests/openapi_surface_baseline.json
+++ b/crates/atm/tests/openapi_surface_baseline.json
@@ -258,6 +258,7 @@
     },
     "SearchRequest": {
       "properties": [
+        "lifecycle",
         "query"
       ],
       "required": [
@@ -273,6 +274,35 @@
       "required": [
         "hits"
       ]
+    },
+    "WorkflowProjectionRequest": {
+      "properties": [
+        "end",
+        "scope_id",
+        "scope_kind",
+        "start",
+        "time_range"
+      ],
+      "required": [
+        "end",
+        "scope_kind",
+        "start"
+      ]
+    },
+    "WorkflowSelector": {
+      "properties": [
+        "stage",
+        "state",
+        "transition"
+      ],
+      "required": []
+    },
+    "WorkflowTimeRange": {
+      "properties": [
+        "since",
+        "until"
+      ],
+      "required": []
     },
     "WriteRequest": {
       "properties": [

--- a/docs/atm-http-runtime/openapi.yaml
+++ b/docs/atm-http-runtime/openapi.yaml
@@ -134,6 +134,31 @@ components:
         query:
           type: object
           description: Public CLI/HTTP primitives compiled by atm-core into the bounded backend-neutral search query.
+        lifecycle:
+          $ref: '#/components/schemas/WorkflowProjectionRequest'
+          description: Optional generic lifecycle projection over the bounded local search result.
+    WorkflowSelector:
+      type: object
+      description: Partial exact selector; at least one selector field is required by the runtime.
+      properties:
+        state: { type: string }
+        stage: { type: string }
+        transition: { type: string }
+    WorkflowTimeRange:
+      type: object
+      properties:
+        since: { type: string, format: date-time }
+        until: { type: string, format: date-time }
+    WorkflowProjectionRequest:
+      type: object
+      required: [scope_kind, start, end]
+      description: Generic one-to-one lifecycle pairing request carried by SearchRequest.lifecycle.
+      properties:
+        scope_kind: { type: string }
+        scope_id: { type: string }
+        start: { $ref: '#/components/schemas/WorkflowSelector' }
+        end: { $ref: '#/components/schemas/WorkflowSelector' }
+        time_range: { $ref: '#/components/schemas/WorkflowTimeRange' }
     SearchResponse:
       type: object
       required: [hits]

--- a/docs/atm-query-surface.md
+++ b/docs/atm-query-surface.md
@@ -40,6 +40,19 @@ adapter. Simple aggregates use the same filters: `--count`,
 Template-metadata values are exact by default; a final `*` requests the
 documented prefix match (`--type qa-*`). Variable values are always exact.
 
+Lifecycle projection is available on the same bounded search contract through
+the CLI flags `--lifecycle-scope-kind`, `--lifecycle-scope-id`,
+`--lifecycle-start-state|stage|transition`, and
+`--lifecycle-end-state|stage|transition`. HTTP callers encode the same
+`SearchRequest.lifecycle` object in the required `request` parameter. Its JSON
+shape is `{ "scope_kind": "...", "scope_id": "...", "start":
+{ "state": "...", "stage": "...", "transition": "..." }, "end":
+{ "state": "...", "stage": "...", "transition": "..." },
+"time_range": { "since": "...", "until": "..." } }`; `scope_kind`,
+`start`, and `end` are required, and each selector must contain at least one
+field. The machine-readable field contract is published in the
+`WorkflowProjectionRequest` schema in `docs/atm-http-runtime/openapi.yaml`.
+
 The HTTP search endpoint is local-only. Authenticated UDS and capability
 loopback callers may search; a peer request is rejected by core policy before
 any search capability is selected.


### PR DESCRIPTION
## Summary
- Fixes REQQA-R2-001-AN11 (openapi.yaml lifecycle search/workflow projection schemas + CLI docs) @ c475a34cb
- Confirms 6 findings already fixed by prior work, no code change needed: ATM-QA-001-AN13, ATM-QA-002-AN13, QA-001-AN13, ATM-QA-003-AN13, REQQA-R2-002-AN11, REQQA-R2-003-AN11

## QA
AN1113LEGACY-QA-1 — quality-mgr VERDICT: **PASS**. All 7 originally-open phase-AN findings independently re-verified against cited SHAs (not taken on developer's word). Full `.triage/phase-an/findings/*.ttl` sweep shows no remaining open records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)