### PR TITLE
docs(release): correct crate count to 12 after PR #924

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@
   manylinux/musllinux/Windows/aarch64 wheel and sdist pipeline, CPython
   3.11-3.14 compatibility, and repo-wide version-sync enforcement consolidated
   onto one canonical gate
-- add `atm-error` and `atm-http-runtime` to the published crate set (11 crates
-  total, up from 9)
+- add `atm-error`, `atm-http-runtime`, and `atm-template-sc-compose` to the
+  published crate set (12 crates total, up from 9); the last was added after
+  release preflight found `atm-daemon-bootstrap` depends on it at runtime
+  while it was still unpublished (issue #923, fixed in PR #924)
 
 ## 1.3.0
 

--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -123,7 +123,7 @@ than features carried by this release.
 
 ## Packaging / Distribution Notes
 
-- crates.io: publish the 11 `publish = true` crates in the manifest's required
+- crates.io: publish the 12 `publish = true` crates in the manifest's required
   dependency order:
   1. `atm-error`
   2. `atm-storage`
@@ -132,14 +132,19 @@ than features carried by this release.
   5. `atm-http-runtime`
   6. `atm-daemon-client`
   7. `atm-runtime`
-  8. `atm-daemon-bootstrap`
-  9. `atm-daemon`
-  10. `atm-graft`
-  11. `agent-team-mail`
+  8. `atm-template-sc-compose`
+  9. `atm-daemon-bootstrap`
+  10. `atm-daemon`
+  11. `atm-graft`
+  12. `agent-team-mail`
 - `atm-error` and `atm-http-runtime` are new entries relative to the 1.3.1
-  nine-crate manifest. The Maturin `atm-graft-python` artifact remains in the
-  release inventory but is published to PyPI as `atm-graft`, so it is not one
-  of the 11 crates.io artifacts.
+  nine-crate manifest. `atm-template-sc-compose` was added after release
+  preflight found `atm-daemon-bootstrap` depends on it at runtime (issue
+  #923, fixed in PR #924) -- it was previously `publish = false` and absent
+  from the manifest, which would have broken `cargo publish` mid-sequence.
+  The Maturin `atm-graft-python` artifact remains in the release inventory
+  but is published to PyPI as `atm-graft`, so it is not one of the 12
+  crates.io artifacts.
 - PyPI/TestPyPI: `hermes-atm` and `atm-graft` have a verified, installable
   TestPyPI milestone. The real PyPI publication is the release execution step,
   not a completed claim in these notes.


### PR DESCRIPTION
Fixes a gap found by the publisher agent's release preflight: release/release-notes.md and CHANGELOG.md still said 11 crates.io crates and omitted atm-template-sc-compose. Both were written the evening before PR #924 merged (which added atm-template-sc-compose as a required 12th crate, fixing issue #923) and never got updated.

- release-notes.md's ordered crate list now includes atm-template-sc-compose at its correct dependency-order slot (8, before atm-daemon-bootstrap), with an explanatory note on why it was added.
- CHANGELOG.md's 1.4.2 entry now says 12 crates and names all three additions since v1.3.1's 9-crate set.