### PR TITLE
AN.15 follow-up: sc-compose JSON escape migration regression coverage

### DIFF
--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -80,7 +80,7 @@ CHECKED_EMISSION_WORKERS = {
     },
     "template-probe": {
         "seam": "sealed atm-template-sc-compose checked final rendering",
-        "oracle": "format classification, escaping, and Unicode are deterministic",
+        "oracle": "format classification, auto/legacy JSON escape compatibility, Unicode, and actionable checked-render rejection are deterministic",
         "command": ("cargo", "test", "-p", "atm-template-sc-compose", "an15_template_probe_"),
     },
     "boundary-probe": {

--- a/.triage/phase-an/findings/FTQ-001-AN15.ttl
+++ b/.triage/phase-an/findings/FTQ-001-AN15.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/FTQ-001-AN15>
+  a triage:Finding ;
+  triage:findingId "FTQ-001-AN15" ;
+  triage:title "timeout_and_failure_remain_best_effort races a fixed 10ms sleep against the async timeout-drop path on loaded Windows runners" ;
+  triage:description "quality-mgr root-caused a Test(windows-latest) FAILED on PR #880 (feature/an15-adversarial-fuzzing, run 31819546649, job 94829518897) to workflow_telemetry::tests::timeout_and_failure_remain_best_effort, panicked at crates/atm-runtime/src/workflow_telemetry.rs:405:9, assertion left==right failed (left: 0, right: 1). The test configures emit_timeout: Duration::from_millis(1), calls try_emit once, then sleeps a fixed Duration::from_millis(10) before asserting diagnostics().dropped_timeout == 1. On a loaded/slow Windows CI runner the background async task that increments dropped_timeout after the 1ms configured timeout can lose the race against the fixed 10ms sleep, observing 0 instead of 1. Confirmed unrelated to the AN.15 fix under review: this test is in atm-runtime (workflow_telemetry.rs), a different crate from the boundaries-lint fix's atm-template-sc-compose (commit f661a8876, 2-string-literal rename only). Test(macos-latest) and Test(ubuntu-latest) passed on the same run; re-running Test(windows-latest) alone succeeded. Remediation: replace the fixed 10ms sleep with a bounded poll/retry loop (or otherwise await the drop-counter reaching 1 with a generous timeout) instead of a single fixed sleep racing the timeout path." ;
+  triage:phaseId "phase-an" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "flaky-test-qa" ;
+  triage:severity "important" ;
+  triage:repeatable true ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-14T16:50:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AN15 ;
+  triage:foundAt "2026-08-14T16:36:54Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001-AN15/AN15-OCC-001> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/FTQ-001-AN15/AN15-OCC-001>
+  a triage:Occurrence ;
+  triage:file "crates/atm-runtime/src/workflow_telemetry.rs" ;
+  triage:line 395 ;
+  triage:snippet "async fn timeout_and_failure_remain_best_effort() {" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/an15-adversarial-fuzzing" ;
+  triage:headSha "f661a8876" ;
+  triage:occursIn <urn:atm:triage:worktree/AN15/f661a8876> .
+
+<urn:atm:triage:worktree/AN15/f661a8876>
+  a triage:WorktreeSnapshot ;
+  triage:path "feature/an15-adversarial-fuzzing" ;
+  triage:branch "feature/an15-adversarial-fuzzing" ;
+  triage:headSha "f661a8876" ;
+  triage:orderIndex 1 .

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -376,6 +376,21 @@ impl AtmError {
         .with_cause(cause)
     }
 
+    /// Reports invalid checked JSON without exposing rendered template content.
+    ///
+    /// `sc-composer` 1.4.x automatically emits complete JSON values. Older
+    /// templates that manually quoted a placeholder therefore become invalid
+    /// JSON after rendering. The public diagnostic gives an agent a concrete,
+    /// safe migration path while the lower-level parser diagnostic remains a
+    /// machine-preserved cause only.
+    pub fn template_json_escape_migration_required(cause: impl fmt::Display) -> Self {
+        Self::new(
+            AtmErrorCode::TemplateRenderVerificationFailed,
+            "JSON template rendered invalid output after checked composition. If it manually quotes a placeholder such as `\"{{ value }}\"`, migrate it to `{{ value }}` for sc-compose automatic JSON escaping, or declare `json_escape_mode: legacy` in the template frontmatter.",
+        )
+        .with_cause(cause)
+    }
+
     pub fn template_include_unresolved(cause: impl fmt::Display) -> Self {
         Self::new(
             AtmErrorCode::TemplateIncludeUnresolved,

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -136,7 +136,10 @@ impl ScComposeTemplateComposer {
                     || error.to_string(),
                     |pass| format!("{error}; final output rejected after render pass {pass}"),
                 );
-                AtmError::template_render_verification_failed(cause)
+                match format {
+                    OutputFormat::Json => AtmError::template_json_escape_migration_required(cause),
+                    OutputFormat::Text => AtmError::template_render_verification_failed(cause),
+                }
             })
     }
 }
@@ -516,14 +519,18 @@ mod tests {
     }
 
     #[test]
-    fn an15_template_probe_preserves_auto_and_legacy_json_escape_contracts() {
+    fn an15_template_probe_regresses_historical_sc_compose_json_escape_migration() {
         let injected = r#"x\", \"injected\": true, \"y\": \"x"#;
+        // These are the two exact placeholder forms changed by ATM's
+        // historical sc-compose 1.4.x migration (95899a6f0 / PR #869). The
+        // `auto` form is the repaired source; `legacy` preserves a valid
+        // migration option for a deliberately manually quoted template.
         for (label, frontmatter, body) in [
-            ("auto", "", r#"{"value": {{ value }}}"#),
+            ("auto", "", r#"{"review_mode": {{ review_mode }}}"#),
             (
                 "legacy",
                 "---\njson_escape_mode: legacy\n---\n",
-                r#"{"value": "{{ value }}"}"#,
+                r#"{"review_mode": "{{ review_mode }}"}"#,
             ),
         ] {
             let root = temporary_root(&format!("json-{label}-escape"));
@@ -534,7 +541,7 @@ mod tests {
                 fs::canonicalize(&template_path).expect("canonical template"),
             );
             let mut vars = Map::new();
-            vars.insert("value".to_owned(), Value::String(injected.to_owned()));
+            vars.insert("review_mode".to_owned(), Value::String(injected.to_owned()));
             let rendered = ScComposeTemplateComposer::new()
                 .compose_file(
                     &source,
@@ -547,9 +554,47 @@ mod tests {
             fs::remove_dir_all(&root).expect("remove isolated template root");
 
             let parsed: Value = serde_json::from_str(&rendered.text).expect("checked JSON body");
-            assert_eq!(parsed["value"], Value::String(injected.to_owned()));
+            assert_eq!(parsed["review_mode"], Value::String(injected.to_owned()));
             assert!(parsed.get("injected").is_none());
         }
+
+        // A pre-1.4.x ATM JSON template did quote the placeholder manually.
+        // It must fail closed under the 1.4.x default without a panic, raw
+        // rendered content, or an opaque error that leaves a newly installed
+        // agent unable to repair the source.
+        let root = temporary_root("an15-historical-auto-escape");
+        let template_path = root.join("rust-best-practices-assignment.json.j2");
+        fs::write(&template_path, r#"{"review_mode": "{{ review_mode }}"}"#)
+            .expect("write historical pre-migration template");
+        let source = TemplateSource::file_backed(
+            fs::read(&template_path).expect("read historical template"),
+            fs::canonicalize(&template_path).expect("canonical historical template"),
+        );
+        let error = ScComposeTemplateComposer::new()
+            .compose_file(
+                &source,
+                &Map::from_iter([("review_mode".to_owned(), Value::String(injected.to_owned()))]),
+                &TemplateRoot {
+                    canonical_path: fs::canonicalize(&root).expect("canonical root"),
+                },
+            )
+            .expect_err("pre-migration manually quoted template must fail closed");
+        fs::remove_dir_all(&root).expect("remove isolated template root");
+
+        assert_eq!(
+            error.code(),
+            atm_storage::AtmErrorCode::TemplateRenderVerificationFailed
+        );
+        assert!(
+            error
+                .message()
+                .contains("sc-compose automatic JSON escaping")
+        );
+        assert!(error.message().contains("json_escape_mode: legacy"));
+        assert!(
+            error.cause().is_some_and(|cause| !cause.contains(injected)),
+            "raw rendered values must not leak through the preserved cause"
+        );
     }
 
     #[test]

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -565,7 +565,7 @@ mod tests {
         let root = temporary_root("an15-historical-auto-escape");
         let template_path = root.join("rust-best-practices-assignment.json.j2");
         fs::write(&template_path, r#"{"review_mode": "{{ review_mode }}"}"#)
-            .expect("write historical pre-migration template");
+            .expect("write historical pre-1.4.x auto-escape template");
         let source = TemplateSource::file_backed(
             fs::read(&template_path).expect("read historical template"),
             fs::canonicalize(&template_path).expect("canonical historical template"),
@@ -578,7 +578,7 @@ mod tests {
                     canonical_path: fs::canonicalize(&root).expect("canonical root"),
                 },
             )
-            .expect_err("pre-migration manually quoted template must fail closed");
+            .expect_err("pre-1.4.x manually quoted template must fail closed");
         fs::remove_dir_all(&root).expect("remove isolated template root");
 
         assert_eq!(

--- a/site/reports/fuzz/an15-checked-emission-20260814.json
+++ b/site/reports/fuzz/an15-checked-emission-20260814.json
@@ -2,11 +2,11 @@
   "campaign": {
     "baseline_ref": "9c3d9e2a40535833bdf8c1a46a6f7eb1de88b44f",
     "campaign_id": "an15-checked-emission-20260814",
-    "candidate_ref": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
+    "candidate_ref": "e97ef4e12a4e4cbf2863506859c431bb9e0140a1",
     "cases_per_worker": 100,
-    "final_ci_commit": "992a0828ef15fa021d46ee32dbea1adf865f21dd",
+    "final_ci_commit": "e97ef4e12a4e4cbf2863506859c431bb9e0140a1",
     "max_workers": 4,
-    "notes": "AN.15 fixed four-worker checked-emission campaign; the execution runner accepts no caller-supplied commands.",
+    "notes": "AN.15 fixed four-worker checked-emission campaign, including the historical sc-compose 1.4.x auto-escape migration regression; the execution runner accepts no caller-supplied commands.",
     "per_worker_timeout_s": 120,
     "promote_regressions": true,
     "sc_compose_issue_evidence": "site/reports/fuzz/an15-sc-compose-448-github.json",
@@ -55,7 +55,7 @@
       "diagnostic_codes": [],
       "error": null,
       "finding_ids": [],
-      "oracle": "format classification, escaping, and Unicode are deterministic",
+      "oracle": "format classification, auto/legacy JSON escape compatibility, Unicode, and actionable checked-render rejection are deterministic",
       "seam": "sealed atm-template-sc-compose checked final rendering",
       "status": "success",
       "target": "atm-template-checked-emission"


### PR DESCRIPTION
## Summary
- Adds regression coverage for historical PR #869's manually-quoted JSON template form (fix commit 95899a6f0), which now fails closed via `AtmError::template_json_escape_migration_required` with an actionable remediation message and no leak of the rendered/injected value.
- Retains a fresh executed 4-worker / 400-case adversarial campaign rerun at e97ef4e1; all workers PASS, zero bugs/inconclusive.

## Verification (quality-mgr, independent)
- `cargo test -p atm-template-sc-compose -p atm-storage` = 17/17 pass, including `an15_template_probe_regresses_historical_sc_compose_json_escape_migration`.
- `clippy -D warnings` clean on both crates.
- Confirmed fail-closed error path does not leak injected/rendered secret content in the preserved cause.
- Fuzz report `site/reports/fuzz/an15-checked-emission-20260814.json` updated with new candidate_ref/final_ci_commit.

## Test plan
- [x] cargo test -p atm-template-sc-compose -p atm-storage (17/17)
- [x] clippy -D warnings clean
- [ ] Full CI gate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)