### PR TITLE
feat(cli): agent@host cross-host shorthand + trusted-peer host resolver (#901/#902)

### DIFF
--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -426,6 +426,30 @@ pub fn with_default_peer_config_store<T>(
     f(assembly.peer_config_store().as_ref())
 }
 
+/// Open the canonical roster and durable peer-authority seams from one
+/// runtime assembly for CLI-only peer address normalization.
+///
+/// Keeping the two reads in the same assembly avoids accidentally composing
+/// a roster from one runtime snapshot with peer trust from another. The
+/// closure receives storage contracts only; no transport or daemon surface is
+/// exposed.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the default SQLite-backed retained runtime cannot
+/// assemble its canonical boundary state.
+pub fn with_default_peer_address_stores<T>(
+    f: impl FnOnce(
+        &(dyn atm_storage::RosterStore + Send + Sync),
+        &(dyn atm_storage::PeerConfigStore + Send + Sync),
+    ) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    let assembly = assemble_default_runtime()?;
+    let roster_store = assembly.shared_roster_store_arc();
+    let peer_config_store = assembly.peer_config_store();
+    f(roster_store.as_ref(), peer_config_store.as_ref())
+}
+
 #[cfg(test)]
 mod replacement_runtime_tests {
     use std::time::Duration;

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -293,7 +293,11 @@ impl HostName {
                 .0
                 .split('.')
                 .all(|label| !label.is_empty() && label.bytes().all(|byte| byte.is_ascii_digit()));
-        !ipv4_shaped && !self.0.to_ascii_lowercase().ends_with(".local")
+        // A stable local-network mDNS name (for example, `rand-m5.local`) is
+        // a durable authority even though the address it resolves to may
+        // change with Wi-Fi, Ethernet, VPN, or DHCP. Literal IPv4 values are
+        // routing observations, not durable peer identities.
+        !ipv4_shaped
     }
 }
 
@@ -592,13 +596,7 @@ mod tests {
 
     #[test]
     fn host_name_distinguishes_durable_peer_names_from_attachment_names() {
-        for attachment_name in [
-            "192.168.128.29",
-            "192.168.128.029",
-            "999.1.1.1",
-            "peer.local",
-            "PEER.LOCAL",
-        ] {
+        for attachment_name in ["192.168.128.29", "192.168.128.029", "999.1.1.1"] {
             let host: HostName = attachment_name.parse().expect("generic host syntax");
             assert!(
                 !host.is_durable_hostname(),
@@ -606,7 +604,7 @@ mod tests {
             );
         }
 
-        for durable_name in ["peer.example", "peer.localhost"] {
+        for durable_name in ["peer.example", "peer.localhost", "peer.local", "PEER.LOCAL"] {
             let host: HostName = durable_name.parse().expect("host");
             assert!(
                 host.is_durable_hostname(),

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -639,9 +639,9 @@ mod tests {
     }
 
     #[test]
-    fn trust_add_and_replace_require_durable_peer_hostnames() {
+    fn trust_add_and_replace_reject_literal_ip_peer_hosts() {
         let store = InMemoryPeerConfigStore::default();
-        for (command, host) in [("add", "192.168.128.29"), ("replace", "peer.local")] {
+        for (command, host) in [("add", "192.168.128.29"), ("replace", "999.1.1.1")] {
             let error = run_peer(
                 &store,
                 &[
@@ -655,8 +655,8 @@ mod tests {
                     "--yes",
                 ],
             )
-            .expect_err("attachment-specific host must be rejected");
-            assert!(error.message().contains("durable DNS hostname"));
+            .expect_err("literal IP host must be rejected");
+            assert!(error.message().contains("not stable peer identities"));
         }
         assert!(store.list_trusted_peers().expect("list peers").is_empty());
     }

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -301,7 +301,7 @@ fn trusted_peer_host(value: &str) -> std::result::Result<HostName, AtmError> {
         .map_err(|_source| AtmError::peer_config_validation("invalid --host"))?;
     if !host.is_durable_hostname() {
         return Err(AtmError::peer_config_validation(
-            "--host must be a durable DNS hostname (IP addresses and .local names are not stable peer identities)",
+            "--host must be a durable DNS or mDNS hostname (IP addresses are not stable peer identities)",
         ));
     }
     Ok(host)

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -237,72 +237,7 @@ impl SendCommand {
         peers: &[TrustedPeer],
     ) -> std::result::Result<String, AtmError> {
         let parsed = CliRecipientInput::parse(&self.to)?;
-        let recipient = match parsed.destination {
-            None => AgentAddress::new(parsed.identity.agent, parsed.identity.chat_id, None, None)?,
-            Some(destination) => {
-                if destination == caller_team.as_str() {
-                    AgentAddress::new(
-                        parsed.identity.agent,
-                        parsed.identity.chat_id,
-                        Some(caller_team.clone()),
-                        None,
-                    )?
-                } else if let Some(team) =
-                    known_teams.iter().find(|team| team.as_str() == destination)
-                {
-                    AgentAddress::new(
-                        parsed.identity.agent,
-                        parsed.identity.chat_id,
-                        Some(team.clone()),
-                        None,
-                    )?
-                } else if Ipv4Addr::from_str(&destination).is_ok() {
-                    let host = resolve_host_input(&destination, peers)?;
-                    AgentAddress::new(
-                        parsed.identity.agent,
-                        parsed.identity.chat_id,
-                        Some(caller_team.clone()),
-                        Some(host),
-                    )?
-                } else if let Some((team, host_input)) = destination.split_once('.') {
-                    let team = team.parse::<TeamName>()?;
-                    if let Some(host) = try_resolve_host_input(host_input, peers)? {
-                        AgentAddress::new(
-                            parsed.identity.agent,
-                            parsed.identity.chat_id,
-                            Some(team),
-                            Some(host),
-                        )?
-                    } else if let Some(host) = resolve_trusted_host(&destination, peers)? {
-                        AgentAddress::new(
-                            parsed.identity.agent,
-                            parsed.identity.chat_id,
-                            Some(caller_team.clone()),
-                            Some(host),
-                        )?
-                    } else {
-                        return Err(peer_resolution_error(
-                            format!("no enabled trusted peer matches '{destination}'"),
-                            "Run `atm peer trust list`; add or enable the intended peer, then retry using `agent@team.host`.",
-                        ));
-                    }
-                } else if let Some(host) = resolve_trusted_host(&destination, peers)? {
-                    AgentAddress::new(
-                        parsed.identity.agent,
-                        parsed.identity.chat_id,
-                        Some(caller_team.clone()),
-                        Some(host),
-                    )?
-                } else {
-                    return Err(peer_resolution_error(
-                        format!(
-                            "'{destination}' is neither a known local team nor an enabled trusted peer"
-                        ),
-                        "Use `atm team list` to select a local team, or add/list the peer with `atm peer trust list` and retry with `agent@team.host`.",
-                    ));
-                }
-            }
-        };
+        let recipient = resolve_cli_recipient(&parsed, caller_team, known_teams, peers)?;
 
         let explicit_host = self
             .host
@@ -509,6 +444,69 @@ impl SendCommand {
             .cloned()
             .ok_or_else(|| Self::template_load_error("--vars must contain a JSON object"))
     }
+}
+
+fn resolve_cli_recipient(
+    input: &CliRecipientInput,
+    caller_team: &TeamName,
+    known_teams: &[TeamName],
+    peers: &[TrustedPeer],
+) -> std::result::Result<AgentAddress, AtmError> {
+    let Some(destination) = input.destination.as_deref() else {
+        return cli_recipient_address(input, None, None);
+    };
+    if destination == caller_team.as_str() {
+        return cli_recipient_address(input, Some(caller_team.clone()), None);
+    }
+    if let Some(team) = known_teams.iter().find(|team| team.as_str() == destination) {
+        return cli_recipient_address(input, Some(team.clone()), None);
+    }
+    resolve_cli_destination(input, destination, caller_team, peers)
+}
+
+fn resolve_cli_destination(
+    input: &CliRecipientInput,
+    destination: &str,
+    caller_team: &TeamName,
+    peers: &[TrustedPeer],
+) -> std::result::Result<AgentAddress, AtmError> {
+    if Ipv4Addr::from_str(destination).is_ok() {
+        let host = resolve_host_input(destination, peers)?;
+        return cli_recipient_address(input, Some(caller_team.clone()), Some(host));
+    }
+    let has_team_host_shape = destination.contains('.');
+    if let Some((team, host_input)) = destination.split_once('.') {
+        let team = team.parse::<TeamName>()?;
+        if let Some(host) = try_resolve_host_input(host_input, peers)? {
+            return cli_recipient_address(input, Some(team), Some(host));
+        }
+    }
+    if let Some(host) = resolve_trusted_host(destination, peers)? {
+        return cli_recipient_address(input, Some(caller_team.clone()), Some(host));
+    }
+    if has_team_host_shape {
+        return Err(peer_resolution_error(
+            format!("no enabled trusted peer matches '{destination}'"),
+            "Run `atm peer trust list`; add or enable the intended peer, then retry using `agent@team.host`.",
+        ));
+    }
+    Err(peer_resolution_error(
+        format!("'{destination}' is neither a known local team nor an enabled trusted peer"),
+        "Use `atm team list` to select a local team, or add/list the peer with `atm peer trust list` and retry with `agent@team.host`.",
+    ))
+}
+
+fn cli_recipient_address(
+    input: &CliRecipientInput,
+    team: Option<TeamName>,
+    host: Option<HostName>,
+) -> std::result::Result<AgentAddress, AtmError> {
+    AgentAddress::new(
+        input.identity.agent.clone(),
+        input.identity.chat_id.clone(),
+        team,
+        host,
+    )
 }
 
 /// CLI-only recipient syntax before a destination is normalized against the

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -245,61 +245,16 @@ impl SendCommand {
             .map(|host| resolve_host_input(host, peers))
             .transpose()?;
 
-        match (recipient.host(), explicit_host) {
-            (Some(address_host), Some(flag_host))
-                if !address_host
-                    .as_str()
-                    .eq_ignore_ascii_case(flag_host.as_str()) =>
-            {
-                Err(peer_resolution_error(
-                    "recipient host and --host disagree",
-                    "Use the same host in both places, or specify it once with either `recipient@team.host` or `--host <host>`.",
-                ))
-            }
-            (Some(_), _) => Ok(recipient.to_string()),
-            (None, None) => Ok(recipient.to_string()),
-            (None, Some(host)) => AgentAddress::new(
-                recipient.agent().clone(),
-                recipient.chat_id().cloned(),
-                Some(
-                    recipient
-                        .team()
-                        .cloned()
-                        .unwrap_or_else(|| caller_team.clone()),
-                ),
-                Some(host),
-            )
-            .map(|target| target.to_string()),
-        }
+        merge_recipient_host(recipient, explicit_host, caller_team).map(|target| target.to_string())
     }
 
     fn legacy_target_with_explicit_host(&self, caller_team: &TeamName) -> Result<String> {
         let explicit_host = self.host.as_deref().map(parse_host_input).transpose()?;
         let recipient: AgentAddress = self.to.parse().map_err(anyhow::Error::from)?;
 
-        match (recipient.host(), explicit_host) {
-            (Some(address_host), Some(flag_host)) if address_host != &flag_host => {
-                Err(Self::message_validation_error(
-                    "recipient host and --host disagree",
-                    "Use the same host in both places, or specify it once with either `recipient@team.host` or `--host <host>`.",
-                ))
-            }
-            (Some(_), _) => Ok(recipient.to_string()),
-            (None, None) => Ok(recipient.to_string()),
-            (None, Some(host)) => AgentAddress::new(
-                recipient.agent().clone(),
-                recipient.chat_id().cloned(),
-                Some(
-                    recipient
-                        .team()
-                        .cloned()
-                        .unwrap_or_else(|| caller_team.clone()),
-                ),
-                Some(host),
-            )
+        merge_recipient_host(recipient, explicit_host, caller_team)
             .map(|target| target.to_string())
-            .map_err(Into::into),
-        }
+            .map_err(Into::into)
     }
 
     fn build_message_source(
@@ -538,6 +493,45 @@ impl CliRecipientInput {
             destination: Some(destination.to_string()),
         })
     }
+}
+
+/// Merges an optional CLI `--host` with an already parsed recipient.
+///
+/// This is deliberately CLI-only: callers have either canonicalized the host
+/// against trusted peer records or validated a diagnostic direct host. The
+/// returned address is therefore the ordinary canonical `AgentAddress` that
+/// crosses the daemon and HTTP boundaries.
+fn merge_recipient_host(
+    recipient: AgentAddress,
+    explicit_host: Option<HostName>,
+    caller_team: &TeamName,
+) -> std::result::Result<AgentAddress, AtmError> {
+    if let (Some(address_host), Some(flag_host)) = (recipient.host(), explicit_host.as_ref())
+        && !address_host
+            .as_str()
+            .eq_ignore_ascii_case(flag_host.as_str())
+    {
+        return Err(peer_resolution_error(
+            "recipient host and --host disagree",
+            "Use the same host in both places, or specify it once with either `recipient@team.host` or `--host <host>`.",
+        ));
+    }
+
+    if recipient.host().is_some() || explicit_host.is_none() {
+        return Ok(recipient);
+    }
+
+    AgentAddress::new(
+        recipient.agent().clone(),
+        recipient.chat_id().cloned(),
+        Some(
+            recipient
+                .team()
+                .cloned()
+                .unwrap_or_else(|| caller_team.clone()),
+        ),
+        explicit_host,
+    )
 }
 
 fn parse_host_input(raw_host: &str) -> Result<HostName> {
@@ -1042,6 +1036,19 @@ mod tests {
             via_destination.to.expect("destination target").to_string(),
             "both forms must create the same host-qualified destination before shared self-send validation"
         );
+    }
+
+    #[test]
+    fn legacy_explicit_host_compares_hostnames_case_insensitively() {
+        let caller_team = TEST_TEAM.parse().expect("caller team");
+        let target = send_command(
+            &format!("{TEST_SENDER}@{TEST_TEAM}.LOCALHOST"),
+            Some("localhost"),
+        )
+        .target_with_explicit_host(&caller_team)
+        .expect("case-only loopback host difference must be accepted");
+
+        assert_eq!(target, format!("{TEST_SENDER}@{TEST_TEAM}.LOCALHOST"));
     }
 
     #[test]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,4 +1,6 @@
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::Result;
 use atm_core::address::AgentAddress;
@@ -6,7 +8,9 @@ use atm_core::load_atm_config;
 use atm_core::send::{
     MessageClassification, SendMessageSource, SendRequest, TemplateSendSource, input,
 };
-use atm_core::types::{HostName, TaskId, TeamName};
+use atm_core::types::{AgentIdentity, HostName, TaskId, TeamName};
+use atm_daemon_bootstrap::with_default_peer_address_stores;
+use atm_storage::{AtmError, PeerConfigStore, RosterStore, TrustedPeer};
 use clap::Args;
 
 use crate::commands::caller_context::{
@@ -182,15 +186,160 @@ impl SendCommand {
     }
 
     fn target_with_explicit_host(&self, caller_team: &TeamName) -> Result<String> {
-        let explicit_host = match self.host.as_deref() {
-            Some(raw_host) => Some(raw_host.parse::<HostName>().map_err(|_source| {
-                Self::message_validation_error(
-                    "invalid --host",
-                    "Pass a valid hostname or IP address to `--host` before retrying `atm send`.",
-                )
-            })?),
-            None => None,
+        if !self.requires_peer_authority_lookup(caller_team) {
+            return self.legacy_target_with_explicit_host(caller_team);
+        }
+
+        // The shorthand is resolved at CLI composition time. The daemon and
+        // HTTP request receive the same canonical AgentAddress as if the user
+        // had typed the full `agent@team.host` form themselves.
+        with_default_peer_address_stores(|roster_store, peer_store| {
+            self.target_with_authorities(caller_team, roster_store, peer_store)
+        })
+        .map_err(Into::into)
+    }
+
+    fn requires_peer_authority_lookup(&self, caller_team: &TeamName) -> bool {
+        if self
+            .host
+            .as_deref()
+            .is_some_and(|host| !is_legacy_direct_host(host))
+        {
+            return true;
+        }
+
+        let Some((_, destination)) = self.to.trim().split_once('@') else {
+            return false;
         };
+        if destination.eq(caller_team.as_str()) {
+            return false;
+        }
+        destination
+            .split_once('.')
+            .is_none_or(|(_, host)| !host.eq_ignore_ascii_case("localhost"))
+    }
+
+    fn target_with_authorities(
+        &self,
+        caller_team: &TeamName,
+        roster_store: &(dyn RosterStore + Send + Sync),
+        peer_store: &(dyn PeerConfigStore + Send + Sync),
+    ) -> std::result::Result<String, AtmError> {
+        let known_teams = roster_store.list_teams()?;
+        let peers = peer_store.list_trusted_peers()?;
+        self.target_with_peer_records(caller_team, &known_teams, &peers)
+    }
+
+    fn target_with_peer_records(
+        &self,
+        caller_team: &TeamName,
+        known_teams: &[TeamName],
+        peers: &[TrustedPeer],
+    ) -> std::result::Result<String, AtmError> {
+        let parsed = CliRecipientInput::parse(&self.to)?;
+        let recipient = match parsed.destination {
+            None => AgentAddress::new(parsed.identity.agent, parsed.identity.chat_id, None, None)?,
+            Some(destination) => {
+                if destination == caller_team.as_str() {
+                    AgentAddress::new(
+                        parsed.identity.agent,
+                        parsed.identity.chat_id,
+                        Some(caller_team.clone()),
+                        None,
+                    )?
+                } else if let Some(team) =
+                    known_teams.iter().find(|team| team.as_str() == destination)
+                {
+                    AgentAddress::new(
+                        parsed.identity.agent,
+                        parsed.identity.chat_id,
+                        Some(team.clone()),
+                        None,
+                    )?
+                } else if Ipv4Addr::from_str(&destination).is_ok() {
+                    let host = resolve_host_input(&destination, peers)?;
+                    AgentAddress::new(
+                        parsed.identity.agent,
+                        parsed.identity.chat_id,
+                        Some(caller_team.clone()),
+                        Some(host),
+                    )?
+                } else if let Some((team, host_input)) = destination.split_once('.') {
+                    let team = team.parse::<TeamName>()?;
+                    if let Some(host) = try_resolve_host_input(host_input, peers)? {
+                        AgentAddress::new(
+                            parsed.identity.agent,
+                            parsed.identity.chat_id,
+                            Some(team),
+                            Some(host),
+                        )?
+                    } else if let Some(host) = resolve_trusted_host(&destination, peers)? {
+                        AgentAddress::new(
+                            parsed.identity.agent,
+                            parsed.identity.chat_id,
+                            Some(caller_team.clone()),
+                            Some(host),
+                        )?
+                    } else {
+                        return Err(peer_resolution_error(
+                            format!("no enabled trusted peer matches '{destination}'"),
+                            "Run `atm peer trust list`; add or enable the intended peer, then retry using `agent@team.host`.",
+                        ));
+                    }
+                } else if let Some(host) = resolve_trusted_host(&destination, peers)? {
+                    AgentAddress::new(
+                        parsed.identity.agent,
+                        parsed.identity.chat_id,
+                        Some(caller_team.clone()),
+                        Some(host),
+                    )?
+                } else {
+                    return Err(peer_resolution_error(
+                        format!(
+                            "'{destination}' is neither a known local team nor an enabled trusted peer"
+                        ),
+                        "Use `atm team list` to select a local team, or add/list the peer with `atm peer trust list` and retry with `agent@team.host`.",
+                    ));
+                }
+            }
+        };
+
+        let explicit_host = self
+            .host
+            .as_deref()
+            .map(|host| resolve_host_input(host, peers))
+            .transpose()?;
+
+        match (recipient.host(), explicit_host) {
+            (Some(address_host), Some(flag_host))
+                if !address_host
+                    .as_str()
+                    .eq_ignore_ascii_case(flag_host.as_str()) =>
+            {
+                Err(peer_resolution_error(
+                    "recipient host and --host disagree",
+                    "Use the same host in both places, or specify it once with either `recipient@team.host` or `--host <host>`.",
+                ))
+            }
+            (Some(_), _) => Ok(recipient.to_string()),
+            (None, None) => Ok(recipient.to_string()),
+            (None, Some(host)) => AgentAddress::new(
+                recipient.agent().clone(),
+                recipient.chat_id().cloned(),
+                Some(
+                    recipient
+                        .team()
+                        .cloned()
+                        .unwrap_or_else(|| caller_team.clone()),
+                ),
+                Some(host),
+            )
+            .map(|target| target.to_string()),
+        }
+    }
+
+    fn legacy_target_with_explicit_host(&self, caller_team: &TeamName) -> Result<String> {
+        let explicit_host = self.host.as_deref().map(parse_host_input).transpose()?;
         let recipient: AgentAddress = self.to.parse().map_err(anyhow::Error::from)?;
 
         match (recipient.host(), explicit_host) {
@@ -362,6 +511,165 @@ impl SendCommand {
     }
 }
 
+/// CLI-only recipient syntax before a destination is normalized against the
+/// local roster and durable peer authorities. It intentionally never crosses
+/// into `atm-core`: every downstream boundary receives `AgentAddress`.
+#[derive(Debug)]
+struct CliRecipientInput {
+    identity: AgentIdentity,
+    destination: Option<String>,
+}
+
+impl CliRecipientInput {
+    fn parse(raw: &str) -> std::result::Result<Self, AtmError> {
+        let raw = raw.trim();
+        let Some((identity, destination)) = raw.split_once('@') else {
+            return Ok(Self {
+                identity: raw.parse()?,
+                destination: None,
+            });
+        };
+        if destination.contains('@') {
+            return Err(AtmError::address_parse("address may contain only one '@'"));
+        }
+        if destination.is_empty() {
+            return Err(AtmError::address_parse("destination must not be empty"));
+        }
+        Ok(Self {
+            identity: identity.parse()?,
+            destination: Some(destination.to_string()),
+        })
+    }
+}
+
+fn parse_host_input(raw_host: &str) -> Result<HostName> {
+    raw_host.parse::<HostName>().map_err(|_source| {
+        SendCommand::message_validation_error(
+            "invalid --host",
+            "Pass a valid hostname or IP address to `--host` before retrying `atm send`.",
+        )
+    })
+}
+
+fn is_legacy_direct_host(raw_host: &str) -> bool {
+    raw_host.eq_ignore_ascii_case("localhost")
+}
+
+fn resolve_host_input(
+    raw_host: &str,
+    peers: &[TrustedPeer],
+) -> std::result::Result<HostName, AtmError> {
+    try_resolve_host_input(raw_host, peers)?.ok_or_else(|| {
+        peer_resolution_error(
+            format!("no enabled trusted peer matches '{raw_host}'"),
+            "Run `atm peer trust list`; add or enable the intended peer, then retry using its registered hostname.",
+        )
+    })
+}
+
+fn try_resolve_host_input(
+    raw_host: &str,
+    peers: &[TrustedPeer],
+) -> std::result::Result<Option<HostName>, AtmError> {
+    let host = raw_host.parse::<HostName>().map_err(|_source| {
+        peer_resolution_error(
+            "invalid host",
+            "Pass a valid trusted hostname (optionally omitting terminal `.local`) or a diagnostic localhost/IP value.",
+        )
+    })?;
+    if is_legacy_direct_host(host.as_str()) {
+        return Ok(Some(host));
+    }
+    if let Ok(ip) = Ipv4Addr::from_str(host.as_str()) {
+        return resolve_trusted_ipv4(ip, peers).map(Some);
+    }
+    resolve_trusted_host(host.as_str(), peers)
+}
+
+fn resolve_trusted_ipv4(
+    target_ip: Ipv4Addr,
+    peers: &[TrustedPeer],
+) -> std::result::Result<HostName, AtmError> {
+    resolve_trusted_ipv4_with_lookup(target_ip, peers, |peer| {
+        let authority = (peer.host.as_str(), peer.https_port.get());
+        authority
+            .to_socket_addrs()
+            .map(|addresses| addresses.map(|address| address.ip()).collect())
+            .map_err(|error| {
+                peer_resolution_error(
+                    format!("trusted peer '{}' could not be resolved: {error}", peer.host),
+                    "Verify the registered DNS/mDNS authority is resolvable, then retry the send with its hostname.",
+                )
+            })
+    })
+}
+
+fn resolve_trusted_ipv4_with_lookup(
+    target_ip: Ipv4Addr,
+    peers: &[TrustedPeer],
+    lookup: impl Fn(&TrustedPeer) -> std::result::Result<Vec<IpAddr>, AtmError>,
+) -> std::result::Result<HostName, AtmError> {
+    const MAX_ENABLED_PEER_LOOKUPS: usize = 32;
+
+    let enabled_peers: Vec<&TrustedPeer> = peers.iter().filter(|peer| peer.enabled).collect();
+    if enabled_peers.len() > MAX_ENABLED_PEER_LOOKUPS {
+        return Err(peer_resolution_error(
+            format!(
+                "literal IP authority resolution exceeds the {MAX_ENABLED_PEER_LOOKUPS}-peer lookup bound"
+            ),
+            "Use the registered hostname directly, or reduce the enabled peer set before retrying the literal IP diagnostic.",
+        ));
+    }
+
+    let mut matches = Vec::new();
+    for peer in enabled_peers {
+        if lookup(peer)?.contains(&IpAddr::V4(target_ip)) {
+            matches.push(peer);
+        }
+    }
+    match matches.as_slice() {
+        [peer] => Ok(peer.host.clone()),
+        [] => Err(peer_resolution_error(
+            format!("no enabled trusted peer resolves to literal IP '{target_ip}'"),
+            "Use a registered hostname, or add/enable the exact trusted peer before retrying.",
+        )),
+        _ => Err(peer_resolution_error(
+            format!("literal IP '{target_ip}' resolves to multiple enabled trusted peers"),
+            "Use the exact registered hostname instead of the shared IP address.",
+        )),
+    }
+}
+
+fn resolve_trusted_host(
+    raw_host: &str,
+    peers: &[TrustedPeer],
+) -> std::result::Result<Option<HostName>, AtmError> {
+    let exact_or_local = |host: &HostName| {
+        let canonical_lower = host.as_str().to_ascii_lowercase();
+        host.as_str().eq_ignore_ascii_case(raw_host)
+            || (!raw_host.to_ascii_lowercase().ends_with(".local")
+                && canonical_lower
+                    .strip_suffix(".local")
+                    .is_some_and(|short| short.eq_ignore_ascii_case(raw_host)))
+    };
+    let matches: Vec<&TrustedPeer> = peers
+        .iter()
+        .filter(|peer| peer.enabled && exact_or_local(&peer.host))
+        .collect();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [peer] => Ok(Some(peer.host.clone())),
+        _ => Err(peer_resolution_error(
+            format!("trusted peer shorthand '{raw_host}' is ambiguous"),
+            "Use the exact registered hostname from `atm peer trust list`, or remove the duplicate enabled peer record before retrying.",
+        )),
+    }
+}
+
+fn peer_resolution_error(message: impl Into<String>, recovery: impl Into<String>) -> AtmError {
+    AtmError::validation_with_recovery(message, recovery)
+}
+
 pub(crate) fn parse_assignment_values(
     values: &[String],
 ) -> Result<serde_json::Map<String, serde_json::Value>> {
@@ -472,12 +780,16 @@ fn validate_classification(
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::num::NonZeroU16;
     use std::path::{Path, PathBuf};
 
-    use super::SendCommand;
+    use super::{SendCommand, resolve_trusted_ipv4_with_lookup};
     use atm_core::roles::ROLE_TEAM_LEAD;
     use atm_core::send::{SendMessageSource, input};
     use atm_core::test_support::{EnvGuard, TEST_SENDER};
+    use atm_core::types::TeamName;
+    use atm_storage::{HostName, TrustedPeer};
     use clap::Parser;
     use serial_test::serial;
     use tempfile::TempDir;
@@ -509,6 +821,213 @@ mod tests {
         }
     }
 
+    fn trusted_peer(host: &str) -> TrustedPeer {
+        TrustedPeer {
+            host: host.parse::<HostName>().expect("host"),
+            fingerprint: "a".repeat(64).parse().expect("fingerprint"),
+            enabled: true,
+            https_port: NonZeroU16::new(43101).expect("port"),
+        }
+    }
+
+    fn known_teams() -> Vec<TeamName> {
+        vec![
+            TEST_TEAM.parse().expect("caller team"),
+            "other-team".parse().expect("team"),
+        ]
+    }
+
+    #[test]
+    fn same_team_host_shorthand_builds_the_existing_canonical_target() {
+        let command = send_command("arch-ctm@rand-m5", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect("same-team host shorthand");
+
+        assert_eq!(target, "arch-ctm@test-team.rand-m5.local");
+    }
+
+    #[test]
+    fn m_dns_suffix_and_hostname_case_are_cli_only_conveniences() {
+        let command = send_command("arch-ctm@RAND-M5.LOCAL", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect("case-insensitive mDNS authority");
+
+        assert_eq!(target, "arch-ctm@test-team.rand-m5.local");
+    }
+
+    #[test]
+    fn dotted_m_dns_host_shorthand_is_not_mistaken_for_team_host_syntax() {
+        let command = send_command("arch-ctm@fastpc4.radiant.local", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("fastpc4.radiant.local")],
+            )
+            .expect("multi-label mDNS authority");
+
+        assert_eq!(target, "arch-ctm@test-team.fastpc4.radiant.local");
+    }
+
+    #[test]
+    fn explicit_remote_team_preserves_team_and_canonicalizes_host() {
+        let command = send_command("arch-ctm@other-team.rand-m5", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect("explicit remote team host");
+
+        assert_eq!(target, "arch-ctm@other-team.rand-m5.local");
+    }
+
+    #[test]
+    fn explicit_team_host_form_wins_over_a_coincidentally_matching_full_hostname() {
+        let command = send_command("arch-ctm@other-team.rand-m5.local", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[
+                    trusted_peer("rand-m5.local"),
+                    trusted_peer("other-team.rand-m5.local"),
+                ],
+            )
+            .expect("explicit team host form");
+
+        assert_eq!(target, "arch-ctm@other-team.rand-m5.local");
+    }
+
+    #[test]
+    fn known_team_wins_over_a_matching_host_shorthand() {
+        let command = send_command("arch-ctm@other-team", None);
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("other-team.local")],
+            )
+            .expect("known team retains legacy meaning");
+
+        assert_eq!(target, "arch-ctm@other-team");
+    }
+
+    #[test]
+    fn untrusted_and_ambiguous_host_shorthand_fail_with_recovery() {
+        let caller_team = TEST_TEAM.parse().expect("caller team");
+        let no_peer_error = send_command("arch-ctm@rand-m5", None)
+            .target_with_peer_records(&caller_team, &known_teams(), &[])
+            .expect_err("untrusted peer must fail closed");
+        assert!(
+            no_peer_error
+                .to_string()
+                .contains("neither a known local team nor an enabled trusted peer")
+        );
+
+        let ambiguous_error = send_command("arch-ctm@rand-m5", None)
+            .target_with_peer_records(
+                &caller_team,
+                &known_teams(),
+                &[trusted_peer("rand-m5.local"), trusted_peer("RAND-M5.LOCAL")],
+            )
+            .expect_err("ambiguous shorthand must fail closed");
+        assert!(ambiguous_error.to_string().contains("ambiguous"));
+
+        let no_fuzzy_error = send_command("arch-ctm@rand-m5.example", None)
+            .target_with_peer_records(
+                &caller_team,
+                &known_teams(),
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect_err("only terminal .local completion is permitted");
+        assert!(
+            no_fuzzy_error
+                .to_string()
+                .contains("no enabled trusted peer")
+        );
+    }
+
+    #[test]
+    fn explicit_host_flag_uses_the_same_trusted_authority_canonicalization() {
+        let command = send_command("arch-ctm@test-team", Some("RAND-M5"));
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect("canonicalized --host");
+
+        assert_eq!(target, "arch-ctm@test-team.rand-m5.local");
+    }
+
+    #[test]
+    fn caller_team_remains_known_when_the_roster_is_empty() {
+        let command = send_command("arch-ctm@test-team", Some("rand-m5"));
+        let target = command
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &[],
+                &[trusted_peer("rand-m5.local")],
+            )
+            .expect("caller team must not depend on a roster row");
+
+        assert_eq!(target, "arch-ctm@test-team.rand-m5.local");
+    }
+
+    #[test]
+    fn literal_ip_resolves_to_the_single_canonical_trusted_hostname() {
+        let peers = [trusted_peer("rand-m5.local")];
+        let canonical =
+            resolve_trusted_ipv4_with_lookup(Ipv4Addr::new(192, 168, 1, 63), &peers, |_| {
+                Ok(vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 63))])
+            })
+            .expect("single trusted authority");
+
+        assert_eq!(canonical.as_str(), "rand-m5.local");
+    }
+
+    #[test]
+    fn literal_ip_fails_closed_when_multiple_trusted_hosts_resolve_to_it() {
+        let peers = [
+            trusted_peer("rand-m5.local"),
+            trusted_peer("fastpc4.radiant.local"),
+        ];
+        let error =
+            resolve_trusted_ipv4_with_lookup(Ipv4Addr::new(192, 168, 1, 63), &peers, |_| {
+                Ok(vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 63))])
+            })
+            .expect_err("shared IP must not choose a peer");
+
+        assert!(error.to_string().contains("multiple enabled trusted peers"));
+    }
+
+    #[test]
+    fn literal_ip_resolution_rejects_an_unbounded_enabled_peer_set() {
+        let peers: Vec<TrustedPeer> = (0..33)
+            .map(|index| trusted_peer(&format!("peer-{index}.local")))
+            .collect();
+        let error =
+            resolve_trusted_ipv4_with_lookup(Ipv4Addr::new(192, 168, 1, 63), &peers, |_| {
+                panic!("lookup must not begin after the preflight bound fails")
+            })
+            .expect_err("lookup set must remain bounded");
+
+        assert!(error.to_string().contains("32-peer lookup bound"));
+    }
+
     #[test]
     #[serial(env)]
     fn explicit_host_is_wire_equivalent_to_a_host_qualified_destination() {
@@ -529,31 +1048,27 @@ mod tests {
 
     #[test]
     #[serial(env)]
-    fn explicit_same_ip_host_qualifies_a_self_send_for_the_shared_guard() {
+    fn explicit_localhost_qualifies_a_self_send_for_the_shared_guard() {
         let _env = EnvGuard::set_many([("ATM_IDENTITY", Some(TEST_SENDER))]);
-        let request = send_command(
-            &format!("{TEST_SENDER}@{TEST_TEAM}"),
-            Some("192.168.128.82"),
-        )
-        .build_request(".".into(), ".".into())
-        .expect("same-IP target");
+        let request = send_command(&format!("{TEST_SENDER}@{TEST_TEAM}"), Some("localhost"))
+            .build_request(".".into(), ".".into())
+            .expect("same-host target");
 
         assert_eq!(
             request.to.expect("target").to_string(),
-            format!("{TEST_SENDER}@{TEST_TEAM}.192.168.128.82")
+            format!("{TEST_SENDER}@{TEST_TEAM}.localhost")
         );
     }
 
     #[test]
-    #[serial(env)]
     fn explicit_host_rejects_a_conflicting_destination_suffix() {
-        let _env = EnvGuard::set_many([("ATM_IDENTITY", Some(TEST_SENDER))]);
-        let error = send_command(
-            &format!("{TEST_SENDER}@{TEST_TEAM}.localhost"),
-            Some("192.168.128.82"),
-        )
-        .build_request(".".into(), ".".into())
-        .expect_err("mismatched host selection must be rejected");
+        let error = send_command("arch-ctm@test-team.rand-m5", Some("fastpc4"))
+            .target_with_peer_records(
+                &TEST_TEAM.parse().expect("caller team"),
+                &known_teams(),
+                &[trusted_peer("rand-m5.local"), trusted_peer("fastpc4.local")],
+            )
+            .expect_err("mismatched host selection must be rejected");
 
         assert!(
             error

--- a/docs/adr/ADR-040-peer-authority-resolution.md
+++ b/docs/adr/ADR-040-peer-authority-resolution.md
@@ -64,8 +64,10 @@ The CLI accepts either the registered hostname (including the documented
 
 - after CLI normalization, a hostname input must exactly match one registered
   canonical hostname;
-- a literal IP input is authorized only when a fresh bounded DNS/mDNS lookup of
-  exactly one registered hostname contains that address;
+- a literal IP input is authorized only when a fresh lookup of no more than 32
+  enabled registered DNS/mDNS hostnames finds exactly one hostname containing
+  that address; a larger enabled peer set fails with recovery to use the
+  registered hostname directly;
 - zero matches are untrusted and two or more matches are ambiguous; both fail
   closed before connection; and
 - reverse-DNS lookup is forbidden. An IP-only registration never authorizes a

--- a/docs/adr/ADR-040-peer-authority-resolution.md
+++ b/docs/adr/ADR-040-peer-authority-resolution.md
@@ -5,23 +5,54 @@
 | ID | ADR-040 |
 | Status | Proposed |
 | Scope | Repository-wide |
-| Relates to | ADR-034, ADR-035, Phase AI.25 |
+| Relates to | ADR-034, ADR-035, Phase AI.25, #901, #902 |
 
 ## Decision
 
-A cross-host peer is registered by a stable DNS hostname, HTTPS port, and
+A cross-host peer is registered by a stable hostname, HTTPS port, and
 pinned certificate fingerprint. The durable record stores only that endpoint
 identity and pin; it never stores a resolved IP alias.
 
-The registered name is a forward-resolvable endpoint name: the peer operator
-is responsible for keeping its A/AAAA record current through ordinary DNS or
-DDNS when VPN or Wi-Fi addressing changes. ATM never discovers that name by
-reverse DNS and does not write an observed address back into durable state.
+The registered name is a forward-resolvable endpoint name. It may be an
+ordinary DNS/DDNS name or a stable local-network mDNS name such as
+`rand-m5.local`. The peer operator is responsible for keeping that name
+resolvable when VPN, Wi-Fi, Ethernet, DHCP, or VPS placement changes. ATM
+never discovers a peer name by reverse DNS and does not write an observed
+address back into durable state.
 
-The peer transport accepts either the registered hostname or a literal IP as a
-destination input:
+## CLI address convenience
 
-- a hostname input must exactly match one registered hostname;
+The CLI resolves destination shorthand before it builds the existing
+fully-qualified HTTP request. The daemon, request schema, wire protocol,
+storage schema, and graft/native-tool APIs receive no new shorthand and do no
+peer-name completion.
+
+- A trusted host input may omit a terminal `.local`: `rand-m5` and
+  `rand-m5.local` select the same canonical enabled trusted authority. The
+  canonical registered hostname is used in the request, output, message
+  provenance, and diagnostics.
+- `agent@host` is same-team cross-host shorthand. If `host` is not a known
+  local team but resolves to exactly one enabled trusted authority, the CLI
+  expands `agent@host` to `agent@<caller-team>.<canonical-host>`.
+- `agent@team.host` remains the explicit different-team cross-host form. The
+  host component receives the same `.local`-optional trusted-authority
+  resolution.
+- Existing `agent@team` handling remains compatible: an exact known team name
+  wins over host shorthand. A string matching neither a known team nor one
+  enabled trusted authority fails closed with structured, actionable recovery.
+- Hostname comparisons are ASCII case-insensitive. Completion is deliberately
+  limited to the terminal `.local` form; ATM does not apply fuzzy, prefix, or
+  arbitrary suffix matching.
+
+This is an input-normalization convenience only. The resolved `AgentAddress`
+is indistinguishable from one supplied in fully-qualified form before the
+existing HTTP request is constructed.
+
+The CLI accepts either the registered hostname (including the documented
+`.local` shorthand) or a literal IP as a destination input:
+
+- after CLI normalization, a hostname input must exactly match one registered
+  canonical hostname;
 - a literal IP input is authorized only when a fresh bounded DNS lookup of
   exactly one registered hostname contains that address;
 - zero matches are untrusted and two or more matches are ambiguous; both fail
@@ -30,11 +61,11 @@ destination input:
   hostname.
 
 After authority resolution, the selected registered hostname and its pin are
-the TLS authority. DNS is routing discovery, not authorization; certificate
-pin verification remains mandatory. The inbound peer supplies its configured
-hostname and port as authenticated transport metadata, and the HTTPS adapter
-verifies that endpoint identity plus its mTLS certificate pin before constructing
-`AuthenticatedPeer`.
+the TLS authority. DNS/mDNS is routing discovery, not authorization;
+certificate pin verification remains mandatory. The inbound peer supplies its
+configured hostname and port as authenticated transport metadata, and the HTTPS
+adapter verifies that endpoint identity plus its mTLS certificate pin before
+constructing `AuthenticatedPeer`.
 
 Changing a durable trust record must atomically refresh the daemon's live peer
 authority snapshot through the control plane. It must not require a second
@@ -42,11 +73,11 @@ daemon or an operator restart merely to make a trust add/revoke effective.
 
 ## Consequences
 
-Operators configure stable names such as `fastpc4.rz.local`; an address change
-does not require an SQLite migration or a new alias record. A direct IP remains
-usable for diagnostics and compatibility only while it resolves from one
-registered hostname. This decision does not add DNS results, retries, receipts,
-or delivery state to storage.
+Operators configure stable names such as `rand-m5.local` and
+`fastpc4.radiant.local`; an address change does not require an SQLite migration
+or a new alias record. A direct IP remains usable for diagnostics and
+compatibility only while it resolves from one registered hostname. This decision
+does not add DNS/mDNS results, retries, receipts, or delivery state to storage.
 
 A host with several account-owned daemons assigns each daemon a distinct
 configured HTTPS port and a distinct endpoint name or otherwise unambiguous

--- a/docs/adr/ADR-040-peer-authority-resolution.md
+++ b/docs/adr/ADR-040-peer-authority-resolution.md
@@ -20,6 +20,14 @@ resolvable when VPN, Wi-Fi, Ethernet, DHCP, or VPS placement changes. ATM
 never discovers a peer name by reverse DNS and does not write an observed
 address back into durable state.
 
+The CLI reads the enabled authority set directly through
+`PeerConfigStore::list_trusted_peers()` at the approved
+`boundaries/atm-storage/peer-config-store.toml` seam. It does not invent a
+parallel configuration read and it does not depend on a running daemon or the
+daemon's separately refreshed in-memory TLS-verifier snapshot. A later send
+still needs the ordinary local-daemon path, but address normalization itself is
+available while that daemon is stopped.
+
 ## CLI address convenience
 
 The CLI resolves destination shorthand before it builds the existing
@@ -43,6 +51,9 @@ peer-name completion.
 - Hostname comparisons are ASCII case-insensitive. Completion is deliberately
   limited to the terminal `.local` form; ATM does not apply fuzzy, prefix, or
   arbitrary suffix matching.
+- `--host <host>` uses this exact same trusted-authority canonicalization as an
+  inline host. Supplying both forms compares their canonical registered names,
+  not their unnormalized spelling.
 
 This is an input-normalization convenience only. The resolved `AgentAddress`
 is indistinguishable from one supplied in fully-qualified form before the
@@ -53,7 +64,7 @@ The CLI accepts either the registered hostname (including the documented
 
 - after CLI normalization, a hostname input must exactly match one registered
   canonical hostname;
-- a literal IP input is authorized only when a fresh bounded DNS lookup of
+- a literal IP input is authorized only when a fresh bounded DNS/mDNS lookup of
   exactly one registered hostname contains that address;
 - zero matches are untrusted and two or more matches are ambiguous; both fail
   closed before connection; and
@@ -78,6 +89,19 @@ Operators configure stable names such as `rand-m5.local` and
 or a new alias record. A direct IP remains usable for diagnostics and
 compatibility only while it resolves from one registered hostname. This decision
 does not add DNS/mDNS results, retries, receipts, or delivery state to storage.
+
+### Platform boundary
+
+macOS, Linux, and Windows all receive the same canonical hostname, matching,
+failure, and recovery behavior. Ordinary DNS/DDNS is the portable baseline.
+An operator may register a `.local` name only where the operating system's
+network stack has mDNS available; on Windows without mDNS resolution, ATM
+fails before dispatch with the same structured unresolved-authority recovery
+as an unavailable DNS name. The operator must use a forward-resolvable
+DNS/DDNS authority or enable the supported local mDNS facility; ATM does not
+silently fall back to an IP or another peer. Windows test coverage must cover
+this fail-closed behavior and successful canonicalization independently of a
+particular LAN's mDNS service.
 
 A host with several account-owned daemons assigns each daemon a distinct
 configured HTTPS port and a distinct endpoint name or otherwise unambiguous

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -316,6 +316,12 @@ Satisfied by:
     observable product behavior, error semantics, and test obligations
   - a feature that lacks one supported-operating-system implementation is
     incomplete and must not be documented as production-ready
+  - peer authority canonicalization is platform-identical. DNS/DDNS is the
+    portable baseline; a `.local` authority is available on any supported OS
+    only when that OS has an mDNS resolver. When mDNS is unavailable (including
+    a Windows installation without the facility enabled), resolution fails
+    closed with actionable recovery to use DNS/DDNS or enable mDNS; it must not
+    fall back to a durable or inferred IP alias
 
 ### 2.1 In Scope
 
@@ -553,8 +559,8 @@ Required behavior:
   address
 - for `atm send`, `--host <host>` qualifies the resolved recipient as
   `agent@team.host`; it is equivalent to spelling that host in the recipient
-  address, and supplying both forms with different hosts fails before daemon
-  dispatch
+  address, passes through ADR-040 trusted-host canonicalization, and supplying
+  both forms with different canonical hosts fails before daemon dispatch
 - caller chat-id resolution is ordered: qualified `--as <agent>:<chat-id>`,
   then `--chat-id`, then `ATM_CHAT_ID`, then a chat-id embedded in
   `ATM_IDENTITY=<agent>:<chat-id>`, then no chat-id. An explicit unqualified
@@ -945,9 +951,9 @@ Product requirement ID:
 - `REQ-P-ADDRESS-001` Address resolution must support the documented
   local-team and CLI-only cross-host convenience forms and precedence rules.
 
-Satisfied by:
-- `REQ-CORE-CONFIG-002` for address parsing, alias rewrite, and
-  team/member validation policy
+The canonical precedence, trusted-host matching, completion exclusions, and
+error/recovery contract are defined by ADR-040. This requirement intentionally
+does not re-derive those rules; implementations must follow ADR-040.
 
 Supported address forms:
 - `agent`
@@ -955,34 +961,17 @@ Supported address forms:
 - `agent@team.host`
 - `agent@host` (CLI same-team cross-host shorthand only)
 
-Resolution order:
-1. explicit `agent@team.host`, after canonical trusted-host resolution
-2. an exact known `agent@team` local/team destination
-3. `agent@host` shorthand when `host` resolves to exactly one enabled trusted
-   authority; the caller team is inserted as the destination team
-4. bare `agent` plus `--team`
-5. bare `agent` plus configured default team
+ADR-040 defines this order: explicit `agent@team.host`, exact known
+`agent@team`, same-team `agent@host` shorthand, then the existing bare-agent
+team/default resolution. It also defines `.local`-only completion,
+ASCII-case-insensitive host comparison, canonical-host persistence, and the
+fail-closed structured recovery for unknown or ambiguous authorities. An
+explicit `@team` suffix takes precedence over `--team`.
 
-An explicit `@team` suffix takes precedence over `--team`.
-
-CLI host convenience rules:
-- `host` and `host.local` are equivalent input only when they resolve to the
-  same enabled trusted canonical authority; the request and all durable output
-  use that canonical registered hostname
-- hostname comparison is ASCII case-insensitive; `.local` completion is the
-  only permitted completion—fuzzy, prefix, and arbitrary suffix matching are
-  forbidden
-- an exact known team name wins over same-token host shorthand, preserving the
-  existing `agent@team` form
-- a token matching neither a known team nor exactly one enabled trusted host,
-  and every ambiguous host completion, fails before HTTP dispatch with
-  structured recovery guidance
-- this resolution is a CLI-only convenience. It completes before the existing
-  fully-qualified HTTP request is built; it must not add a daemon-side address
-  resolution path, HTTP/wire field, storage field, or graft/native-tool API
-- the CLI must preserve the canonical registered hostname in the resolved
-  destination, request output, and message provenance. Resolved IP addresses
-  are transient routing data only and must not be persisted as peer identity
+`--host <host>` uses the same CLI-only trusted-authority canonicalization as
+an inline host. Before HTTP dispatch, either form becomes the existing
+fully-qualified `agent@team.canonical-host` request; it adds no daemon-side
+resolution path, HTTP/wire field, storage field, or graft/native-tool API.
 
 Aliases are resolved after splitting `agent@team`, so only the agent token is
 rewritten.
@@ -1126,7 +1115,8 @@ Write one message into one target inbox.
 
 ### 6.2 Required Flags And Inputs
 
-- positional target: `agent` or `agent@team`
+- positional target: `agent`, `agent@team`, `agent@team.host`, or the
+  ADR-040 same-team shorthand `agent@host`
 - optional positional message text
 - `--team <name>`
 - `--file <path>`
@@ -3876,9 +3866,11 @@ mail correctness.
     - whitespace
     - wildcard or pattern characters that could be interpreted by current or
       future parsers, including at minimum `*`, `?`, `[` and `]`
-  - the supported remote-send CLI form is exactly
+  - the canonical remote-send CLI form is
     `atm send <agent>@<team>.<host> ...`; host qualification is part of the
-    typed address grammar, not a second flag or alternate route
+    typed address grammar. Per ADR-040, `agent@host` and `--host <host>` are
+    CLI-only same-team aliases that normalize to that exact form before the
+    existing request is constructed; they are not a second route
   - because team names cannot contain `.`, the inline form splits at the first
     `.` after `@`; the remainder is the host and may be a DNS name or IP
     address containing additional periods
@@ -3931,7 +3923,7 @@ mail correctness.
     its durable HTTPS port selects the endpoint. CLI input may omit the
     terminal `.local` only as specified by `REQ-P-ADDRESS-001`, and must be
     canonicalized before request construction
-  - a literal IP target is accepted only when a bounded fresh DNS lookup of
+  - a literal IP target is accepted only when a bounded fresh DNS/mDNS lookup of
     exactly one registered hostname contains that address
   - resolved addresses are not stored in SQLite or another durable alias store
   - zero or multiple matching registered names fail closed before TLS or route

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -943,7 +943,7 @@ command identity.
 
 Product requirement ID:
 - `REQ-P-ADDRESS-001` Address resolution must support the documented
-  `agent`/`agent@team` forms and precedence rules.
+  local-team and CLI-only cross-host convenience forms and precedence rules.
 
 Satisfied by:
 - `REQ-CORE-CONFIG-002` for address parsing, alias rewrite, and
@@ -952,13 +952,37 @@ Satisfied by:
 Supported address forms:
 - `agent`
 - `agent@team`
+- `agent@team.host`
+- `agent@host` (CLI same-team cross-host shorthand only)
 
 Resolution order:
-1. explicit `agent@team`
-2. bare `agent` plus `--team`
-3. bare `agent` plus configured default team
+1. explicit `agent@team.host`, after canonical trusted-host resolution
+2. an exact known `agent@team` local/team destination
+3. `agent@host` shorthand when `host` resolves to exactly one enabled trusted
+   authority; the caller team is inserted as the destination team
+4. bare `agent` plus `--team`
+5. bare `agent` plus configured default team
 
 An explicit `@team` suffix takes precedence over `--team`.
+
+CLI host convenience rules:
+- `host` and `host.local` are equivalent input only when they resolve to the
+  same enabled trusted canonical authority; the request and all durable output
+  use that canonical registered hostname
+- hostname comparison is ASCII case-insensitive; `.local` completion is the
+  only permitted completion—fuzzy, prefix, and arbitrary suffix matching are
+  forbidden
+- an exact known team name wins over same-token host shorthand, preserving the
+  existing `agent@team` form
+- a token matching neither a known team nor exactly one enabled trusted host,
+  and every ambiguous host completion, fails before HTTP dispatch with
+  structured recovery guidance
+- this resolution is a CLI-only convenience. It completes before the existing
+  fully-qualified HTTP request is built; it must not add a daemon-side address
+  resolution path, HTTP/wire field, storage field, or graft/native-tool API
+- the CLI must preserve the canonical registered hostname in the resolved
+  destination, request output, and message provenance. Resolved IP addresses
+  are transient routing data only and must not be persisted as peer identity
 
 Aliases are resolved after splitting `agent@team`, so only the agent token is
 rewritten.
@@ -3899,20 +3923,24 @@ mail correctness.
   - if no enabled interface rows exist, no cross-host listener binds
   - environment variables must not configure cross-host networking or trust
 
-- `REQ-CORE-TRANSPORT-002D` A peer authority is one durable registered DNS
+- `REQ-CORE-TRANSPORT-002D` A peer authority is one durable registered
   hostname, HTTPS port, and pinned certificate fingerprint.
 
   Required behavior:
-  - a hostname target exact-matches one registered authority name; its durable
-    HTTPS port selects the endpoint
+  - a canonical hostname target exact-matches one registered authority name;
+    its durable HTTPS port selects the endpoint. CLI input may omit the
+    terminal `.local` only as specified by `REQ-P-ADDRESS-001`, and must be
+    canonicalized before request construction
   - a literal IP target is accepted only when a bounded fresh DNS lookup of
     exactly one registered hostname contains that address
   - resolved addresses are not stored in SQLite or another durable alias store
   - zero or multiple matching registered names fail closed before TLS or route
   - reverse DNS is forbidden; an IP-only registration never authorizes a name
   - every registered hostname must be forward-resolvable by the peers that
-    use it; a changing VPN or Wi-Fi address is updated by the host's normal
-    DNS/DDNS mechanism, never by ATM reverse lookup or a SQLite IP alias
+    use it through ordinary DNS/DDNS or local-network mDNS. A changing VPN,
+    Wi-Fi, Ethernet, DHCP, or VPS address is updated by the host's normal
+    name-resolution mechanism, never by ATM reverse lookup or a SQLite IP
+    alias
   - several account-owned daemons may use the same current host IP only when
     each authority has a distinct `(hostname, port)` endpoint and certificate
     pin; an OS bind collision fails closed and must not select another port


### PR DESCRIPTION
## Summary
- CLI-convenience-only implementation of GitHub #901 (trusted-peer canonical host resolver) and #902 (agent@host cross-host shorthand)
- First commit: docs-only CLI host shorthand resolution contract

## Test plan
- [ ] req-qa / arch-qa / ruthless-boundary-qa QA-1 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)