### PR TITLE
docs: add PyPI install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ The library crate is also published as:
 cargo add agent-team-mail-core
 ```
 
+### PyPI
+
+`hermes-atm` and `atm-graft` 1.4.2 are live on TestPyPI; publishing to
+production PyPI is pending.
+
+```bash
+python -m pip install --upgrade \
+  --index-url https://test.pypi.org/simple \
+  --extra-index-url https://pypi.org/simple \
+  "hermes-atm==1.4.2" "atm-graft==1.4.2"
+```
+
+For Hermes setup and verification, see
+[the hermes-atm guide](docs/user-documents/hermes-atm.md).
+
 ### winget
 
 ```powershell


### PR DESCRIPTION
Adds a PyPI installation section for hermes-atm/atm-graft to README.md's Installation block, matching the existing crates.io/winget section style.

States current status honestly: live on TestPyPI, production PyPI pending. Links to the new hermes-atm user guide (#916) for full setup/verification.

Part of the v1.4.2 release-doc cleanup (task #115 of 5).