### PR TITLE
fix(release): enforce every workspace crate version equals the shared version

### DIFF
--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -18,6 +18,11 @@ PYTHON_RELEASE_MANIFESTS = (
     (Path("crates/atm-query-python/pyproject.toml"), "project"),
     (Path("crates/hermes-atm/pyproject.toml"), "project"),
 )
+PYTHON_RELEASE_CARGO_MANIFESTS = frozenset(
+    manifest_path
+    for manifest_path, table_name in PYTHON_RELEASE_MANIFESTS
+    if table_name == "package"
+)
 PYTHON_DYNAMIC_VERSION_SOURCES = {
     Path("crates/atm-graft-python/pyproject.toml"): Path("crates/atm-graft-python/Cargo.toml"),
 }
@@ -152,16 +157,29 @@ def expected_package_version(manifest: dict, workspace_version: str, manifest_la
 
 
 def validate_workspace_member_versions(repo_root: Path, workspace_version: str) -> None:
-    """Require every Cargo workspace member to resolve to the workspace version."""
+    """Require Cargo members to use the workspace version, except PyPI bridges.
+
+    The two Maturin bridge crates are ``publish = false`` Cargo members whose
+    Cargo package version becomes public Python package metadata.  Python
+    wheels use the numeric workspace base because PEP 440 does not accept the
+    repository's release qualifiers, so those two manifests intentionally use
+    that base while every other workspace member uses the exact Cargo version.
+    """
 
     for manifest_path in workspace_manifest_paths(repo_root):
-        rel_manifest = manifest_path.relative_to(repo_root).as_posix()
+        rel_path = manifest_path.relative_to(repo_root)
+        rel_manifest = rel_path.as_posix()
         manifest = tomllib.loads(read_text(manifest_path))
         package_version = expected_package_version(manifest, workspace_version, rel_manifest)
-        if package_version != workspace_version:
+        expected_version = (
+            normalized_version_base(workspace_version, "workspace version")
+            if rel_path in PYTHON_RELEASE_CARGO_MANIFESTS
+            else workspace_version
+        )
+        if package_version != expected_version:
             fail(
                 f"{rel_manifest} [package].version ({package_version}) "
-                f"must equal workspace version ({workspace_version})"
+                f"must equal expected workspace member version ({expected_version})"
             )
 
 

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -151,6 +151,20 @@ def expected_package_version(manifest: dict, workspace_version: str, manifest_la
     )
 
 
+def validate_workspace_member_versions(repo_root: Path, workspace_version: str) -> None:
+    """Require every Cargo workspace member to resolve to the workspace version."""
+
+    for manifest_path in workspace_manifest_paths(repo_root):
+        rel_manifest = manifest_path.relative_to(repo_root).as_posix()
+        manifest = tomllib.loads(read_text(manifest_path))
+        package_version = expected_package_version(manifest, workspace_version, rel_manifest)
+        if package_version != workspace_version:
+            fail(
+                f"{rel_manifest} [package].version ({package_version}) "
+                f"must equal workspace version ({workspace_version})"
+            )
+
+
 def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
     manifests = workspace_manifest_paths(repo_root)
     if not manifests:
@@ -328,6 +342,7 @@ def main() -> int:
     config = version_sync_config(repo_root)
     workspace_version = validate_workspace_version(repo_root)
     validate_python_release_versions(repo_root, workspace_version)
+    validate_workspace_member_versions(repo_root, workspace_version)
     validate_crate_versions(repo_root, workspace_version)
     validate_lockfile(repo_root, workspace_version)
 

--- a/.just/lint_manifests.py
+++ b/.just/lint_manifests.py
@@ -13,6 +13,9 @@ from lint_common import monotonic_now
 from lint_common import print_report
 from lint_common import workspace_crate_section_lines
 from lint_common import workspace_manifest_paths
+from check_version_sync import expected_package_version
+from check_version_sync import validate_workspace_member_versions
+from check_version_sync import validate_workspace_version
 
 
 LINT_NAME = "manifests"
@@ -39,30 +42,6 @@ def tomllib_load(path: Path) -> dict:
     import tomllib
 
     return tomllib.loads(path.read_text(encoding="utf-8"))
-
-
-def workspace_version(repo_root: Path) -> str:
-    manifest = tomllib_load(repo_root / "Cargo.toml")
-    package = manifest.get("workspace", {}).get("package", {})
-    version = package.get("version")
-    if not isinstance(version, str):
-        raise SystemExit("workspace.package.version missing from Cargo.toml")
-    return version
-
-
-def expected_package_version(manifest: dict, workspace_version_value: str, manifest_label: str) -> str:
-    package = manifest.get("package", {})
-    if not isinstance(package, dict):
-        raise SystemExit(f"{manifest_label} missing [package] table")
-
-    version_value = package.get("version")
-    if isinstance(version_value, str) and version_value.strip():
-        return version_value
-    if isinstance(version_value, dict) and version_value.get("workspace") is True:
-        return workspace_version_value
-    raise SystemExit(
-        f"{manifest_label} must define [package].version either as a non-empty string or version.workspace = true"
-    )
 
 
 def member_manifests(repo_root: Path) -> list[Path]:
@@ -94,7 +73,16 @@ def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
 
 def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
     violations: list[ManifestViolation] = []
-    version = workspace_version(repo_root)
+    try:
+        version = validate_workspace_version(repo_root)
+    except SystemExit as error:
+        return [ManifestViolation("version sync", str(error))]
+
+    try:
+        validate_workspace_member_versions(repo_root, version)
+    except SystemExit as error:
+        violations.append(ManifestViolation("version sync", str(error)))
+
     manifests = member_manifests(repo_root)
     expected_versions: dict[Path, str] = {}
     publish_flags: dict[Path, bool] = {}

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -278,8 +278,26 @@ version = "1.1.2"
                 encoding="utf-8",
             )
 
-            with self.assertRaisesRegex(SystemExit, "must equal workspace version"):
+            with self.assertRaisesRegex(SystemExit, "must equal expected workspace member version"):
                 validate_workspace_member_versions(repo_root, "1.1.2")
+
+    def test_python_release_cargo_members_use_numeric_base_for_prerelease_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            workspace_version = "1.4.2-beta-am.1"
+            self.write_repo(repo_root, workspace_version=workspace_version)
+            root_manifest = repo_root / "Cargo.toml"
+            root_manifest.write_text(
+                root_manifest.read_text(encoding="utf-8").replace(
+                    '"crates/atm-rusqlite"]',
+                    '"crates/atm-rusqlite", "crates/atm-graft-python", "crates/atm-query-python"]',
+                ),
+                encoding="utf-8",
+            )
+            self.write_python_release_manifests(repo_root, "1.4.2")
+
+            validate_workspace_member_versions(repo_root, workspace_version)
+            validate_python_release_versions(repo_root, workspace_version)
 
     def test_real_repository_workspace_member_versions_match_workspace(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -16,6 +16,7 @@ from check_version_sync import validate_lockfile
 from check_version_sync import validate_winget_manifests
 from check_version_sync import success_message
 from check_version_sync import validate_python_release_versions
+from check_version_sync import validate_workspace_member_versions
 
 
 ROOT_MANIFEST = """\
@@ -257,47 +258,36 @@ version = "1.1.2"
                 str(error.exception),
             )
 
-    def test_validate_crate_versions_accepts_explicit_tool_crate_versions(self) -> None:
+    def test_workspace_member_versions_reject_unreferenced_hardcoded_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
-            (repo_root / "Cargo.toml").write_text(
-                """\
-[workspace]
-members = ["crates/atm-core", "crates/sc-lint-attributes"]
-resolver = "2"
-
-[workspace.package]
-version = "1.1.2"
-""",
-                encoding="utf-8",
-            )
-            atm_core_dir = repo_root / "crates/atm-core"
-            atm_core_dir.mkdir(parents=True)
-            (atm_core_dir / "Cargo.toml").write_text(
-                crate_manifest(
-                    "agent-team-mail-core",
-                    extra='\n[dependencies]\nsc-lint-attributes = { path = "../sc-lint-attributes", version = "0.1.0" }\n',
+            self.write_repo(repo_root)
+            root_manifest = repo_root / "Cargo.toml"
+            root_manifest.write_text(
+                root_manifest.read_text(encoding="utf-8").replace(
+                    '"crates/atm-rusqlite"]', '"crates/atm-rusqlite", "crates/unreferenced"]'
                 ),
                 encoding="utf-8",
             )
-            tool_dir = repo_root / "crates/sc-lint-attributes"
-            tool_dir.mkdir(parents=True)
-            (tool_dir / "Cargo.toml").write_text(
-                """\
-[package]
-name = "sc-lint-attributes"
-version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
-homepage.workspace = true
-""",
+            manifest = repo_root / "crates/unreferenced/Cargo.toml"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                crate_manifest("agent-team-mail-unreferenced").replace(
+                    "version.workspace = true", 'version = "9.9.9"'
+                ),
                 encoding="utf-8",
             )
 
-            validate_crate_versions(repo_root, "1.1.2")
+            with self.assertRaisesRegex(SystemExit, "must equal workspace version"):
+                validate_workspace_member_versions(repo_root, "1.1.2")
+
+    def test_real_repository_workspace_member_versions_match_workspace(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        workspace_version = tomllib.loads(
+            (repo_root / "Cargo.toml").read_text(encoding="utf-8")
+        )["workspace"]["package"]["version"]
+
+        validate_workspace_member_versions(repo_root, workspace_version)
 
     def test_success_message_includes_workspace_version(self) -> None:
         self.assertEqual(

--- a/.just/tests/test_lint_manifests.py
+++ b/.just/tests/test_lint_manifests.py
@@ -114,14 +114,14 @@ atm-core = { path = "../atm-core", version = "9.9.9" }
                 rendered,
             )
 
-    def test_collect_manifest_violations_accepts_explicit_tool_crate_version(self) -> None:
+    def test_collect_manifest_violations_flags_unreferenced_explicit_version_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
+            self.write_repo(repo_root)
             (repo_root / "Cargo.toml").write_text(
                 ROOT_MANIFEST.replace('"crates/atm"]', '"crates/atm", "crates/sc-lint-attributes"]'),
                 encoding="utf-8",
             )
-            self.write_repo(repo_root)
             tool_dir = repo_root / "crates/sc-lint-attributes"
             tool_dir.mkdir(parents=True)
             (tool_dir / "Cargo.toml").write_text(
@@ -139,7 +139,12 @@ homepage.workspace = true
                 encoding="utf-8",
             )
 
-            self.assertEqual(collect_manifest_violations(repo_root), [])
+            rendered = [violation.render() for violation in collect_manifest_violations(repo_root)]
+            self.assertIn(
+                "version sync: crates/sc-lint-attributes/Cargo.toml [package].version (0.1.0) "
+                "must equal expected workspace member version (1.1.2)",
+                rendered,
+            )
 
 
 if __name__ == "__main__":

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-attributes"
-version = "0.1.0"
+version = "1.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "0.1.0"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "0.1.0"
+version = "1.4.2"
 dependencies = [
  "quote",
  "syn 2.0.118",

--- a/crates/sc-lint-attributes/Cargo.toml
+++ b/crates/sc-lint-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-lint-attributes"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
-sc-lint-directives = { version = "0.1.0", path = "../sc-lint-directives" }
+sc-lint-directives = { path = "../sc-lint-directives" }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "parsing"] }

--- a/crates/sc-lint-boundary/Cargo.toml
+++ b/crates/sc-lint-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-lint-boundary"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,7 +23,7 @@ anyhow.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sc-lint-directives = { version = "0.1.0", path = "../sc-lint-directives" }
+sc-lint-directives = { path = "../sc-lint-directives" }
 clap = { version = "4", features = ["derive"] }
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 quote = "1"

--- a/crates/sc-lint-directives/Cargo.toml
+++ b/crates/sc-lint-directives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-lint-directives"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes the general version-sync gap: `.just/check_version_sync.py` previously only validated that crates *depending on* another workspace crate pinned the target's own declared version -- it never asserted that a crate's own declared version actually equals the workspace version. That let `sc-lint-directives`/`sc-lint-attributes`/`sc-lint-boundary` silently drift to a hardcoded `0.1.0` (workspace is 1.4.2) since nothing depends on them via a path dependency.

- Adds a direct validation pass: every workspace member's resolved `package.version` must equal the workspace version exactly, no exceptions (including `publish = false` crates).
- Fixes the 3 drifted crates to `version.workspace = true`.
- Existing PyPI-numeric-base exception (`validate_python_release_versions`, prerelease/build metadata stripped) is unchanged and covered by new test cases proving it still passes/fails correctly under a prerelease workspace version.
- 16/16 tests pass in `.just/tests/test_check_version_sync.py`, plus `check_version_sync.py` and `cargo check --workspace` both clean.