### PR TITLE
fix(benchmark): safe quiesce/recovery for managed-daemon admission-capacity benchmark

### DIFF
--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -296,6 +296,7 @@ class ManagedDaemonLifecycle:
     backup: HostStateBackup | None = None
     pre_pair: dict[str, str | None] | None = None
     quiesced: bool = False
+    isolated_service_running: bool = False
 
     def begin(self) -> None:
         # Record only the selected binaries before stopping the service.  A
@@ -318,10 +319,42 @@ class ManagedDaemonLifecycle:
                 ) from error
             raise
 
+    def start_isolated_service(self) -> None:
+        """Start the already-selected candidate against the disposable state.
+
+        Managed-host benchmarking must measure the same launch-managed daemon
+        that will remain installed for dogfooding.  The feature-gated child is
+        reserved for the clean OS-user mode, where no managed service exists.
+        """
+        if self.backup is None or not self.quiesced:
+            raise SmokeError("managed benchmark cannot start before state isolation")
+        daemon_switch_result("restart", self.options)
+        after = daemon_switch_result("status", self.options, doctor=True)
+        if self.pre_pair is not None and selected_pair(after) != self.pre_pair:
+            raise SmokeError("managed daemon selectors changed before benchmark execution")
+        self.quiesced = False
+        self.isolated_service_running = True
+
+    def restart_isolated_service(self) -> None:
+        """Prove the selected candidate survives a restart on disposable state."""
+        if not self.isolated_service_running:
+            raise SmokeError("managed benchmark daemon is not running on disposable state")
+        daemon_switch_result("quiesce", self.options)
+        self.quiesced = True
+        self.isolated_service_running = False
+        self.start_isolated_service()
+
     def restore(self) -> None:
-        if not self.quiesced:
+        if self.backup is None:
             return
         failures: list[str] = []
+        if self.isolated_service_running:
+            try:
+                daemon_switch_result("quiesce", self.options)
+                self.quiesced = True
+                self.isolated_service_running = False
+            except Exception as error:
+                failures.append(f"could not quiesce benchmark daemon: {error}")
         if self.backup is not None:
             try:
                 self.backup.restore()
@@ -1249,6 +1282,11 @@ def run_capacity(
         "worker_limit": workers,
         "source_revision": source_revision(),
         "release": {"atm": str(atm), "atm_daemon_benchmark": str(daemon)},
+        "execution_daemon": (
+            "selected_managed_service"
+            if isolation_mode == "backup_restore"
+            else "feature_gated_benchmark_child"
+        ),
         "atm_home": str(home),
         "host_state_isolation": isolation_mode,
         "runs": [],
@@ -1273,7 +1311,8 @@ def run_capacity(
             assert managed_daemon is not None
             managed_lifecycle = ManagedDaemonLifecycle(managed_daemon)
             managed_lifecycle.begin()
-        before = count_atm_daemon_processes()
+        else:
+            before = count_atm_daemon_processes()
         home.mkdir(parents=True, exist_ok=False)
         prepare_capacity_roster(atm, env, home, roster)
         evidence["decomposition"]["async_storage_admission"] = run_direct_storage_probe(
@@ -1286,14 +1325,20 @@ def run_capacity(
             env,
             workers,
         )
-        process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
-        doctor = command_result(
-            [str(atm), "doctor", "--json"],
-            timeout=10.0,
-            env=host_runtime_client_environment(env),
-        )
-        doctor_payload = benchmark_doctor_payload(doctor)
-        evidence["daemon_pid"] = process.pid
+        if managed_lifecycle is not None:
+            managed_lifecycle.start_isolated_service()
+            managed_status = daemon_switch_result("status", managed_daemon, doctor=True)
+            doctor_payload = managed_status["doctor"]
+            evidence["managed_daemon"] = selected_pair(managed_status)
+        else:
+            process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
+            doctor = command_result(
+                [str(atm), "doctor", "--json"],
+                timeout=10.0,
+                env=host_runtime_client_environment(env),
+            )
+            doctor_payload = benchmark_doctor_payload(doctor)
+            evidence["daemon_pid"] = process.pid
         evidence["doctor"] = doctor_payload
         evidence["doctor_status"] = "passed"
         endpoint = local_endpoint(transport)
@@ -1339,21 +1384,25 @@ def run_capacity(
         evidence["passed"] = evidence["thresholds"]["passed"]
         expected_accepted_count = sum(item["accepted_count"] for item in profile["intervals"])
 
-        # This intentionally restarts the same isolated daemon.  A transport
-        # success alone is not durable evidence, so prove every committed row
-        # survived using an exact read-only count of its disposable store.
-        reap_owned_daemon(process)
-        daemon_output.join()
-        evidence["pre_restart_daemon_output"] = daemon_output.evidence()
-        process = None
-        daemon_output = None
-        process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
-        restart_doctor = command_result(
-            [str(atm), "doctor", "--json"],
-            timeout=10.0,
-            env=host_runtime_client_environment(env),
-        )
-        benchmark_doctor_payload(restart_doctor)
+        # Restart the actual execution daemon. A transport success alone is
+        # not durable evidence, so prove every committed row survived using an
+        # exact read-only count of its disposable store.
+        if managed_lifecycle is not None:
+            managed_lifecycle.restart_isolated_service()
+            daemon_switch_result("status", managed_daemon, doctor=True)
+        else:
+            reap_owned_daemon(process)
+            daemon_output.join()
+            evidence["pre_restart_daemon_output"] = daemon_output.evidence()
+            process = None
+            daemon_output = None
+            process, daemon_output = start_capacity_daemon(daemon, home, env, hook_mode)
+            restart_doctor = command_result(
+                [str(atm), "doctor", "--json"],
+                timeout=10.0,
+                env=host_runtime_client_environment(env),
+            )
+            benchmark_doctor_payload(restart_doctor)
         # The full doctor payload is host-private diagnostics; publication only
         # needs the asserted healthy result after the restart.
         evidence["doctor_after_restart"] = {"status": "passed"}

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -285,8 +285,11 @@ class ManagedDaemonLifecycle:
 
     The state root is moved only after daemon-switch has stopped the managed
     daemon, so an open SQLite connection cannot race the snapshot. The selected
-    pair is captured before quiescence and compared after restart; this flow
-    never changes CLI/daemon selectors or their configuration.
+    pair is captured before quiescence and compared after restart. Capturing
+    selectors does not require an initial doctor result: controlled quiescence
+    is the recovery path for an unavailable managed daemon. Recovery always
+    requires a ready doctor result and this flow never changes CLI/daemon
+    selectors or their configuration.
     """
 
     options: ManagedDaemonOptions
@@ -295,7 +298,12 @@ class ManagedDaemonLifecycle:
     quiesced: bool = False
 
     def begin(self) -> None:
-        before = daemon_switch_result("status", self.options, doctor=True)
+        # Record only the selected binaries before stopping the service.  A
+        # managed daemon may be unavailable precisely because this benchmark
+        # is being used to validate/recover a release candidate.  Requiring
+        # doctor here makes that safe recovery impossible; doctor is enforced
+        # after restoration below.
+        before = daemon_switch_result("status", self.options)
         self.pre_pair = selected_pair(before)
         daemon_switch_result("quiesce", self.options)
         self.quiesced = True

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -251,7 +251,40 @@ class AdmissionCapacityTests(unittest.TestCase):
         clean.assert_called_once_with(smoke_label="admission-capacity smoke")
         self.assertEqual(
             calls,
-            [("status", True), ("quiesce", False), ("restart", False), ("status", True)],
+            [("status", False), ("quiesce", False), ("restart", False), ("status", True)],
+        )
+
+    def test_managed_lifecycle_recovers_an_unavailable_pre_quiesce_daemon(self):
+        """Initial selector capture must not require the very doctor recovery restores."""
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        pre_quiesce = healthy_managed_status()
+        pre_quiesce.pop("doctor")
+        after_restore = healthy_managed_status()
+        calls: list[tuple[str, bool]] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append((action, doctor))
+            if action == "status" and doctor:
+                return after_restore
+            return pre_quiesce
+
+        with tempfile.TemporaryDirectory() as temp:
+            os_home = Path(temp)
+            state = os_home / ".atm"
+            state.mkdir()
+            (state / "mail.db").write_text("managed-state", encoding="utf-8")
+            with (
+                mock.patch.object(RUNNER, "os_account_home", return_value=os_home),
+                mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+                mock.patch.object(RUNNER, "require_clean_host_daemon_state"),
+            ):
+                lifecycle = RUNNER.ManagedDaemonLifecycle(options)
+                lifecycle.begin()
+                lifecycle.restore()
+
+        self.assertEqual(
+            calls,
+            [("status", False), ("quiesce", False), ("restart", False), ("status", True)],
         )
 
     def test_backup_snapshot_failure_restarts_the_managed_pair(self):

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -287,6 +287,40 @@ class AdmissionCapacityTests(unittest.TestCase):
             [("status", False), ("quiesce", False), ("restart", False), ("status", True)],
         )
 
+    def test_managed_lifecycle_executes_and_restarts_the_selected_service_on_disposable_state(self):
+        options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
+        calls: list[tuple[str, bool]] = []
+
+        def daemon_switch(action, _options, *, doctor=False):
+            calls.append((action, doctor))
+            return healthy_managed_status()
+
+        with tempfile.TemporaryDirectory() as temp:
+            os_home = Path(temp)
+            state = os_home / ".atm"
+            state.mkdir()
+            (state / "mail.db").write_text("managed-state", encoding="utf-8")
+            with (
+                mock.patch.object(RUNNER, "os_account_home", return_value=os_home),
+                mock.patch.object(RUNNER, "daemon_switch_result", side_effect=daemon_switch),
+                mock.patch.object(RUNNER, "require_clean_host_daemon_state"),
+            ):
+                lifecycle = RUNNER.ManagedDaemonLifecycle(options)
+                lifecycle.begin()
+                lifecycle.start_isolated_service()
+                lifecycle.restart_isolated_service()
+                lifecycle.restore()
+
+        self.assertEqual(
+            calls,
+            [
+                ("status", False), ("quiesce", False),
+                ("restart", False), ("status", True),
+                ("quiesce", False), ("restart", False), ("status", True),
+                ("quiesce", False), ("restart", False), ("status", True),
+            ],
+        )
+
     def test_backup_snapshot_failure_restarts_the_managed_pair(self):
         options = RUNNER.ManagedDaemonOptions(service="com.example.atm")
         status = healthy_managed_status()
@@ -434,9 +468,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                 mock.patch.object(RUNNER, "prepare_capacity_roster"),
                 mock.patch.object(RUNNER, "run_direct_storage_probe"),
                 mock.patch.object(RUNNER, "run_direct_core_write_probe"),
-                mock.patch.object(
-                    RUNNER, "start_capacity_daemon", side_effect=RUNNER.SmokeError("benchmark failed"),
-                ),
+                mock.patch.object(RUNNER, "local_endpoint", side_effect=RUNNER.SmokeError("benchmark failed")),
                 mock.patch.object(RUNNER, "write_raw_evidence", return_value=root / "raw.json"),
                 mock.patch.object(
                     RUNNER,
@@ -454,7 +486,10 @@ class AdmissionCapacityTests(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertEqual(captured["failure"], "benchmark failed")
         self.assertEqual(captured["managed_daemon_recovery"], "doctor-verified")
-        self.assertEqual(calls, ["status", "quiesce", "restart", "status"])
+        self.assertEqual(
+            calls,
+            ["status", "quiesce", "restart", "status", "status", "quiesce", "restart", "status"],
+        )
 
     def test_transport_is_platform_explicit(self):
         self.assertEqual(RUNNER.validate_transport("tcp"), "tcp")


### PR DESCRIPTION
## Summary
- BENCHMARK-MANAGED-RECOVERY-001: revises the admission-capacity benchmark lifecycle to record the selected daemon pair, safely quiesce the declared managed service, verify no owner remains, isolate state, run the benchmark, restore state, restart the same pair, and require doctor-ready health only at that final step.
- Controlled quiescence/recovery no longer requires a healthy doctor up front (this was blocking M5 benchmark runs when the managed daemon wasn't already doctor-ready).
- Preserves fail-closed ownership checks and rejects raw/unmanaged daemon handling.

## Test plan
- [x] Local lifecycle tests: 73/73 PASS (per arch-ctm)
- [ ] QA review (quality-mgr) — to be dispatched
- [ ] M5 live benchmark validation (arch-ctm, in progress in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)