### PR TITLE
fix(release): install pydantic in release-preflight workflow

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install Python validation dependencies
+        run: python -m pip install codespell 'pydantic>=2.12,<3'
+
       - name: Install just
         uses: taiki-e/install-action@just
 
@@ -68,9 +71,6 @@ jobs:
 
       - name: Install cargo-modules
         run: cargo binstall cargo-modules@0.26.0 --no-confirm
-
-      - name: Install codespell
-        run: python -m pip install codespell
 
       - name: Normalize version input
         id: meta

--- a/.just/tests/test_release_preflight.py
+++ b/.just/tests/test_release_preflight.py
@@ -21,6 +21,16 @@ class ReleasePreflightWorkflowTests(unittest.TestCase):
         self.assertIn("python3 scripts/validate_release.py all \\", text)
         self.assertIn("--staged-install-root \"${STAGED_INSTALL_ROOT}\"", text)
 
+    def test_release_preflight_installs_validation_python_dependencies_before_validation(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        install_python = text.index("- name: Install Python\n")
+        install_dependencies = text.index("- name: Install Python validation dependencies")
+        validate = text.index("- name: Run canonical retained release validation suite")
+        self.assertLess(install_python, install_dependencies)
+        self.assertLess(install_dependencies, validate)
+        self.assertIn("python -m pip install codespell 'pydantic>=2.12,<3'", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the real blocker found by the publisher agent's Release Preflight dispatch (run 32001104443, failed): .github/workflows/release-preflight.yml never installed pydantic, but scripts/smoke/benchmark_schema.py requires it unconditionally (since Phase AI's benchmark-report pipeline, commit d691ac48e). ci.yml already pins pydantic>=2.12,<3 in several steps, so this passed locally/in ci.yml by coincidence but failed in release-preflight's clean runner with ModuleNotFoundError.

- Adds a single "Install Python validation dependencies" step (codespell + pydantic>=2.12,<3) right after setup-python, and removes the now-redundant separate codespell-only step.
- Adds workflow ordering/requirement regression coverage.
- Full CI-vs-preflight dependency sweep confirmed pydantic was the only gap for the validation path release-preflight actually executes -- the other CI-only Maturin/PyO3/pydantic install variants belong to isolated wheel/ABI/sdist jobs that release-preflight doesn't run.

Validated: test_release_preflight.py (3/3), test_benchmark_report.py (11/11), git diff --check.