### PR TITLE
docs(plan): Phase AP — outbound-only corporate network peer connectivity (not-hardened)

### DIFF
--- a/docs/plans/phase-ap/plan-phase-ap.md
+++ b/docs/plans/phase-ap/plan-phase-ap.md
@@ -1,8 +1,8 @@
 ---
 title: Phase AP Plan — Outbound-Only Corporate Network Peer Connectivity
-status: proposed
-branch: plan/phase-ao-tls-and-ap-outbound-connectivity
-worktree: ../atm-core-worktrees/plan/phase-ao-tls-and-ap-outbound-connectivity
+status: not-hardened
+branch: plan/phase-ap
+worktree: ../atm-core-worktrees/plan/phase-ap
 target: develop
 ---
 


### PR DESCRIPTION
## What Phase AP is

Phase AP adds support for daemons that sit behind a corporate firewall/NAT/
VPN/proxy and cannot accept unsolicited inbound peer TCP. The proposed
transport is an authenticated **outbound** mTLS Server-Sent-Events (SSE)
session from the restricted daemon to a reachable peer, with an ordinary
authenticated HTTP POST for the response leg — no inbound listener, no relay,
no durable outbox.

Sprint sequence (`docs/plans/phase-ap/`):
- **AP.1** — real CWin/M4/M5 outbound mTLS SSE+POST feasibility proof (non-negotiable entry gate; no simulation/tunnel/relay substitutes allowed)
- **AP.2** — typed session/correlation/error contract + architecture guards
- **AP.3** — authenticated live SSE session, bounded in-memory registry
- **AP.4** — canonical write/response bridge through the existing write handler
- **AP.5** — doctor/controls/negative-case coverage, reports, physical CWin proof

AP.2–AP.5 are gated on AP.1 passing and on Phase AO's mTLS proof merging into
the Tokio/Axum line first.

## What this PR actually does

This branch does **not** implement any of that. It only:
1. Marks `docs/plans/phase-ap/plan-phase-ap.md` frontmatter `status: not-hardened` — the plan doc exists but has not been through `/plan-hardening` review yet.
2. Corrects stale frontmatter (`branch`, `worktree`) that still pointed at the already-merged combined `plan/phase-ao-tls-and-ap-outbound-connectivity` branch.

This PR exists so the not-hardened status is visible and tracked, not
forgotten, while Phase AO development proceeds in parallel.

**Do not merge until plan-hardening runs on the Phase AP sprint docs (AP.1–AP.5).**

## Test plan
- [ ] Run `/plan-hardening` on Phase AP (AP.1-AP.5)
- [ ] plan-hardening QA PASS via quality-mgr