### PR TITLE
feat(release): PyPI/TestPyPI publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
     branches: [develop, main, "integrate/*"]
   push:

--- a/.github/workflows/hermes-atm-pypi-publish.yml
+++ b/.github/workflows/hermes-atm-pypi-publish.yml
@@ -1,0 +1,123 @@
+name: Publish Hermes ATM to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Package index to receive this explicitly approved release"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  build-release-artifacts:
+    name: Build verified Hermes ATM release artifacts
+    uses: ./.github/workflows/ci.yml
+
+  prepare-publish-artifacts:
+    name: Inspect and stage PyPI artifacts
+    needs: [build-release-artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download manylinux x86_64 wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-linux-x86_64
+          path: artifacts/hermes-atm-wheels-linux-x86_64
+
+      - name: Download musllinux x86_64 wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-linux-musl-x86_64
+          path: artifacts/hermes-atm-wheels-linux-musl-x86_64
+
+      - name: Download manylinux aarch64 wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-linux-aarch64
+          path: artifacts/hermes-atm-wheels-linux-aarch64
+
+      - name: Download macOS aarch64 wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-macos-aarch64
+          path: artifacts/hermes-atm-wheels-macos-aarch64
+
+      - name: Download Windows x86_64 wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-wheels-windows-x86_64
+          path: artifacts/hermes-atm-wheels-windows-x86_64
+
+      - name: Download atm-graft source distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: atm-graft-sdist
+          path: artifacts/atm-graft-sdist
+
+      - name: Verify artifact cardinality and stage upload set
+        run: python scripts/prepare_hermes_atm_publish_artifacts.py --artifacts artifacts --output publish-dist
+
+      - name: Upload verified publish set
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-atm-pypi-publish-set
+          path: publish-dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish Hermes ATM to TestPyPI
+    needs: [prepare-publish-artifacts]
+    if: ${{ inputs.target == 'testpypi' }}
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - name: Download verified publish set
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-pypi-publish-set
+          path: publish-dist
+
+      - name: Install Twine
+        run: python -m pip install twine
+
+      - name: Validate distributions
+        run: twine check publish-dist/*
+
+      - name: Upload to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: twine upload --non-interactive --repository-url https://test.pypi.org/legacy/ publish-dist/*
+
+  publish-pypi:
+    name: Publish Hermes ATM to PyPI
+    needs: [prepare-publish-artifacts]
+    if: ${{ inputs.target == 'pypi' }}
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Download verified publish set
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-atm-pypi-publish-set
+          path: publish-dist
+
+      - name: Install Twine
+        run: python -m pip install twine
+
+      - name: Validate distributions
+        run: twine check publish-dist/*
+
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload --non-interactive publish-dist/*

--- a/.just/tests/test_hermes_atm_pypi_publish_workflow.py
+++ b/.just/tests/test_hermes_atm_pypi_publish_workflow.py
@@ -5,6 +5,7 @@ import unittest
 
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "hermes-atm-pypi-publish.yml"
+CI_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
 
 
 class HermesAtmPyPiPublishWorkflowTests(unittest.TestCase):
@@ -36,6 +37,7 @@ class HermesAtmPyPiPublishWorkflowTests(unittest.TestCase):
             self.assertIn(artifact, workflow)
         self.assertIn("prepare_hermes_atm_publish_artifacts.py", workflow)
         self.assertIn("twine check publish-dist/*", workflow)
+        self.assertIn("workflow_call:", CI_WORKFLOW.read_text(encoding="utf-8"))
 
     def test_publish_workflow_uses_target_scoped_twine_tokens(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/.just/tests/test_hermes_atm_pypi_publish_workflow.py
+++ b/.just/tests/test_hermes_atm_pypi_publish_workflow.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "hermes-atm-pypi-publish.yml"
+
+
+class HermesAtmPyPiPublishWorkflowTests(unittest.TestCase):
+    def test_publish_workflow_is_manual_with_explicit_target_environments(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertNotIn("push:", workflow)
+        self.assertIn("- testpypi", workflow)
+        self.assertIn("- pypi", workflow)
+        self.assertIn("environment: testpypi", workflow)
+        self.assertIn("environment: pypi", workflow)
+        self.assertIn("inputs.target == 'testpypi'", workflow)
+        self.assertIn("inputs.target == 'pypi'", workflow)
+
+    def test_publish_workflow_reuses_ci_builds_and_validates_artifact_cardinality(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("uses: ./.github/workflows/ci.yml", workflow)
+        for artifact in (
+            "hermes-atm-wheels-linux-x86_64",
+            "hermes-atm-wheels-linux-musl-x86_64",
+            "hermes-atm-wheels-linux-aarch64",
+            "hermes-atm-wheels-macos-aarch64",
+            "hermes-atm-wheels-windows-x86_64",
+            "atm-graft-sdist",
+        ):
+            self.assertIn(artifact, workflow)
+        self.assertIn("prepare_hermes_atm_publish_artifacts.py", workflow)
+        self.assertIn("twine check publish-dist/*", workflow)
+
+    def test_publish_workflow_uses_target_scoped_twine_tokens(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("secrets.TEST_PYPI_TOKEN", workflow)
+        self.assertIn("secrets.PYPI_TOKEN", workflow)
+        self.assertIn("https://test.pypi.org/legacy/", workflow)
+        self.assertIn("twine upload --non-interactive publish-dist/*", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_prepare_hermes_atm_publish_artifacts.py
+++ b/.just/tests/test_prepare_hermes_atm_publish_artifacts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from prepare_hermes_atm_publish_artifacts import prepare_publish_artifacts
+from prepare_hermes_atm_publish_artifacts import WHEEL_ARTIFACT_PREFIX
+from prepare_hermes_atm_publish_artifacts import WHEEL_ARTIFACTS
+
+
+class PrepareHermesAtmPublishArtifactsTests(unittest.TestCase):
+    def write_artifacts(self, root: Path) -> None:
+        for platform in WHEEL_ARTIFACTS:
+            directory = root / f"{WHEEL_ARTIFACT_PREFIX}{platform}"
+            directory.mkdir(parents=True)
+            (directory / f"atm_graft-1.4.2-cp311-abi3-{platform}.whl").touch()
+            (directory / "hermes_atm-1.4.2-py3-none-any.whl").touch()
+        sdist_directory = root / "atm-graft-sdist"
+        sdist_directory.mkdir()
+        (sdist_directory / "atm_graft-1.4.2.tar.gz").touch()
+
+    def test_stages_all_native_wheels_one_universal_wheel_and_sdist(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifacts = Path(temporary_directory) / "artifacts"
+            self.write_artifacts(artifacts)
+            output = Path(temporary_directory) / "publish-dist"
+
+            staged = prepare_publish_artifacts(artifacts, output)
+
+            self.assertEqual(len(staged), 7)
+            self.assertEqual(len(list(output.glob("atm_graft*.whl"))), 5)
+            self.assertEqual(len(list(output.glob("hermes_atm*.whl"))), 1)
+            self.assertEqual(len(list(output.glob("atm_graft*.tar.gz"))), 1)
+
+    def test_rejects_missing_platform_native_wheel(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifacts = Path(temporary_directory) / "artifacts"
+            self.write_artifacts(artifacts)
+            missing = artifacts / f"{WHEEL_ARTIFACT_PREFIX}linux-aarch64" / "atm_graft-1.4.2-cp311-abi3-linux-aarch64.whl"
+            missing.unlink()
+
+            with self.assertRaisesRegex(SystemExit, "linux-aarch64 atm-graft wheel"):
+                prepare_publish_artifacts(artifacts, Path(temporary_directory) / "publish-dist")
+
+    def test_rejects_duplicate_source_distribution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifacts = Path(temporary_directory) / "artifacts"
+            self.write_artifacts(artifacts)
+            (artifacts / "atm-graft-sdist" / "atm_graft-1.4.3.tar.gz").touch()
+
+            with self.assertRaisesRegex(SystemExit, "source distribution"):
+                prepare_publish_artifacts(artifacts, Path(temporary_directory) / "publish-dist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/prepare_hermes_atm_publish_artifacts.py
+++ b/scripts/prepare_hermes_atm_publish_artifacts.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate and stage the exact Hermes ATM files eligible for a PyPI upload."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+WHEEL_ARTIFACTS = (
+    "linux-x86_64",
+    "linux-musl-x86_64",
+    "linux-aarch64",
+    "macos-aarch64",
+    "windows-x86_64",
+)
+WHEEL_ARTIFACT_PREFIX = "hermes-atm-wheels-"
+SDIST_ARTIFACT = "atm-graft-sdist"
+
+
+def exactly_one(directory: Path, pattern: str, description: str) -> Path:
+    matches = sorted(directory.glob(pattern))
+    if len(matches) != 1:
+        found = ", ".join(path.name for path in matches) or "none"
+        raise SystemExit(
+            f"expected exactly one {description} matching {pattern!r} in {directory}; found {found}"
+        )
+    return matches[0]
+
+
+def prepare_publish_artifacts(artifacts_directory: Path, output_directory: Path) -> list[Path]:
+    """Copy the platform-native wheels, one universal wheel, and the atm-graft sdist."""
+
+    if output_directory.exists():
+        shutil.rmtree(output_directory)
+    output_directory.mkdir(parents=True)
+
+    universal_wheel: Path | None = None
+    staged: list[Path] = []
+    for platform in WHEEL_ARTIFACTS:
+        artifact_directory = artifacts_directory / f"{WHEEL_ARTIFACT_PREFIX}{platform}"
+        native_wheel = exactly_one(artifact_directory, "atm_graft*.whl", f"{platform} atm-graft wheel")
+        hermes_wheel = exactly_one(artifact_directory, "hermes_atm*.whl", f"{platform} hermes-atm wheel")
+        staged.append(Path(shutil.copy2(native_wheel, output_directory / native_wheel.name)))
+        if universal_wheel is None:
+            universal_wheel = hermes_wheel
+        elif hermes_wheel.name != universal_wheel.name:
+            raise SystemExit(
+                f"hermes-atm wheel filename differs for {platform}: "
+                f"expected {universal_wheel.name}, found {hermes_wheel.name}"
+            )
+
+    if universal_wheel is None:
+        raise SystemExit("no Hermes ATM wheel artifacts were supplied")
+    staged.append(Path(shutil.copy2(universal_wheel, output_directory / universal_wheel.name)))
+
+    sdist_directory = artifacts_directory / SDIST_ARTIFACT
+    sdist = exactly_one(sdist_directory, "atm_graft*.tar.gz", "atm-graft source distribution")
+    staged.append(Path(shutil.copy2(sdist, output_directory / sdist.name)))
+
+    if len(staged) != len(WHEEL_ARTIFACTS) + 2:
+        raise SystemExit(f"expected seven publish artifacts, staged {len(staged)}")
+    return staged
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    staged = prepare_publish_artifacts(args.artifacts, args.output)
+    for artifact in staged:
+        print(artifact)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Builds the actual PyPI publish mechanism -- previously missing entirely (quality-mgr's original blocker #2: "no publish mechanism exists anywhere, no twine/maturin-publish step, no token, no Trusted Publisher OIDC").

- `workflow_dispatch`-only, never runs on push/PR/tag -- publishing is always a manual, deliberate action.
- Single required input selects exactly one target: `testpypi` or `pypi`. No dual-target runs.
- Reuses the existing, already-verified CI build matrix via `workflow_call` rather than duplicating the maturin-action config -- builds the same 5 native wheel pairs (manylinux x86_64/aarch64, musllinux x86_64, macOS aarch64, Windows x86_64) plus sdist.
- Fail-closed cardinality checks: exactly one wheel/sdist file per platform, 0 or 2+ fails loudly, matching the existing `if-no-files-found: error` discipline from the build jobs.
- Two separate environment-gated jobs (`environment: testpypi` / `environment: pypi`), each using its own scoped token secret (`TEST_PYPI_TOKEN` / `PYPI_TOKEN`) via Twine -- so any environment-level approval gates Rand has configured are respected, not bypassed.
- The `pypi` job only runs when the dispatch input explicitly selects `pypi`.

**Safety boundary**: arch-ctm will validate the TestPyPI path for real (trigger it, confirm packages land and install from test.pypi.org) once CI is green. The real PyPI target will not be triggered by arch-ctm under any circumstances -- that remains Rand's action alone, every time.