### PR TITLE
test(hermes-atm): multi-target wheel and CPython 3.11-3.14 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.14"
 
       - name: Install Python test dependencies
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
@@ -273,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,3 +265,31 @@ jobs:
         continue-on-error: true
         if: ${{ always() && needs.ci-scope.outputs.runtime == 'true' }}
         run: python scripts/smoke/run_thorough_shared_host.py
+
+  hermes-atm-wheel:
+    name: Hermes ATM wheel (Python ${{ matrix.python-version }})
+    needs: [ci-scope]
+    if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Maturin
+        run: python -m pip install maturin
+
+      - name: Build, install, and test isolated ATM wheels
+        run: python .just/run_hermes_graft_bridge_tests.py

--- a/.just/lint_atm_graft_python_boundary.py
+++ b/.just/lint_atm_graft_python_boundary.py
@@ -9,6 +9,7 @@ import tomllib
 
 BOUNDARY = Path("boundaries/atm-graft-python/hermes-graft-binding.toml")
 PACKAGE = Path("crates/atm-graft-python/pyproject.toml")
+HERMES_PACKAGE = Path("crates/hermes-atm/pyproject.toml")
 EXPECTED = {"pydantic"}
 
 @dataclass(frozen=True)
@@ -22,6 +23,7 @@ def _name(spec: str) -> str:
 def collect_violations(root: Path) -> list[Violation]:
     boundary = tomllib.loads((root / BOUNDARY).read_text(encoding="utf-8"))
     package = tomllib.loads((root / PACKAGE).read_text(encoding="utf-8"))
+    hermes_package = tomllib.loads((root / HERMES_PACKAGE).read_text(encoding="utf-8"))
     declared = set(boundary.get("dependencies", {}).get("allowed_dependencies", []))
     dependencies = {_name(value) for value in package.get("project", {}).get("dependencies", [])}
     findings: list[Violation] = []
@@ -29,6 +31,15 @@ def collect_violations(root: Path) -> list[Violation]:
         findings.append(Violation(str(PACKAGE), f"Python dependencies must be exactly {sorted(EXPECTED)}"))
     if not dependencies <= declared:
         findings.append(Violation(str(BOUNDARY), "allowed_dependencies must include every Python package dependency"))
+    graft_python_range = package.get("project", {}).get("requires-python")
+    hermes_python_range = hermes_package.get("project", {}).get("requires-python")
+    if graft_python_range != hermes_python_range:
+        findings.append(
+            Violation(
+                str(PACKAGE),
+                f"requires-python ({graft_python_range!r}) must match {HERMES_PACKAGE} ({hermes_python_range!r})",
+            )
+        )
     contracts = boundary.get("contracts", {})
     required = {"AtmSendRequest", "AtmReadRequest", "AtmListRequest", "AtmSendResult", "AtmReadResult", "AtmListResult"}
     present = set(contracts.get("request_types", [])) | set(contracts.get("response_types", []))

--- a/.just/run_hermes_graft_bridge_tests.py
+++ b/.just/run_hermes_graft_bridge_tests.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
 import venv
 import zipfile
 
@@ -17,6 +18,25 @@ ROOT = Path(__file__).resolve().parents[1]
 CRATE = ROOT / "crates" / "atm-graft-python"
 TESTS = ROOT / "crates" / "hermes-atm" / "tests"
 HERMES_PACKAGE = ROOT / "crates" / "hermes-atm"
+
+
+def project_dependency_requirement(manifest_path: Path, package_name: str) -> str:
+    """Return one declared project dependency, preserving its version constraint."""
+
+    metadata = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    dependencies = metadata.get("project", {}).get("dependencies", [])
+    for dependency in dependencies:
+        if isinstance(dependency, str) and dependency.split("=", 1)[0].split("<", 1)[0].split(">", 1)[0] == package_name:
+            return dependency
+    raise RuntimeError(f"{manifest_path} does not declare required dependency {package_name}")
+
+
+def require_universal_python_wheel(wheel_path: Path) -> None:
+    if not wheel_path.name.endswith("-py3-none-any.whl"):
+        raise RuntimeError(
+            "expected hermes-atm to ship one universal Python wheel, found "
+            f"{wheel_path.name}"
+        )
 
 
 def bridge_test_environment(venv_dir: Path, python: Path) -> dict[str, str]:
@@ -88,17 +108,19 @@ def main() -> None:
         hermes_wheels = sorted(wheel_dir.glob("hermes_atm*.whl"))
         if len(hermes_wheels) != 1:
             raise RuntimeError(f"expected one hermes-atm wheel, found {len(hermes_wheels)}")
-        if not hermes_wheels[0].name.endswith("-py3-none-any.whl"):
-            raise RuntimeError(
-                "expected hermes-atm to ship one universal Python wheel, found "
-                f"{hermes_wheels[0].name}"
-            )
+        require_universal_python_wheel(hermes_wheels[0])
         # The generic graft wheel owns the strict Pydantic ingress models.
         # Install that declared runtime dependency explicitly because this
         # contract runner intentionally installs both project wheels with
         # ``--no-deps`` to avoid resolving an unrelated published ATM wheel.
         subprocess.run(
-            [str(python), "-m", "pip", "install", "pydantic>=2,<3"],
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                project_dependency_requirement(CRATE / "pyproject.toml", "pydantic"),
+            ],
             check=True,
             cwd=ROOT,
             env=env,

--- a/.just/run_hermes_graft_bridge_tests.py
+++ b/.just/run_hermes_graft_bridge_tests.py
@@ -88,6 +88,11 @@ def main() -> None:
         hermes_wheels = sorted(wheel_dir.glob("hermes_atm*.whl"))
         if len(hermes_wheels) != 1:
             raise RuntimeError(f"expected one hermes-atm wheel, found {len(hermes_wheels)}")
+        if not hermes_wheels[0].name.endswith("-py3-none-any.whl"):
+            raise RuntimeError(
+                "expected hermes-atm to ship one universal Python wheel, found "
+                f"{hermes_wheels[0].name}"
+            )
         # The generic graft wheel owns the strict Pydantic ingress models.
         # Install that declared runtime dependency explicitly because this
         # contract runner intentionally installs both project wheels with

--- a/.just/tests/test_lint_atm_graft_python_boundary.py
+++ b/.just/tests/test_lint_atm_graft_python_boundary.py
@@ -7,10 +7,21 @@ from lint_atm_graft_python_boundary import collect_violations
 
 class Tests(unittest.TestCase):
     def fixture(self, root):
-        for path in ("boundaries/atm-graft-python/hermes-graft-binding.toml", "crates/atm-graft-python/pyproject.toml"):
+        for path in (
+            "boundaries/atm-graft-python/hermes-graft-binding.toml",
+            "crates/atm-graft-python/pyproject.toml",
+            "crates/hermes-atm/pyproject.toml",
+        ):
             source = JUST.parent / path; target = root / path; target.parent.mkdir(parents=True, exist_ok=True); shutil.copy2(source, target)
     def test_undeclared_dependency_fails(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp); self.fixture(root); path = root / "crates/atm-graft-python/pyproject.toml"
             path.write_text(path.read_text().replace('dependencies = ["pydantic>=2,<3"]', 'dependencies = ["pydantic>=2,<3", "other"]'))
+            self.assertTrue(collect_violations(root))
+
+    def test_mismatched_supported_python_range_fails(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.fixture(root)
+            path = root / "crates/atm-graft-python/pyproject.toml"
+            path.write_text(path.read_text().replace('requires-python = ">=3.11,<3.15"', 'requires-python = ">=3.11"'))
             self.assertTrue(collect_violations(root))

--- a/.just/tests/test_run_hermes_graft_bridge_tests.py
+++ b/.just/tests/test_run_hermes_graft_bridge_tests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import tomllib
 import unittest
 from unittest import mock
 
@@ -23,11 +24,20 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
         self.assertNotIn("PYTHONPATH", environment)
         self.assertNotIn("HERMES_SRC", environment)
 
-    def test_ci_test_matrix_runs_the_bridge_boundary_suite(self) -> None:
+    def test_ci_runs_the_bridge_boundary_suite_for_each_supported_python(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
         self.assertIn("Run Hermes graft steer boundary tests", workflow)
         self.assertIn("python .just/run_hermes_graft_bridge_tests.py", workflow)
+        self.assertIn("Hermes ATM wheel (Python", workflow)
+        for version in ("3.11", "3.12", "3.13", "3.14"):
+            self.assertIn(f'"{version}"', workflow)
+
+    def test_hermes_atm_declares_the_supported_python_release_range(self) -> None:
+        manifest = ROOT / "crates" / "hermes-atm" / "pyproject.toml"
+        metadata = tomllib.loads(manifest.read_text(encoding="utf-8"))
+
+        self.assertEqual(metadata["project"]["requires-python"], ">=3.11,<3.15")
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_run_hermes_graft_bridge_tests.py
+++ b/.just/tests/test_run_hermes_graft_bridge_tests.py
@@ -13,6 +13,8 @@ if str(JUST_DIR) not in sys.path:
     sys.path.insert(0, str(JUST_DIR))
 
 from run_hermes_graft_bridge_tests import bridge_test_environment
+from run_hermes_graft_bridge_tests import project_dependency_requirement
+from run_hermes_graft_bridge_tests import require_universal_python_wheel
 
 
 class HermesGraftBridgeRunnerTests(unittest.TestCase):
@@ -33,11 +35,24 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
         for version in ("3.11", "3.12", "3.13", "3.14"):
             self.assertIn(f'"{version}"', workflow)
 
-    def test_hermes_atm_declares_the_supported_python_release_range(self) -> None:
-        manifest = ROOT / "crates" / "hermes-atm" / "pyproject.toml"
-        metadata = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    def test_bridge_runner_rejects_non_universal_hermes_wheel(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "universal Python wheel"):
+            require_universal_python_wheel(Path("hermes_atm-1.4.2-cp311-cp311-any.whl"))
 
-        self.assertEqual(metadata["project"]["requires-python"], ">=3.11,<3.15")
+    def test_bridge_runner_uses_graft_manifest_pydantic_constraint(self) -> None:
+        requirement = project_dependency_requirement(
+            ROOT / "crates" / "atm-graft-python" / "pyproject.toml", "pydantic"
+        )
+
+        self.assertEqual(requirement, "pydantic>=2,<3")
+
+    def test_python_artifacts_declare_the_same_supported_python_release_range(self) -> None:
+        for manifest in (
+            ROOT / "crates" / "atm-graft-python" / "pyproject.toml",
+            ROOT / "crates" / "hermes-atm" / "pyproject.toml",
+        ):
+            metadata = tomllib.loads(manifest.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["project"]["requires-python"], ">=3.11,<3.15")
 
 
 if __name__ == "__main__":

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "atm-graft"
 version = "1.4.2"
-requires-python = ">=3.9"
+requires-python = ">=3.11,<3.15"
 dependencies = ["pydantic>=2,<3"]
 
 [tool.maturin]

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -7,7 +7,7 @@ name = "hermes-atm"
 version = "1.4.2"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11,<3.15"
 dependencies = ["atm-graft>=1.4,<1.5"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

Requested directly by Rand after RC verification confirmed the live 1.4.2 wheel was not installed on a test profile -- adds explicit multi-Python compatibility coverage so this class of issue is caught by CI going forward.

- `hermes-atm` now declares `CPython >=3.11,<3.15` support explicitly.
- CI adds isolated build/install/contract coverage for Python 3.11, 3.12, 3.13, and 3.14.
- Test runner asserts the hermes-atm artifact is a universal `py3-none-any` wheel.

Split out from PR #897 (version-alignment fix), which it was briefly and incorrectly bundled into mid-QA-round.

Commit: `5b3d70cc`

## Test plan
- [x] Local isolated wheel proofs passed on 3.11 and 3.14: matching atm-graft wheels installed, all 17 hermes-atm tests passed each run
- [ ] Full CI matrix (3.11/3.12/3.13/3.14)
- [ ] quality-mgr QA pass