### PR TITLE
docs(phase-an): mark AN.15 complete

### DIFF
--- a/docs/plans/phase-an/plan-phase-an.md
+++ b/docs/plans/phase-an/plan-phase-an.md
@@ -1,6 +1,6 @@
 ---
 title: Phase AN Plan — Decomposed Template Messages and a Template-Agnostic Query Surface
-status: AN.1–AN.14 complete; AN.15 in progress
+status: AN.1–AN.15 complete
 branch: plan/phase-an
 baseline: integrate/phase-al @ 0ef581e1 (assumes Phase AM deletion completes first; see Entry gate)
 ---

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1227,7 +1227,7 @@ Acceptance:
   proven dead, no guard is merged early, and the minimality proof confirms
   no compatibility shim survives.
 
-## 45. Phase AN — Decomposed Template Messages And Query Surface [AN.1–AN.14 COMPLETE; AN.15 IN PROGRESS]
+## 45. Phase AN — Decomposed Template Messages And Query Surface [AN.1–AN.15 COMPLETE]
 
 - **Phase AN: Decomposed Template Messages And Query Surface [AN.1–AN.10 COMPLETE]** —
   Added a bounded `sc-composer` adapter boundary, durable template catalog and
@@ -1261,7 +1261,7 @@ Sprint line:
 - `AN.14` `feature/an14-sc-compose-141-checked-emission` — adapter-only
   checked emission that rejects malformed JSON before send or render-on-read
 
-- **AN.13–AN.15 checked-render upgrade and assurance [AN.15 IN PROGRESS]** — AN.13 establishes
+- **AN.13–AN.15 checked-render upgrade and assurance [COMPLETE]** — AN.13 establishes
   durable adapter-derived output-format identity and adopts the released
   exact `sc-sha`/`sc-composer` 1.4.1 dependency chain in its adapter; AN.14
   makes the
@@ -1269,8 +1269,8 @@ Sprint line:
   sending, caching, or render-on-read output. AN.15 then runs a bounded,
   deterministic adversarial campaign over the checked template/catalog
   lifecycle, including captured-environment and immutable-revision oracles.
-  The remaining AN.15 HTTP-seam addendum (PR #887,
-  `feature/an15-http-fuzz-campaign`) exercises the current Tokio/Axum
+  The AN.15 HTTP-seam addendum (PR #887,
+  `feature/an15-http-fuzz-campaign`) is merged and exercises the current Tokio/Axum
   `atm-http-runtime` boundary with a separately retained, commit-pinned
   four-worker campaign; it is not duplicate pre-Tokio AI.51 work against the
   removed `api::http_frame_reader` module. AN.15 does not make ATM a


### PR DESCRIPTION
Updates the four stale AN.15 status references after PRs #882 and #887 merged to develop.

Changes:
- mark Phase AN and AN.13–AN.15 complete in docs/project-plan.md
- describe PR #887 HTTP seam addendum as merged
- mark phase-an plan frontmatter complete

Validation: `just test` PASS (511 Python fixture tests; full Rust workspace/unit/integration/doc suite passed).