### PR TITLE
fix(hermes-atm): PyPI publish-readiness CI/pipeline gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
             artifact: linux-x86_64
             target: x86_64-unknown-linux-gnu
             manylinux: "2014"
+            platform_tag: manylinux_2_17_x86_64.manylinux2014_x86_64
             interpreter: python3.11
             container: ""
             smoke: native
@@ -291,6 +292,7 @@ jobs:
             artifact: linux-musl-x86_64
             target: x86_64-unknown-linux-musl
             manylinux: musllinux_1_2
+            platform_tag: musllinux_1_2_x86_64
             interpreter: python3.11
             container: ""
             smoke: musl
@@ -302,6 +304,7 @@ jobs:
             artifact: linux-aarch64
             target: ""
             manylinux: "2014"
+            platform_tag: manylinux_2_17_aarch64.manylinux2014_aarch64
             interpreter: python3.11
             container: quay.io/pypa/manylinux2014_aarch64:latest
             smoke: native
@@ -310,6 +313,7 @@ jobs:
             artifact: macos-aarch64
             target: aarch64-apple-darwin
             manylinux: "off"
+            platform_tag: macosx_11_0_arm64
             interpreter: python3.11
             container: ""
             smoke: native
@@ -318,6 +322,7 @@ jobs:
             artifact: windows-x86_64
             target: x86_64-pc-windows-msvc
             manylinux: "off"
+            platform_tag: win_amd64
             interpreter: python
             container: ""
             smoke: native
@@ -355,17 +360,10 @@ jobs:
         run: python -m pip wheel --no-deps --wheel-dir dist crates/hermes-atm
 
       - name: Verify abi3 artifact metadata
-        shell: python
         run: |
-          from pathlib import Path
-          import zipfile
-
-          wheels = sorted(Path("dist").glob("atm_graft*.whl"))
-          assert len(wheels) == 1, wheels
-          assert "cp311-abi3" in wheels[0].name, wheels[0]
-          with zipfile.ZipFile(wheels[0]) as archive:
-              wheel_metadata = next(name for name in archive.namelist() if name.endswith(".dist-info/WHEEL"))
-              assert "Tag: cp311-abi3" in archive.read(wheel_metadata).decode("utf-8")
+          python .just/verify_atm_graft_wheel.py \
+            --wheel dist/atm_graft*.whl \
+            --platform-tag ${{ matrix.platform_tag }}
 
       - name: Smoke-test native wheel on its host target
         if: ${{ matrix.smoke == 'native' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,8 @@ jobs:
           if len(wheels) != 1:
               raise RuntimeError(f"expected one downloaded atm-graft wheel, found {wheels}")
           with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as environment:
-              environment.write(f"ATM_GRAFT_WHEEL={wheels[0].resolve()}\\n")
-              environment.write(f"ATM_WHEEL_OUTPUT_DIR={Path('bridge-wheels').resolve()}\\n")
+              environment.write(f"ATM_GRAFT_WHEEL={wheels[0].resolve()}\n")
+              environment.write(f"ATM_WHEEL_OUTPUT_DIR={Path('bridge-wheels').resolve()}\n")
 
       - name: Run Hermes graft steer boundary tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,37 +279,43 @@ jobs:
             artifact: linux-x86_64
             target: x86_64-unknown-linux-gnu
             manylinux: "2014"
-            cflags: ""
+            interpreter: python3.11
+            container: ""
             smoke: true
           - name: musllinux x86_64
             os: ubuntu-latest
             artifact: linux-musl-x86_64
             target: x86_64-unknown-linux-musl
             manylinux: musllinux_1_2
-            cflags: ""
+            interpreter: python3.11
+            container: ""
             smoke: false
           - name: manylinux aarch64
-            os: ubuntu-latest
+            # Build natively on ARM. The x86_64 cross image does not compile
+            # ring's pregenerated assembly correctly, whereas this official
+            # manylinux image provides the required PyPI ABI on ARM.
+            os: ubuntu-24.04-arm
             artifact: linux-aarch64
-            target: aarch64-unknown-linux-gnu
+            target: ""
             manylinux: "2014"
-            # ring's pregenerated aarch64 assembly requires this macro when
-            # compiled by the manylinux cross toolchain.
-            cflags: -march=armv8-a
+            interpreter: python3.11
+            container: quay.io/pypa/manylinux2014_aarch64:latest
             smoke: false
           - name: macOS aarch64
             os: macos-14
             artifact: macos-aarch64
             target: aarch64-apple-darwin
             manylinux: "off"
-            cflags: ""
+            interpreter: python3.11
+            container: ""
             smoke: true
           - name: Windows x86_64
             os: windows-latest
             artifact: windows-x86_64
             target: x86_64-pc-windows-msvc
             manylinux: "off"
-            cflags: ""
+            interpreter: python
+            container: ""
             smoke: true
     runs-on: ${{ matrix.os }}
     steps:
@@ -322,16 +328,15 @@ jobs:
 
       - name: Build PyPI-compatible atm-graft wheel
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
-        env:
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.cflags }}
         with:
           command: build
           maturin-version: v1.11.5
           rust-toolchain: "1.94.1"
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
+          container: ${{ matrix.container }}
           working-directory: crates/atm-graft-python
-          args: --release --locked --compatibility pypi --out ../../dist
+          args: --release --locked --compatibility pypi -i ${{ matrix.interpreter }} --out ../../dist
 
       - name: Build universal hermes-atm wheel
         run: python -m pip wheel --no-deps --wheel-dir dist crates/hermes-atm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
           changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "$GITHUB_SHA")"
-          if [[ -z "$changed_files" ]] || grep -qvE '^(docs/|site/|\.github/workflows/ci\.yml|.*\.md$)' <<< "$changed_files"; then
+          if [[ -z "$changed_files" ]] || grep -qvE '^(docs/|site/|.*\.md$)' <<< "$changed_files"; then
             echo "runtime=true" >> "$GITHUB_OUTPUT"
           else
             echo "runtime=false" >> "$GITHUB_OUTPUT"
@@ -266,14 +266,129 @@ jobs:
         if: ${{ always() && needs.ci-scope.outputs.runtime == 'true' }}
         run: python scripts/smoke/run_thorough_shared_host.py
 
-  hermes-atm-wheel:
-    name: Hermes ATM wheel (Python ${{ matrix.python-version }})
+  hermes-atm-release-wheels:
+    name: Hermes ATM release wheel (${{ matrix.name }})
     needs: [ci-scope]
     if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - name: manylinux x86_64
+            os: ubuntu-latest
+            artifact: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            manylinux: "2014"
+            smoke: true
+          - name: musllinux x86_64
+            os: ubuntu-latest
+            artifact: linux-musl-x86_64
+            target: x86_64-unknown-linux-musl
+            manylinux: musllinux_1_2
+            smoke: false
+          - name: manylinux aarch64
+            os: ubuntu-latest
+            artifact: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+            manylinux: "2014"
+            smoke: false
+          - name: macOS aarch64
+            os: macos-14
+            artifact: macos-aarch64
+            target: aarch64-apple-darwin
+            manylinux: "off"
+            smoke: true
+          - name: Windows x86_64
+            os: windows-latest
+            artifact: windows-x86_64
+            target: x86_64-pc-windows-msvc
+            manylinux: "off"
+            smoke: true
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python for package smoke verification
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build PyPI-compatible atm-graft wheel
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        with:
+          command: build
+          maturin-version: v1.11.5
+          rust-toolchain: "1.94.1"
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          working-directory: crates/atm-graft-python
+          args: --release --locked --compatibility pypi --out ../../dist
+
+      - name: Build universal hermes-atm wheel
+        run: python -m pip wheel --no-deps --wheel-dir dist crates/hermes-atm
+
+      - name: Verify abi3 artifact metadata
+        shell: python
+        run: |
+          from pathlib import Path
+          import zipfile
+
+          wheels = sorted(Path("dist").glob("atm_graft*.whl"))
+          assert len(wheels) == 1, wheels
+          assert "cp311-abi3" in wheels[0].name, wheels[0]
+          with zipfile.ZipFile(wheels[0]) as archive:
+              wheel_metadata = next(name for name in archive.namelist() if name.endswith(".dist-info/WHEEL"))
+              assert "Tag: cp311-abi3" in archive.read(wheel_metadata).decode("utf-8")
+
+      - name: Smoke-test native wheel on its host target
+        if: ${{ matrix.smoke }}
+        shell: bash
+        run: |
+          python -m pip install 'pydantic>=2,<3'
+          python -m pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
+          python -c "import atm_graft, hermes_atm"
+
+      - name: Upload release-wheel candidates
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-atm-wheels-${{ matrix.artifact }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  hermes-atm-abi3-compat:
+    name: Hermes ATM abi3 compatibility (Python ${{ matrix.python-version }})
+    needs: [ci-scope, hermes-atm-release-wheels]
+    if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download manylinux x86_64 candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-linux-x86_64
+          path: dist
+
+      - name: Install and test abi3 wheel pair
+        run: |
+          python -m pip install 'pydantic>=2,<3'
+          python -m pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
+          python -c "import atm_graft, hermes_atm"
+          python -m unittest discover -s crates/hermes-atm/tests -p "test_*.py"
+
+  hermes-atm-sdist:
+    name: Hermes ATM source-distribution fallback
+    needs: [ci-scope]
+    if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -282,24 +397,29 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
 
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install Maturin
         run: python -m pip install maturin
 
-      - name: Build, install, and test isolated ATM wheels
-        env:
-          ATM_WHEEL_OUTPUT_DIR: ${{ runner.temp }}/hermes-atm-wheels
-        run: python .just/run_hermes_graft_bridge_tests.py
+      - name: Build atm-graft source distribution
+        run: maturin sdist --manifest-path crates/atm-graft-python/Cargo.toml --out dist
 
-      - name: Upload tested Hermes ATM wheels
+      - name: Install source distribution in a fresh environment
+        shell: bash
+        run: |
+          python -m venv "$RUNNER_TEMP/atm-graft-sdist-venv"
+          "$RUNNER_TEMP/atm-graft-sdist-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/atm-graft-sdist-venv/bin/python" -m pip install dist/atm_graft*.tar.gz
+          "$RUNNER_TEMP/atm-graft-sdist-venv/bin/python" -c "import atm_graft"
+
+      - name: Upload source-distribution candidate
         uses: actions/upload-artifact@v4
         with:
-          name: hermes-atm-wheels-ubuntu-py${{ matrix.python-version }}
-          path: ${{ runner.temp }}/hermes-atm-wheels/*.whl
+          name: atm-graft-sdist
+          path: dist/atm_graft*.tar.gz
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,16 @@ jobs:
           manylinux: ${{ matrix.manylinux }}
           container: ${{ matrix.container }}
           working-directory: crates/atm-graft-python
-          args: --release --locked --compatibility pypi -i ${{ matrix.interpreter }} --out ../../dist
+          # The manylinux container writes as root. Keep its output separate
+          # from the host-owned directory used by pip for the pure-Python
+          # hermes-atm wheel, then collect it below.
+          args: --release --locked --compatibility pypi -i ${{ matrix.interpreter }} --out ../../native-dist
+
+      - name: Collect native atm-graft wheel
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp native-dist/atm_graft*.whl dist/
 
       - name: Build universal hermes-atm wheel
         run: python -m pip wheel --no-deps --wheel-dir dist crates/hermes-atm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
             manylinux: "2014"
             interpreter: python3.11
             container: ""
-            smoke: true
+            smoke: native
           - name: musllinux x86_64
             os: ubuntu-latest
             artifact: linux-musl-x86_64
@@ -293,7 +293,7 @@ jobs:
             manylinux: musllinux_1_2
             interpreter: python3.11
             container: ""
-            smoke: false
+            smoke: musl
           - name: manylinux aarch64
             # Build natively on ARM. The x86_64 cross image does not compile
             # ring's pregenerated assembly correctly, whereas this official
@@ -304,7 +304,7 @@ jobs:
             manylinux: "2014"
             interpreter: python3.11
             container: quay.io/pypa/manylinux2014_aarch64:latest
-            smoke: false
+            smoke: native
           - name: macOS aarch64
             os: macos-14
             artifact: macos-aarch64
@@ -312,7 +312,7 @@ jobs:
             manylinux: "off"
             interpreter: python3.11
             container: ""
-            smoke: true
+            smoke: native
           - name: Windows x86_64
             os: windows-latest
             artifact: windows-x86_64
@@ -320,7 +320,7 @@ jobs:
             manylinux: "off"
             interpreter: python
             container: ""
-            smoke: true
+            smoke: native
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -368,12 +368,27 @@ jobs:
               assert "Tag: cp311-abi3" in archive.read(wheel_metadata).decode("utf-8")
 
       - name: Smoke-test native wheel on its host target
-        if: ${{ matrix.smoke }}
+        if: ${{ matrix.smoke == 'native' }}
         shell: bash
         run: |
           python -m pip install 'pydantic>=2,<3'
           python -m pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
           python -c "import atm_graft, hermes_atm"
+
+      - name: Smoke-test musllinux wheel in a clean musl environment
+        if: ${{ matrix.smoke == 'musl' }}
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "$PWD:/workspace:ro" \
+            --workdir /workspace \
+            python:3.11-alpine \
+            sh -euxc '
+              python -m venv /tmp/atm-wheel-smoke
+              /tmp/atm-wheel-smoke/bin/pip install --disable-pip-version-check "pydantic>=2,<3"
+              /tmp/atm-wheel-smoke/bin/pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
+              /tmp/atm-wheel-smoke/bin/python -c "import atm_graft, hermes_atm"
+            '
 
       - name: Upload release-wheel candidates
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,7 @@ jobs:
         run: python -m pip wheel --no-deps --wheel-dir dist crates/hermes-atm
 
       - name: Verify abi3 artifact metadata
+        shell: bash
         run: |
           python .just/verify_atm_graft_wheel.py \
             --wheel dist/atm_graft*.whl \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,4 +293,13 @@ jobs:
         run: python -m pip install maturin
 
       - name: Build, install, and test isolated ATM wheels
+        env:
+          ATM_WHEEL_OUTPUT_DIR: ${{ runner.temp }}/hermes-atm-wheels
         run: python .just/run_hermes_graft_bridge_tests.py
+
+      - name: Upload tested Hermes ATM wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-atm-wheels-ubuntu-py${{ matrix.python-version }}
+          path: ${{ runner.temp }}/hermes-atm-wheels/*.whl
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,12 +154,18 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
-    needs: [clippy, ci-scope]
-    if: ${{ !cancelled() && needs.clippy.result == 'success' }}
+    needs: [clippy, ci-scope, hermes-atm-release-wheels]
+    if: ${{ always() && !cancelled() && needs.clippy.result == 'success' && (needs.ci-scope.outputs.runtime != 'true' || needs.hermes-atm-release-wheels.result == 'success') }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            release_artifact: linux-x86_64
+          - os: macos-latest
+            release_artifact: macos-aarch64
+          - os: windows-latest
+            release_artifact: windows-x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Documentation-only runtime skip
@@ -251,6 +257,27 @@ jobs:
       - name: Install Maturin for Hermes graft bridge tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -m pip install maturin
+
+      - name: Download host release-wheel candidate
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-${{ matrix.release_artifact }}
+          path: release-wheels
+
+      - name: Select host release atm-graft wheel
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+
+          wheels = sorted(Path("release-wheels").glob("atm_graft*.whl"))
+          if len(wheels) != 1:
+              raise RuntimeError(f"expected one downloaded atm-graft wheel, found {wheels}")
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as environment:
+              environment.write(f"ATM_GRAFT_WHEEL={wheels[0].resolve()}\\n")
+              environment.write(f"ATM_WHEEL_OUTPUT_DIR={Path('bridge-wheels').resolve()}\\n")
 
       - name: Run Hermes graft steer boundary tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,30 +279,37 @@ jobs:
             artifact: linux-x86_64
             target: x86_64-unknown-linux-gnu
             manylinux: "2014"
+            cflags: ""
             smoke: true
           - name: musllinux x86_64
             os: ubuntu-latest
             artifact: linux-musl-x86_64
             target: x86_64-unknown-linux-musl
             manylinux: musllinux_1_2
+            cflags: ""
             smoke: false
           - name: manylinux aarch64
             os: ubuntu-latest
             artifact: linux-aarch64
             target: aarch64-unknown-linux-gnu
             manylinux: "2014"
+            # ring's pregenerated aarch64 assembly requires this macro when
+            # compiled by the manylinux cross toolchain.
+            cflags: -march=armv8-a
             smoke: false
           - name: macOS aarch64
             os: macos-14
             artifact: macos-aarch64
             target: aarch64-apple-darwin
             manylinux: "off"
+            cflags: ""
             smoke: true
           - name: Windows x86_64
             os: windows-latest
             artifact: windows-x86_64
             target: x86_64-pc-windows-msvc
             manylinux: "off"
+            cflags: ""
             smoke: true
     runs-on: ${{ matrix.os }}
     steps:
@@ -315,6 +322,8 @@ jobs:
 
       - name: Build PyPI-compatible atm-graft wheel
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        env:
+          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.cflags }}
         with:
           command: build
           maturin-version: v1.11.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
+          # Keep these components explicit even though this job only calls
+          # maturin/cargo test. Without them, maturin's nested toolchain
+          # resolution can race the hosted runner's preinstalled cargo-fmt
+          # and fail with rustfmt-preview's `bin/cargo-fmt` conflict.
           components: clippy, rustfmt
 
       - name: Install Python
@@ -420,6 +424,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.94.1"
+          # See the matching test-job setup above. Maturin resolves Rust
+          # tooling during the sdist build; explicit components avoid the
+          # hosted-runner rustfmt-preview `bin/cargo-fmt` install conflict.
           components: clippy, rustfmt
 
       - name: Install Python

--- a/.just/run_hermes_graft_bridge_tests.py
+++ b/.just/run_hermes_graft_bridge_tests.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CRATE = ROOT / "crates" / "atm-graft-python"
 TESTS = ROOT / "crates" / "hermes-atm" / "tests"
 HERMES_PACKAGE = ROOT / "crates" / "hermes-atm"
+WHEEL_OUTPUT_DIR_ENV = "ATM_WHEEL_OUTPUT_DIR"
 
 
 def project_dependency_requirement(manifest_path: Path, package_name: str) -> str:
@@ -51,6 +52,15 @@ def bridge_test_environment(venv_dir: Path, python: Path) -> dict[str, str]:
     return environment
 
 
+def wheel_output_dir(temp_dir: Path) -> Path:
+    """Return a retained CI output directory, or a temporary local one."""
+
+    configured = os.environ.get(WHEEL_OUTPUT_DIR_ENV)
+    output_dir = Path(configured).resolve() if configured else temp_dir / "wheels"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="atm-graft-hermes-bridge-") as temp:
         venv_dir = Path(temp) / "venv"
@@ -60,8 +70,7 @@ def main() -> None:
         if maturin is None:
             raise RuntimeError("maturin is required for the Hermes graft bridge test")
         env = bridge_test_environment(venv_dir, python)
-        wheel_dir = Path(temp) / "wheels"
-        wheel_dir.mkdir()
+        wheel_dir = wheel_output_dir(Path(temp))
         subprocess.run(
             [str(python), "-m", "pip", "install", "--quiet", "wheel"],
             check=True,

--- a/.just/run_hermes_graft_bridge_tests.py
+++ b/.just/run_hermes_graft_bridge_tests.py
@@ -19,6 +19,7 @@ CRATE = ROOT / "crates" / "atm-graft-python"
 TESTS = ROOT / "crates" / "hermes-atm" / "tests"
 HERMES_PACKAGE = ROOT / "crates" / "hermes-atm"
 WHEEL_OUTPUT_DIR_ENV = "ATM_WHEEL_OUTPUT_DIR"
+GRAFT_WHEEL_ENV = "ATM_GRAFT_WHEEL"
 
 
 def project_dependency_requirement(manifest_path: Path, package_name: str) -> str:
@@ -61,14 +62,40 @@ def wheel_output_dir(temp_dir: Path) -> Path:
     return output_dir
 
 
+def build_or_locate_graft_wheel(
+    *, python: Path, wheel_dir: Path, environment: dict[str, str]
+) -> Path:
+    """Use a release-built graft wheel when provided, otherwise build one."""
+
+    configured = os.environ.get(GRAFT_WHEEL_ENV)
+    if configured:
+        wheel_path = Path(configured).resolve()
+        if not wheel_path.is_file() or not wheel_path.name.startswith("atm_graft"):
+            raise RuntimeError(
+                f"{GRAFT_WHEEL_ENV} must name one existing atm-graft wheel, got {wheel_path}"
+            )
+        return wheel_path
+
+    maturin = shutil.which("maturin")
+    if maturin is None:
+        raise RuntimeError("maturin is required for the Hermes graft bridge test")
+    subprocess.run(
+        [maturin, "build", "--manifest-path", str(CRATE / "Cargo.toml"), "--out", str(wheel_dir)],
+        check=True,
+        cwd=ROOT,
+        env=environment,
+    )
+    graft_wheels = sorted(wheel_dir.glob("atm_graft*.whl"))
+    if len(graft_wheels) != 1:
+        raise RuntimeError(f"expected one atm-graft wheel, found {len(graft_wheels)}")
+    return graft_wheels[0]
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="atm-graft-hermes-bridge-") as temp:
         venv_dir = Path(temp) / "venv"
         venv.EnvBuilder(with_pip=True).create(venv_dir)
         python = venv_dir / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
-        maturin = shutil.which("maturin")
-        if maturin is None:
-            raise RuntimeError("maturin is required for the Hermes graft bridge test")
         env = bridge_test_environment(venv_dir, python)
         wheel_dir = wheel_output_dir(Path(temp))
         subprocess.run(
@@ -77,16 +104,10 @@ def main() -> None:
             cwd=ROOT,
             env=env,
         )
-        subprocess.run(
-            [maturin, "build", "--manifest-path", str(CRATE / "Cargo.toml"), "--out", str(wheel_dir)],
-            check=True,
-            cwd=ROOT,
-            env=env,
+        graft_wheel = build_or_locate_graft_wheel(
+            python=python, wheel_dir=wheel_dir, environment=env
         )
-        graft_wheels = sorted(wheel_dir.glob("atm_graft*.whl"))
-        if len(graft_wheels) != 1:
-            raise RuntimeError(f"expected one atm-graft wheel, found {len(graft_wheels)}")
-        with zipfile.ZipFile(graft_wheels[0]) as wheel:
+        with zipfile.ZipFile(graft_wheel) as wheel:
             wheel_files = set(wheel.namelist())
         retired_sources = {
             "atm_graft_hermes_adapter/__init__.py",
@@ -135,7 +156,7 @@ def main() -> None:
             env=env,
         )
         subprocess.run(
-            [str(python), "-m", "pip", "install", "--no-deps", str(graft_wheels[0]), str(hermes_wheels[0])],
+            [str(python), "-m", "pip", "install", "--no-deps", str(graft_wheel), str(hermes_wheels[0])],
             check=True,
             cwd=ROOT,
             env=env,

--- a/.just/tests/test_run_hermes_graft_bridge_tests.py
+++ b/.just/tests/test_run_hermes_graft_bridge_tests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import tempfile
 import tomllib
 import unittest
 from unittest import mock
@@ -13,8 +14,12 @@ if str(JUST_DIR) not in sys.path:
     sys.path.insert(0, str(JUST_DIR))
 
 from run_hermes_graft_bridge_tests import bridge_test_environment
+from run_hermes_graft_bridge_tests import build_or_locate_graft_wheel
+from run_hermes_graft_bridge_tests import GRAFT_WHEEL_ENV
 from run_hermes_graft_bridge_tests import project_dependency_requirement
 from run_hermes_graft_bridge_tests import require_universal_python_wheel
+from run_hermes_graft_bridge_tests import WHEEL_OUTPUT_DIR_ENV
+from run_hermes_graft_bridge_tests import wheel_output_dir
 
 
 class HermesGraftBridgeRunnerTests(unittest.TestCase):
@@ -26,6 +31,42 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
         self.assertNotIn("PYTHONPATH", environment)
         self.assertNotIn("HERMES_SRC", environment)
 
+    def test_wheel_output_dir_honors_configured_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configured_directory = Path(temporary_directory) / "release-output"
+            with mock.patch.dict(
+                "os.environ", {WHEEL_OUTPUT_DIR_ENV: str(configured_directory)}, clear=True
+            ):
+                output_directory = wheel_output_dir(Path(temporary_directory) / "temporary")
+
+            self.assertEqual(output_directory, configured_directory.resolve())
+            self.assertTrue(output_directory.is_dir())
+
+    def test_graft_wheel_override_uses_existing_release_wheel(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            wheel_path = Path(temporary_directory) / "atm_graft-1.4.2-cp311-abi3-win_amd64.whl"
+            wheel_path.touch()
+            with mock.patch.dict("os.environ", {GRAFT_WHEEL_ENV: str(wheel_path)}, clear=True):
+                selected_wheel = build_or_locate_graft_wheel(
+                    python=Path("/unused/python"),
+                    wheel_dir=Path(temporary_directory),
+                    environment={},
+                )
+
+            self.assertEqual(selected_wheel, wheel_path.resolve())
+
+    def test_graft_wheel_override_rejects_missing_or_wrong_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            invalid_wheel = Path(temporary_directory) / "not-atm-graft.whl"
+            invalid_wheel.touch()
+            with mock.patch.dict("os.environ", {GRAFT_WHEEL_ENV: str(invalid_wheel)}, clear=True):
+                with self.assertRaisesRegex(RuntimeError, GRAFT_WHEEL_ENV):
+                    build_or_locate_graft_wheel(
+                        python=Path("/unused/python"),
+                        wheel_dir=Path(temporary_directory),
+                        environment={},
+                    )
+
     def test_ci_runs_the_bridge_boundary_suite_for_each_supported_python(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
@@ -33,6 +74,9 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
         self.assertIn("python .just/run_hermes_graft_bridge_tests.py", workflow)
         self.assertIn("Hermes ATM release wheel (${{ matrix.name }})", workflow)
         self.assertIn("Hermes ATM abi3 compatibility (Python", workflow)
+        self.assertIn("Download host release-wheel candidate", workflow)
+        self.assertIn("ATM_GRAFT_WHEEL=", workflow)
+        self.assertIn("ATM_WHEEL_OUTPUT_DIR=", workflow)
         for version in ("3.11", "3.12", "3.13", "3.14"):
             self.assertIn(f'"{version}"', workflow)
 

--- a/.just/tests/test_run_hermes_graft_bridge_tests.py
+++ b/.just/tests/test_run_hermes_graft_bridge_tests.py
@@ -31,7 +31,8 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
 
         self.assertIn("Run Hermes graft steer boundary tests", workflow)
         self.assertIn("python .just/run_hermes_graft_bridge_tests.py", workflow)
-        self.assertIn("Hermes ATM wheel (Python", workflow)
+        self.assertIn("Hermes ATM release wheel (${{ matrix.name }})", workflow)
+        self.assertIn("Hermes ATM abi3 compatibility (Python", workflow)
         for version in ("3.11", "3.12", "3.13", "3.14"):
             self.assertIn(f'"{version}"', workflow)
 

--- a/.just/tests/test_run_hermes_graft_bridge_tests.py
+++ b/.just/tests/test_run_hermes_graft_bridge_tests.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import sys
 import tempfile
+import textwrap
 import tomllib
 import unittest
 from unittest import mock
@@ -20,6 +22,15 @@ from run_hermes_graft_bridge_tests import project_dependency_requirement
 from run_hermes_graft_bridge_tests import require_universal_python_wheel
 from run_hermes_graft_bridge_tests import WHEEL_OUTPUT_DIR_ENV
 from run_hermes_graft_bridge_tests import wheel_output_dir
+
+
+def release_wheel_selector_script(workflow: str) -> str:
+    step_start = workflow.index("      - name: Select host release atm-graft wheel")
+    step_end = workflow.index("\n      - name:", step_start + 1)
+    step = workflow[step_start:step_end]
+    run_marker = "        run: |\n"
+    script_start = step.index(run_marker) + len(run_marker)
+    return textwrap.dedent(step[script_start:])
 
 
 class HermesGraftBridgeRunnerTests(unittest.TestCase):
@@ -79,6 +90,35 @@ class HermesGraftBridgeRunnerTests(unittest.TestCase):
         self.assertIn("ATM_WHEEL_OUTPUT_DIR=", workflow)
         for version in ("3.11", "3.12", "3.13", "3.14"):
             self.assertIn(f'"{version}"', workflow)
+
+    def test_ci_release_wheel_selector_writes_distinct_environment_lines(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        selector = release_wheel_selector_script(workflow)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            release_wheels = temporary_path / "release-wheels"
+            release_wheels.mkdir()
+            wheel = release_wheels / "atm_graft-1.4.2-cp311-abi3-win_amd64.whl"
+            wheel.touch()
+            github_environment = temporary_path / "github-env"
+            original_directory = Path.cwd()
+            try:
+                os.chdir(temporary_path)
+                with mock.patch.dict(
+                    "os.environ", {"GITHUB_ENV": str(github_environment)}, clear=True
+                ):
+                    exec(selector, {"__name__": "__main__"})
+            finally:
+                os.chdir(original_directory)
+
+            self.assertEqual(
+                github_environment.read_text(encoding="utf-8").splitlines(),
+                [
+                    f"ATM_GRAFT_WHEEL={wheel.resolve()}",
+                    f"ATM_WHEEL_OUTPUT_DIR={(temporary_path / 'bridge-wheels').resolve()}",
+                ],
+            )
 
     def test_bridge_runner_rejects_non_universal_hermes_wheel(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "universal Python wheel"):

--- a/.just/tests/test_verify_atm_graft_wheel.py
+++ b/.just/tests/test_verify_atm_graft_wheel.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from verify_atm_graft_wheel import verify_release_wheel
+
+
+class VerifyAtmGraftWheelTests(unittest.TestCase):
+    def write_wheel(self, directory: Path, filename: str, tags: list[str]) -> Path:
+        wheel_path = directory / filename
+        with zipfile.ZipFile(wheel_path, "w") as archive:
+            archive.writestr(
+                "atm_graft-1.4.2.dist-info/WHEEL",
+                "Wheel-Version: 1.0\n" + "".join(f"Tag: {tag}\n" for tag in tags),
+            )
+        return wheel_path
+
+    def test_accepts_composite_manylinux_filename_and_metadata_tags(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            wheel = self.write_wheel(
+                Path(temporary_directory),
+                "atm_graft-1.4.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                ["cp311-abi3-manylinux_2_17_x86_64", "cp311-abi3-manylinux2014_x86_64"],
+            )
+
+            verify_release_wheel(wheel, "manylinux_2_17_x86_64.manylinux2014_x86_64")
+
+    def test_rejects_wrong_platform_filename_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            wheel = self.write_wheel(
+                Path(temporary_directory),
+                "atm_graft-1.4.2-cp311-abi3-win_amd64.whl",
+                ["cp311-abi3-win_amd64"],
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "manylinux_2_17_x86_64"):
+                verify_release_wheel(wheel, "manylinux_2_17_x86_64")
+
+    def test_rejects_missing_platform_metadata_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            wheel = self.write_wheel(
+                Path(temporary_directory),
+                "atm_graft-1.4.2-cp311-abi3-musllinux_1_2_x86_64.whl",
+                ["cp311-abi3-manylinux_2_17_x86_64"],
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "musllinux_1_2_x86_64"):
+                verify_release_wheel(wheel, "musllinux_1_2_x86_64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/verify_atm_graft_wheel.py
+++ b/.just/verify_atm_graft_wheel.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify the release tags carried by one built atm-graft wheel."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import zipfile
+
+
+def wheel_metadata_tags(wheel_path: Path) -> set[str]:
+    """Read normalized wheel tags from the wheel metadata."""
+
+    with zipfile.ZipFile(wheel_path) as archive:
+        metadata_path = next(
+            (name for name in archive.namelist() if name.endswith(".dist-info/WHEEL")),
+            None,
+        )
+        if metadata_path is None:
+            raise RuntimeError(f"{wheel_path.name} has no WHEEL metadata")
+        return {
+            line.removeprefix("Tag: ")
+            for line in archive.read(metadata_path).decode("utf-8").splitlines()
+            if line.startswith("Tag: ")
+        }
+
+
+def verify_release_wheel(wheel_path: Path, platform_tag: str) -> None:
+    """Require a cp311-abi3 filename and WHEEL metadata for every platform tag."""
+
+    if not wheel_path.is_file():
+        raise RuntimeError(f"expected an existing wheel, got {wheel_path}")
+    expected_filename_suffix = f"-cp311-abi3-{platform_tag}.whl"
+    if not wheel_path.name.endswith(expected_filename_suffix):
+        raise RuntimeError(
+            f"expected {wheel_path.name} to end with {expected_filename_suffix}"
+        )
+
+    metadata_tags = wheel_metadata_tags(wheel_path)
+    for tag in platform_tag.split("."):
+        expected_tag = f"cp311-abi3-{tag}"
+        if expected_tag not in metadata_tags:
+            raise RuntimeError(
+                f"{wheel_path.name} is missing WHEEL metadata tag {expected_tag}"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("--platform-tag", required=True)
+    arguments = parser.parse_args()
+    verify_release_wheel(arguments.wheel, arguments.platform_tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -16,6 +16,11 @@ name = "atm_graft_python"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["abi3"]
+# The public Python surface uses only PyO3 APIs compatible with CPython's
+# stable ABI.  One CPython 3.11 abi3 wheel therefore supports CPython 3.11+
+# on a given operating-system/architecture target.
+abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -17,4 +17,4 @@ python-source = "python"
 # Hermes lifecycle and Telegram policy are distributed separately as
 # ``hermes-atm``.
 python-packages = ["atm_graft"]
-features = ["extension-module"]
+features = ["abi3", "extension-module"]


### PR DESCRIPTION
Addresses 4 of the 7 blockers found by quality-mgr's QA-RELEASE-READINESS-PYPI-1 investigation (cross-cutting release-readiness review, not a sprint QA round):

1. No manylinux/musllinux wheel pipeline -- plain `maturin build` on ubuntu-latest with no `--manylinux`/auditwheel repair, wheel tag not PyPI-compliant.
2. No wheel artifact ever persisted -- CI jobs built into a tempdir that got deleted. **In progress @ 663b1e7f: retains tested graft/hermes-atm wheels outside the tempdir and uploads per-Python CI artifacts.**
3. No Windows/aarch64 wheel targets, no abi3 -- matrix expansion in progress.
4. sdist fallback unverified in CI/release automation -- in progress.

Draft PR opened immediately after first push per team policy -- work in progress, not yet ready for review.

Co-owned effort: items 5-9 (manifest registration, pyproject metadata, SkillRX redaction) are being handled in parallel by the m4-side team on a separate branch.