### PR TITLE
fix(release): package CLI OpenAPI contract

### DIFF
--- a/crates/atm/openapi.yaml
+++ b/crates/atm/openapi.yaml
@@ -1,0 +1,214 @@
+openapi: 3.1.0
+info:
+  title: ATM daemon API
+  version: v1
+  description: HTTP contract shared by local UDS and future peer HTTPS adapters.
+servers:
+  - url: /v1/atm
+paths:
+  /messages/search:
+    get:
+      operationId: searchMessages
+      description: Local-only typed search. Peer-authenticated callers are rejected before storage selection.
+      parameters:
+        - name: request
+          in: query
+          required: true
+          description: Unpadded URL-safe base64 encoding of the JSON SearchRequest contract.
+          schema: { type: string, format: base64url }
+      responses:
+        '200': { description: Local typed search result, content: { application/json: { schema: { $ref: '#/components/schemas/SearchResponse' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /messages:
+    get:
+      operationId: listMessages
+      requestBody: { required: false, content: { application/json: { schema: { $ref: '#/components/schemas/ListQuery' } } } }
+      parameters:
+        - $ref: '#/components/parameters/Agent'
+        - $ref: '#/components/parameters/ChatId'
+      responses:
+        '200': { description: Messages, content: { application/json: { schema: { $ref: '#/components/schemas/MessageList' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+    post:
+      operationId: writeMessage
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/WriteRequest' } } } }
+      responses:
+        '201': { description: Created message, content: { application/json: { schema: { $ref: '#/components/schemas/Message' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+    delete:
+      operationId: clearMessages
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/ClearQuery' } } } }
+      responses:
+        '204':
+          description: Cleared; no response body.
+          headers:
+            X-ATM-Clear-Outcome:
+              description: Base64url-encoded clear result for CLI rendering.
+              schema: { type: string }
+        default: { $ref: '#/components/responses/AtmError' }
+  /messages/inspect:
+    post:
+      operationId: inspectMessages
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/PeekQuery' } } } }
+      responses:
+        '200': { description: Messages, content: { application/json: { schema: { $ref: '#/components/schemas/MessageList' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /messages/read:
+    post:
+      operationId: readMessages
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/ReadQuery' } } } }
+      responses:
+        '200': { description: Messages, content: { application/json: { schema: { $ref: '#/components/schemas/MessageList' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /doctor:
+    get:
+      operationId: doctor
+      responses:
+        '200': { description: Daemon health, content: { application/json: { schema: { type: object } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /compatibility:
+    post:
+      operationId: compatibilityPreflight
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/CompatibilityPreflight' } } } }
+      responses:
+        '200': { description: Compatibility verdict, content: { application/json: { schema: { $ref: '#/components/schemas/CompatibilityVerdict' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /heartbeat:
+    post:
+      operationId: teamMemberHeartbeat
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/HeartbeatRequest' } } } }
+      responses:
+        '200': { description: Heartbeat result, content: { application/json: { schema: { $ref: '#/components/schemas/HeartbeatResponse' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /runtime/reload:
+    post:
+      operationId: reloadRuntimeView
+      requestBody: { required: true, content: { application/json: { schema: { type: 'null' } } } }
+      responses:
+        '200': { description: Runtime view reloaded, content: { application/json: { schema: { type: 'null' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+components:
+  parameters:
+    Agent: { name: agent, in: query, schema: { type: string } }
+    ChatId: { name: chat_id, in: query, schema: { type: string } }
+    Peer: { name: peer, in: path, required: true, schema: { type: string } }
+  responses:
+    AtmError:
+      description: ATM error
+      content: { application/json: { schema: { $ref: '#/components/schemas/AtmError' } } }
+  schemas:
+    AgentAddress:
+      type: object
+      required: [agent, team]
+      properties:
+        agent: { type: string }
+        chat_id: { type: string }
+        team: { type: string }
+        host: { type: string }
+    WriteRequest:
+      type: object
+      required: [message_id, from, to, body]
+      properties:
+        message_id: { type: string }
+        from: { $ref: '#/components/schemas/AgentAddress' }
+        to: { $ref: '#/components/schemas/AgentAddress' }
+        body: { type: string }
+        requires_ack: { type: boolean }
+        acknowledges_message_id: { type: string }
+    PeekQuery:
+      type: object
+      description: Canonical inspect query; fields are validated by the daemon.
+    ReadQuery:
+      type: object
+      description: Canonical read query; fields are validated by the daemon.
+    ClearQuery:
+      type: object
+      description: Canonical clear query; fields are validated by the daemon.
+    ListQuery:
+      type: object
+      description: Canonical list query; fields are validated by the daemon.
+    SearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: object
+          description: Public CLI/HTTP primitives compiled by atm-core into the bounded backend-neutral search query.
+        lifecycle:
+          $ref: '#/components/schemas/WorkflowProjectionRequest'
+          description: Optional generic lifecycle projection over the bounded local search result.
+    WorkflowSelector:
+      type: object
+      description: Partial exact selector; at least one selector field is required by the runtime.
+      properties:
+        state: { type: string }
+        stage: { type: string }
+        transition: { type: string }
+    WorkflowTimeRange:
+      type: object
+      properties:
+        since: { type: string, format: date-time }
+        until: { type: string, format: date-time }
+    WorkflowProjectionRequest:
+      type: object
+      required: [scope_kind, start, end]
+      description: Generic one-to-one lifecycle pairing request carried by SearchRequest.lifecycle.
+      properties:
+        scope_kind: { type: string }
+        scope_id: { type: string }
+        start: { $ref: '#/components/schemas/WorkflowSelector' }
+        end: { $ref: '#/components/schemas/WorkflowSelector' }
+        time_range: { $ref: '#/components/schemas/WorkflowTimeRange' }
+    SearchResponse:
+      type: object
+      required: [hits]
+      properties:
+        hits: { type: array, items: { $ref: '#/components/schemas/SearchHit' } }
+        aggregate: { type: object }
+        next_cursor: { type: string }
+    SearchHit:
+      type: object
+      required: [key, message_at, from_agent, to_agent, snippet]
+      properties:
+        key: { type: object }
+        message_id: { type: string }
+        message_at: { type: string, format: date-time }
+        from_agent: { $ref: '#/components/schemas/AgentAddress' }
+        to_agent: { $ref: '#/components/schemas/AgentAddress' }
+        template_type: { type: string }
+        category: { type: string }
+        snippet: { type: string }
+    CompatibilityPreflight:
+      type: object
+      description: Client and daemon release compatibility request.
+    CompatibilityVerdict:
+      type: object
+      description: Compatibility result.
+    HeartbeatRequest:
+      type: object
+      description: Team-member heartbeat request.
+    HeartbeatResponse:
+      type: object
+      description: Team-member heartbeat result.
+    Message:
+      type: object
+      required: [message_id, from, to, body]
+      properties:
+        message_id: { type: string }
+        from: { $ref: '#/components/schemas/AgentAddress' }
+        to: { $ref: '#/components/schemas/AgentAddress' }
+        body: { type: string }
+        requires_ack: { type: boolean }
+        acknowledges_message_id: { type: string }
+    MessageList:
+      type: object
+      required: [messages]
+      properties:
+        messages: { type: array, items: { $ref: '#/components/schemas/Message' } }
+        cursor: { type: string }
+    AtmError:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }

--- a/crates/atm/src/commands/api.rs
+++ b/crates/atm/src/commands/api.rs
@@ -3,7 +3,10 @@ use clap::{Args, Subcommand};
 
 use crate::observability::CliObservability;
 
-const OPENAPI_YAML: &str = include_str!("../../../../docs/atm-http-runtime/openapi.yaml");
+// The CLI embeds its publishable OpenAPI copy from its own crate tree. The
+// repository documentation copy remains canonical; `openapi_surface` enforces
+// that this packaged derivative cannot drift from it.
+const OPENAPI_YAML: &str = include_str!("../../openapi.yaml");
 
 #[derive(Debug, Args)]
 pub struct ApiCommand {

--- a/crates/atm/tests/openapi_surface.rs
+++ b/crates/atm/tests/openapi_surface.rs
@@ -26,6 +26,10 @@ fn document_path() -> PathBuf {
     workspace_root().join("docs/atm-http-runtime/openapi.yaml")
 }
 
+fn packaged_document_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("openapi.yaml")
+}
+
 fn baseline_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/openapi_surface_baseline.json")
 }
@@ -184,6 +188,19 @@ fn openapi_routes_match_live_router_surface() {
         "OpenAPI routes must exactly match live routing; live routes missing from OpenAPI: \
          {missing_from_openapi:?}; OpenAPI routes not registered live: \
          {undocumented_live_routes:?}"
+    );
+}
+
+#[test]
+fn packaged_openapi_copy_matches_the_canonical_documentation_contract() {
+    let canonical = std::fs::read(document_path()).expect("read canonical OpenAPI contract");
+    let packaged =
+        std::fs::read(packaged_document_path()).expect("read packaged OpenAPI contract copy");
+
+    assert_eq!(
+        packaged, canonical,
+        "crates/atm/openapi.yaml is a packaged derivative of the canonical \
+         docs/atm-http-runtime/openapi.yaml contract; update both together"
     );
 }
 


### PR DESCRIPTION
Fixes the crates.io publish failure for agent-team-mail (the atm CLI crate) -- the final and only remaining unpublished crate of the v1.4.2 release. 11 of 12 crates already published successfully.

Root cause: crates/atm/src/commands/api.rs's include_str! reached outside the crate's own directory (../../../../docs/atm-http-runtime/openapi.yaml). cargo publish only bundles files within a crate's own tree into the package tarball, so this file was absent during the isolated verification build, which failed with a hard compile error.

Fix: crates/atm/openapi.yaml is now the packaged derivative, embedded via a same-crate-relative include_str!. docs/atm-http-runtime/openapi.yaml remains the canonical copy. openapi_surface.rs gained a byte-for-byte drift guard so the two can never silently diverge.

Verified for real, not just cargo build: cargo publish --dry-run --allow-dirty succeeds (isolated package verification), cargo package --list --allow-dirty confirms openapi.yaml is actually in the tarball, cargo test -p agent-team-mail --test openapi_surface (4/4), cargo fmt --check.

Urgent -- this is the last blocker before the v1.4.2 crates.io release can complete.