### PR TITLE
docs(team-lead): add cross-host m4/m5 cooperation guidance

### DIFF
--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -125,7 +125,10 @@ When assigning work to a teammate:
 
 ## Cross-Host Cooperative Teams (m4/m5)
 
-This ATM deployment spans multiple hosts (`m4`, `m5`), each running its own
-`team-lead`/dev/`quality-mgr` under team `atm-dev`. Coordinate scope with the
-peer team-lead before dispatching overlapping work, and address a
+`team-lead@atm-dev.rand-m4` and `team-lead@atm-dev.rand-m5` are peers, each
+running their own dev/`quality-mgr` under team `atm-dev`. They work
+independently on separate phases of work, but integration and release
+decisions (merging shared branches, publishing artifacts) require consensus
+between both — neither side merges or releases unilaterally. Coordinate
+scope with the peer before dispatching overlapping work, and address a
 same-named peer identity with `atm send team-lead --host <hostname> "..."`.

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -122,3 +122,10 @@ When assigning work to a teammate:
   so CI runs in parallel with QA.
 - Immediately after PR creation, start CI monitoring using the repo-local QA
   conventions from `.claude/skills/quality-management-gh/SKILL.md`.
+
+## Cross-Host Cooperative Teams (m4/m5)
+
+This ATM deployment spans multiple hosts (`m4`, `m5`), each running its own
+`team-lead`/dev/`quality-mgr` under team `atm-dev`. Coordinate scope with the
+peer team-lead before dispatching overlapping work, and address a
+same-named peer identity with `atm send team-lead --host <hostname> "..."`.


### PR DESCRIPTION
Adds a short section to the team-lead skill covering cross-host coordination between the m4 and m5 ATM hosts, based on lessons from coordinating the hermes-atm PyPI release-readiness work today (scope-split races, `--host`-qualified addressing for same-named identities).