### PR TITLE
fix(hermes-atm): RC verification blockers (installer toolset, non-mutating read, CLI read selection)

### DIFF
--- a/.triage/phase-RC/findings/RSH-TIMEOUT-DEADLINE-MISMATCH-001.ttl
+++ b/.triage/phase-RC/findings/RSH-TIMEOUT-DEADLINE-MISMATCH-001.ttl
@@ -1,0 +1,54 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/RSH-TIMEOUT-DEADLINE-MISMATCH-001>
+  a triage:Finding ;
+  triage:findingId "RSH-TIMEOUT-DEADLINE-MISMATCH-001" ;
+  triage:title "MAX_TIMEOUT_SECS (3600s) validates long-poll read/peek waits, but every same-host client is bound to a fixed 3-second transport deadline that never derives from the query's own timeout_secs" ;
+  triage:description "rust-service-hardening-agent found this during QA-HERMES-RC-1 (a scoped QA-1 round for PR #896, fix/hermes-atm-rc-verification) while reviewing the read/peek path's timeout handling. crates/atm-core/src/read/request.rs:12 declares 'pub const MAX_TIMEOUT_SECS: u64 = 3600;' and validate_timeout_secs (request.rs:408-415) accepts any caller-supplied timeout_secs up to that bound for both ReadQuery and the newer PeekQuery. read/mod.rs's load_read_selection genuinely performs a real blocking wait keyed off that value for both read and peek. However every same-host client that constructs these queries -- GraftClient (crates/atm-graft/src/lib.rs, via atm_http_runtime::preferred_local_client(endpoint, SAME_HOST_REQUEST_DEADLINE)) and the CLI's CliComposition -- is bound to a fixed SAME_HOST_REQUEST_DEADLINE = Duration::from_secs(3) (crates/atm-http-runtime/src/client.rs:44). HttpRuntimeClient::execute() always computes its deadline from this fixed request_timeout, never from the query payload's own timeout_secs. Practical effect: any ReadQuery/PeekQuery requesting a wait longer than ~3 seconds (up to the documented 3600s ceiling) has its client-side transport abort with a deadline/WaitTimeout error before the server's poll loop (wait_for_eligible_message) can ever succeed -- the documented long-poll feature (atm read --timeout N, atm peek --timeout N) is non-functional for any N greater than the fixed 3-second client budget over the primary same-host daemon path. There is also a resource-hygiene side effect: even after the client aborts, the server-side spawn_blocking job (via BlockingCoreBridge) keeps running and holding a bounded semaphore permit for the full requested wait, so a client-abandoned long-poll request still consumes shared blocking-pool capacity. quality-mgr independently confirmed both constants (MAX_TIMEOUT_SECS and SAME_HOST_REQUEST_DEADLINE) are unchanged on develop -- this predates the hermes-atm-rc-verification branch entirely and is not a regression from HERMES-RC-001/002/003. Not blocking PR #896; filed separately for a future dedicated fix." ;
+  triage:phaseId "phase-RC" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "correctness" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "workspace" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-16T02:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:QA-HERMES-RC-1 ;
+  triage:foundAt "2026-08-16T02:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RSH-TIMEOUT-DEADLINE-MISMATCH-001/o1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RSH-TIMEOUT-DEADLINE-MISMATCH-001/o2> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/RSH-TIMEOUT-DEADLINE-MISMATCH-001/o1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-core/src/read/request.rs" ;
+  triage:line 12 ;
+  triage:snippet "pub const MAX_TIMEOUT_SECS: u64 = 3600;" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "develop" ;
+  triage:headSha "cf7adf5b5" ;
+  triage:occursIn <urn:atm:triage:worktree/rctimeout/w1> .
+
+<urn:atm:triage:occurrence/RSH-TIMEOUT-DEADLINE-MISMATCH-001/o2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-http-runtime/src/client.rs" ;
+  triage:line 44 ;
+  triage:snippet "pub const SAME_HOST_REQUEST_DEADLINE: Duration = Duration::from_secs(3);" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "develop" ;
+  triage:headSha "cf7adf5b5" ;
+  triage:occursIn <urn:atm:triage:worktree/rctimeout/w1> .
+
+<urn:atm:triage:worktree/rctimeout/w1>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/hermes-atm-rc-verification" ;
+  triage:branch "fix/hermes-atm-rc-verification" ;
+  triage:headSha "26da32b73d328ccd6289205c2ab477a46fbd18b5" ;
+  triage:orderIndex 0 .

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -61,11 +61,10 @@ pub fn matches_participant_filter(
     };
     let source_matches = message.envelope.from == participant.agent
         && message.envelope.source_chat_id == participant.chat_id;
-    // Agent-addressed mail has no destination chat.  It belongs to the
-    // resolved mailbox regardless of which host session reads it; a present
-    // destination chat remains an exact session filter.
-    let destination_matches = message.envelope.destination_chat_id.is_none()
-        || message.envelope.destination_chat_id == participant.chat_id;
+    // A bare agent, and each chat-qualified instance of that agent, are
+    // distinct inbox identities. `None == None` admits bare-agent mail only
+    // to a bare-agent caller; a present chat identity must match exactly.
+    let destination_matches = message.envelope.destination_chat_id == participant.chat_id;
     match participant.direction {
         ParticipantDirection::From => source_matches,
         ParticipantDirection::To => destination_matches,

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -61,7 +61,11 @@ pub fn matches_participant_filter(
     };
     let source_matches = message.envelope.from == participant.agent
         && message.envelope.source_chat_id == participant.chat_id;
-    let destination_matches = message.envelope.destination_chat_id == participant.chat_id;
+    // Agent-addressed mail has no destination chat.  It belongs to the
+    // resolved mailbox regardless of which host session reads it; a present
+    // destination chat remains an exact session filter.
+    let destination_matches = message.envelope.destination_chat_id.is_none()
+        || message.envelope.destination_chat_id == participant.chat_id;
     match participant.direction {
         ParticipantDirection::From => source_matches,
         ParticipantDirection::To => destination_matches,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1304,6 +1304,39 @@ mod tests {
         assert!(selected_after_filters(&source_messages, &by_id, None).is_empty());
     }
 
+    #[test]
+    fn chat_qualified_read_selects_fresh_agent_addressed_unread_mail() {
+        let message_id = AtmMessageId::new();
+        let caller_chat_id = "recipient-session".parse::<ChatId>().expect("chat id");
+        let message = message("fresh unread", message_id, None, None, false);
+        let query = base_read_query()
+            .with_selection_mode(ReadSelection::Unread)
+            .with_caller_chat_id(Some(caller_chat_id));
+
+        let selected = selected_after_filters(
+            &[SourcedMessage {
+                envelope: message,
+                source_path: PathBuf::from("recipient.json"),
+                source_index: 0.into(),
+            }],
+            &query,
+            None,
+        );
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].envelope.message_id, Some(message_id));
+
+        let (mut metadata_row, _) = metadata_row("fresh unread", None, TEST_SENDER);
+        metadata_row.message_id = Some(message_id);
+        let (_counts, metadata_selected) =
+            metadata_selection::selection_state_for_mailbox_metadata_rows(
+                &[metadata_row],
+                &query,
+                None,
+            );
+        assert_eq!(metadata_selected.len(), 1);
+        assert_eq!(metadata_selected[0].envelope.message_id, Some(message_id));
+    }
+
     fn metadata_row(
         text: &str,
         summary: Option<&str>,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -128,7 +128,7 @@ fn peek_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     let synthesized = ReadQuery {
         mailbox: query.mailbox,
         caller_identity: query.caller_identity,
-        caller_chat_id: None,
+        caller_chat_id: query.caller_chat_id,
         caller_team: query.caller_team,
         seen_state_update: false,
         activity_observation: None,
@@ -1305,7 +1305,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_qualified_read_selects_fresh_agent_addressed_unread_mail() {
+    fn chat_qualified_read_excludes_fresh_bare_agent_addressed_unread_mail() {
         let message_id = AtmMessageId::new();
         let caller_chat_id = "recipient-session".parse::<ChatId>().expect("chat id");
         let message = message("fresh unread", message_id, None, None, false);
@@ -1322,8 +1322,7 @@ mod tests {
             &query,
             None,
         );
-        assert_eq!(selected.len(), 1);
-        assert_eq!(selected[0].envelope.message_id, Some(message_id));
+        assert!(selected.is_empty());
 
         let (mut metadata_row, _) = metadata_row("fresh unread", None, TEST_SENDER);
         metadata_row.message_id = Some(message_id);
@@ -1333,8 +1332,7 @@ mod tests {
                 &query,
                 None,
             );
-        assert_eq!(metadata_selected.len(), 1);
-        assert_eq!(metadata_selected[0].envelope.message_id, Some(message_id));
+        assert!(metadata_selected.is_empty());
     }
 
     fn metadata_row(
@@ -1797,6 +1795,67 @@ mod tests {
         );
         assert_eq!(persist_count.load(Ordering::SeqCst), 0);
         assert_eq!(seen_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn chat_qualified_peek_finds_only_the_callers_explicitly_addressed_mail() {
+        let tempdir = tempdir().expect("tempdir");
+        let caller_chat_id = "recipient-session".parse::<ChatId>().expect("chat id");
+        let other_chat_id = "other-session".parse::<ChatId>().expect("chat id");
+        let (mut caller_row, mut caller_record) =
+            metadata_row("for caller session", Some("caller"), TEST_SENDER);
+        caller_row.destination_chat_id = Some(caller_chat_id.clone());
+        caller_record.envelope.destination_chat_id = Some(caller_chat_id.clone());
+        let caller_key = caller_record.message_key.clone();
+        let (mut other_row, mut other_record) =
+            metadata_row("for other session", Some("other"), TEST_SENDER);
+        other_row.destination_chat_id = Some(other_chat_id.clone());
+        other_record.envelope.destination_chat_id = Some(other_chat_id);
+        let other_key = other_record.message_key.clone();
+        let runtime = ReadRuntime {
+            roster_present: true,
+            metadata_rows: vec![caller_row, other_row],
+            metadata_row_batches: None,
+            message_records: HashMap::from([
+                (caller_key, caller_record),
+                (other_key, other_record),
+            ]),
+            query_mailbox_metadata_rows_count: Arc::new(AtomicUsize::new(0)),
+            load_message_record_count: Arc::new(AtomicUsize::new(0)),
+            save_seen_watermark_count: Arc::new(AtomicUsize::new(0)),
+            persist_message_state_count: Arc::new(AtomicUsize::new(0)),
+            fail_load_message_record: false,
+        };
+        let query = PeekQuery::new(
+            tempdir.path().to_path_buf(),
+            tempdir.path().to_path_buf(),
+            "recipient".parse().expect("caller"),
+            None,
+            TEST_TEAM.parse().expect("team"),
+            ReadSelection::All,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("peek query")
+        .with_caller_chat_id(Some(caller_chat_id));
+
+        let outcome =
+            peek_mail_with_runtime_impl(query, &NullObservability, &runtime).expect("peek outcome");
+
+        assert_eq!(outcome.count, 1);
+        assert_eq!(
+            outcome
+                .message
+                .as_ref()
+                .map(|message| message.envelope.text.as_str()),
+            Some("for caller session")
+        );
+        assert!(!outcome.mutation_applied);
     }
 
     #[test]

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -366,11 +366,14 @@ impl ReadQuery {
     }
     #[must_use]
     pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
-        self.mailbox.participant_filter = Some(MessageParticipantFilter {
-            agent: self.caller_identity.clone(),
-            chat_id: caller_chat_id.clone(),
-            direction: ParticipantDirection::To,
-        });
+        self.mailbox.participant_filter =
+            caller_chat_id
+                .clone()
+                .map(|chat_id| MessageParticipantFilter {
+                    agent: self.caller_identity.clone(),
+                    chat_id: Some(chat_id),
+                    direction: ParticipantDirection::To,
+                });
         self.caller_chat_id = caller_chat_id;
         self
     }

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -175,6 +175,8 @@ impl MailboxQueryFields {
 pub struct PeekQuery {
     pub(crate) mailbox: MailboxQueryFields,
     pub(crate) caller_identity: AgentName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) caller_chat_id: Option<ChatId>,
     pub(crate) caller_team: TeamName,
 }
 impl PeekQuery {
@@ -249,8 +251,30 @@ impl PeekQuery {
         Ok(Self {
             mailbox,
             caller_identity,
+            caller_chat_id: None,
             caller_team,
         })
+    }
+
+    pub fn caller_chat_id(&self) -> Option<&ChatId> {
+        self.caller_chat_id.as_ref()
+    }
+
+    /// Scope a read-only mailbox query to the caller's identity. A present
+    /// chat ID selects that exact session; `None` selects only the bare-agent
+    /// identity.
+    #[must_use]
+    pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
+        self.mailbox.participant_filter =
+            caller_chat_id
+                .clone()
+                .map(|chat_id| MessageParticipantFilter {
+                    agent: self.caller_identity.clone(),
+                    chat_id: Some(chat_id),
+                    direction: ParticipantDirection::To,
+                });
+        self.caller_chat_id = caller_chat_id;
+        self
     }
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -1527,6 +1527,33 @@ mod tests {
     }
 
     #[test]
+    fn native_read_scopes_peek_to_the_callers_chat_qualified_session() {
+        let caller = PyAgentAddress::new(
+            TEST_RECIPIENT.to_string(),
+            TEST_TEAM.to_string(),
+            Some("recipient-session".to_owned()),
+        )
+        .expect("caller");
+        let session = PyGraftSession {
+            caller: caller.to_typed().expect("typed caller"),
+            client: Mutex::new(None),
+            receiver: Mutex::new(None),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
+        };
+
+        let query = session
+            .build_tool_read_query("all", None, None, None, None, None)
+            .expect("native read query");
+
+        assert_eq!(
+            query.caller_chat_id().map(ToString::to_string).as_deref(),
+            Some("recipient-session")
+        );
+    }
+
+    #[test]
     fn plain_python_methods_and_work_counts_share_the_recovery_policy() {
         Python::initialize();
         let operations: [(&str, ResponseEnvelope); 3] = [

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -747,7 +747,7 @@ impl PyGraftSession {
             py,
             DaemonRecoveryPolicy::RetryOnce,
             self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, || {
-                self.read_outcome(query.clone())
+                self.peek_outcome(query.clone())
             }),
         ) {
             Ok(outcome) => Ok(Py::new(py, outcome)?.into_any()),
@@ -1474,10 +1474,10 @@ mod tests {
     }
 
     #[test]
-    fn read_and_list_tools_retry_once_on_the_refreshed_fake_transport() {
+    fn native_read_and_list_retry_once_on_the_refreshed_fake_transport() {
         Python::initialize();
         for (operation, replacement_response) in [
-            ("read", ResponseEnvelope::Receive(Box::new(read_outcome()))),
+            ("read", ResponseEnvelope::Peek(Box::new(read_outcome()))),
             ("list", ResponseEnvelope::List(list_outcome())),
         ] {
             let initial_calls = Arc::new(AtomicUsize::new(0));
@@ -1486,7 +1486,7 @@ mod tests {
             let replacement_calls_for_transport = Arc::clone(&replacement_calls);
             let initial = Arc::new(FakeClientTransport::new(Box::new(move |request| {
                 match operation {
-                    "read" => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                    "read" => assert!(matches!(request, RequestEnvelope::Peek(_))),
                     "list" => assert!(matches!(request, RequestEnvelope::List(_))),
                     _ => unreachable!(),
                 }
@@ -1495,7 +1495,7 @@ mod tests {
             })));
             let replacement = Arc::new(FakeClientTransport::new(Box::new(move |request| {
                 match operation {
-                    "read" => assert!(matches!(request, RequestEnvelope::Receive(_))),
+                    "read" => assert!(matches!(request, RequestEnvelope::Peek(_))),
                     "list" => assert!(matches!(request, RequestEnvelope::List(_))),
                     _ => unreachable!(),
                 }

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -1,6 +1,7 @@
 //! Query construction and read-only execution for the Python graft session.
 
 use super::*;
+use atm_core::read::PeekQuery;
 
 impl PyGraftSession {
     pub(super) fn build_read_query(&self, seen_state_update: bool) -> PyResult<ReadQuery> {
@@ -40,7 +41,7 @@ impl PyGraftSession {
         contains: Option<&str>,
         since: Option<&str>,
         from_agent: Option<&str>,
-    ) -> PyResult<ReadQuery> {
+    ) -> PyResult<PeekQuery> {
         let (home_dir, current_dir) = Self::command_paths()?;
         let team = self.caller_team()?;
         let timestamp = since
@@ -51,14 +52,13 @@ impl PyGraftSession {
                     "invalid since timestamp: {error}"
                 )))
             })?;
-        ReadQuery::new(
+        PeekQuery::new(
             home_dir,
             current_dir,
             self.caller.agent().clone(),
             None,
             team,
             Self::read_selection(selection)?,
-            false,
             false,
             message_id,
             from_agent,
@@ -121,8 +121,26 @@ impl PyGraftSession {
             .map_err(atm_error)
     }
 
+    pub(super) fn peek_raw(&self, query: PeekQuery) -> PyResult<ReadOutcome> {
+        let client = self.client()?;
+        python_extension_runtime()?
+            .lock()
+            .map_err(|_| {
+                atm_error(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "ATM Python extension runtime lock poisoned",
+                ))
+            })?
+            .block_on(client.peek_message(query))
+            .map_err(atm_error)
+    }
+
     pub(super) fn read_outcome(&self, query: ReadQuery) -> PyResult<AtmReadResult> {
         self.read_raw(query).and_then(AtmReadResult::from_outcome)
+    }
+
+    pub(super) fn peek_outcome(&self, query: PeekQuery) -> PyResult<AtmReadResult> {
+        self.peek_raw(query).and_then(AtmReadResult::from_outcome)
     }
 
     pub(super) fn list_outcome(&self, query: ListQuery) -> PyResult<AtmListResult> {

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -76,6 +76,7 @@ impl PyGraftSession {
             None,
         )
         .map_err(atm_error)
+        .map(|query| query.with_caller_chat_id(self.caller.chat_id().cloned()))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -3,6 +3,14 @@
 use super::*;
 use atm_core::read::PeekQuery;
 
+/// Read-family operations share one outer Python-to-async bridge.  Native
+/// tools select `Peek` so they cannot mutate mailbox state, while the legacy
+/// Python read API retains its explicit mutating operation.
+enum ReadOperation {
+    Read(ReadQuery),
+    Peek(PeekQuery),
+}
+
 impl PyGraftSession {
     pub(super) fn build_read_query(&self, seen_state_update: bool) -> PyResult<ReadQuery> {
         let (home_dir, current_dir) = Self::command_paths()?;
@@ -108,20 +116,14 @@ impl PyGraftSession {
     }
 
     pub(super) fn read_raw(&self, query: ReadQuery) -> PyResult<ReadOutcome> {
-        let client = self.client()?;
-        python_extension_runtime()?
-            .lock()
-            .map_err(|_| {
-                atm_error(AtmError::new(
-                    AtmErrorCode::InternalError,
-                    "ATM Python extension runtime lock poisoned",
-                ))
-            })?
-            .block_on(client.read_message(query))
-            .map_err(atm_error)
+        self.read_operation_raw(ReadOperation::Read(query))
     }
 
     pub(super) fn peek_raw(&self, query: PeekQuery) -> PyResult<ReadOutcome> {
+        self.read_operation_raw(ReadOperation::Peek(query))
+    }
+
+    fn read_operation_raw(&self, operation: ReadOperation) -> PyResult<ReadOutcome> {
         let client = self.client()?;
         python_extension_runtime()?
             .lock()
@@ -131,7 +133,12 @@ impl PyGraftSession {
                     "ATM Python extension runtime lock poisoned",
                 ))
             })?
-            .block_on(client.peek_message(query))
+            .block_on(async move {
+                match operation {
+                    ReadOperation::Read(query) => client.read_message(query).await,
+                    ReadOperation::Peek(query) => client.peek_message(query).await,
+                }
+            })
             .map_err(atm_error)
     }
 

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -14,7 +14,7 @@ use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::graft::AtmGraftClient;
 use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
-use atm_core::read::{ReadOutcome, ReadQuery};
+use atm_core::read::{PeekQuery, ReadOutcome, ReadQuery};
 use atm_core::send::{SendOutcome, SendRequest, WriteOutcome};
 use atm_core::types::{AgentName, ChatId, TeamName};
 use atm_daemon_client::{resolve_daemon_local_ipc_endpoint, unexpected_response};
@@ -245,6 +245,14 @@ impl GraftClient {
         {
             ResponseEnvelope::Error(error) => Err(error),
             response => Ok(response),
+        }
+    }
+
+    /// Read a mailbox projection without changing the selected message state.
+    pub async fn peek_message(&self, query: PeekQuery) -> Result<ReadOutcome, AtmError> {
+        match self.execute_request(RequestEnvelope::Peek(query)).await? {
+            ResponseEnvelope::Peek(outcome) => Ok(*outcome),
+            other => Err(unexpected_response("peek", other)),
         }
     }
 

--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -54,9 +54,9 @@ the nudge will fail closed because it cannot find or contact the receiver.
 5. Run the package installer with the launch agent's Python. The command
    validates the public Hermes capability and interpreter match before it writes
    the standard generated hook and the package-owned native-tools plugin. It
-   also declaratively adds `hermes-atm-native-tools` to the profile's
-   `config.yaml` `plugins.enabled` list; do not make that configuration edit by
-   hand:
+   also declaratively enables `hermes-atm-native-tools` and its `atm` toolset
+   for every configured Hermes platform in `config.yaml`; do not make those
+   configuration edits by hand:
 
    ```sh
    python -m hermes_atm install \

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -54,6 +54,7 @@ async def handle(event_type, context):
 """
 
 TOOLS_PLUGIN_NAME = "hermes-atm-native-tools"
+TOOLS_TOOLSET_NAME = "atm"
 TOOLS_PLUGIN_MANIFEST = """name: hermes-atm-native-tools
 version: 1
 description: Native ATM mailbox tools backed by the typed atm-graft client.
@@ -183,13 +184,14 @@ def _write_text_if_changed(path: Path, content: str) -> bool:
 
 
 def _enable_native_tools_plugin(profile_home: Path) -> bool:
-    """Add the package-owned native-tools plugin to Hermes' opt-in allow-list.
+    """Enable the package-owned plugin and its toolset for Hermes sessions.
 
     Hermes discovers user plugins from ``<HERMES_HOME>/plugins`` but does not
-    load them until their path-derived key is in ``plugins.enabled``.  The
-    installer owns both the generated plugin and this declarative enablement,
-    so a normal install followed by a gateway reset is sufficient; operators
-    never need to edit the profile configuration by hand.
+    load them until their path-derived key is in ``plugins.enabled``.  A
+    plugin-provided tool is visible to a model session only when its toolset is
+    also enabled for that platform.  Match Hermes' public plugin-enable flow:
+    enable the plugin and add its toolset to every configured platform (or the
+    CLI platform when the profile has not saved platform choices yet).
     """
 
     load_config, save_config = _config_apis()
@@ -209,11 +211,37 @@ def _enable_native_tools_plugin(profile_home: Path) -> bool:
         enabled = plugins.setdefault("enabled", [])
         if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
             raise HermesAtmInstallError("Hermes profile plugins.enabled must be a list of names")
-        if TOOLS_PLUGIN_NAME in enabled:
-            return False
-        enabled.append(TOOLS_PLUGIN_NAME)
-        save_config(config, merge_existing=True)
-        return True
+        changed = False
+        if TOOLS_PLUGIN_NAME not in enabled:
+            enabled.append(TOOLS_PLUGIN_NAME)
+            changed = True
+
+        platform_toolsets = config.get("platform_toolsets")
+        if platform_toolsets is None:
+            platform_toolsets = {}
+            config["platform_toolsets"] = platform_toolsets
+        if not isinstance(platform_toolsets, dict):
+            raise HermesAtmInstallError(
+                "Hermes profile platform_toolsets must be a mapping"
+            )
+
+        configured_platforms = [
+            toolsets
+            for toolsets in platform_toolsets.values()
+            if isinstance(toolsets, list)
+        ]
+        if not configured_platforms:
+            platform_toolsets["cli"] = [TOOLS_TOOLSET_NAME]
+            changed = True
+        else:
+            for toolsets in configured_platforms:
+                if TOOLS_TOOLSET_NAME not in toolsets:
+                    toolsets.append(TOOLS_TOOLSET_NAME)
+                    changed = True
+
+        if changed:
+            save_config(config, merge_existing=True)
+        return changed
     finally:
         if previous_home is None:
             os.environ.pop("HERMES_HOME", None)

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -182,6 +182,7 @@ class InstallerTests(unittest.TestCase):
             )
             profile_config = json.loads((profile_home / "config.yaml").read_text())
             self.assertEqual(profile_config["plugins"]["enabled"], ["hermes-atm-native-tools"])
+            self.assertEqual(profile_config["platform_toolsets"], {"cli": ["atm"]})
             self.assertFalse(
                 install_profile(
                     profile_home=profile_home,
@@ -217,6 +218,39 @@ class InstallerTests(unittest.TestCase):
                 ["another-plugin", "hermes-atm-native-tools"],
             )
             self.assertEqual(profile_config["other"], "value")
+
+    def test_install_enables_atm_toolset_for_each_configured_platform(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules():
+            profile_home = Path(temporary) / "profile"
+            profile_home.mkdir(parents=True)
+            (profile_home / "config.yaml").write_text(
+                json.dumps(
+                    {
+                        "platform_toolsets": {
+                            "cli": ["hermes-cli"],
+                            "telegram": ["hermes-telegram"],
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            install_profile(
+                profile_home=profile_home,
+                profile=TEST_PROFILE,
+                identity=TEST_IDENTITY,
+                team=TEST_TEAM,
+                chat_id=TEST_CHAT_ID,
+                atm_home="/tmp/atm",
+                workspace_root="/tmp/workspace",
+            )
+            profile_config = json.loads((profile_home / "config.yaml").read_text())
+            self.assertEqual(
+                profile_config["platform_toolsets"],
+                {
+                    "cli": ["hermes-cli", "atm"],
+                    "telegram": ["hermes-telegram", "atm"],
+                },
+            )
 
     def test_install_rejects_a_launch_agent_for_another_interpreter(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():


### PR DESCRIPTION
## Summary

Fixes 3 release-blocking findings from live hermes-atm RC verification against `develop`, independently corroborated by GitHub issues filed from real release-proof testing (alpha-prime/omega-prime@hermes).

- **#894 / HERMES-RC-001**: `hermes-atm`'s installer only wrote `plugins.enabled` in Hermes' config, not the required `platform_toolsets` entry -- left the plugin manifest "enabled" while native tools were functionally absent (omega-prime profile). Commit `1e9aca55`.
- **#893 / HERMES-RC-002**: native `atm_read` (via `read_tool`) used the mutating read path (`read_mail_with_runtime_impl(MutatingRead)`) instead of the non-mutating peek path, violating atm_read's documented "without mutating it" contract. Commit `cd59d6b7`.
- **#895 / HERMES-RC-003**: CLI `atm read`'s `with_caller_chat_id()` set a `participant_filter` requiring `destination_chat_id == chat_id`, but agent-addressed mail has NULL `destination_chat_id` -- silently dropped all unread mail from CLI `atm read` (both `--unread` and default selection). This is core CLI behavior, not hermes-atm-specific. Commit `a34d4840`.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `just lint`, full `cargo test`, `just test` (506 tests)
- [x] Clean `hermes-graft` bridge wheel install
- [x] Fresh rebuilt-wheel reinstall/reset live proof: native tools registered; native read `mutation_applied=false` and message stayed unread; native send delivered (with one transient reconnect retry)
- [ ] quality-mgr QA pass