### PR TITLE
docs+feat: permissive sender-identity ADR + non-blocking roster warning

### DIFF
--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -4,6 +4,7 @@ use atm_core::schema::AtmMessageId;
 use clap::Args;
 
 use crate::commands::caller_context::{CallerTeamOverride, resolve_cli_mutation_caller_context};
+use crate::commands::sender_roster::unrostered_sender_warning;
 use crate::composition::{
     AtmHomePath, CliComposition, InvocationDir, resolve_command_runtime_context,
 };
@@ -35,7 +36,13 @@ impl AckCommand {
             InvocationDir::new(&current_dir),
             AtmHomePath::new(&home_dir),
         )?;
-        let outcome = composition.ack(request).await?;
+        let caller_identity = request.caller_identity.clone();
+        let caller_team = request.caller_team.clone();
+        let mut outcome = composition.ack(request).await?;
+
+        if let Some(warning) = unrostered_sender_warning(&caller_identity, &caller_team) {
+            outcome.warnings.push(warning);
+        }
 
         output::print_ack_result(&outcome, json)
     }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod read;
 pub(crate) mod retained_roster;
 pub mod search;
 pub mod send;
+pub(crate) mod sender_roster;
 pub mod teams;
 pub mod templates;
 pub(crate) mod util;

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use atm_core::address::AgentAddress;
 use atm_core::load_atm_config;
 use atm_core::send::{
-    MessageClassification, SendMessageSource, SendRequest, TemplateSendSource, input,
+    MessageClassification, SendMessageSource, SendRequest, TemplateSendSource, WarningEntry, input,
 };
-use atm_core::types::{AgentIdentity, HostName, TaskId, TeamName};
+use atm_core::types::{AgentIdentity, AgentName, HostName, TaskId, TeamName};
 use atm_daemon_bootstrap::with_default_peer_address_stores;
 use atm_storage::{AtmError, PeerConfigStore, RosterStore, TrustedPeer};
 use clap::Args;
@@ -137,7 +137,13 @@ impl SendCommand {
             InvocationDir::new(&current_dir),
             AtmHomePath::new(&home_dir),
         )?;
-        let outcome = composition.send(request).await?;
+        let caller_identity = request.caller_identity.clone();
+        let caller_team = request.caller_team.clone();
+        let mut outcome = composition.send(request).await?;
+
+        if let Some(warning) = unrostered_sender_warning(&caller_identity, &caller_team) {
+            outcome.warnings.push(warning);
+        }
 
         output::print_send_result(&outcome, json)
     }
@@ -399,6 +405,45 @@ impl SendCommand {
             .cloned()
             .ok_or_else(|| Self::template_load_error("--vars must contain a JSON object"))
     }
+}
+
+/// Return an advisory only when the claimed local sender has no roster entry.
+///
+/// Sender identity is intentionally a trusted-local assertion rather than an
+/// authorization credential. A missing roster row must therefore never block
+/// or alter a completed send. The roster read is best-effort too: failure to
+/// inspect local metadata cannot turn a successful daemon result into a CLI
+/// failure.
+fn unrostered_sender_warning(sender: &AgentName, team: &TeamName) -> Option<WarningEntry> {
+    with_default_peer_address_stores(|roster_store, _peer_store| {
+        roster_store.load_roster(team).map(|snapshot| {
+            sender_roster_warning(
+                sender,
+                team,
+                snapshot.members.iter().map(|member| &member.agent_name),
+            )
+        })
+    })
+    .ok()
+    .flatten()
+}
+
+fn sender_roster_warning<'a>(
+    sender: &AgentName,
+    team: &TeamName,
+    roster_members: impl IntoIterator<Item = &'a AgentName>,
+) -> Option<WarningEntry> {
+    let rostered = roster_members.into_iter().any(|member| member == sender);
+    (!rostered).then(|| {
+        WarningEntry::new(
+            format!(
+                "declared sender {sender}@{team} is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments."
+            ),
+            Some(format!(
+                "Add it with `atm teams add-member {team} {sender}` if this identity needs an inbox."
+            )),
+        )
+    })
 }
 
 fn resolve_cli_recipient(
@@ -776,7 +821,7 @@ mod tests {
     use std::num::NonZeroU16;
     use std::path::{Path, PathBuf};
 
-    use super::{SendCommand, resolve_trusted_ipv4_with_lookup};
+    use super::{SendCommand, resolve_trusted_ipv4_with_lookup, sender_roster_warning};
     use atm_core::roles::ROLE_TEAM_LEAD;
     use atm_core::send::{SendMessageSource, input};
     use atm_core::test_support::{EnvGuard, TEST_SENDER};
@@ -827,6 +872,38 @@ mod tests {
             TEST_TEAM.parse().expect("caller team"),
             "other-team".parse().expect("team"),
         ]
+    }
+
+    #[test]
+    fn rostered_declared_sender_does_not_add_an_advisory() {
+        let sender = "arch-ctm".parse().expect("sender");
+        let team = TEST_TEAM.parse().expect("team");
+
+        assert!(sender_roster_warning(&sender, &team, [&sender]).is_none());
+    }
+
+    #[test]
+    fn unrostered_declared_sender_gets_non_blocking_inbox_advisory() {
+        let sender = "unregistered-tool".parse().expect("sender");
+        let rostered_member = "arch-ctm".parse().expect("rostered member");
+        let team = TEST_TEAM.parse().expect("team");
+
+        let warning = sender_roster_warning(&sender, &team, [&rostered_member])
+            .expect("unrostered sender warning");
+
+        assert!(warning.message.contains("unregistered-tool@test-team"));
+        assert!(warning.message.contains("has no inbox"));
+        assert!(
+            warning
+                .message
+                .contains("cannot receive replies or assignments")
+        );
+        assert_eq!(
+            warning.recovery.as_deref(),
+            Some(
+                "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
+            )
+        );
     }
 
     #[test]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use atm_core::address::AgentAddress;
 use atm_core::load_atm_config;
 use atm_core::send::{
-    MessageClassification, SendMessageSource, SendRequest, TemplateSendSource, WarningEntry, input,
+    MessageClassification, SendMessageSource, SendRequest, TemplateSendSource, input,
 };
-use atm_core::types::{AgentIdentity, AgentName, HostName, TaskId, TeamName};
+use atm_core::types::{AgentIdentity, HostName, TaskId, TeamName};
 use atm_daemon_bootstrap::with_default_peer_address_stores;
 use atm_storage::{AtmError, PeerConfigStore, RosterStore, TrustedPeer};
 use clap::Args;
@@ -17,6 +17,7 @@ use crate::commands::caller_context::{
     CallerChatIdOverride, CallerContextOverrides, CallerIdentityOverride, CallerTeamOverride,
     resolve_cli_mutation_caller_context, resolve_cli_mutation_caller_context_with_overrides,
 };
+use crate::commands::sender_roster::unrostered_sender_warning;
 use crate::composition::{
     AtmHomePath, CliComposition, InvocationDir, resolve_command_runtime_context,
 };
@@ -414,38 +415,6 @@ impl SendCommand {
 /// or alter a completed send. The roster read is best-effort too: failure to
 /// inspect local metadata cannot turn a successful daemon result into a CLI
 /// failure.
-fn unrostered_sender_warning(sender: &AgentName, team: &TeamName) -> Option<WarningEntry> {
-    with_default_peer_address_stores(|roster_store, _peer_store| {
-        roster_store.load_roster(team).map(|snapshot| {
-            sender_roster_warning(
-                sender,
-                team,
-                snapshot.members.iter().map(|member| &member.agent_name),
-            )
-        })
-    })
-    .ok()
-    .flatten()
-}
-
-fn sender_roster_warning<'a>(
-    sender: &AgentName,
-    team: &TeamName,
-    roster_members: impl IntoIterator<Item = &'a AgentName>,
-) -> Option<WarningEntry> {
-    let rostered = roster_members.into_iter().any(|member| member == sender);
-    (!rostered).then(|| {
-        WarningEntry::new(
-            format!(
-                "declared sender {sender}@{team} is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments."
-            ),
-            Some(format!(
-                "Add it with `atm teams add-member {team} {sender}` if this identity needs an inbox."
-            )),
-        )
-    })
-}
-
 fn resolve_cli_recipient(
     input: &CliRecipientInput,
     caller_team: &TeamName,
@@ -821,7 +790,7 @@ mod tests {
     use std::num::NonZeroU16;
     use std::path::{Path, PathBuf};
 
-    use super::{SendCommand, resolve_trusted_ipv4_with_lookup, sender_roster_warning};
+    use super::{SendCommand, resolve_trusted_ipv4_with_lookup};
     use atm_core::roles::ROLE_TEAM_LEAD;
     use atm_core::send::{SendMessageSource, input};
     use atm_core::test_support::{EnvGuard, TEST_SENDER};
@@ -872,38 +841,6 @@ mod tests {
             TEST_TEAM.parse().expect("caller team"),
             "other-team".parse().expect("team"),
         ]
-    }
-
-    #[test]
-    fn rostered_declared_sender_does_not_add_an_advisory() {
-        let sender = TEST_SENDER.parse().expect("sender");
-        let team = TEST_TEAM.parse().expect("team");
-
-        assert!(sender_roster_warning(&sender, &team, [&sender]).is_none());
-    }
-
-    #[test]
-    fn unrostered_declared_sender_gets_non_blocking_inbox_advisory() {
-        let sender = "unregistered-tool".parse().expect("sender");
-        let rostered_member = TEST_SENDER.parse().expect("rostered member");
-        let team = TEST_TEAM.parse().expect("team");
-
-        let warning = sender_roster_warning(&sender, &team, [&rostered_member])
-            .expect("unrostered sender warning");
-
-        assert!(warning.message.contains("unregistered-tool@test-team"));
-        assert!(warning.message.contains("has no inbox"));
-        assert!(
-            warning
-                .message
-                .contains("cannot receive replies or assignments")
-        );
-        assert_eq!(
-            warning.recovery.as_deref(),
-            Some(
-                "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
-            )
-        );
     }
 
     #[test]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn rostered_declared_sender_does_not_add_an_advisory() {
-        let sender = "arch-ctm".parse().expect("sender");
+        let sender = TEST_SENDER.parse().expect("sender");
         let team = TEST_TEAM.parse().expect("team");
 
         assert!(sender_roster_warning(&sender, &team, [&sender]).is_none());
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn unrostered_declared_sender_gets_non_blocking_inbox_advisory() {
         let sender = "unregistered-tool".parse().expect("sender");
-        let rostered_member = "arch-ctm".parse().expect("rostered member");
+        let rostered_member = TEST_SENDER.parse().expect("rostered member");
         let team = TEST_TEAM.parse().expect("team");
 
         let warning = sender_roster_warning(&sender, &team, [&rostered_member])

--- a/crates/atm/src/commands/sender_roster.rs
+++ b/crates/atm/src/commands/sender_roster.rs
@@ -1,0 +1,104 @@
+use atm_core::send::WarningEntry;
+use atm_core::types::{AgentName, TeamName};
+use atm_daemon_bootstrap::with_default_peer_address_stores;
+use atm_storage::AtmError;
+
+/// Return a local, non-blocking advisory when a claimed sender has no inbox.
+///
+/// The claimed identity remains a trusted-local assertion. A roster lookup is
+/// therefore informational only: a failed lookup and an absent row must never
+/// block a successfully completed CLI write.
+pub(crate) fn unrostered_sender_warning(
+    sender: &AgentName,
+    team: &TeamName,
+) -> Option<WarningEntry> {
+    unrostered_sender_warning_with_lookup(sender, team, || {
+        with_default_peer_address_stores(|roster_store, _peer_store| {
+            roster_store.load_roster(team).map(|snapshot| {
+                snapshot
+                    .members
+                    .into_iter()
+                    .map(|member| member.agent_name)
+                    .collect()
+            })
+        })
+    })
+}
+
+fn unrostered_sender_warning_with_lookup(
+    sender: &AgentName,
+    team: &TeamName,
+    lookup: impl FnOnce() -> Result<Vec<AgentName>, AtmError>,
+) -> Option<WarningEntry> {
+    let roster_members = lookup().ok()?;
+    sender_roster_warning(sender, team, roster_members.iter())
+}
+
+fn sender_roster_warning<'a>(
+    sender: &AgentName,
+    team: &TeamName,
+    roster_members: impl IntoIterator<Item = &'a AgentName>,
+) -> Option<WarningEntry> {
+    let rostered = roster_members.into_iter().any(|member| member == sender);
+    (!rostered).then(|| {
+        WarningEntry::new(
+            format!(
+                "declared sender {sender}@{team} is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments."
+            ),
+            Some(format!(
+                "Add it with `atm teams add-member {team} {sender}` if this identity needs an inbox."
+            )),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sender_roster_warning, unrostered_sender_warning_with_lookup};
+    use atm_core::error::AtmError;
+    use atm_core::test_support::{TEST_SENDER, TEST_TEAM};
+
+    #[test]
+    fn rostered_declared_sender_does_not_add_an_advisory() {
+        let sender = TEST_SENDER.parse().expect("sender");
+        let team = TEST_TEAM.parse().expect("team");
+
+        assert!(sender_roster_warning(&sender, &team, [&sender]).is_none());
+    }
+
+    #[test]
+    fn unrostered_declared_sender_gets_non_blocking_inbox_advisory() {
+        let sender = "unregistered-tool".parse().expect("sender");
+        let rostered_member = TEST_SENDER.parse().expect("rostered member");
+        let team = TEST_TEAM.parse().expect("team");
+
+        let warning = sender_roster_warning(&sender, &team, [&rostered_member])
+            .expect("unrostered sender warning");
+
+        assert!(warning.message.contains("unregistered-tool@test-team"));
+        assert!(warning.message.contains("has no inbox"));
+        assert!(
+            warning
+                .message
+                .contains("cannot receive replies or assignments")
+        );
+        assert_eq!(
+            warning.recovery.as_deref(),
+            Some(
+                "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
+            )
+        );
+    }
+
+    #[test]
+    fn failed_roster_lookup_is_silent_and_cannot_block_a_cli_write() {
+        let sender = "unregistered-tool".parse().expect("sender");
+        let team = TEST_TEAM.parse().expect("team");
+
+        let warning = unrostered_sender_warning_with_lookup(&sender, &team, || {
+            Err(AtmError::daemon_unavailable("test roster lookup failure"))
+        });
+
+        assert!(warning.is_none());
+    }
+}

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -828,6 +828,36 @@ mod tests {
     use super::{render_bootstrap_trace_section, render_doctor_peer_config};
 
     #[test]
+    fn send_outcome_json_preserves_unrostered_sender_advisory() {
+        let outcome = json!({
+            "action": "send",
+            "team": "test-team",
+            "agent": "recipient",
+            "sender": "unregistered-tool",
+            "outcome": "sent",
+            "message_id": "01KX5TEST00000000000000001",
+            "requires_ack": false,
+            "warnings": [{
+                "message": "declared sender unregistered-tool@test-team is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments.",
+                "recovery": "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
+            }]
+        });
+
+        let outcome: atm_core::send::SendOutcome =
+            serde_json::from_value(outcome).expect("send outcome with advisory");
+        let rendered = serde_json::to_value(outcome).expect("JSON output");
+
+        assert_eq!(
+            rendered["warnings"][0]["message"],
+            "declared sender unregistered-tool@test-team is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments."
+        );
+        assert_eq!(
+            rendered["warnings"][0]["recovery"],
+            "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
+        );
+    }
+
+    #[test]
     fn bootstrap_trace_section_renders_doctor_output_block() {
         let rendered = render_bootstrap_trace_section(&BootstrapTraceReport {
             daemon_connect: BootstrapConnectOutcome::Connected,

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -11,6 +11,7 @@ use atm_core::observability::{AtmLogRecord, AtmLogSnapshot};
 use atm_core::protocol::{RuntimeLivenessState, RuntimeReadinessState, RuntimeStatusSnapshot};
 use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
+use atm_core::send::WarningEntry;
 use atm_core::team_admin::{
     AddMemberOutcome, BackupOutcome, ClearNudgeTemplateOverrideOutcome,
     DisableNudgeTemplateOverrideOutcome, RemoveMemberOutcome, RestoreOutcome, RestorePlan,
@@ -19,18 +20,8 @@ use atm_core::team_admin::{
 
 /// Print one send result in human-readable or JSON form.
 pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
-    if json {
-        println!("{}", serde_json::to_string_pretty(outcome)?);
-    } else {
-        println!(
-            "Sent to {}@{} [message_id: {}]",
-            outcome.agent, outcome.team, outcome.message_id
-        );
-    }
-
-    for warning in &outcome.warnings {
-        eprintln!("{}", warning.render());
-    }
+    print!("{}", render_send_stdout(outcome, json)?);
+    print_warnings_to_stderr(&outcome.warnings);
 
     Ok(())
 }
@@ -165,11 +156,34 @@ pub fn print_ack_result(outcome: &AckOutcome, json: bool) -> Result<()> {
         println!("{}", render_ack_result_line(outcome));
     }
 
-    for warning in &outcome.warnings {
-        eprintln!("{}", warning.render());
-    }
+    print_warnings_to_stderr(&outcome.warnings);
 
     Ok(())
+}
+
+fn render_send_stdout(outcome: &SendOutcome, json: bool) -> Result<String> {
+    if json {
+        return Ok(format!("{}\n", serde_json::to_string_pretty(outcome)?));
+    }
+
+    Ok(format!(
+        "Sent to {}@{} [message_id: {}]\n",
+        outcome.agent, outcome.team, outcome.message_id
+    ))
+}
+
+fn print_warnings_to_stderr(warnings: &[WarningEntry]) {
+    let rendered = render_warnings_to_stderr(warnings);
+    if !rendered.is_empty() {
+        eprint!("{rendered}");
+    }
+}
+
+fn render_warnings_to_stderr(warnings: &[WarningEntry]) -> String {
+    warnings
+        .iter()
+        .map(|warning| format!("{}\n", warning.render()))
+        .collect()
 }
 
 fn render_ack_result_line(outcome: &AckOutcome) -> String {
@@ -825,7 +839,10 @@ mod tests {
     };
     use serde_json::json;
 
-    use super::{render_bootstrap_trace_section, render_doctor_peer_config};
+    use super::{
+        render_bootstrap_trace_section, render_doctor_peer_config, render_send_stdout,
+        render_warnings_to_stderr,
+    };
 
     #[test]
     fn send_outcome_json_preserves_unrostered_sender_advisory() {
@@ -855,6 +872,36 @@ mod tests {
             rendered["warnings"][0]["recovery"],
             "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
         );
+    }
+
+    #[test]
+    fn sender_advisory_stays_on_stderr_while_json_stdout_remains_parseable() {
+        let outcome: atm_core::send::SendOutcome = serde_json::from_value(json!({
+            "action": "send",
+            "team": "test-team",
+            "agent": "recipient",
+            "sender": "unregistered-tool",
+            "outcome": "sent",
+            "message_id": "01KX5TEST00000000000000001",
+            "requires_ack": false,
+            "warnings": [{
+                "message": "declared sender unregistered-tool@test-team is not on the ATM roster; this identity has no inbox and cannot receive replies or assignments.",
+                "recovery": "Add it with `atm teams add-member test-team unregistered-tool` if this identity needs an inbox."
+            }]
+        }))
+        .expect("send outcome");
+
+        let stdout = render_send_stdout(&outcome, true).expect("JSON stdout");
+        let stderr = render_warnings_to_stderr(&outcome.warnings);
+
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON stdout");
+        assert_eq!(
+            parsed["warnings"][0]["message"],
+            outcome.warnings[0].message
+        );
+        assert!(!stdout.contains("Recovery:"));
+        assert!(stderr.contains("Recovery:"));
+        assert!(stderr.contains("unregistered-tool@test-team"));
     }
 
     #[test]

--- a/docs/adr/ADR-050-permissive-declared-sender-identity.md
+++ b/docs/adr/ADR-050-permissive-declared-sender-identity.md
@@ -1,0 +1,79 @@
+# ADR-050 — Permissive Declared Sender Identity and Roster Advisory
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Scope | Local CLI sender declaration, roster metadata, message envelopes |
+| Relates to | ADR-001, ADR-026, ADR-035; GitHub issue #881 |
+
+## Context
+
+ATM runs in a trusted-local environment. The sender recorded in a message is
+the identity asserted by the invoking CLI or integration; it is not an
+authenticated principal. This is intentional: constrained harnesses,
+temporary or isolated agents, bootstrap workflows, and automation tools can
+send useful, self-describing messages before they have a roster entry. For
+example, a future tool may identify itself as `gh`, `git`, or `github` in a
+team without ATM reserving any of those names.
+
+Treating roster membership as authorization would not provide meaningful local
+security. A process that can alter its CLI environment can also claim a
+rostered identity, while rejecting unknown identities would force legitimate
+temporary tooling to impersonate a known agent. The roster instead describes
+where a declared identity has an inbox and can receive follow-up work.
+
+## Decision
+
+ATM continues to accept any syntactically valid declared sender identity in
+the trusted-local CLI path. It does not reject, authenticate, normalize to a
+fixed vocabulary, or otherwise alter delivery for an identity absent from the
+team roster. The canonical HTTP request and daemon write path remain exactly
+the same whether the sender is rostered or unrostered.
+
+After a successful `atm send`, the CLI performs a best-effort local roster
+lookup for the claimed sender and caller team. If no roster entry exists, it
+adds a non-blocking `SendOutcome` warning stating that the identity has no
+inbox and cannot receive replies or assignments. The warning includes the
+recovery command:
+
+```text
+atm teams add-member <team> <identity>
+```
+
+Human CLI output renders this advisory on stderr. JSON output retains it in
+the outcome's structured `warnings` array, leaving stdout valid JSON. A roster
+lookup failure emits no advisory and never changes the send result: local
+metadata inspection cannot turn a completed delivery into a CLI failure.
+
+## Consequences
+
+- A useful unrostered identity remains visible in the message envelope rather
+  than being hidden behind a misleading impersonated roster identity.
+- Senders receive an immediate reminder on every successful send that an
+  unrostered identity cannot receive a mailbox reply or assignment.
+- Recipients and team leads may inspect roster membership when an unexpected
+  sender appears; this is organizational diagnosis, not an authorization
+  decision.
+- A future authenticated-principal model, if needed, must be introduced as a
+  separate capability and transport decision. It must not reinterpret today's
+  roster metadata as retroactive authentication.
+
+## Rejected alternatives
+
+1. **Reject sends whose declared sender is absent from the roster.** This
+   blocks legitimate bootstrap and automation workflows while a local process
+   can still trivially claim a rostered identity. It creates friction without
+   delivering a real security boundary.
+2. **Silently accept unrostered identities.** This preserves flexibility but
+   leaves a sender expecting replies with no indication that it has no inbox.
+3. **Reserve a fixed list of tool identities.** ATM must remain workflow and
+   tool agnostic. Sender names are descriptive caller data, not ATM business
+   vocabulary.
+
+## Required evidence
+
+- A rostered sender produces no advisory.
+- An unrostered sender produces the inbox/recovery advisory in the human CLI
+  path and serializes it through `SendOutcome.warnings` for JSON callers.
+- Both sends use the same successful canonical daemon request and delivery
+  path; the advisory is appended only after a successful CLI outcome.

--- a/docs/adr/ADR-050-permissive-declared-sender-identity.md
+++ b/docs/adr/ADR-050-permissive-declared-sender-identity.md
@@ -30,11 +30,11 @@ fixed vocabulary, or otherwise alter delivery for an identity absent from the
 team roster. The canonical HTTP request and daemon write path remain exactly
 the same whether the sender is rostered or unrostered.
 
-After a successful `atm send`, the CLI performs a best-effort local roster
-lookup for the claimed sender and caller team. If no roster entry exists, it
-adds a non-blocking `SendOutcome` warning stating that the identity has no
-inbox and cannot receive replies or assignments. The warning includes the
-recovery command:
+After a successful CLI write (`atm send` or `atm ack`), the CLI performs a
+best-effort local roster lookup for the claimed sender and caller team. If no
+roster entry exists, it adds a non-blocking outcome warning stating that the
+identity has no inbox and cannot receive replies or assignments. The warning
+includes the recovery command:
 
 ```text
 atm teams add-member <team> <identity>
@@ -42,15 +42,15 @@ atm teams add-member <team> <identity>
 
 Human CLI output renders this advisory on stderr. JSON output retains it in
 the outcome's structured `warnings` array, leaving stdout valid JSON. A roster
-lookup failure emits no advisory and never changes the send result: local
+lookup failure emits no advisory and never changes the write result: local
 metadata inspection cannot turn a completed delivery into a CLI failure.
 
 ## Consequences
 
 - A useful unrostered identity remains visible in the message envelope rather
   than being hidden behind a misleading impersonated roster identity.
-- Senders receive an immediate reminder on every successful send that an
-  unrostered identity cannot receive a mailbox reply or assignment.
+- Senders receive an immediate reminder on every successful send or ack that
+  an unrostered identity cannot receive a mailbox reply or assignment.
 - Recipients and team leads may inspect roster membership when an unexpected
   sender appears; this is organizational diagnosis, not an authorization
   decision.
@@ -74,6 +74,8 @@ metadata inspection cannot turn a completed delivery into a CLI failure.
 
 - A rostered sender produces no advisory.
 - An unrostered sender produces the inbox/recovery advisory in the human CLI
-  path and serializes it through `SendOutcome.warnings` for JSON callers.
-- Both sends use the same successful canonical daemon request and delivery
-  path; the advisory is appended only after a successful CLI outcome.
+  path and serializes it through the relevant outcome's `warnings` array for
+  JSON callers.
+- Both CLI write commands use their existing successful canonical daemon
+  request and delivery path; the advisory is appended only after a successful
+  CLI outcome.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -55,6 +55,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-045 — Runtime Observation Attribution](./ADR-045-runtime-observation-attribution.md)
 - [ADR-046 — Template-Declared Workflow Metadata And Admission Snapshots](./ADR-046-template-declared-workflow-metadata.md)
 - [ADR-049 — hermes-atm/atm-graft First Public PyPI Release Versioning](./ADR-049-hermes-atm-first-public-pypi-release-versioning.md)
+- [ADR-050 — Permissive Declared Sender Identity and Roster Advisory](./ADR-050-permissive-declared-sender-identity.md)
 
 ## Extracted Crate-Local ADRs
 


### PR DESCRIPTION
## Summary
- ADR-050: trusted-local ATM permits unregistered asserted sender identities for isolated/bootstrap members and constrained harness delegation/impersonation. Roster is organizational metadata, not authorization; consequential work is gated by task/approval/evidence controls, not roster membership. Future tool-originated declared identities (gh@team, git@team, github@team, etc.) preserved as rationale/examples only — no fixed vocabulary or new authorization policy introduced.
- Non-blocking notification: successful `atm send` now appends a warning (stderr for human CLI, structured field in JSON output without corrupting stdout) when the claimed sender is absent from its caller-team roster. Wording states the identity has no inbox and won't receive replies/assignments, and gives the `atm teams add-member` recovery path.
- No change to delivery/recipient behavior for unrostered senders — advisory only.

## Test plan
- [x] Unit tests: rostered vs. unrostered sends, human-CLI and JSON output paths
- [x] JSON warning serialization verified
- [x] Real HTTP-daemon dry-run JSON verified
- [x] cargo clippy clean
- [ ] `just test`: reaches pre-existing unrelated boundary-lint failures (stale atm-daemon allowlist, atm-storage-rusqlite tempfile allowlist) — not introduced by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)