### PR TITLE
chore(release): bump version to 1.4.2

### DIFF
--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.4.2-beta-am
+PackageVersion: 1.4.2
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.2-beta-am/atm_1.4.2-beta-am_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.2/atm_1.4.2_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.4.2-beta-am
+ManifestVersion: 1.4.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -328,14 +328,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.4.2-beta-am"
+version = "1.4.2"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.2-beta-am"
+version = "1.4.2"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-error = { path = "../atm-error", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/bin/atm-daemon-benchmark.rs"
 required-features = ["benchmark-harness"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2-beta-am" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am" }
-atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2" }
+atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.2" }
 tokio.workspace = true
 fs4 = "0.13"
 serde_json.workspace = true

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
@@ -20,5 +20,5 @@ tracing = "0.1"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -17,8 +17,8 @@ sc-observability-types.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.2" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -19,12 +19,12 @@ crate-type = ["cdylib", "rlib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.2-beta-am" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
+atm-graft = { path = "../atm-graft", version = "1.4.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
 pyo3 = "0.29"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
-atm-graft = { path = "../atm-graft", version = "1.4.2-beta-am", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.2", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,14 +13,14 @@ homepage.workspace = true
 test-support = ["atm-core/test-utils"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.2" }
 async-trait.workspace = true
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2-beta-am" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2" }
 tracing.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
 base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
@@ -29,8 +29,8 @@ ulid.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -10,8 +10,8 @@ homepage.workspace = true
 description = "Provisioning and bounded curl mTLS interoperability fixture for ATM."
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 rustls.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -18,9 +18,9 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2" }
 
 [dev-dependencies]
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am", features = ["test-support"] }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.2-beta-am" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2-beta-am", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.4.2" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.2", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,8 +16,8 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Shared audited storage contract and canonical domain types for ATM."
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.2-beta-am" }
+atm-error = { path = "../atm-error", version = "1.4.2" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/atm-template-sc-compose/Cargo.toml
+++ b/crates/atm-template-sc-compose/Cargo.toml
@@ -14,8 +14,8 @@ publish = false
 name = "atm_template_sc_compose"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 sc-composer = "=1.4.1"
 sc-sha = "=1.4.1"
 serde_json.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,11 +33,11 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.2-beta-am" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.2-beta-am" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2-beta-am" }
-atm-storage = { path = "../atm-storage", version = "1.4.2-beta-am" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.2" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.2" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.2" }
+atm-storage = { path = "../atm-storage", version = "1.4.2" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -53,8 +53,8 @@ async-trait.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.2-beta-am", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2-beta-am", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.2", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.2", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"


### PR DESCRIPTION
## Summary
- Drop the `-beta-am` prerelease suffix: workspace version `1.4.2-beta-am` → `1.4.2` across root `Cargo.toml` and all crate path-dependency version pins.
- Regenerate `Cargo.lock` via `cargo update --workspace`.
- Sync `.winget/randlee.agent-team-mail.yaml` (`PackageVersion`, `InstallerUrl`, `ManifestVersion`) to match.

## Test plan
- [x] `just test` — full workspace + doc tests pass
- [x] `just lint` — `version` check passes; `deny` failure is pre-existing local `cargo-deny` 0.20.2 CLI-arg drift, unrelated to this change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)