### PR TITLE
docs: review and update user documents for 1.4.2

### DIFF
--- a/docs/user-documents/README.md
+++ b/docs/user-documents/README.md
@@ -1,7 +1,7 @@
 ---
 title: ATM User Guide
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # ATM User Guide

--- a/docs/user-documents/doctor-and-log.md
+++ b/docs/user-documents/doctor-and-log.md
@@ -1,7 +1,7 @@
 ---
 title: Doctor And Log
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Doctor And Log
@@ -51,10 +51,11 @@ atm log filter --level warn --match command=send
 atm log tail --level error
 ```
 
-Retained ATM logs live under the runtime state root, not under the installed
-document tree. The ordinary operator expectation is the canonical retained log
-path `{ATM_HOME}/.atm/logs/atm.log.jsonl`, with `ATM_LOG_DIR` as the supported
-override when the retained log must live somewhere else.
+Retained ATM logs are host-scoped, not selected by workspace `ATM_HOME` and not
+stored in the installed document tree. The ordinary operator expectation is
+`~/.atm/logs/atm.log.jsonl`; `ATM_LOG_DIR` is the supported absolute-directory
+override when the retained log must live somewhere else. `atm doctor --json`
+reports the active log path for the current host.
 
 ## Separation Of Concerns
 

--- a/docs/user-documents/examples/quickstart/install-paths.json
+++ b/docs/user-documents/examples/quickstart/install-paths.json
@@ -1,8 +1,8 @@
 {
-  "install_root": "~/.local/atm/1.3.1",
-  "binary_path": "~/.local/atm/1.3.1/bin/atm",
-  "daemon_binary_path": "~/.local/atm/1.3.1/bin/atm-daemon",
-  "doc_root": "~/.local/atm/1.3.1/share/doc/atm",
-  "doc_entrypoint": "~/.local/atm/1.3.1/share/doc/atm/README.md",
+  "install_root": "~/.local/atm/1.4.2",
+  "binary_path": "~/.local/atm/1.4.2/bin/atm",
+  "daemon_binary_path": "~/.local/atm/1.4.2/bin/atm-daemon",
+  "doc_root": "~/.local/atm/1.4.2/share/doc/atm",
+  "doc_entrypoint": "~/.local/atm/1.4.2/share/doc/atm/README.md",
   "runtime_state_root": "~/.atm"
 }

--- a/docs/user-documents/hooks.md
+++ b/docs/user-documents/hooks.md
@@ -1,7 +1,7 @@
 ---
 title: Hooks
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Hooks

--- a/docs/user-documents/identity-and-team.md
+++ b/docs/user-documents/identity-and-team.md
@@ -1,7 +1,7 @@
 ---
 title: Identity And Team
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Identity And Team
@@ -19,7 +19,8 @@ comes from the supported CLI and environment surfaces for the active command.
 The accepted operator model is:
 
 - inspection-only commands may inspect another mailbox explicitly
-- mutating commands act as the real caller only
+- mutating commands require the ambient caller and cannot impersonate another
+  base agent
 - command-line values override environment values when that command supports
   the override
 
@@ -44,7 +45,9 @@ atm peek quality-mgr@atm-dev --team atm-dev --as quality-mgr
 Mailbox inspection and mailbox mutation are different surfaces:
 
 - inspection commands observe queue state
-- mutating commands act as the real caller
+- mutating commands act as the real caller. Where a mutating command accepts
+  `--as`, its base agent must match `ATM_IDENTITY`; it may select the caller's
+  chat identity but cannot impersonate another agent.
 
 Inspection-only surfaces:
 
@@ -68,7 +71,9 @@ Mutating surfaces:
   `ATM_IDENTITY`, then no chat ID. An unqualified `--as agent` explicitly
   selects no chat ID.
 - use `--team <team>` when the command supports an explicit team override
-- use `--as <agent>` only on inspection-only commands
+- use `--as <agent>` to inspect that agent's mailbox on inspection-only
+  commands. On a mutating command that accepts `--as`, use only the same base
+  agent as `ATM_IDENTITY`.
 
 Do not assume that runtime state under `~/.atm/` changes your caller identity.
 Caller identity is resolved by ATM command inputs and environment rules, not by

--- a/docs/user-documents/install-layout.md
+++ b/docs/user-documents/install-layout.md
@@ -1,7 +1,7 @@
 ---
 title: Install Layout
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Install Layout
@@ -21,7 +21,7 @@ Long-form user docs live under `share/doc/atm/`.
 A typical local install layout looks like this:
 
 ```text
-~/.local/atm/1.3.1/
+~/.local/atm/1.4.2/
   bin/
     atm
     atm-daemon
@@ -36,7 +36,12 @@ A typical local install layout looks like this:
 
 ## Runtime State
 
-Runtime state lives under `~/.atm/`.
+Daemon coordination and durable mailbox state are host-scoped under the OS
+account's `~/.atm/` root. The managed daemon and its database are shared by
+that OS account rather than selected per workspace.
+
+`ATM_HOME` remains a workspace/config discovery input. It does not select a
+different daemon, daemon endpoint, database, or retained-log root.
 
 Runtime state is not the installed documentation tree. Do not treat `~/.atm/`
 as the source for long-form help content.

--- a/docs/user-documents/mailbox-workflows.md
+++ b/docs/user-documents/mailbox-workflows.md
@@ -1,7 +1,7 @@
 ---
 title: Mailbox Workflows
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Mailbox Workflows
@@ -33,14 +33,14 @@ atm peek quality-mgr@atm-dev --team atm-dev --as quality-mgr --json
 Use message-handling commands when you intend to read, acknowledge, clear, or
 reply through the supported ATM workflow.
 
-Owner-only mutating surfaces:
+Caller-scoped mutating surfaces:
 
 - `atm send`
 - `atm read`
 - `atm ack`
 - `atm clear`
 
-Typical owner-only flow:
+Typical caller-scoped flow:
 
 ```bash
 export ATM_TEAM=atm-dev
@@ -52,13 +52,21 @@ atm ack 01KRFK5QTF2R6NRS3Q0F8Z9K0S "received"
 atm clear --team atm-dev --dry-run
 ```
 
+For template-backed delivery, first use `atm compose --template <path>` to
+preview the exact local rendering, then use `atm send <recipient> --template
+<path>` with the same variables. Composition is local and does not mutate a
+mailbox.
+
 ## Workflow Guidance
 
 - inspect before mutating when you need to confirm queue state
 - read the actual message before acting on it
 - use the supported acknowledge path when a task or sender requires it
 - use `atm clear` only for the resolved caller's mailbox state
-- do not use inspection examples as a substitute for owner-only mutation
+- do not use inspection examples as a substitute for caller-scoped mutation
+- a mutating command's optional `--as` value may only name the same base agent
+  as `ATM_IDENTITY`; it can select that caller's chat identity, never another
+  agent's mailbox state
 
 ## Clear Guidance
 

--- a/docs/user-documents/nudge-templates.md
+++ b/docs/user-documents/nudge-templates.md
@@ -1,7 +1,7 @@
 ---
 title: Nudge Templates
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Nudge Templates

--- a/docs/user-documents/quickstart.md
+++ b/docs/user-documents/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Quickstart
@@ -12,7 +12,8 @@ Use this guide when you need the smallest working ATM path.
 
 1. Confirm your repo is ATM-enabled and you know the current team.
 2. Run `atm doctor` first when you need a health/config check.
-3. Send a message with `atm send`.
+3. Send a message with `atm send`, or preview template-backed content with
+   `atm compose` before sending it.
 4. Inspect queues with `atm list` or `atm peek`.
 5. Read messages with `atm read`.
 6. Acknowledge a pending-ack message with `atm ack`.
@@ -31,6 +32,17 @@ atm read --team atm-dev
 atm ack 01KRFK5QTF2R6NRS3Q0F8Z9K0S "received"
 ```
 
+## Template-Backed Messages
+
+For generated content, preview the exact rendered body locally before
+delivery. `atm compose` does not read or write a mailbox; `atm send --template`
+uses the same template and variables for delivery.
+
+```bash
+atm compose --template notice.j2 --vars notice-vars.json
+atm send quality-mgr@atm-dev --template notice.j2 --vars notice-vars.json
+```
+
 Cross-agent inspection without mutation:
 
 ```bash
@@ -45,11 +57,11 @@ not rely on direct database access or private files under `~/.atm/`.
 
 If the installed ATM binary is at:
 
-- `~/.local/atm/1.3.1/bin/atm`
+- `~/.local/atm/1.4.2/bin/atm`
 
 then the installed long-form doc entrypoint is:
 
-- `~/.local/atm/1.3.1/share/doc/atm/README.md`
+- `~/.local/atm/1.4.2/share/doc/atm/README.md`
 
 ## Next Documents
 

--- a/docs/user-documents/troubleshooting.md
+++ b/docs/user-documents/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 audience: end-user
-reviewed_for_release: 1.3.1
+reviewed_for_release: 1.4.2
 ---
 
 # Troubleshooting
@@ -46,6 +46,9 @@ Symptoms:
 
 - ATM cannot reach the local daemon path
 - the command reports daemon startup/connect trouble
+
+The managed daemon uses host-scoped state. Changing `ATM_HOME` does not select
+another daemon, endpoint, database, or retained-log root.
 
 Supported recovery:
 


### PR DESCRIPTION
Reviews and updates all 9 files in docs/user-documents/ for 1.4.2 accuracy, closing the docs-currency gate found by the publisher agent's preflight (all 9 files carried stale reviewed_for_release: 1.3.1).

**Substantive content fixes** (behavior actually changed since v1.3.1, not just a version bump):
- quickstart.md, mailbox-workflows.md — template composition/delivery, 1.4.2 install examples
- identity-and-team.md, install-layout.md — host-scoped daemon/database/log behavior
- troubleshooting.md, doctor-and-log.md — mutation `--as` safety, correct log path

**Review-marker-only** (content verified still accurate, no fix needed): README.md, hooks.md, nudge-templates.md

Validation: `git diff --check`, `verify_user_docs.py --release-version 1.4.2`, `test_verify_user_docs.py` (5/5) all pass.

Note: while reviewing, a separate pre-existing issue was found and confirmed independently -- `crates/atm/tests/cli_surface_baseline.json` is stale (missing several legitimately-shipped CLI additions). Not touched in this PR; tracked separately (task #118).

Part of the v1.4.2 release-doc cleanup (task #117 of 5).