### PR TITLE
fix(release): PyPI release-readiness metadata fixes (items 5-9)

### DIFF
--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -18,6 +18,9 @@ PYTHON_RELEASE_MANIFESTS = (
     (Path("crates/atm-query-python/pyproject.toml"), "project"),
     (Path("crates/hermes-atm/pyproject.toml"), "project"),
 )
+PYTHON_DYNAMIC_VERSION_SOURCES = {
+    Path("crates/atm-graft-python/pyproject.toml"): Path("crates/atm-graft-python/Cargo.toml"),
+}
 VERSION_BASE_PATTERN = re.compile(
     r"^(?P<base>\d+\.\d+\.\d+)"
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
@@ -100,6 +103,27 @@ def validate_python_release_versions(
         manifest = tomllib.loads(read_text(repo_root / manifest_path))
         table = manifest.get(table_name, {})
         actual = table.get("version") if isinstance(table, dict) else None
+        dynamic = table.get("dynamic", []) if isinstance(table, dict) else []
+        cargo_manifest = PYTHON_DYNAMIC_VERSION_SOURCES.get(manifest_path)
+        if actual is None and cargo_manifest is not None and "version" in dynamic:
+            cargo_data = tomllib.loads(read_text(repo_root / cargo_manifest))
+            cargo_package = cargo_data.get("package", {})
+            cargo_version = cargo_package.get("version") if isinstance(cargo_package, dict) else None
+            if isinstance(cargo_version, str) and cargo_version.strip():
+                actual = cargo_version
+            elif isinstance(cargo_version, dict) and cargo_version.get("workspace") is True:
+                actual = workspace_version
+            else:
+                fail(
+                    f"{rel_manifest} dynamically derives version from "
+                    f"{cargo_manifest.as_posix()}, which must define [package].version"
+                )
+            if actual != expected:
+                fail(
+                    f"{rel_manifest} dynamically derives version from "
+                    f"{cargo_manifest.as_posix()} [package].version ({actual}) "
+                    f"but it must equal workspace version base ({expected})"
+                )
         if not isinstance(actual, str) or not actual.strip():
             fail(
                 f"{rel_manifest} [{table_name}].version ({actual!r}) must equal "

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -101,6 +101,37 @@ class CheckVersionSyncTests(unittest.TestCase):
 
             validate_python_release_versions(repo_root, "1.4.1-beta-ai-15+build.7", manifests)
 
+    def test_python_release_versions_accept_dynamic_maturin_version_from_cargo(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            manifests = self.write_python_release_manifests(repo_root, "1.4.1")
+            (repo_root / "crates/atm-graft-python/pyproject.toml").write_text(
+                '[project]\nname = "atm-graft"\ndynamic = ["version"]\n',
+                encoding="utf-8",
+            )
+
+            validate_python_release_versions(repo_root, "1.4.1", manifests)
+
+    def test_python_release_versions_reject_wrong_dynamic_maturin_cargo_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            manifests = self.write_python_release_manifests(repo_root, "1.4.1")
+            (repo_root / "crates/atm-graft-python/pyproject.toml").write_text(
+                '[project]\nname = "atm-graft"\ndynamic = ["version"]\n',
+                encoding="utf-8",
+            )
+            cargo_path = repo_root / "crates/atm-graft-python/Cargo.toml"
+            cargo_path.write_text(
+                cargo_path.read_text(encoding="utf-8").replace('version = "1.4.1"', 'version = "1.4.2"'),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as error:
+                validate_python_release_versions(repo_root, "1.4.1", manifests)
+
+            self.assertIn("crates/atm-graft-python/Cargo.toml", str(error.exception))
+            self.assertIn("1.4.2", str(error.exception))
+
     def test_python_release_versions_reject_wrong_patch(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "atm-graft-python"
+# Published to PyPI by Maturin as `atm-graft`; never cargo-publish this bridge
+# crate as a separate crates.io artifact.
+publish = false
 # Maturin consumes this crate's Cargo version as Python package metadata; keep
 # it equivalent to the workspace release while using PEP 440-compatible form.
 version = "1.4.2"

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "atm-graft"
-version = "1.4.2"
+# Maturin derives the wheel version from Cargo.toml, the canonical package
+# version for this mixed Rust/Python distribution.
+dynamic = ["version"]
 requires-python = ">=3.11,<3.15"
 dependencies = ["pydantic>=2,<3"]
 

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "atm-peer-tls-interop"
+# Test/provisioning fixture only; it is not a standalone crates.io product.
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "atm-query-python"
+# This local analyst binding is not part of the current public release surface.
+publish = false
 version = "1.4.2"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/hermes-atm/NATIVE_TOOLS_TASKLIST.md
+++ b/crates/hermes-atm/NATIVE_TOOLS_TASKLIST.md
@@ -2,7 +2,7 @@
 
 Scope: `atm_send`, read-only `atm_read`, and `atm_list` in `hermes-atm`.
 Execution rule: complete and verify each item before marking it done. Do not
-perform live SkillRX testing until every offline item and the second-pass review
+perform live gateway-profile testing until every offline item and the second-pass review
 are complete.
 
 - [x] 1. Reconcile package boundary: add `pydantic` to `atm-graft-python`,
@@ -22,6 +22,6 @@ are complete.
 - [x] 8. Second pass: re-read this checklist, requirements/ADR, boundary
   policy, and implementation; review crate/Python boundaries, error recovery,
   ownership, and test coverage for best-practice compliance.
-- [x] 9. Write a low-risk SkillRX proof plan: package-only install, managed
+- [x] 9. Write a low-risk installed-package proof plan: package-only install, managed
   gateway reset, one distinct tool invocation per operation, observation,
   and rollback criteria. Do not execute it without clean offline validation.

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -9,6 +9,20 @@ description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
 dependencies = ["atm-graft>=1.4,<1.5"]
+authors = [{ name = "atm-core contributors" }]
+license = { text = "MIT OR Apache-2.0" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -1,12 +1,12 @@
 schema_version = 1
 
 [[crates]]
-artifact = "agent-team-mail-core"
-package = "agent-team-mail-core"
-cargo_toml = "crates/atm-core/Cargo.toml"
+artifact = "atm-error"
+package = "atm-error"
+cargo_toml = "crates/atm-error/Cargo.toml"
 required = true
 publish = true
-publish_order = 2
+publish_order = 1
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -17,18 +17,18 @@ package = "atm-storage"
 cargo_toml = "crates/atm-storage/Cargo.toml"
 required = true
 publish = true
-publish_order = 1
-preflight_check = "full"
+publish_order = 2
+preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
 
 [[crates]]
-artifact = "atm-daemon-client"
-package = "atm-daemon-client"
-cargo_toml = "crates/atm-daemon-client/Cargo.toml"
+artifact = "agent-team-mail-core"
+package = "agent-team-mail-core"
+cargo_toml = "crates/atm-core/Cargo.toml"
 required = true
 publish = true
-publish_order = 5
+publish_order = 3
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -39,7 +39,29 @@ package = "atm-storage-rusqlite"
 cargo_toml = "crates/atm-storage-rusqlite/Cargo.toml"
 required = true
 publish = true
-publish_order = 3
+publish_order = 4
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-http-runtime"
+package = "atm-http-runtime"
+cargo_toml = "crates/atm-http-runtime/Cargo.toml"
+required = true
+publish = true
+publish_order = 5
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-daemon-client"
+package = "atm-daemon-client"
+cargo_toml = "crates/atm-daemon-client/Cargo.toml"
+required = true
+publish = true
+publish_order = 6
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -50,7 +72,7 @@ package = "atm-runtime"
 cargo_toml = "crates/atm-runtime/Cargo.toml"
 required = true
 publish = true
-publish_order = 6
+publish_order = 7
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -61,7 +83,7 @@ package = "atm-daemon-bootstrap"
 cargo_toml = "crates/atm-daemon-bootstrap/Cargo.toml"
 required = true
 publish = true
-publish_order = 7
+publish_order = 8
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -72,7 +94,7 @@ package = "atm-daemon"
 cargo_toml = "crates/atm-daemon/Cargo.toml"
 required = true
 publish = true
-publish_order = 8
+publish_order = 9
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -83,7 +105,7 @@ package = "atm-graft"
 cargo_toml = "crates/atm-graft/Cargo.toml"
 required = false
 publish = true
-publish_order = 9
+publish_order = 10
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
@@ -94,7 +116,20 @@ package = "agent-team-mail"
 cargo_toml = "crates/atm/Cargo.toml"
 required = true
 publish = true
-publish_order = 10
+publish_order = 11
+preflight_check = "locked"
+wait_after_publish_seconds = 0
+verify_install = true
+
+[[crates]]
+# This Maturin package is published to PyPI as `atm-graft`, not to crates.io.
+# Keep it in the release inventory so validation cannot silently omit it.
+artifact = "atm-graft-python"
+package = "atm-graft-python"
+cargo_toml = "crates/atm-graft-python/Cargo.toml"
+required = true
+publish = false
+publish_order = 0
 preflight_check = "locked"
 wait_after_publish_seconds = 0
 verify_install = true


### PR DESCRIPTION
## Summary
- Adds `atm-graft-python` to `release/publish-artifacts.toml` as the Maturin/PyPI artifact
- Adds `dynamic = [...]` metadata field to `atm-graft-python/pyproject.toml`
- Adds `license`, `classifiers`, `authors` to `hermes-atm`'s `pyproject.toml`
- Redacts internal codename "SkillRX" from `crates/hermes-atm/NATIVE_TOOLS_TASKLIST.md`
- Corrects `cargo publish = false` gaps across previously-unaccounted Cargo packages (marks non-release crates publish=false, adds atm-error/atm-http-runtime to publish dependency order)
- Makes the graft wheel version Cargo-derived with version-sync coverage

Mechanical release-metadata housekeeping only — no PyPI account/token setup, no version-number decisions (both remain held for direct user call).

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `just test-hermes-graft-bridge` (17/17)
- [x] version-sync unit tests (17/17)
- [x] `cargo fmt`
- [x] Hermes boundary lint
- [x] release-manifest validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)