### PR TITLE
fix(release): install sc-compose in release preflight

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install Python validation dependencies
         run: python -m pip install codespell 'pydantic>=2.12,<3'
 
+      - name: Install sc-compose CLI
+        # Template JSON escaping requires the released sc-compose 1.4.0 API.
+        # Keep this pin aligned with .github/workflows/ci.yml.
+        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+
       - name: Install just
         uses: taiki-e/install-action@just
 


### PR DESCRIPTION
Fixes the real blocker from Release Preflight run 32003316553 (failed): FileNotFoundError: 'sc-compose' during pytests. ci.yml installs sc-compose (two places, two pinned revisions); release-preflight.yml never did.

Adds the missing install step matching ci.yml's main lint-job pin (6a8af1ff, line 65).

No pipeline refactor -- narrow, targeted fix only, per explicit direction.