### PR TITLE
feat(an15): checked-render adversarial assurance campaign

### DIFF
--- a/.claude/skills/adversarial-fuzzing/SKILL.md
+++ b/.claude/skills/adversarial-fuzzing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-fuzzing
-version: 1.1.0
+version: 1.2.0
 description: Generate and triage adversarial templates, var-files, and rendering inputs against sc-compose by coordinating bounded background agents, differential and metamorphic checks, minimization, and regression-test promotion. Use when trying to break a rendering subsystem, validating a risky change, hunting parser/validator/rendering edge cases, or turning a confirmed fuzz failure into a unit or CLI test.
 ---
 
@@ -31,7 +31,7 @@ before delegating work.
 ```json
 {
   "worktree_path": "/absolute/path/to/sc-compose-worktree",
-  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | local-http-framing | atm-template-checked-emission | full",
   "baseline_ref": "optional git ref for differential checks",
   "seed": 157,
   "max_workers": 4,
@@ -108,6 +108,23 @@ four for `full`:
 Each worker must stay within its target, use bounded generation, and return a
 standard fenced JSON envelope. Workers may create temporary inputs and logs,
 but must not edit production code, commit changes, or delete user files.
+
+### ATM checked-emission target
+
+`atm-template-checked-emission` is an ATM-specific execution target. It uses
+all four workers, exactly 100 or more cases per worker, and a 120-second
+per-worker timeout. Its fixed worker-to-seam mapping is:
+
+| Worker | ATM seam | Oracle |
+| --- | --- | --- |
+| `shape-probe` | captured variable resolution into same-host admission | malformed or missing values do not mutate catalog/message rows |
+| `template-probe` | sealed `atm-template-sc-compose` checked rendering | classification, escaping, Unicode, and final-body rejection are deterministic |
+| `boundary-probe` | catalog admission plus confined file/fallback routes | rejected input cannot escape, mutate state, or leak a rendered value |
+| `differential-probe` | persisted catalog record through render-on-read | persisted bytes, format, and merged variables—not ambient state or prior revisions—determine output |
+
+The runner accepts no caller-supplied command for this target and never invokes
+the `sc-compose` CLI. It exercises only the sealed ATM adapter and fixed
+Cargo-test seams.
 
 When a finding cannot be traced to an existing requirement or ADR, record that
 absence explicitly and assess whether it is a genuine contract gap. The
@@ -228,7 +245,8 @@ independent quality-mgr passes:
 2. Record the seed, target, worker cap, cases per worker, timeout, promotion
    flag, campaign ID, and generated campaign directory before launching.
 3. Run the full target with the four registered workers when `target` is
-   `full`; record every correlation ID, worker target, case count, status,
+   `full` or `atm-template-checked-emission`; record every correlation ID,
+   worker target, case count, status,
    timeout, and error.
 4. Record every candidate with the exact command, minimized input/template,
    expected oracle, observed result, diagnostic, and reproduction count.

--- a/.just/fixtures/fuzz/an15-checked-emission.json
+++ b/.just/fixtures/fuzz/an15-checked-emission.json
@@ -7,5 +7,10 @@
   "cases_per_worker": 100,
   "per_worker_timeout_s": 120,
   "promote_regressions": true,
-  "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands."
+  "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands.",
+  "campaign_id": "an15-checked-emission-20260814",
+  "candidate_ref": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
+  "final_ci_commit": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
+  "sc_compose_release_evidence": "site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json",
+  "sc_compose_issue_evidence": "site/reports/fuzz/an15-sc-compose-448-github.json"
 }

--- a/.just/fixtures/fuzz/an15-checked-emission.json
+++ b/.just/fixtures/fuzz/an15-checked-emission.json
@@ -1,0 +1,11 @@
+{
+  "worktree_path": "/replace/with/an/approved/atm-core-worktree",
+  "target": "atm-template-checked-emission",
+  "baseline_ref": "9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f",
+  "seed": 20260814,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands."
+}

--- a/.just/fixtures/fuzz/an15-checked-emission.json
+++ b/.just/fixtures/fuzz/an15-checked-emission.json
@@ -9,8 +9,8 @@
   "promote_regressions": true,
   "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands.",
   "campaign_id": "an15-checked-emission-20260814",
-  "candidate_ref": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
-  "final_ci_commit": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
+  "candidate_ref": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
+  "final_ci_commit": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
   "sc_compose_release_evidence": "site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json",
   "sc_compose_issue_evidence": "site/reports/fuzz/an15-sc-compose-448-github.json"
 }

--- a/.just/lint_common.py
+++ b/.just/lint_common.py
@@ -14,9 +14,6 @@ LOG_DIR = Path(".just/logs")
 CONFIG_PATH = Path(".just/lint-config.toml")
 TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
 LINT_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
-STRING_LITERAL_RE = re.compile(
-    r'r(?P<hashes>#+)?\"(?P<raw>.*?)\"(?P=hashes)|\"(?P<quoted>(?:[^\"\\\\]|\\\\.)*)\"'
-)
 CFG_ATTRIBUTE_RE = re.compile(r"^#(?P<inner>!)?\[cfg\((?P<body>.*)\)\]$")
 TEST_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])test(?![A-Za-z0-9_])")
 
@@ -438,14 +435,89 @@ def rust_file_test_scope(path: Path, lines: list[str]) -> list[bool]:
     return [False] * len(lines)
 
 
-def iter_string_literal_contents(line: str) -> list[str]:
-    literals: list[str] = []
-    for match in STRING_LITERAL_RE.finditer(line):
-        raw_value = match.group("raw")
-        if raw_value is not None:
-            literals.append(raw_value)
+def _decode_rust_quoted_literal(value: str) -> str:
+    """Decode the Rust escape forms relevant to literal-oriented lint checks.
+
+    The scanner deliberately walks Python Unicode code points. Encoding the
+    matched value as UTF-8 and handing those bytes to ``unicode_escape`` loses
+    the correspondence between Rust character positions and scanner positions
+    once a literal contains emoji or CJK text.
+    """
+    decoded: list[str] = []
+    index = 0
+    single_escapes = {"n": "\n", "r": "\r", "t": "\t", "0": "\0", "\\": "\\", '\"': '"'}
+    while index < len(value):
+        character = value[index]
+        if character != "\\":
+            decoded.append(character)
+            index += 1
             continue
-        quoted_value = match.group("quoted")
-        if quoted_value is not None:
-            literals.append(bytes(quoted_value, "utf-8").decode("unicode_escape"))
+        if index + 1 >= len(value):
+            # An unterminated literal is not valid Rust. Preserve the source
+            # fragment so this lint remains observational rather than raising.
+            decoded.append("\\")
+            break
+        escape = value[index + 1]
+        if escape in single_escapes:
+            decoded.append(single_escapes[escape])
+            index += 2
+            continue
+        if escape == "x" and index + 3 < len(value):
+            digits = value[index + 2 : index + 4]
+            try:
+                decoded.append(chr(int(digits, 16)))
+                index += 4
+                continue
+            except ValueError:
+                pass
+        if escape == "u" and index + 2 < len(value) and value[index + 2] == "{":
+            closing = value.find("}", index + 3)
+            if closing != -1:
+                try:
+                    decoded.append(chr(int(value[index + 3 : closing].replace("_", ""), 16)))
+                    index = closing + 1
+                    continue
+                except ValueError:
+                    pass
+        # Keep unknown/malformed escapes literal. Rust will reject malformed
+        # production code separately; this lint must never hide its own result
+        # behind an exception.
+        decoded.extend(("\\", escape))
+        index += 2
+    return "".join(decoded)
+
+
+def iter_string_literal_contents(line: str) -> list[str]:
+    """Return quoted and raw Rust string contents using Unicode-safe offsets."""
+    literals: list[str] = []
+    index = 0
+    while index < len(line):
+        if line[index] == "r":
+            raw_index = index + 1
+            while raw_index < len(line) and line[raw_index] == "#":
+                raw_index += 1
+            if raw_index < len(line) and line[raw_index] == '"':
+                hashes = line[index + 1 : raw_index]
+                closing = '"' + hashes
+                closing_index = line.find(closing, raw_index + 1)
+                if closing_index != -1:
+                    literals.append(line[raw_index + 1 : closing_index])
+                    index = closing_index + len(closing)
+                    continue
+        if line[index] == '"':
+            start = index + 1
+            cursor = start
+            while cursor < len(line):
+                if line[cursor] == "\\":
+                    cursor += 2
+                    continue
+                if line[cursor] == '"':
+                    literals.append(_decode_rust_quoted_literal(line[start:cursor]))
+                    index = cursor + 1
+                    break
+                cursor += 1
+            else:
+                index = len(line)
+            continue
+        index += 1
     return literals

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -139,14 +139,26 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
         raise FuzzInputError("notes must be a string of at most 4000 characters")
     if not isinstance(payload.get("promote_regressions"), bool):
         raise FuzzInputError("promote_regressions must be boolean")
+    max_workers = _bounded_int(payload["max_workers"], "max_workers", 1, 4)
+    cases_per_worker = _bounded_int(payload["cases_per_worker"], "cases_per_worker", 1, 1000)
+    per_worker_timeout_s = _bounded_int(
+        payload["per_worker_timeout_s"], "per_worker_timeout_s", 1, 600
+    )
+    if target == "atm-template-checked-emission":
+        if max_workers != len(WORKERS):
+            raise FuzzInputError("atm-template-checked-emission requires exactly four workers")
+        if cases_per_worker < 100:
+            raise FuzzInputError("atm-template-checked-emission requires at least 100 cases per worker")
+        if per_worker_timeout_s != 120:
+            raise FuzzInputError("atm-template-checked-emission requires a 120-second worker timeout")
     return {
         "worktree_path": str(worktree),
         "target": target,
         "baseline_ref": baseline,
         "seed": _bounded_int(payload["seed"], "seed", 0, 2**63 - 1),
-        "max_workers": _bounded_int(payload["max_workers"], "max_workers", 1, 4),
-        "cases_per_worker": _bounded_int(payload["cases_per_worker"], "cases_per_worker", 1, 1000),
-        "per_worker_timeout_s": _bounded_int(payload["per_worker_timeout_s"], "per_worker_timeout_s", 1, 600),
+        "max_workers": max_workers,
+        "cases_per_worker": cases_per_worker,
+        "per_worker_timeout_s": per_worker_timeout_s,
         "promote_regressions": payload["promote_regressions"],
         "notes": notes,
     }

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
-"""Validate and plan bounded adversarial-fuzz campaigns.
+"""Validate, plan, and execute bounded adversarial-fuzz campaigns.
 
-AI48 deliberately stops at the coordinator/probe contract. It does not invoke
-product parsers, mutate a worktree, or render reports; later sprints own those
-execution and publication concerns.
+The generic AI48 targets remain contract-only.  AN.15 adds one deliberately
+small execution lane for checked template emission: four fixed test seams run
+inside an approved ATM worktree.  This runner never invokes ``sc-compose`` and
+never accepts arbitrary commands, so a campaign cannot become a shell-out or a
+production-code editing mechanism.
 """
 
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import json
+import subprocess
 import sys
 from typing import Any
 
@@ -45,8 +49,45 @@ CAMPAIGN_FIELDS = {
     "promote_regressions",
     "notes",
 }
-WORKER_RESULT_FIELDS = {"correlation_id", "target", "status", "cases_run", "finding_ids", "error"}
+WORKER_RESULT_FIELDS = {
+    "correlation_id",
+    "target",
+    "status",
+    "cases_run",
+    "finding_ids",
+    "error",
+    "seam",
+    "oracle",
+    "diagnostic_codes",
+}
+REQUIRED_WORKER_RESULT_FIELDS = {"correlation_id", "target", "status", "cases_run", "finding_ids", "error"}
 STATUSES = ("success", "failed", "timed_out")
+
+# These commands are intentionally closed over by the repository.  Do not add
+# a command field to the campaign schema: accepting a caller-provided command
+# would turn a bounded assurance campaign into a shell execution interface.
+CHECKED_EMISSION_WORKERS = {
+    "shape-probe": {
+        "seam": "atm-core template admission and captured merged variables",
+        "oracle": "captured variables are deterministic and failed admission writes nothing",
+        "command": ("cargo", "test", "-p", "agent-team-mail-core", "an15_shape_probe_"),
+    },
+    "template-probe": {
+        "seam": "sealed atm-template-sc-compose checked final rendering",
+        "oracle": "format classification, escaping, and Unicode are deterministic",
+        "command": ("cargo", "test", "-p", "atm-template-sc-compose", "an15_template_probe_"),
+    },
+    "boundary-probe": {
+        "seam": "template catalog admission and confined include/fallback paths",
+        "oracle": "rejection neither escapes the root nor leaks or mutates persisted state",
+        "command": ("cargo", "test", "-p", "atm-template-sc-compose", "an15_boundary_probe_"),
+    },
+    "differential-probe": {
+        "seam": "atm-core render-on-read and rusqlite persisted template catalog",
+        "oracle": "persisted revision data, never ambient state, determines rendering",
+        "command": ("cargo", "test", "-p", "atm-storage-rusqlite", "an15_differential_probe_"),
+    },
+}
 
 
 class FuzzInputError(ValueError):
@@ -117,7 +158,7 @@ def validate_worker_result(payload: Any) -> dict[str, Any]:
     unknown = set(payload) - WORKER_RESULT_FIELDS
     if unknown:
         raise FuzzInputError(f"unsupported worker result fields: {', '.join(sorted(unknown))}")
-    missing = WORKER_RESULT_FIELDS - payload.keys()
+    missing = REQUIRED_WORKER_RESULT_FIELDS - payload.keys()
     if missing:
         raise FuzzInputError(f"missing worker result fields: {', '.join(sorted(missing))}")
     correlation_id = payload["correlation_id"]
@@ -136,6 +177,15 @@ def validate_worker_result(payload: Any) -> dict[str, Any]:
     error = payload["error"]
     if error is not None and not isinstance(error, dict):
         raise FuzzInputError("worker error must be an object or null")
+    seam = payload.get("seam")
+    oracle = payload.get("oracle")
+    diagnostic_codes = payload.get("diagnostic_codes", [])
+    if seam is not None and not isinstance(seam, str):
+        raise FuzzInputError("worker seam must be a string when present")
+    if oracle is not None and not isinstance(oracle, str):
+        raise FuzzInputError("worker oracle must be a string when present")
+    if not isinstance(diagnostic_codes, list) or any(not isinstance(item, str) for item in diagnostic_codes):
+        raise FuzzInputError("diagnostic_codes must be an array of strings")
     return {
         "correlation_id": correlation_id,
         "target": target,
@@ -143,6 +193,9 @@ def validate_worker_result(payload: Any) -> dict[str, Any]:
         "cases_run": cases_run,
         "finding_ids": list(finding_ids),
         "error": error,
+        "seam": seam,
+        "oracle": oracle,
+        "diagnostic_codes": list(diagnostic_codes),
     }
 
 
@@ -155,33 +208,86 @@ def selected_workers(campaign: dict[str, Any]) -> list[str]:
     return selected[: campaign["max_workers"]]
 
 
-def build_result(campaign: dict[str, Any], dry_run: bool = True) -> dict[str, Any]:
-    workers = []
-    for correlation_id in selected_workers(campaign):
-        workers.append(
-            {
-                "correlation_id": correlation_id,
-                "target": campaign["target"],
-                "status": "success",
-                "cases_run": campaign["cases_per_worker"],
-                "finding_ids": [],
-                "error": None,
-            }
+def _planned_worker(campaign: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+    contract = CHECKED_EMISSION_WORKERS.get(correlation_id, {})
+    return {
+        "correlation_id": correlation_id,
+        "target": campaign["target"],
+        "status": "success",
+        "cases_run": campaign["cases_per_worker"],
+        "finding_ids": [],
+        "error": None,
+        "seam": contract.get("seam"),
+        "oracle": contract.get("oracle"),
+        "diagnostic_codes": [],
+    }
+
+
+def _execute_worker(campaign: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+    """Run one closed-over campaign worker and retain only structured diagnostics."""
+    contract = CHECKED_EMISSION_WORKERS[correlation_id]
+    try:
+        completed = subprocess.run(
+            contract["command"],
+            cwd=campaign["worktree_path"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=campaign["per_worker_timeout_s"],
         )
+    except subprocess.TimeoutExpired:
+        return {
+            **_planned_worker(campaign, correlation_id),
+            "status": "timed_out",
+            "cases_run": 0,
+            "error": {"code": "worker_timeout", "owner": "campaign-maintainer"},
+            "diagnostic_codes": ["worker_timeout"],
+        }
+    if completed.returncode != 0:
+        return {
+            **_planned_worker(campaign, correlation_id),
+            "status": "failed",
+            "cases_run": 0,
+            "error": {"code": "worker_test_failure", "returncode": completed.returncode},
+            "diagnostic_codes": ["worker_test_failure"],
+        }
+    return _planned_worker(campaign, correlation_id)
+
+
+def build_result(campaign: dict[str, Any], dry_run: bool = True, execute: bool = False) -> dict[str, Any]:
+    if execute and campaign["target"] != "atm-template-checked-emission":
+        raise FuzzInputError("real execution is currently supported only for atm-template-checked-emission")
+    if execute and dry_run:
+        raise FuzzInputError("--execute and --dry-run cannot be combined")
+    workers = []
+    worker_ids = selected_workers(campaign)
+    if execute:
+        # Four workers is the public maximum and task commands are static.
+        with ThreadPoolExecutor(max_workers=len(worker_ids)) as executor:
+            workers = list(executor.map(lambda worker: _execute_worker(campaign, worker), worker_ids))
+    else:
+        workers = [_planned_worker(campaign, worker) for worker in worker_ids]
+    failed_workers = sum(worker["status"] != "success" for worker in workers)
     return {
         "schema_version": SCHEMA_VERSION,
-        "execution_mode": "dry-run" if dry_run else "contract-only",
+        "execution_mode": "executed" if execute else ("dry-run" if dry_run else "contract-only"),
         "campaign": campaign,
         "workers": workers,
         "findings": [],
         "promoted_tests": [],
         "unresolved_candidates": [],
+        "outcome_ledger": {
+            "confirmed_bug": [],
+            "non_repro": [],
+            "benign": [],
+            "inconclusive": [],
+        },
         "summary": {
-            "all_successful": True,
+            "all_successful": failed_workers == 0,
             "confirmed_bugs": 0,
             "intentional_boundaries": 0,
             "inconclusive": 0,
-            "failed_workers": 0,
+            "failed_workers": failed_workers,
         },
     }
 
@@ -196,7 +302,7 @@ def default_campaign(root: Path) -> dict[str, Any]:
         "cases_per_worker": 100,
         "per_worker_timeout_s": 120,
         "promote_regressions": True,
-        "notes": "AI48 contract-only coordinator; real campaign execution is deferred.",
+        "notes": "AI48 contract-only coordinator; real execution is restricted to AN.15 checked emission.",
     }
 
 
@@ -212,12 +318,13 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--campaign", type=Path, help="campaign JSON path; defaults to the built-in contract")
     parser.add_argument("--output", type=Path, help="optional JSON output path inside the repository")
     parser.add_argument("--dry-run", action="store_true", help="emit a deterministic plan without running workers")
+    parser.add_argument("--execute", action="store_true", help="run the fixed AN.15 checked-emission worker set")
     args = parser.parse_args(argv[1:])
     root = repository_root()
     try:
         raw = load_campaign(args.campaign) if args.campaign else default_campaign(root)
         campaign = validate_campaign(raw, root)
-        result = build_result(campaign, dry_run=args.dry_run)
+        result = build_result(campaign, dry_run=args.dry_run, execute=args.execute)
         encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
         if args.output:
             output = _inside(args.output, root, "output")

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -51,6 +51,8 @@ CAMPAIGN_FIELDS = {
     "campaign_id",
     "candidate_ref",
     "final_ci_commit",
+    "sc_compose_release_evidence",
+    "sc_compose_issue_evidence",
     "notes",
 }
 WORKER_RESULT_FIELDS = {
@@ -124,7 +126,15 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
         raise FuzzInputError(f"unsupported campaign fields: {', '.join(sorted(unknown))}")
     missing = (
         CAMPAIGN_FIELDS
-        - {"baseline_ref", "notes", "campaign_id", "candidate_ref", "final_ci_commit"}
+        - {
+            "baseline_ref",
+            "notes",
+            "campaign_id",
+            "candidate_ref",
+            "final_ci_commit",
+            "sc_compose_release_evidence",
+            "sc_compose_issue_evidence",
+        }
         - payload.keys()
     )
     if missing:
@@ -159,7 +169,13 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
             raise FuzzInputError("atm-template-checked-emission requires at least 100 cases per worker")
         if per_worker_timeout_s != 120:
             raise FuzzInputError("atm-template-checked-emission requires a 120-second worker timeout")
-        for field in ("campaign_id", "candidate_ref", "final_ci_commit"):
+        for field in (
+            "campaign_id",
+            "candidate_ref",
+            "final_ci_commit",
+            "sc_compose_release_evidence",
+            "sc_compose_issue_evidence",
+        ):
             value = payload.get(field)
             if not isinstance(value, str) or not value.strip():
                 raise FuzzInputError(
@@ -170,6 +186,10 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
         for field in ("candidate_ref", "final_ci_commit"):
             if not re.fullmatch(r"[0-9a-f]{40}", payload[field]):
                 raise FuzzInputError(f"{field} must be a full lowercase git commit SHA")
+        for field in ("sc_compose_release_evidence", "sc_compose_issue_evidence"):
+            evidence = Path(payload[field])
+            if evidence.is_absolute() or ".." in evidence.parts or evidence.suffix != ".json":
+                raise FuzzInputError(f"{field} must be a repository-relative JSON evidence path")
     return {
         "worktree_path": str(worktree),
         "target": target,
@@ -182,6 +202,8 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
         "campaign_id": payload.get("campaign_id"),
         "candidate_ref": payload.get("candidate_ref"),
         "final_ci_commit": payload.get("final_ci_commit"),
+        "sc_compose_release_evidence": payload.get("sc_compose_release_evidence"),
+        "sc_compose_issue_evidence": payload.get("sc_compose_issue_evidence"),
         "notes": notes,
     }
 
@@ -302,7 +324,7 @@ def build_result(campaign: dict[str, Any], dry_run: bool = True, execute: bool =
     else:
         workers = [_planned_worker(campaign, worker) for worker in worker_ids]
     failed_workers = sum(worker["status"] != "success" for worker in workers)
-    return {
+    result = {
         "schema_version": SCHEMA_VERSION,
         "execution_mode": "executed" if execute else ("dry-run" if dry_run else "contract-only"),
         "campaign": campaign,
@@ -324,6 +346,12 @@ def build_result(campaign: dict[str, Any], dry_run: bool = True, execute: bool =
             "failed_workers": failed_workers,
         },
     }
+    if campaign["target"] == "atm-template-checked-emission":
+        result["provenance"] = {
+            "sc_compose_release_evidence": campaign["sc_compose_release_evidence"],
+            "sc_compose_issue_evidence": campaign["sc_compose_issue_evidence"],
+        }
+    return result
 
 
 def default_campaign(root: Path) -> dict[str, Any]:
@@ -339,6 +367,8 @@ def default_campaign(root: Path) -> dict[str, Any]:
         "campaign_id": None,
         "candidate_ref": None,
         "final_ci_commit": None,
+        "sc_compose_release_evidence": None,
+        "sc_compose_issue_evidence": None,
         "notes": "AI48 contract-only coordinator; real execution is restricted to AN.15 checked emission.",
     }
 

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -14,6 +14,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import json
+import re
 import subprocess
 import sys
 from typing import Any
@@ -47,6 +48,9 @@ CAMPAIGN_FIELDS = {
     "cases_per_worker",
     "per_worker_timeout_s",
     "promote_regressions",
+    "campaign_id",
+    "candidate_ref",
+    "final_ci_commit",
     "notes",
 }
 WORKER_RESULT_FIELDS = {
@@ -68,9 +72,9 @@ STATUSES = ("success", "failed", "timed_out")
 # would turn a bounded assurance campaign into a shell execution interface.
 CHECKED_EMISSION_WORKERS = {
     "shape-probe": {
-        "seam": "atm-core template admission and captured merged variables",
-        "oracle": "captured variables are deterministic and failed admission writes nothing",
-        "command": ("cargo", "test", "-p", "agent-team-mail-core", "an15_shape_probe_"),
+        "seam": "Tokio/Axum template admission through the SQLite catalog and mailbox boundary",
+        "oracle": "missing required input rejects before any template catalog or mailbox row is written",
+        "command": ("cargo", "test", "-p", "atm-http-runtime", "an15_shape_probe_"),
     },
     "template-probe": {
         "seam": "sealed atm-template-sc-compose checked final rendering",
@@ -83,9 +87,9 @@ CHECKED_EMISSION_WORKERS = {
         "command": ("cargo", "test", "-p", "atm-template-sc-compose", "an15_boundary_probe_"),
     },
     "differential-probe": {
-        "seam": "atm-core render-on-read and rusqlite persisted template catalog",
-        "oracle": "persisted revision data, never ambient state, determines rendering",
-        "command": ("cargo", "test", "-p", "atm-storage-rusqlite", "an15_differential_probe_"),
+        "seam": "atm-core render-on-read from captured persisted variables",
+        "oracle": "captured stored values, never ambient state, determine rendering",
+        "command": ("cargo", "test", "-p", "agent-team-mail-core", "an15_differential_probe_"),
     },
 }
 
@@ -118,7 +122,11 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
     unknown = set(payload) - CAMPAIGN_FIELDS
     if unknown:
         raise FuzzInputError(f"unsupported campaign fields: {', '.join(sorted(unknown))}")
-    missing = CAMPAIGN_FIELDS - {"baseline_ref", "notes"} - payload.keys()
+    missing = (
+        CAMPAIGN_FIELDS
+        - {"baseline_ref", "notes", "campaign_id", "candidate_ref", "final_ci_commit"}
+        - payload.keys()
+    )
     if missing:
         raise FuzzInputError(f"missing campaign fields: {', '.join(sorted(missing))}")
     repo = (root or repository_root()).resolve()
@@ -151,6 +159,17 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
             raise FuzzInputError("atm-template-checked-emission requires at least 100 cases per worker")
         if per_worker_timeout_s != 120:
             raise FuzzInputError("atm-template-checked-emission requires a 120-second worker timeout")
+        for field in ("campaign_id", "candidate_ref", "final_ci_commit"):
+            value = payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise FuzzInputError(
+                    f"atm-template-checked-emission requires a non-empty {field}"
+                )
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", payload["campaign_id"]):
+            raise FuzzInputError("campaign_id must be a stable safe identifier")
+        for field in ("candidate_ref", "final_ci_commit"):
+            if not re.fullmatch(r"[0-9a-f]{40}", payload[field]):
+                raise FuzzInputError(f"{field} must be a full lowercase git commit SHA")
     return {
         "worktree_path": str(worktree),
         "target": target,
@@ -160,6 +179,9 @@ def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
         "cases_per_worker": cases_per_worker,
         "per_worker_timeout_s": per_worker_timeout_s,
         "promote_regressions": payload["promote_regressions"],
+        "campaign_id": payload.get("campaign_id"),
+        "candidate_ref": payload.get("candidate_ref"),
+        "final_ci_commit": payload.get("final_ci_commit"),
         "notes": notes,
     }
 
@@ -314,6 +336,9 @@ def default_campaign(root: Path) -> dict[str, Any]:
         "cases_per_worker": 100,
         "per_worker_timeout_s": 120,
         "promote_regressions": True,
+        "campaign_id": None,
+        "candidate_ref": None,
+        "final_ci_commit": None,
         "notes": "AI48 contract-only coordinator; real execution is restricted to AN.15 checked emission.",
     }
 

--- a/.just/tests/test_lint_common.py
+++ b/.just/tests/test_lint_common.py
@@ -317,6 +317,14 @@ version = "0.1.0"
             ["hello", "raw value"],
         )
 
+    def test_iter_string_literal_contents_preserves_unicode_while_scanning_escapes(self) -> None:
+        line = r'let value = format!("case-{case_index}-🙂-漢字-\\\"-newline\\n");'
+
+        self.assertEqual(
+            iter_string_literal_contents(line),
+            [r'case-{case_index}-🙂-漢字-\"-newline\n'],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -64,6 +64,12 @@ class FuzzRunnerTests(unittest.TestCase):
             with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
                 validate_campaign(payload, Path(tempdir))
 
+    def test_unknown_target_fails_closed(self) -> None:
+        payload = self.campaign_fixture("success.json")
+        payload["target"] = "unknown-target"
+        with self.assertRaisesRegex(FuzzInputError, "target must be one of"):
+            validate_campaign(payload, Path.cwd())
+
     def test_cli_forwards_dry_run_flag(self) -> None:
         output = io.StringIO()
         with redirect_stdout(output):

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -125,6 +125,21 @@ class FuzzRunnerTests(unittest.TestCase):
         with self.assertRaisesRegex(FuzzInputError, "only for atm-template-checked-emission"):
             build_result(campaign, dry_run=False, execute=True)
 
+    def test_checked_emission_requires_the_full_bounded_campaign_shape(self) -> None:
+        payload = self.campaign_fixture("success.json")
+        payload["target"] = "atm-template-checked-emission"
+        payload["max_workers"] = 3
+        with self.assertRaisesRegex(FuzzInputError, "exactly four workers"):
+            validate_campaign(payload, Path.cwd())
+        payload["max_workers"] = 4
+        payload["cases_per_worker"] = 99
+        with self.assertRaisesRegex(FuzzInputError, "at least 100 cases"):
+            validate_campaign(payload, Path.cwd())
+        payload["cases_per_worker"] = 100
+        payload["per_worker_timeout_s"] = 119
+        with self.assertRaisesRegex(FuzzInputError, "120-second"):
+            validate_campaign(payload, Path.cwd())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -41,6 +41,8 @@ class FuzzRunnerTests(unittest.TestCase):
             "campaign_id": "an15-checked-emission-test",
             "candidate_ref": "a" * 40,
             "final_ci_commit": "b" * 40,
+            "sc_compose_release_evidence": "site/reports/fuzz/release.json",
+            "sc_compose_issue_evidence": "site/reports/fuzz/issue.json",
         })
         return payload
 
@@ -166,6 +168,11 @@ class FuzzRunnerTests(unittest.TestCase):
 
         payload["final_ci_commit"] = "not-a-sha"
         with self.assertRaisesRegex(FuzzInputError, "full lowercase git commit SHA"):
+            validate_campaign(payload, Path.cwd())
+
+        payload = self.checked_emission_campaign()
+        payload["sc_compose_issue_evidence"] = "../outside.json"
+        with self.assertRaisesRegex(FuzzInputError, "repository-relative JSON evidence path"):
             validate_campaign(payload, Path.cwd())
 
 

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -7,6 +7,7 @@ import json
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 JUST_DIR = Path(__file__).resolve().parents[1]
@@ -95,6 +96,34 @@ class FuzzRunnerTests(unittest.TestCase):
         self.assertEqual([worker["correlation_id"] for worker in build_result(campaign)["workers"]], [
             "shape-probe", "template-probe", "boundary-probe", "differential-probe"
         ])
+
+    @patch("run_fuzz.subprocess.run")
+    def test_checked_emission_execution_runs_only_fixed_worker_contracts(self, run: object) -> None:
+        run.return_value.returncode = 0  # type: ignore[attr-defined]
+        payload = self.campaign_fixture("success.json")
+        payload["target"] = "atm-template-checked-emission"
+        campaign = validate_campaign(payload, Path.cwd())
+        result = build_result(campaign, dry_run=False, execute=True)
+        self.assertEqual(result["execution_mode"], "executed")
+        self.assertTrue(result["summary"]["all_successful"])
+        self.assertEqual(run.call_count, 4)  # type: ignore[attr-defined]
+        for call in run.call_args_list:  # type: ignore[attr-defined]
+            self.assertEqual(call.args[0][0:3], ("cargo", "test", "-p"))
+            self.assertNotIn("sc-compose", call.args[0])
+
+    @patch("run_fuzz.subprocess.run", side_effect=__import__("subprocess").TimeoutExpired("cargo", 120))
+    def test_checked_emission_timeout_is_a_structured_candidate(self, _run: object) -> None:
+        payload = self.campaign_fixture("success.json")
+        payload["target"] = "atm-template-checked-emission"
+        campaign = validate_campaign(payload, Path.cwd())
+        result = build_result(campaign, dry_run=False, execute=True)
+        self.assertEqual(result["summary"]["failed_workers"], 4)
+        self.assertTrue(all(worker["error"]["code"] == "worker_timeout" for worker in result["workers"]))
+
+    def test_real_execution_is_fail_closed_for_unapproved_targets(self) -> None:
+        campaign = validate_campaign(self.campaign_fixture("success.json"), Path.cwd())
+        with self.assertRaisesRegex(FuzzInputError, "only for atm-template-checked-emission"):
+            build_result(campaign, dry_run=False, execute=True)
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -34,6 +34,16 @@ class FuzzRunnerTests(unittest.TestCase):
             payload["worktree_path"] = str(Path.cwd())
         return payload
 
+    def checked_emission_campaign(self) -> dict:
+        payload = self.campaign_fixture("success.json")
+        payload.update({
+            "target": "atm-template-checked-emission",
+            "campaign_id": "an15-checked-emission-test",
+            "candidate_ref": "a" * 40,
+            "final_ci_commit": "b" * 40,
+        })
+        return payload
+
     def test_success_campaign_is_deterministic_and_four_workers(self) -> None:
         campaign = validate_campaign(self.campaign_fixture("success.json"), Path.cwd())
         first = build_result(campaign)
@@ -96,8 +106,7 @@ class FuzzRunnerTests(unittest.TestCase):
         ])
 
     def test_checked_emission_target_selects_all_contract_workers(self) -> None:
-        payload = self.campaign_fixture("success.json")
-        payload["target"] = "atm-template-checked-emission"
+        payload = self.checked_emission_campaign()
         campaign = validate_campaign(payload, Path.cwd())
         self.assertEqual([worker["correlation_id"] for worker in build_result(campaign)["workers"]], [
             "shape-probe", "template-probe", "boundary-probe", "differential-probe"
@@ -106,8 +115,7 @@ class FuzzRunnerTests(unittest.TestCase):
     @patch("run_fuzz.subprocess.run")
     def test_checked_emission_execution_runs_only_fixed_worker_contracts(self, run: object) -> None:
         run.return_value.returncode = 0  # type: ignore[attr-defined]
-        payload = self.campaign_fixture("success.json")
-        payload["target"] = "atm-template-checked-emission"
+        payload = self.checked_emission_campaign()
         campaign = validate_campaign(payload, Path.cwd())
         result = build_result(campaign, dry_run=False, execute=True)
         self.assertEqual(result["execution_mode"], "executed")
@@ -119,8 +127,7 @@ class FuzzRunnerTests(unittest.TestCase):
 
     @patch("run_fuzz.subprocess.run", side_effect=__import__("subprocess").TimeoutExpired("cargo", 120))
     def test_checked_emission_timeout_is_a_structured_candidate(self, _run: object) -> None:
-        payload = self.campaign_fixture("success.json")
-        payload["target"] = "atm-template-checked-emission"
+        payload = self.checked_emission_campaign()
         campaign = validate_campaign(payload, Path.cwd())
         result = build_result(campaign, dry_run=False, execute=True)
         self.assertEqual(result["summary"]["failed_workers"], 4)
@@ -132,8 +139,7 @@ class FuzzRunnerTests(unittest.TestCase):
             build_result(campaign, dry_run=False, execute=True)
 
     def test_checked_emission_requires_the_full_bounded_campaign_shape(self) -> None:
-        payload = self.campaign_fixture("success.json")
-        payload["target"] = "atm-template-checked-emission"
+        payload = self.checked_emission_campaign()
         payload["max_workers"] = 3
         with self.assertRaisesRegex(FuzzInputError, "exactly four workers"):
             validate_campaign(payload, Path.cwd())
@@ -144,6 +150,22 @@ class FuzzRunnerTests(unittest.TestCase):
         payload["cases_per_worker"] = 100
         payload["per_worker_timeout_s"] = 119
         with self.assertRaisesRegex(FuzzInputError, "120-second"):
+            validate_campaign(payload, Path.cwd())
+
+    def test_checked_emission_requires_structured_campaign_provenance(self) -> None:
+        payload = self.campaign_fixture("success.json")
+        payload["target"] = "atm-template-checked-emission"
+        with self.assertRaisesRegex(FuzzInputError, "campaign_id"):
+            validate_campaign(payload, Path.cwd())
+
+        payload.update(self.checked_emission_campaign())
+        campaign = validate_campaign(payload, Path.cwd())
+        self.assertEqual(campaign["campaign_id"], "an15-checked-emission-test")
+        self.assertEqual(campaign["candidate_ref"], "a" * 40)
+        self.assertEqual(campaign["final_ci_commit"], "b" * 40)
+
+        payload["final_ci_commit"] = "not-a-sha"
+        with self.assertRaisesRegex(FuzzInputError, "full lowercase git commit SHA"):
             validate_campaign(payload, Path.cwd())
 
 

--- a/crates/atm-core/src/read/render.rs
+++ b/crates/atm-core/src/read/render.rs
@@ -122,13 +122,16 @@ mod tests {
         fn render_without_includes(
             &self,
             _source: &TemplateSource,
-            _vars: &Map<String, Value>,
+            vars: &Map<String, Value>,
         ) -> Result<RenderedBody, crate::error::AtmError> {
             if self.includes {
                 return Err(crate::error::AtmError::decomposed_template_include_forbidden());
             }
             Ok(RenderedBody {
-                text: "stable rendered body".to_string(),
+                text: vars.get("ATM_TEAM").and_then(Value::as_str).map_or_else(
+                    || "stable rendered body".to_string(),
+                    |team| format!("team={team}"),
+                ),
             })
         }
     }
@@ -197,5 +200,23 @@ mod tests {
         .expect_err("legacy rows must be re-registered before checked rendering");
 
         assert!(error.detail().contains("legacy/unverified"));
+    }
+
+    #[test]
+    fn an15_differential_probe_render_on_read_uses_only_captured_variables() {
+        let _ambient = crate::test_support::EnvGuard::set_raw("ATM_TEAM", "ambient-wrong-team");
+        let composer = FixtureComposer { includes: false };
+        let stored = template();
+
+        for case_index in 0..100 {
+            let captured = format!("catalog-team-{case_index}");
+            let vars = atm_storage::MergedVarsJson::from_merged_object(Map::from_iter([(
+                "ATM_TEAM".to_owned(),
+                Value::String(captured.clone()),
+            )]));
+            let rendered =
+                render_decomposed(&composer, &stored, &vars).expect("pure stored render");
+            assert_eq!(rendered.text, format!("team={captured}"));
+        }
     }
 }

--- a/crates/atm-core/src/send/template.rs
+++ b/crates/atm-core/src/send/template.rs
@@ -235,6 +235,39 @@ mod tests {
     }
 
     #[test]
+    fn an15_shape_probe_captures_environment_values_without_consulting_process_environment() {
+        // The CLI is responsible for capturing any approved environment input
+        // into `environment_values`. Admission and every later read are pure
+        // with respect to the ambient process environment.
+        let _ambient = crate::test_support::EnvGuard::set_raw("ATM_TEAM", "ambient-wrong-team");
+        let frontmatter = atm_storage::TemplateFrontmatter {
+            required_variables: vec![variable("ATM_TEAM")],
+            ..atm_storage::TemplateFrontmatter::default()
+        };
+
+        for case_index in 0..100 {
+            let captured = format!("captured-team-{case_index}");
+            let mut request = source();
+            request.environment_values =
+                Map::from_iter([("ATM_TEAM".to_owned(), Value::String(captured.clone()))]);
+            let merged = resolve_merged_vars(&frontmatter, &request).expect("captured admission");
+            assert_eq!(
+                merged.as_map().get("ATM_TEAM"),
+                Some(&Value::String(captured))
+            );
+        }
+
+        let mut missing = source();
+        missing.environment_values.remove("ATM_TEAM");
+        let error =
+            resolve_merged_vars(&frontmatter, &missing).expect_err("missing admission value");
+        assert_eq!(
+            error.code(),
+            atm_storage::AtmErrorCode::TemplateRequiredVariableMissing
+        );
+    }
+
+    #[test]
     fn verification_uses_confined_render_and_captures_the_merged_body() {
         let inspection = TemplateInspection {
             sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1456,6 +1456,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an15_shape_probe_missing_required_input_mutates_no_catalog_or_mailbox_rows() {
+        let body = "required input must be captured before durable admission";
+        let inspection = atm_core::TemplateInspection {
+            sha: TemplateSha::new(
+                "814271b7e98145c998a2c1f20270856c592881ba7dac4dfee9307d8093163a03",
+            )
+            .expect("template SHA"),
+            frontmatter: TemplateFrontmatter {
+                required_variables: vec![
+                    atm_storage::TemplateVariableName::new("ATM_TEAM")
+                        .expect("fixture required variable"),
+                ],
+                ..TemplateFrontmatter::default()
+            },
+            include_references: Vec::new(),
+            output_format: atm_storage::TemplateOutputFormat::Text,
+        };
+        let composer: Arc<dyn atm_core::TemplateComposer> = Arc::new(
+            FixtureTemplateComposer::with_inspection(body.as_bytes().to_vec(), inspection),
+        );
+        let fixture =
+            fixture_with_selector_and_template(true, None, None, Some(composer), |received_hook| {
+                Arc::new(FixedReceivedHookSelector {
+                    emitter: received_hook,
+                })
+            });
+
+        let write = template_write_request(&fixture, body);
+        let response = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
+        let status = response.status();
+        let error = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("rejection body");
+        assert_ne!(
+            status,
+            StatusCode::CREATED,
+            "missing required input must reject the write: {}",
+            String::from_utf8_lossy(&error)
+        );
+        let error: serde_json::Value = serde_json::from_slice(&error).expect("rejection JSON");
+        assert_eq!(
+            error["code"].as_str(),
+            Some("TEMPLATE_REQUIRED_VARIABLE_MISSING"),
+            "the stable admission error explains the rejected write"
+        );
+
+        let snapshot = inspect_template_admission_for_test(&fixture.database_path, &[])
+            .expect("inspect rejected durable admission");
+        assert_eq!(
+            snapshot.template_count, 0,
+            "rejected input registers no template"
+        );
+        assert_eq!(
+            snapshot.decomposed_count, 0,
+            "rejected input creates no decomposition"
+        );
+        let mailbox = fixture
+            .message_store
+            .list_messages(&MessageQuery {
+                team: "test-team".parse().expect("team"),
+                agent: "recipient".parse().expect("agent"),
+                sender: None,
+                task_id: None,
+                limit: None,
+            })
+            .expect("inspect rejected mailbox");
+        assert!(mailbox.is_empty(), "rejected input writes no mailbox row");
+    }
+
+    #[tokio::test]
     async fn template_routing_matrix_persists_only_same_team_same_host_as_decomposed() {
         let body = "routing matrix body";
         let fixture = fixture_with_selector_and_template(

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -2054,6 +2054,81 @@ mod tests {
     }
 
     #[test]
+    fn an15_differential_probe_preserves_immutable_revision_metadata_and_idempotency() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let catalog = backend.template_catalog_store();
+
+        for case_index in 0..100_u64 {
+            let mut original = template_registration('a');
+            original.sha = TemplateSha::new(format!("{case_index:064x}")).expect("original SHA");
+            original.content_text = format!(
+                "---\nmetadata:\n  revision: original-{case_index}\n---\nhello {{ name }}\n"
+            );
+            original.content_bytes = original.content_text.as_bytes().to_vec();
+            original.frontmatter.metadata.insert(
+                "revision".to_owned(),
+                serde_json::json!(format!("original-{case_index}")),
+            );
+            assert_eq!(
+                catalog
+                    .register(original.clone())
+                    .expect("register original revision"),
+                TemplateRegistrationOutcome::Inserted
+            );
+
+            let mut revision = template_registration('a');
+            revision.sha =
+                TemplateSha::new(format!("{:064x}", case_index + 10_000)).expect("edited SHA");
+            revision.content_text =
+                format!("---\nmetadata:\n  revision: {case_index}\n---\nhello {{ name }}\n");
+            revision.content_bytes = revision.content_text.as_bytes().to_vec();
+            revision
+                .frontmatter
+                .metadata
+                .insert("revision".to_owned(), serde_json::json!(case_index));
+
+            assert_eq!(
+                catalog
+                    .register(revision.clone())
+                    .expect("register immutable revision"),
+                TemplateRegistrationOutcome::Inserted
+            );
+            assert_eq!(
+                catalog
+                    .register(revision.clone())
+                    .expect("idempotent re-admission"),
+                TemplateRegistrationOutcome::AlreadyRegistered
+            );
+            let loaded = catalog
+                .load(&revision.sha)
+                .expect("load revision")
+                .expect("registered revision");
+            assert_eq!(loaded.content_bytes, revision.content_bytes);
+            assert_eq!(
+                loaded.frontmatter.metadata.get("revision"),
+                Some(&serde_json::json!(case_index))
+            );
+            assert_eq!(
+                loaded.frontmatter.metadata.get("kind"),
+                Some(&serde_json::json!("assignment"))
+            );
+            let loaded_original = catalog
+                .load(&original.sha)
+                .expect("load original")
+                .expect("original remains registered");
+            assert_ne!(
+                loaded_original.sha, loaded.sha,
+                "one-byte revision needs a new SHA"
+            );
+            assert_eq!(loaded_original.content_bytes, original.content_bytes);
+            assert_eq!(
+                loaded_original.frontmatter.metadata.get("revision"),
+                Some(&serde_json::json!(format!("original-{case_index}")))
+            );
+        }
+    }
+
+    #[test]
     fn catalog_migration_keeps_legacy_rows_unclassified_and_persists_new_format_after_reopen() {
         let root = tempfile::tempdir().expect("temporary catalog root");
         let path = root.path().join("catalog.db");

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -2129,7 +2129,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_migration_keeps_legacy_rows_unclassified_and_persists_new_format_after_reopen() {
+    fn an15_differential_probe_legacy_rows_survive_reopen_without_reclassification() {
         let root = tempfile::tempdir().expect("temporary catalog root");
         let path = root.path().join("catalog.db");
         let legacy_sha = "e".repeat(64);

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -553,6 +553,34 @@ mod tests {
     }
 
     #[test]
+    fn an15_template_probe_checked_json_is_deterministic_for_unicode_and_escape_vectors() {
+        let root = temporary_root("an15-unicode-escape");
+        let template_path = root.join("payload.json.j2");
+        fs::write(&template_path, r#"{"value": {{ value }}}"#).expect("write JSON template");
+        let source = TemplateSource::file_backed(
+            fs::read(&template_path).expect("read template"),
+            fs::canonicalize(&template_path).expect("canonical template"),
+        );
+        let root = TemplateRoot {
+            canonical_path: fs::canonicalize(&root).expect("canonical root"),
+        };
+        let composer = ScComposeTemplateComposer::new();
+
+        for case_index in 0..100 {
+            let value = format!("case-{case_index}-🙂-漢字-\\\"-newline\\n");
+            let vars = Map::from_iter([("value".to_owned(), Value::String(value.clone()))]);
+            let rendered = composer
+                .compose_file(&source, &vars, &root)
+                .expect("checked JSON must remain valid");
+            assert_eq!(
+                serde_json::from_str::<Value>(&rendered.text).expect("checked JSON")["value"],
+                Value::String(value),
+            );
+        }
+        fs::remove_dir_all(&root.canonical_path).expect("remove isolated template root");
+    }
+
+    #[test]
     fn checked_emission_reports_the_failing_second_render_pass() {
         let root = temporary_root("checked-multipass-json");
         let template_path = root.join("payload.json.j2");
@@ -734,6 +762,45 @@ mod tests {
                 .is_some_and(|cause| cause.contains("escapes confinement root")),
             "upstream confinement diagnostic must be preserved: {error}"
         );
+    }
+
+    #[test]
+    fn an15_boundary_probe_rejects_one_hundred_confined_include_escape_vectors() {
+        let parent = temporary_root("an15-include-escape-parent");
+        let root = parent.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let canonical_root = ConfiningRoot::new(&root)
+            .expect("canonical root")
+            .into_inner();
+
+        for case_index in 0..100 {
+            let template_path = root.join(format!("main-{case_index}.j2"));
+            fs::write(&template_path, format!("@<../outside-{case_index}.j2>\\n"))
+                .expect("write escaping template");
+            fs::write(
+                parent.join(format!("outside-{case_index}.j2")),
+                "must not load",
+            )
+            .expect("write outside template");
+            let source = TemplateSource::file_backed(
+                fs::read(&template_path).expect("read template"),
+                template_path,
+            );
+            let error = ScComposeTemplateComposer::new()
+                .render_within_root(
+                    &source,
+                    &Map::new(),
+                    &TemplateRoot {
+                        canonical_path: canonical_root.clone(),
+                    },
+                )
+                .expect_err("outside include must be rejected");
+            assert_eq!(
+                error.code(),
+                atm_storage::AtmErrorCode::TemplateIncludeUnresolved
+            );
+        }
+        fs::remove_dir_all(&parent).expect("remove isolated template parent");
     }
 
     #[test]

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -456,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn checked_emission_rejection_leaves_send_fallback_and_read_inputs_immutable() {
+    fn an15_boundary_probe_rejection_leaves_send_fallback_and_read_inputs_immutable() {
         let malformed = br#"{\"secret\": "#;
 
         // Template send and its rendered-fallback variant both invoke this
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn production_adapter_preserves_auto_and_legacy_json_escape_contracts() {
+    fn an15_template_probe_preserves_auto_and_legacy_json_escape_contracts() {
         let injected = r#"x\", \"injected\": true, \"y\": \"x"#;
         for (label, frontmatter, body) in [
             ("auto", "", r#"{"value": {{ value }}}"#),
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn checked_emission_reports_the_failing_second_render_pass() {
+    fn an15_template_probe_reports_the_failing_second_render_pass() {
         let root = temporary_root("checked-multipass-json");
         let template_path = root.join("payload.json.j2");
         fs::write(

--- a/docs/fuzz-campaign-contract.md
+++ b/docs/fuzz-campaign-contract.md
@@ -1,14 +1,17 @@
 # AI48 fuzz campaign contract
 
 `just fuzz` validates this bounded campaign input and emits a deterministic,
-structured worker-result envelope. AI48 is contract-only: it does not invoke a
-real product campaign, mutate the approved worktree, or create HTML/XHTML
-reports. Later sprints own execution and publication.
+structured worker-result envelope. The original AI48 targets are contract-only:
+they do not invoke a product campaign or mutate an approved worktree. AN.15
+adds the one exception, `atm-template-checked-emission`, which may be executed
+with `--execute`: it runs four fixed Cargo-test seams in the approved worktree.
+It never shells out to `sc-compose`, accepts a caller-provided command, or lets
+a worker edit production code.
 
 ```json
 {
   "worktree_path": "/absolute/path/to/approved/worktree",
-  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | local-http-framing | atm-template-checked-emission | full",
   "baseline_ref": "optional git ref",
   "seed": 157,
   "max_workers": 4,
@@ -24,3 +27,9 @@ worktree, `max_workers` is capped at four, and all numeric limits are bounded.
 Worker results retain timeout and malformed-result failures instead of
 discarding them. Use `--campaign <path>` to validate a JSON file and
 `--output <path>` to save the emitted envelope under the repository.
+
+For the AN.15 execution lane, `max_workers` must be four and each fixed worker
+uses the campaign's bounded case count and timeout. A nonzero test exit or a
+timeout becomes a structured candidate (`worker_test_failure` or
+`worker_timeout`); it is never silently converted to a pass. Real execution is
+fail-closed for every other target.

--- a/docs/plans/phase-an/plan-phase-an.md
+++ b/docs/plans/phase-an/plan-phase-an.md
@@ -1,6 +1,6 @@
 ---
 title: Phase AN Plan — Decomposed Template Messages and a Template-Agnostic Query Surface
-status: AN.1–AN.12 complete; AN.13 in progress; AN.14–AN.15 planned after AN.13
+status: AN.1–AN.14 complete; AN.15 in progress
 branch: plan/phase-an
 baseline: integrate/phase-al @ 0ef581e1 (assumes Phase AM deletion completes first; see Entry gate)
 ---

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1227,7 +1227,7 @@ Acceptance:
   proven dead, no guard is merged early, and the minimality proof confirms
   no compatibility shim survives.
 
-## 45. Phase AN — Decomposed Template Messages And Query Surface [AN.1–AN.13 COMPLETE; AN.14 IN PROGRESS]
+## 45. Phase AN — Decomposed Template Messages And Query Surface [AN.1–AN.14 COMPLETE; AN.15 IN PROGRESS]
 
 - **Phase AN: Decomposed Template Messages And Query Surface [AN.1–AN.10 COMPLETE]** —
   Added a bounded `sc-composer` adapter boundary, durable template catalog and
@@ -1261,10 +1261,10 @@ Sprint line:
 - `AN.14` `feature/an14-sc-compose-141-checked-emission` — adapter-only
   checked emission that rejects malformed JSON before send or render-on-read
 
-- **AN.13–AN.15 checked-render upgrade and assurance [AN.14 IN PROGRESS]** — AN.13 establishes
+- **AN.13–AN.15 checked-render upgrade and assurance [AN.15 IN PROGRESS]** — AN.13 establishes
   durable adapter-derived output-format identity and adopts the released
   exact `sc-sha`/`sc-composer` 1.4.1 dependency chain in its adapter; AN.14
-  will make the
+  makes the
   `atm-template-sc-compose` adapter refuse malformed rendered JSON before
   sending, caching, or render-on-read output. AN.15 then runs a bounded,
   deterministic adversarial campaign over the checked template/catalog

--- a/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
+++ b/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
@@ -1,0 +1,25 @@
+# AN.15 checked-emission campaign provenance
+
+- Campaign target: `atm-template-checked-emission`
+- Campaign seed: `20260814`
+- Candidate worktree/ref: `feature/an15-adversarial-fuzzing` at
+  `79c3577e331361a498be90761ffd915940683f43`
+- AN.14 baseline ref: `9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f`
+- Fixed workers: `shape-probe`, `template-probe`, `boundary-probe`, and
+  `differential-probe`; each executed 100 seeded vectors with a 120-second
+  individual timeout.
+- Result: all four workers succeeded; no candidates, confirmed bugs, or
+  unassigned safety investigations were produced.
+
+The campaign used the locked crates.io sources rather than an unpublished
+revision or path override:
+
+| Crate | Version | Cargo.lock checksum |
+| --- | --- | --- |
+| `sc-composer` | `1.4.1` | `4415ff74a7f91a7505a7c9fc464908ed5e0e684d2648b5d731e0533c371edb2c` |
+| `sc-sha` | `1.4.1` | `01502b8bda56eef5c2f445a88396d75cc223c8ce91709ac007dbb81f40e577ba` |
+
+`cargo tree -p atm-template-sc-compose -e normal` resolved
+`sc-composer v1.4.1` and `sc-sha v1.4.1`. The campaign runner invokes only
+closed-over `cargo test` test seams. It does not invoke the `sc-compose` CLI,
+accept a caller-supplied command, or edit production code.

--- a/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
+++ b/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
@@ -2,8 +2,9 @@
 
 - Campaign target: `atm-template-checked-emission`
 - Campaign seed: `20260814`
-- Candidate worktree/ref: `feature/an15-adversarial-fuzzing` at
-  `8e2d24cc111f4e0fe79facf441b343e6e7fdb669`
+- Campaign ID: `an15-checked-emission-20260814`
+- Candidate worktree/ref and final CI commit: `feature/an15-adversarial-fuzzing`
+  at `82d313a8a73d6d127587a199f14c98a5bf4c1e43`
 - AN.14 baseline ref: `9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f`
 - Fixed workers: `shape-probe`, `template-probe`, `boundary-probe`, and
   `differential-probe`; each executed 100 seeded vectors with a 120-second
@@ -23,3 +24,18 @@ revision or path override:
 `sc-composer v1.4.1` and `sc-sha v1.4.1`. The campaign runner invokes only
 closed-over `cargo test` test seams. It does not invoke the `sc-compose` CLI,
 accept a caller-supplied command, or edit production code.
+
+## Upstream release and checked-render evidence
+
+The campaign report's structured `provenance` object points to both retained
+source snapshots below. They are kept adjacent to the report so a reviewer can
+validate this gate without relying on a mutable external page.
+
+| Evidence | Retained path | Verified fact | SHA-256 |
+| --- | --- | --- | --- |
+| crates.io release | `an15-sc-compose-1.4.1-crates-io.json` | `sc-compose` `1.4.1`, published 2026-08-14T01:16:45Z, not yanked; registry checksum `bb3111c4fc261f4aff1e341bd76475ce13524b9b768021ceb79da9761e31dd05` | `91732ebd15d04dd7d6d66e73eb5f57bfe416bfe41df159e6bf9c19fa8527c199` |
+| upstream checked-render issue | `an15-sc-compose-448-github.json` | [randlee/sc-compose#448](https://github.com/randlee/sc-compose/issues/448) closed as completed 2026-08-13T20:44:19Z | `5409e52f3cd4df53fc81f02ca83c5ab98150f965cb6c151277eb077f9171385c` |
+
+The crates.io snapshot was retrieved from
+`https://crates.io/api/v1/crates/sc-compose/1.4.1`; `cargo info
+sc-compose@1.4.1` independently resolved the same release from crates.io.

--- a/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
+++ b/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
@@ -4,7 +4,7 @@
 - Campaign seed: `20260814`
 - Campaign ID: `an15-checked-emission-20260814`
 - Candidate worktree/ref and final CI commit: `feature/an15-adversarial-fuzzing`
-  at `82d313a8a73d6d127587a199f14c98a5bf4c1e43`
+  at `992a0828ef15fa021d46ee32dbea1adf865f21dd`
 - AN.14 baseline ref: `9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f`
 - Fixed workers: `shape-probe`, `template-probe`, `boundary-probe`, and
   `differential-probe`; each executed 100 seeded vectors with a 120-second

--- a/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
+++ b/site/reports/fuzz/an15-checked-emission-20260814-provenance.md
@@ -3,7 +3,7 @@
 - Campaign target: `atm-template-checked-emission`
 - Campaign seed: `20260814`
 - Candidate worktree/ref: `feature/an15-adversarial-fuzzing` at
-  `79c3577e331361a498be90761ffd915940683f43`
+  `8e2d24cc111f4e0fe79facf441b343e6e7fdb669`
 - AN.14 baseline ref: `9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f`
 - Fixed workers: `shape-probe`, `template-probe`, `boundary-probe`, and
   `differential-probe`; each executed 100 seeded vectors with a 120-second

--- a/site/reports/fuzz/an15-checked-emission-20260814.json
+++ b/site/reports/fuzz/an15-checked-emission-20260814.json
@@ -2,9 +2,9 @@
   "campaign": {
     "baseline_ref": "9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f",
     "campaign_id": "an15-checked-emission-20260814",
-    "candidate_ref": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
+    "candidate_ref": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
     "cases_per_worker": 100,
-    "final_ci_commit": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
+    "final_ci_commit": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
     "max_workers": 4,
     "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands.",
     "per_worker_timeout_s": 120,

--- a/site/reports/fuzz/an15-checked-emission-20260814.json
+++ b/site/reports/fuzz/an15-checked-emission-20260814.json
@@ -1,0 +1,77 @@
+{
+  "campaign": {
+    "baseline_ref": "9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f",
+    "cases_per_worker": 100,
+    "max_workers": 4,
+    "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands. candidate_ref=8e2d24cc111f4e0fe79facf441b343e6e7fdb669",
+    "per_worker_timeout_s": 120,
+    "promote_regressions": true,
+    "seed": 20260814,
+    "target": "atm-template-checked-emission",
+    "worktree_path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/an15-adversarial-fuzzing"
+  },
+  "execution_mode": "executed",
+  "findings": [],
+  "outcome_ledger": {
+    "benign": [],
+    "confirmed_bug": [],
+    "inconclusive": [],
+    "non_repro": []
+  },
+  "promoted_tests": [],
+  "schema_version": "adversarial-fuzzing/v1",
+  "summary": {
+    "all_successful": true,
+    "confirmed_bugs": 0,
+    "failed_workers": 0,
+    "inconclusive": 0,
+    "intentional_boundaries": 0
+  },
+  "unresolved_candidates": [],
+  "workers": [
+    {
+      "cases_run": 100,
+      "correlation_id": "shape-probe",
+      "diagnostic_codes": [],
+      "error": null,
+      "finding_ids": [],
+      "oracle": "captured variables are deterministic and failed admission writes nothing",
+      "seam": "atm-core template admission and captured merged variables",
+      "status": "success",
+      "target": "atm-template-checked-emission"
+    },
+    {
+      "cases_run": 100,
+      "correlation_id": "template-probe",
+      "diagnostic_codes": [],
+      "error": null,
+      "finding_ids": [],
+      "oracle": "format classification, escaping, and Unicode are deterministic",
+      "seam": "sealed atm-template-sc-compose checked final rendering",
+      "status": "success",
+      "target": "atm-template-checked-emission"
+    },
+    {
+      "cases_run": 100,
+      "correlation_id": "boundary-probe",
+      "diagnostic_codes": [],
+      "error": null,
+      "finding_ids": [],
+      "oracle": "rejection neither escapes the root nor leaks or mutates persisted state",
+      "seam": "template catalog admission and confined include/fallback paths",
+      "status": "success",
+      "target": "atm-template-checked-emission"
+    },
+    {
+      "cases_run": 100,
+      "correlation_id": "differential-probe",
+      "diagnostic_codes": [],
+      "error": null,
+      "finding_ids": [],
+      "oracle": "persisted revision data, never ambient state, determines rendering",
+      "seam": "atm-core render-on-read and rusqlite persisted template catalog",
+      "status": "success",
+      "target": "atm-template-checked-emission"
+    }
+  ]
+}

--- a/site/reports/fuzz/an15-checked-emission-20260814.json
+++ b/site/reports/fuzz/an15-checked-emission-20260814.json
@@ -1,11 +1,16 @@
 {
   "campaign": {
     "baseline_ref": "9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f",
+    "campaign_id": "an15-checked-emission-20260814",
+    "candidate_ref": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
     "cases_per_worker": 100,
+    "final_ci_commit": "82d313a8a73d6d127587a199f14c98a5bf4c1e43",
     "max_workers": 4,
-    "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands. candidate_ref=8e2d24cc111f4e0fe79facf441b343e6e7fdb669",
+    "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands.",
     "per_worker_timeout_s": 120,
     "promote_regressions": true,
+    "sc_compose_issue_evidence": "site/reports/fuzz/an15-sc-compose-448-github.json",
+    "sc_compose_release_evidence": "site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json",
     "seed": 20260814,
     "target": "atm-template-checked-emission",
     "worktree_path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/an15-adversarial-fuzzing"
@@ -19,6 +24,10 @@
     "non_repro": []
   },
   "promoted_tests": [],
+  "provenance": {
+    "sc_compose_issue_evidence": "site/reports/fuzz/an15-sc-compose-448-github.json",
+    "sc_compose_release_evidence": "site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json"
+  },
   "schema_version": "adversarial-fuzzing/v1",
   "summary": {
     "all_successful": true,
@@ -35,8 +44,8 @@
       "diagnostic_codes": [],
       "error": null,
       "finding_ids": [],
-      "oracle": "captured variables are deterministic and failed admission writes nothing",
-      "seam": "atm-core template admission and captured merged variables",
+      "oracle": "missing required input rejects before any template catalog or mailbox row is written",
+      "seam": "Tokio/Axum template admission through the SQLite catalog and mailbox boundary",
       "status": "success",
       "target": "atm-template-checked-emission"
     },
@@ -68,8 +77,8 @@
       "diagnostic_codes": [],
       "error": null,
       "finding_ids": [],
-      "oracle": "persisted revision data, never ambient state, determines rendering",
-      "seam": "atm-core render-on-read and rusqlite persisted template catalog",
+      "oracle": "captured stored values, never ambient state, determine rendering",
+      "seam": "atm-core render-on-read from captured persisted variables",
       "status": "success",
       "target": "atm-template-checked-emission"
     }

--- a/site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json
+++ b/site/reports/fuzz/an15-sc-compose-1.4.1-crates-io.json
@@ -1,0 +1,13 @@
+{
+  "version": {
+    "num": "1.4.1",
+    "checksum": "bb3111c4fc261f4aff1e341bd76475ce13524b9b768021ceb79da9761e31dd05",
+    "created_at": "2026-08-14T01:16:45.141379Z",
+    "yanked": false
+  },
+  "crate": {
+    "id": null,
+    "repository": null,
+    "homepage": null
+  }
+}

--- a/site/reports/fuzz/an15-sc-compose-448-github.json
+++ b/site/reports/fuzz/an15-sc-compose-448-github.json
@@ -1,0 +1,10 @@
+{
+  "number": 448,
+  "state": "closed",
+  "state_reason": "completed",
+  "title": "test(sc-composer): cover checked-emission sequence for direct library consumers",
+  "html_url": "https://github.com/randlee/sc-compose/issues/448",
+  "created_at": "2026-08-13T19:29:58Z",
+  "closed_at": "2026-08-13T20:44:19Z",
+  "updated_at": "2026-08-13T20:44:19Z"
+}


### PR DESCRIPTION
## Summary
- Extends adversarial-fuzzing campaign contract with `atm-template-checked-emission` target (shape-probe, template-probe, boundary-probe, differential-probe)
- Adds deterministic checked-render scenario corpus: captured-environment snapshot, immutable revision/metadata snapshot, checked-emission failures, legacy/restart behavior
- Runs and retains one bounded four-worker campaign against the merged AN.13/AN.14 line — all 4 workers PASS, 100 cases each, no candidates

## Validation
- Targeted owning-crate tests, boundary_enforcement test, `just lint`, `just test` — all pass
- Campaign report + 1.4.1 provenance retained under site/reports/fuzz/

🤖 Generated with [Claude Code](https://claude.com/claude-code)