### PR TITLE
docs(plans): Phase AR — codex-atm host integration requirements

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -15,19 +15,29 @@ approval_policy = "on-failure"
 
 [startup.team-lead]
 all = ["Read /graph-orchestration SKILL.md and /triaging-findings SKILL.md",
-       "HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see CLAUDE.md Architecture Direction)",
        "Use native atm send or atm ack for messages to arch-ctm or quality-mgr",
        "Use native atm read to read messages from team-members" ]
 
 [startup.arch-ctm]
-all = ["HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see AGENTS.md hard rule)",
-       "Use native atm send or atm ack for messages to team-lead or quality-mgr",
+all = ["Use native atm send or atm ack for messages to team-lead or quality-mgr",
        "Use native atm read to read messages from team-members" ]
 
 [startup.quality-mgr]
 all = ["read .claude/agents/quality-mgr.md for directive",
-       "HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — classify legacy-daemon runtime findings as non-findings (never Blocking/Important) and reject any reviewer proposal to remodel/patch the old daemon; valid remediation is the AL.5-AL.7 atm-http-runtime cutover",
        "Use native atm send or atm ack for messages to team-lead or arch-ctm",
+       "Use native atm read to read messages from team-members" ]
+
+
+[startup.da]
+all = ["Read docs/plans/phase-AR/plan-phase-AR.md in the atm-core repo — the codex-atm integration plan; your working directory is the codex-atm checkout",
+       "HARD RULE: sc-lint boundary rules are the contract on the codex repo — ATM integration code stays behind its module boundary; never leak atm types into codex internals beyond the sanctioned seam; never reach into codex internals from ATM code beyond documented touch points; run `just lint atm` before every commit and treat violations as blockers, not advisories",
+       "Use native atm send or atm ack for messages to arch-ctm, team-lead, or vinci",
+       "Use native atm read to read messages from team-members" ]
+
+[startup.vinci]
+all = ["Read docs/plans/phase-AR/plan-phase-AR.md in the atm-core repo — the codex-atm integration plan; your working directory is the codex-atm checkout",
+       "HARD RULE: sc-lint boundary rules are the contract on the codex repo — ATM integration code stays behind its module boundary; never leak atm types into codex internals beyond the sanctioned seam; never reach into codex internals from ATM code beyond documented touch points; run `just lint atm` before every commit and treat violations as blockers, not advisories",
+       "Use native atm send or atm ack for messages to arch-ctm, team-lead, or da",
        "Use native atm read to read messages from team-members" ]
 
 # ── rmux: tmux session launcher ──────────────────────────────────────
@@ -57,3 +67,15 @@ tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "da"
+command = "cd /Users/randlee/Documents/forks/codex-atm-worktrees/develop && codex -c features.hooks=true --yolo --model terra"
+color = "green"
+env = { ATM_IDENTITY = "da", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "vinci"
+command = "cd /Users/randlee/Documents/forks/codex-atm-worktrees/develop && codex -c features.hooks=true --yolo --model luna"
+color = "green"
+env = { ATM_IDENTITY = "vinci", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }

--- a/docs/plans/phase-AR/README.md
+++ b/docs/plans/phase-AR/README.md
@@ -1,0 +1,24 @@
+# Phase AR — codex-atm host integration (planning)
+
+Phase AR plans atm-core's side of embedding ATM into the codex CLI
+(`randlee/codex-atm`, fork of openai/codex): the second production host after
+hermes-agent, and the first pure-Rust, crates.io-consuming one.
+
+Status: PLANNING — requirements drafted, pending arch-ctm review. No sprints
+cut yet.
+
+Planning source of truth:
+
+- [`plan-phase-AR.md`](./plan-phase-AR.md) — requirements R1–R7 + the R4
+  protocol-sequencing decision.
+
+Related:
+
+- Issues #899 (graft connection inversion / daemon long-poll sessions) and
+  #900 (fail-loud activation; drop the `.atm.toml` gate) — both graduate to
+  prerequisites/decision inputs here.
+- ADR-033…ADR-037 (Phase AI): HTTP over UDS locally — the protocol direction
+  R4 sequences against.
+- Host-side precedent: hermes-agent-atm integration + maintenance pipeline
+  (hendrix repo, `hermes-ops/README.md` — START HERE) — the workflow Phase AR
+  consumers replicate for codex.

--- a/docs/plans/phase-AR/plan-phase-AR.md
+++ b/docs/plans/phase-AR/plan-phase-AR.md
@@ -44,6 +44,13 @@ prompt.
   sender-side mode routing that feeds it) is atm-core work under this
   requirement. Host-side consumption design:
   hendrix `codex-ops/STEER-QUEUE-DESIGN.md`.
+- **Queue-channel semantics — staged work, not nudges**: the queue stages
+  tasks/beads (backlogs of hundreds; days of work) held DURABLY upstream
+  (daemon/mailbox), trickled to the host through a BOUNDED channel (prefetch
+  window) with backpressure when full. Delivery acknowledgment on
+  consumption: a task is acked only when the host actually injects it into a
+  turn; unacked tasks are redelivered on reconnect, so a host crash/restart
+  loses nothing. The steer channel stays lightweight/unbuffered by contrast.
 - Tokio compatibility: codex is tokio-based. Preferred: tokio-native
   activation (aligns with atm-http-runtime). Minimum: a documented thread
   model so the host bridges callbacks safely.

--- a/docs/plans/phase-AR/plan-phase-AR.md
+++ b/docs/plans/phase-AR/plan-phase-AR.md
@@ -89,6 +89,20 @@ prompt.
   hendrix `hermes-ops/` + grecon cron.
 - Leonardo's system prompt stays general-purpose rust architecture.
 
+## Staffing (initial integration)
+
+The develop-branch integration is an **atm-dev team** project, not a hermes
+one: a codex agent (or two) runs ON the codex-atm repo as atm-dev team
+members, with **arch-ctm** as atm-side architect. This is the established
+pattern — arch-ctm already runs as a codex agent in the atm-core rmux layout.
+Coordination uses the existing terminal-agent atm path (tmux nudge + `atm
+read`) until the native integration they are building supersedes it —
+deliberate dogfooding. The codex-atm workspace gets its own `.atm.toml`
+(atm-dev team, dev-agent panes, startup directives pointing at this plan and
+the R5 boundary rules). Ongoing MAINTENANCE (release-triggered sync pipeline,
+leonardo escalation) stays on the hermes/hendrix side and is out of scope for
+the dev team.
+
 ## Proposed sequencing
 
 1. arch-ctm review of this plan; R4 ruling.

--- a/docs/plans/phase-AR/plan-phase-AR.md
+++ b/docs/plans/phase-AR/plan-phase-AR.md
@@ -1,0 +1,98 @@
+# Phase AR plan — requirements on atm-core for the codex-atm integration
+
+Drafted 2026-08-16 (Rand + hendrix-side planning; source draft in the hendrix
+repo `codex-ops/ATM-CORE-INTEGRATION-REQUIREMENTS.md`). Pending arch-ctm
+review; R4 is the blocking architectural decision.
+
+## Context
+
+`randlee/codex-atm` (fork of openai/codex) will carry an ATM integration on
+its `develop` branch: the codex CLI gains native agent-team-mail via the
+`atm-graft` crate — `a)` atm-graft + integration + unit tests, `b)` sc-lint
+boundary rules so the implementation does not leak into codex internals.
+Integration updates are release-triggered (codex releases ~2×/week). The
+maintenance workflow replicates the hermes-agent-atm pipeline (mechanical
+runner → contessa → alpha-prime chain; beads; idempotent re-runs) with
+**leonardo** (kimi-k3, general-purpose rust architect) as the escalation
+agent. Deliberate constraint carried over from the hermes design: ALL
+codex-specific knowledge lives in docs that travel with the codex patch stack
+(`docs/atm/CODEX-PATCH-REQUIREMENTS.md` there), never in leonardo's system
+prompt.
+
+## Requirements
+
+### R1 — Publishable, consumable crate
+- `atm-graft` + dependency closure (incl. `agent-team-mail-core`) on
+  crates.io, semver-disciplined. The 1.4.2 version-alignment gates
+  (`check_version_sync.py`, `version_alignment.rs`) are the enforcement; the
+  crates.io staging order (core first, per RELEASE_READINESS.md) must be
+  unblocked.
+- Committed codex-atm Cargo.toml references the crates.io version; local
+  development uses `[patch.crates-io]`; CI/pipeline builds succeed WITHOUT a
+  local atm-core checkout.
+- Apache-2.0-compatible licensing; MSRV ≤ codex's pinned toolchain; no
+  build.rs network/system-dep surprises.
+
+### R2 — Rust-native host embedding API (the codex seam)
+- Public, rustdoc'd, stability-stated Rust API on `atm-graft` for an external
+  host: activate receiver (identity, team, host binding), register nudge
+  callback, clean shutdown — the Rust equivalent of what `atm-graft-python`
+  gives hermes.
+- Tokio compatibility: codex is tokio-based. Preferred: tokio-native
+  activation (aligns with atm-http-runtime). Minimum: a documented thread
+  model so the host bridges callbacks safely.
+- Library-call send/read/ack (no shelling out to the `atm` binary from codex).
+
+### R3 — Fail-loud activation (issue #900 becomes a prerequisite)
+- Activation keyed on ATM_IDENTITY + ATM_TEAM (+ host binding). `.atm.toml`
+  must not gate activation; every activation failure raises. The silent no-op
+  is disqualifying for a crates.io consumer. Land #900 before or with the
+  first codex integration release.
+
+### R4 — Protocol sequencing (DECISION REQUIRED, blocks seam design)
+- Does codex integrate against the current file-rendezvous/loopback graft
+  protocol, or against the daemon long-poll session protocol (#899), which
+  ADR-033…ADR-037 already point at (HTTP over UDS locally)?
+- Position for review: codex is a greenfield consumer and the natural FIRST
+  client of the session protocol. Integrating it against the legacy
+  rendezvous means running the hermes-style migration twice. If even a
+  minimal session slice can land first, codex never carries the legacy.
+- Requirement: arch-ctm ruling + migration statement either way.
+
+### R5 — Boundary enforcement (sc-lint)
+- Packaged `sc-lint-*` boundary rule-set + config consumable from codex-atm:
+  ATM code stays behind its module boundary; no atm types leak into codex
+  internals beyond the sanctioned seam; no reaching into codex internals from
+  ATM code beyond documented touch points. Versioned with atm-core releases;
+  invoked as `just lint atm` in codex-atm.
+
+### R6 — Hermetic test & smoke support
+- Test-support surface (feature or fixtures crate): mock/loopback delivery,
+  deterministic nudge injection, handshake fixtures — enough for codex-atm's
+  `just test atm` to run with NO live daemon.
+- `just smoke atm` = live round-trip against a local daemon (hermes-atm-smoke
+  contract style); may require a running daemon and says so.
+- The seam contract tests live IN the codex-atm patch stack (mirror of the
+  hermes `test_inject_internal_message.py` suite); atm-core supplies the
+  harness, codex-atm owns the contract.
+
+### R7 — Cadence & compatibility
+- Pinned, consumable releases (never yank-and-replace a version).
+- Per-release compatibility statement: protocol/daemon versions supported —
+  one host machine runs the hermes fleet AND codex agents against one daemon.
+
+## Non-goals (owned elsewhere)
+
+- Codex-side seam design, patch stack, CODEX-PATCH-REQUIREMENTS.md → codex-atm
+  repo (develop branch).
+- Maintenance pipeline (runner, review chain, beads, leonardo escalation) →
+  hendrix `hermes-ops/` + grecon cron.
+- Leonardo's system prompt stays general-purpose rust architecture.
+
+## Proposed sequencing
+
+1. arch-ctm review of this plan; R4 ruling.
+2. R1 unblock (crates.io staging) + R3 (#900) — independent of R4.
+3. R2 API shaped by the R4 ruling; R5/R6 packaging alongside.
+4. codex-atm develop stack work proceeds against R1–R3/R5–R6; the
+  release-triggered pipeline is built in parallel on the hendrix side.

--- a/docs/plans/phase-AR/plan-phase-AR.md
+++ b/docs/plans/phase-AR/plan-phase-AR.md
@@ -92,16 +92,19 @@ prompt.
 ## Staffing (initial integration)
 
 The develop-branch integration is an **atm-dev team** project, not a hermes
-one: a codex agent (or two) runs ON the codex-atm repo as atm-dev team
-members, with **arch-ctm** as atm-side architect. This is the established
-pattern — arch-ctm already runs as a codex agent in the atm-core rmux layout.
-Coordination uses the existing terminal-agent atm path (tmux nudge + `atm
-read`) until the native integration they are building supersedes it —
-deliberate dogfooding. The codex-atm workspace gets its own `.atm.toml`
-(atm-dev team, dev-agent panes, startup directives pointing at this plan and
-the R5 boundary rules). Ongoing MAINTENANCE (release-triggered sync pipeline,
-leonardo escalation) stays on the hermes/hendrix side and is out of scope for
-the dev team.
+one. The team runs out of the atm-dev repo AS FAR AS ATM IS CONCERNED — the
+existing atm-core `.atm.toml`/rmux layout is the team anchor, extended with
+panes for 1–2 additional dev agents whose WORKING DIRECTORY is the codex-atm
+checkout (the proven multi-repo pattern: each agent's context stays focused on
+a single repo; team plumbing stays in one place). **arch-ctm** is atm-side
+architect but expects little atm-graft dev work — the crate is proven — so his
+role is support and infrastructure (R5 rule packaging, R6 fixtures, R2 API
+surface review). Dev-agent startup directives point at this plan and the R5
+boundary rules. Coordination uses the existing terminal-agent atm path (tmux
+nudge + `atm read`) until the native integration they are building supersedes
+it — deliberate dogfooding. Ongoing MAINTENANCE (release-triggered sync
+pipeline, leonardo escalation) stays on the hermes/hendrix side and is out of
+scope for the dev team.
 
 ## Proposed sequencing
 

--- a/docs/plans/phase-AR/plan-phase-AR.md
+++ b/docs/plans/phase-AR/plan-phase-AR.md
@@ -35,9 +35,15 @@ prompt.
 
 ### R2 — Rust-native host embedding API (the codex seam)
 - Public, rustdoc'd, stability-stated Rust API on `atm-graft` for an external
-  host: activate receiver (identity, team, host binding), register nudge
-  callback, clean shutdown — the Rust equivalent of what `atm-graft-python`
-  gives hermes.
+  host: activate receiver (identity, team, host binding), clean shutdown —
+  the Rust equivalent of what `atm-graft-python` gives hermes.
+- **API shape: TWO Rust channels** (literally channels, e.g.
+  `tokio::sync::mpsc::Receiver<Nudge>` × 2) handed to the host on
+  activation — one for **steer**-mode nudges, one for **queue**-mode nudges.
+  atm-graft carries one delivery channel today; growing the second (and the
+  sender-side mode routing that feeds it) is atm-core work under this
+  requirement. Host-side consumption design:
+  hendrix `codex-ops/STEER-QUEUE-DESIGN.md`.
 - Tokio compatibility: codex is tokio-based. Preferred: tokio-native
   activation (aligns with atm-http-runtime). Minimum: a documented thread
   model so the host bridges callbacks safely.


### PR DESCRIPTION
Planning proposal for Phase AR: requirements on atm-core for embedding ATM into the codex CLI (randlee/codex-atm, second production host after hermes).

R1 crates.io publishable atm-graft · R2 Rust-native tokio-compatible embedding API · R3 fail-loud activation (#900 as prerequisite) · R4 **protocol sequencing decision** (legacy rendezvous vs #899 sessions per ADR-033…037 — blocks seam design; position: codex should be the first client of the session protocol) · R5 packaged sc-lint boundary rules · R6 hermetic test/smoke support (just test/lint/smoke atm) · R7 release cadence + compat statements.

For arch-ctm review. Host-side precedent and pipeline: hendrix hermes-ops (START HERE README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)