### PR TITLE
chore: prove publish-kit branch overlay

### DIFF
--- a/.claude/lib/sc_compose_dependency.py
+++ b/.claude/lib/sc_compose_dependency.py
@@ -6,6 +6,7 @@ import re
 
 
 SC_COMPOSE_SOURCE_REV = "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661"
+SC_COMPOSE_PARITY_SOURCE_REV = "113729e60e3409ad8c651a74956ffa5c167dd1b6"
 MIN_SC_COMPOSE = (1, 4, 0)
 MIN_SC_COMPOSE_TEXT = (
     ">= 1.4.0 (released v1.4.0 source revision "
@@ -16,6 +17,10 @@ MIN_SC_COMPOSE_BINDING_TEXT = ">= 1.2.0"
 SC_COMPOSE_INSTALL = (
     "cargo install --git https://github.com/randlee/sc-compose.git "
     f"--rev {SC_COMPOSE_SOURCE_REV} --locked --bin sc-compose"
+)
+SC_COMPOSE_PARITY_INSTALL = (
+    "cargo install --git https://github.com/randlee/sc-compose.git "
+    f"--rev {SC_COMPOSE_PARITY_SOURCE_REV} --locked --bin sc-compose"
 )
 SC_COMPOSE_BINDING_INSTALL = (
     "python3 -m pip install --user --break-system-packages "

--- a/.github/actions/setup-lint-toolchain/action.yml
+++ b/.github/actions/setup-lint-toolchain/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Released sc-lint version to install
     required: false
     default: "0.4.0"
+  include-sc-lint:
+    description: Install the externally released sc-lint bundle
+    required: false
+    default: "true"
   cargo-deny-version:
     description: Pinned cargo-deny version
     required: false
@@ -21,6 +25,7 @@ runs:
   using: composite
   steps:
     - name: Set up sc-lint
+      if: inputs.include-sc-lint == 'true'
       uses: ./.github/actions/setup-sc-lint
       with:
         version: ${{ inputs.sc-lint-version }}

--- a/.github/scripts/check_boundary_lint_status.py
+++ b/.github/scripts/check_boundary_lint_status.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Translate a sc-lint-boundary JSON report into a process exit status."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_boundary_lint_status.py <report.json>", file=sys.stderr)
+        return 2
+
+    report_path = Path(argv[1])
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"failed to read boundary-lint report {report_path}: {error}", file=sys.stderr)
+        return 2
+
+    status = report.get("status") if isinstance(report, dict) else None
+    if status == "pass":
+        return 0
+    if status == "fail":
+        return 1
+
+    print(
+        f"boundary-lint report {report_path} has invalid status: {status!r}",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the repository-pinned sc-compose CLI for parity tests."""
+"""Install the repository-pinned sc-compose CLI for release-preflight tests."""
 
 from __future__ import annotations
 

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Install the repository-pinned sc-compose CLI for parity tests."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPOSITORY_ROOT / ".claude"))
+
+from lib.sc_compose_dependency import SC_COMPOSE_INSTALL  # noqa: E402
+
+
+def main() -> int:
+    return subprocess.run(shlex.split(SC_COMPOSE_INSTALL), check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the repository-pinned sc-compose CLI for release-preflight tests."""
+"""Install the repository-pinned sc-compose CLI for passthrough parity tests."""
 
 from __future__ import annotations
 
@@ -12,11 +12,11 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPOSITORY_ROOT / ".claude"))
 
-from lib.sc_compose_dependency import SC_COMPOSE_INSTALL  # noqa: E402
+from lib.sc_compose_dependency import SC_COMPOSE_PARITY_INSTALL  # noqa: E402
 
 
 def main() -> int:
-    return subprocess.run(shlex.split(SC_COMPOSE_INSTALL), check=False).returncode
+    return subprocess.run(shlex.split(SC_COMPOSE_PARITY_INSTALL), check=False).returncode
 
 
 if __name__ == "__main__":

--- a/.github/scripts/release_python_receipt.py
+++ b/.github/scripts/release_python_receipt.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Emit a source-bound SHA-256 receipt for manifest-selected Python assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+import zipfile
+from email import message_from_bytes
+from pathlib import Path
+
+from release_manifest import load_manifest
+
+
+def distribution_metadata(path: Path) -> tuple[str, str]:
+    """Read the normalized distribution name and version from one artifact."""
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(members) != 1:
+                raise SystemExit(f"{path}: expected exactly one wheel METADATA file")
+            metadata = message_from_bytes(archive.read(members[0]))
+    elif path.name.endswith(".tar.gz"):
+        with tarfile.open(path, "r:gz") as archive:
+            members = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+            if len(members) != 1:
+                raise SystemExit(f"{path}: expected exactly one sdist PKG-INFO file")
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise SystemExit(f"{path}: unable to read sdist PKG-INFO")
+            metadata = message_from_bytes(extracted.read())
+    else:
+        raise SystemExit(f"{path}: unsupported Python artifact")
+    name, version = metadata.get("Name"), metadata.get("Version")
+    if not name or not version:
+        raise SystemExit(f"{path}: package metadata must provide Name and Version")
+    return name, version
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_receipt(manifest_path: Path, asset_dir: Path, version: str, source_commit: str) -> dict[str, object]:
+    manifest = load_manifest(manifest_path)
+    expected = {
+        entry["name"]: {"wheel": len(entry["wheels"]), "sdist": int(entry["sdist"])}
+        for entry in manifest["python_distributions"]
+    }
+    if not expected:
+        raise SystemExit("manifest must define [[python_distributions]]")
+    found = {name: {"wheel": 0, "sdist": 0} for name in expected}
+    artifacts: list[dict[str, str]] = []
+    for path in sorted(asset_dir.iterdir()):
+        if not path.is_file() or (path.suffix != ".whl" and not path.name.endswith(".tar.gz")):
+            continue
+        name, actual_version = distribution_metadata(path)
+        if name not in expected:
+            raise SystemExit(f"{path}: unexpected Python distribution {name!r}")
+        if actual_version != version:
+            raise SystemExit(f"{path}: expected version {version}, found {actual_version}")
+        found[name]["wheel" if path.suffix == ".whl" else "sdist"] += 1
+        artifacts.append({"filename": path.name, "package": name, "sha256": sha256(path)})
+    if not artifacts:
+        raise SystemExit(f"no Python artifacts found in {asset_dir}")
+    if found != expected:
+        raise SystemExit(f"Python artifact set mismatch: expected {expected}, found {found}")
+    return {
+        "source_commit": source_commit,
+        "manifest_sha256": sha256(manifest_path),
+        "version": version,
+        "artifacts": artifacts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--asset-dir", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    receipt = create_receipt(args.manifest, args.asset_dir, args.version, args.source_commit)
+    args.output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_check_boundary_lint_status.py
+++ b/.github/scripts/tests/test_check_boundary_lint_status.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "check_boundary_lint_status.py"
+)
+
+
+def run_status_check(report_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(report_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_boundary_lint_status_check_passes_only_a_pass_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(json.dumps({"status": "pass", "findings": []}), encoding="utf-8")
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 0
+
+
+def test_boundary_lint_status_check_fails_a_report_with_findings(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(
+        json.dumps({"status": "fail", "findings": [{"rule_id": "SCB-CYCLE-001"}]}),
+        encoding="utf-8",
+    )
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 1
+
+
+def test_boundary_lint_status_check_rejects_a_malformed_status(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(json.dumps({"status": "unknown"}), encoding="utf-8")
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 2
+    assert "invalid status" in result.stderr

--- a/.github/scripts/tests/test_install.py
+++ b/.github/scripts/tests/test_install.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-INSTALLER = Path(__file__).resolve().parents[3] / "install.py"
+INSTALLER = next(path / "install.py" for path in Path(__file__).resolve().parents if (path / "install.py").is_file())
 SPEC = importlib.util.spec_from_file_location("sc_publish_install", INSTALLER)
 assert SPEC is not None and SPEC.loader is not None
 INSTALL = importlib.util.module_from_spec(SPEC)
@@ -24,42 +24,129 @@ class InstallValuesTests(unittest.TestCase):
     @staticmethod
     def valid_values() -> dict[str, object]:
         return {
-            "release": {"version_source": "Cargo.toml", "tag_prefix": "v"},
-            "artifacts": {
-                "crates": [
-                    {
-                        "artifact": "example-core",
-                        "package": "example-core",
-                        "cargo_toml": "crates/example-core/Cargo.toml",
-                        "required": True,
-                        "publish": True,
-                        "publish_order": 1,
-                        "preflight_check": "full",
-                        "wait_after_publish_seconds": 0,
-                        "verify_install": False,
-                    },
-                    {
-                        "artifact": "example-cli",
-                        "package": "example-cli",
-                        "cargo_toml": "crates/example-cli/Cargo.toml",
-                        "required": True,
-                        "publish": True,
-                        "publish_order": 2,
-                        "preflight_check": "full",
-                        "wait_after_publish_seconds": 0,
-                        "verify_install": False,
-                    },
-                ],
-                "wheels": [{"package": "example-python", "python_package": "example_python"}],
-                "binaries": ["example"],
+            "schema_version": 1,
+            "project": {
+                "name": "example",
+                "archive_prefix": "example",
+                "description": "Example release package",
+                "homepage": "https://example.test/example",
+                "license": "MIT",
+                "readme_dependency_crate": "example-core",
+                "renderer_archive_path": "bin/example",
             },
+            "release_targets": [
+                {"target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest", "archive": "tar.gz"}
+            ],
+            "crates": [
+                {
+                    "artifact": "example-core",
+                    "package": "example-core",
+                    "cargo_toml": "crates/example-core/Cargo.toml",
+                    "required": True,
+                    "publish": True,
+                    "publish_order": 1,
+                    "preflight_check": "locked",
+                    "wait_after_publish_seconds": 0,
+                    "verify_install": False,
+                },
+                {
+                    "artifact": "example-python",
+                    "package": "example-python",
+                    "cargo_toml": "crates/example-python/Cargo.toml",
+                    "required": True,
+                    "publish": False,
+                    "publish_order": 0,
+                    "preflight_check": "locked",
+                    "wait_after_publish_seconds": 0,
+                    "verify_install": True,
+                },
+            ],
+            "release_binaries": [
+                {
+                    "name": "example",
+                    "bundled_paths": [
+                        {
+                            "source": "docs",
+                            "destination": "share/doc/example",
+                            "homebrew_destination_components": ["pkgshare"],
+                        }
+                    ],
+                }
+            ],
+            "installed_docs": {
+                "source_root": "docs",
+                "install_root": "share/doc/example",
+                "entrypoint": "share/doc/example/README.md",
+            },
+            "python_packages": [
+                {
+                    "artifact": "example-wheel",
+                    "package": "example",
+                    "manifest": "python/pyproject.toml",
+                    "module": "example",
+                    "publish": "pypi",
+                }
+            ],
+            "python_distributions": [
+                {
+                    "name": "example",
+                    "source": "python",
+                    "cargo_manifest": "crates/example-python/Cargo.toml",
+                    "module_path": "python/example",
+                    "sdist": True,
+                    "wheels": ["ubuntu-latest", "macos-latest", "windows-latest"],
+                },
+                {
+                    "name": "example-plugin",
+                    "source": "plugin",
+                    "build_system": "setuptools",
+                    "module_path": "plugin/src/example_plugin",
+                    "sdist": True,
+                    "wheels": ["ubuntu-latest"],
+                },
+            ],
             "channels": {
-                "github_release": {"enabled": True},
-                "crates_io": {"enabled": True},
-                "pypi": {"enabled": False, "workflow": "pypi-publish.yml"},
-                "homebrew": {"enabled": False},
-                "scoop": {"enabled": False},
-                "winget": {"enabled": False},
+                "pypi": {
+                    "workflow": "pypi-publish.yml",
+                    "dispatch_inputs": {"target": "production"},
+                    "credential_rehearsal_inputs": {"target": "testpypi"},
+                    "test_repository": "testpypi",
+                    "production_repository": "pypi",
+                },
+                "homebrew": {
+                    "workflow": "homebrew-publish.yml",
+                    "dispatch_inputs": {},
+                    "tap_repository": "example/tap",
+                    "renderer_target": "x86_64-unknown-linux-gnu",
+                    "formulas": [
+                        {
+                            "path": "Formula/example.rb",
+                            "template": "release/homebrew/formula.rb.j2",
+                            "class": "Example",
+                            "binaries": ["example"],
+                            "test_command": "--help",
+                            "test_output": "Example release package",
+                            "release_track": "stable",
+                        }
+                    ],
+                    "assets": [{"key": "linux", "target": "x86_64-unknown-linux-gnu"}],
+                },
+                "winget": {
+                    "workflow": "winget-publish.yml",
+                    "dispatch_inputs": {},
+                    "identifier": "example.example",
+                    "installer_target": "x86_64-pc-windows-msvc",
+                },
+                "scoop": {
+                    "workflow": "scoop-publish.yml",
+                    "dispatch_inputs": {},
+                    "bucket_repository": "example/scoop-bucket",
+                    "manifest_path": "bucket/example.json",
+                    "manifest_template": "release/scoop/manifest.json.j2",
+                    "installer_target": "x86_64-pc-windows-msvc",
+                    "binary": "bin/example.exe",
+                    "renderer_target": "x86_64-unknown-linux-gnu",
+                },
             },
         }
 
@@ -71,150 +158,59 @@ class InstallValuesTests(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("--example-json [INSTALL.json]", result.stdout)
+        self.assertIn("--input INSTALL.json", result.stdout)
         self.assertIn("workflow:", result.stdout)
-        self.assertIn("caller-owned JSON input", result.stdout)
+        self.assertIn("caller-owned complete JSON input", result.stdout)
 
-    def test_example_json_writes_a_complete_reviewable_contract(self) -> None:
+    def test_load_install_values_accepts_the_complete_manifest_contract(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            destination = root / "install.json"
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-S",
-                    str(INSTALLER),
-                    "--example-json",
-                    str(destination),
-                    str(root),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            contract = json.loads(destination.read_text(encoding="utf-8"))
-        self.assertEqual(set(contract["channels"]), set(INSTALL.CHANNEL_NAMES))
-        self.assertEqual(contract["artifacts"], {"crates": [], "wheels": [], "binaries": []})
-        self.assertIn("wrote reviewable install input", result.stdout)
-
-    def test_example_json_refuses_to_overwrite_a_reviewed_contract(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            destination = root / "install.json"
-            destination.write_text('{"reviewed": true}\n', encoding="utf-8")
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-S",
-                    str(INSTALLER),
-                    "--example-json",
-                    str(destination),
-                    str(root),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            self.assertNotEqual(result.returncode, 0)
-            self.assertEqual(destination.read_text(encoding="utf-8"), '{"reviewed": true}\n')
-        self.assertIn("refusing to overwrite", result.stderr)
-
-    def test_input_and_example_modes_are_mutually_exclusive(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            input_path = root / "input.json"
-            input_path.write_text("{}", encoding="utf-8")
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-S",
-                    str(INSTALLER),
-                    "--input",
-                    str(input_path),
-                    "--example-json",
-                    str(root),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("not allowed with argument", result.stderr)
-
-    def test_example_json_enables_only_supported_channels(self) -> None:
-        with (
-            patch.object(
-                INSTALL,
-                "discover_crates",
-                return_value=[
-                    {
-                        "name": "example-core",
-                        "cargo_toml": "crates/example-core/Cargo.toml",
-                    }
-                ],
-            ),
-            patch.object(INSTALL, "discover_wheels", return_value=[]),
-            patch.object(INSTALL, "discover_binaries", return_value=[]),
-        ):
-            values = INSTALL.example_values(Path("consumer"))
-        self.assertTrue(values["channels"]["crates_io"]["enabled"])
-        self.assertEqual(
-            values["artifacts"]["crates"],
-            [
-                {
-                    "artifact": "example-core",
-                    "package": "example-core",
-                    "cargo_toml": "crates/example-core/Cargo.toml",
-                    "required": True,
-                    "publish": True,
-                    "publish_order": 1,
-                    "preflight_check": "full",
-                    "wait_after_publish_seconds": 0,
-                    "verify_install": False,
-                }
-            ],
-        )
-        self.assertFalse(values["channels"]["pypi"]["enabled"])
-        self.assertFalse(values["channels"]["homebrew"]["enabled"])
-        self.assertFalse(values["channels"]["winget"]["enabled"])
-
-    def test_load_install_values_requires_explicit_artifacts_and_channels(self) -> None:
-        values = self.valid_values()
-        with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "input.json"
+            path = root / "input.json"
+            values = self.valid_values()
             path.write_text(json.dumps(values), encoding="utf-8")
             loaded = INSTALL.load_install_values(path)
-        self.assertEqual(loaded["artifacts"]["crates"], values["artifacts"]["crates"])
-        self.assertEqual(
-            loaded["artifacts"]["wheels"],
-            [{"package": "example-python", "python_package": "example_python"}],
-        )
-        self.assertEqual(loaded["artifacts"]["binaries"], ["example"])
-        self.assertTrue(loaded["channels"]["crates_io"]["enabled"])
-        self.assertFalse(loaded["channels"]["scoop"]["enabled"])
+        self.assertEqual(loaded, values)
+        self.assertEqual(set(loaded["channels"]), set(INSTALL.CHANNEL_NAMES))
+        self.assertEqual(loaded["python_distributions"][1]["build_system"], "setuptools")
 
     def test_load_install_values_rejects_invalid_publish_orders(self) -> None:
         cases = {
-            "boolean": (True, "positive integer"),
-            "zero": (0, "positive integer"),
-            "negative": (-1, "positive integer"),
-            "duplicate": (1, "unique"),
+            "boolean": (True, "integer"),
+            "zero": (0, "positive when publish is true"),
+            "negative": (-1, "non-negative integer"),
         }
         for name, (publish_order, message) in cases.items():
             with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
                 values = self.valid_values()
-                values["artifacts"]["crates"][1]["publish_order"] = publish_order
+                values["crates"][0]["publish_order"] = publish_order
                 path = Path(directory) / "input.json"
                 path.write_text(json.dumps(values), encoding="utf-8")
                 with self.assertRaisesRegex(Exception, message):
                     INSTALL.load_install_values(path)
+        with tempfile.TemporaryDirectory() as directory:
+            values = self.valid_values()
+            values["crates"][1].update(publish=True, publish_order=1)
+            path = Path(directory) / "input.json"
+            path.write_text(json.dumps(values), encoding="utf-8")
+            with self.assertRaisesRegex(Exception, "unique"):
+                INSTALL.load_install_values(path)
 
-    def test_load_install_values_rejects_missing_channel_activation(self) -> None:
+    def test_load_install_values_rejects_missing_complete_contract_fields(self) -> None:
+        values = self.valid_values()
+        del values["project"]["license"]
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "input.json"
-            path.write_text("{}", encoding="utf-8")
-            with self.assertRaisesRegex(Exception, "release must be an object"):
+            path.write_text(json.dumps(values), encoding="utf-8")
+            with self.assertRaisesRegex(Exception, "project.license"):
+                INSTALL.load_install_values(path)
+
+    def test_load_install_values_rejects_ambiguous_python_distribution(self) -> None:
+        values = self.valid_values()
+        values["python_distributions"][0]["build_system"] = "setuptools"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "input.json"
+            path.write_text(json.dumps(values), encoding="utf-8")
+            with self.assertRaisesRegex(Exception, "must not set both"):
                 INSTALL.load_install_values(path)
 
     def test_install_places_executable_release_helpers_at_every_workflow_path(self) -> None:
@@ -224,6 +220,9 @@ class InstallValuesTests(unittest.TestCase):
         parity-only check from accepting workflows that still call an obsolete
         consumer-local scripts/ path.
         """
+
+        if not (INSTALLER.parent / ".sc-publish-source-root").is_file():
+            self.skipTest("installed consumers do not re-run the package source installer")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/.github/scripts/tests/test_publish_kit_assets.py
+++ b/.github/scripts/tests/test_publish_kit_assets.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = next(path for path in Path(__file__).resolve().parents if (path / "install.py").is_file())
 AGENTS = PACKAGE_ROOT / ".claude" / "agents"
 PUBLISHING = PACKAGE_ROOT / ".claude" / "skills" / "publishing"
 

--- a/.github/scripts/tests/test_publish_kit_scripts.py
+++ b/.github/scripts/tests/test_publish_kit_scripts.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = next(path for path in Path(__file__).resolve().parents if (path / "install.py").is_file())
 SCRIPTS = PACKAGE_ROOT / ".github" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 import release_manifest  # noqa: E402

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1171,6 +1171,8 @@ def test_release_workflow_enforces_python_release_invariants() -> None:
     assert "release_tag: ${{ inputs.tag }}" in pypi_text
     assert "gh release download" in pypi_text
     assert "verify-python-release-assets" in pypi_text
+    assert "release_python_receipt.py" in pypi_text
+    assert "pypi-release-receipt-${{ inputs.tag }}" in pypi_text
     assert "maturin build" not in pypi_text
     assert "maturin sdist" not in pypi_text
     assert "name: Publish manifest-declared wheels and sdists to TestPyPI" in pypi_text

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1651,6 +1651,19 @@ def test_release_preflight_collects_independent_failures_before_denial() -> None
     assert "REGISTRY_STATE" in preflight_text
 
 
+def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
+    preflight_text = release_preflight_workflow_text()
+    toolchain_text = (
+        repo_root() / ".github" / "actions" / "setup-lint-toolchain" / "action.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'include-sc-lint: "false"' in preflight_text
+    assert "cargo run -p sc-lint-boundary --release -- analyze --root . --format json" in preflight_text
+    assert "BOUNDARY_LINT" in preflight_text
+    assert "include-sc-lint:" in toolchain_text
+    assert "if: inputs.include-sc-lint == 'true'" in toolchain_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -199,7 +199,7 @@ def repo_root() -> Path:
     # Tests are installed at <consumer>/.github/scripts/tests.  Keep this
     # relative to the consumer root so the untouched vendored suite works in
     # every repository that installs the publish kit.
-    return Path(__file__).resolve().parents[3]
+    return next(path for path in Path(__file__).resolve().parents if (path / "install.py").is_file())
 
 
 def scripts_root() -> Path:

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1661,6 +1661,8 @@ def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
 
     assert 'include-sc-lint: "false"' in preflight_text
     assert "cargo run -p sc-lint-boundary --release -- analyze --root . --format json" in preflight_text
+    assert "> boundary-lint.json" in preflight_text
+    assert "python3 .github/scripts/check_boundary_lint_status.py boundary-lint.json" in preflight_text
     assert "BOUNDARY_LINT" in preflight_text
     assert "include-sc-lint:" in toolchain_text
     assert "if: inputs.include-sc-lint == 'true'" in toolchain_text

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1682,6 +1682,13 @@ def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_t
     assert "sc_compose_dependency" in installer_text
 
 
+def test_release_preflight_denies_a_failed_sc_compose_cli_install() -> None:
+    preflight_text = release_preflight_workflow_text()
+
+    assert "SC_COMPOSE_CLI: ${{ steps.sc_compose_cli.outcome }}" in preflight_text
+    assert 'record sc-compose-cli "${SC_COMPOSE_CLI}"' in preflight_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1678,7 +1678,7 @@ def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_t
     workspace_tests = "run: cargo test --workspace"
     assert install_step in preflight_text
     assert preflight_text.index(install_step) < preflight_text.index(workspace_tests)
-    assert "SC_COMPOSE_INSTALL" in installer_text
+    assert "SC_COMPOSE_PARITY_INSTALL" in installer_text
     assert "sc_compose_dependency" in installer_text
 
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1668,6 +1668,20 @@ def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
     assert "if: inputs.include-sc-lint == 'true'" in toolchain_text
 
 
+def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_tests() -> None:
+    preflight_text = release_preflight_workflow_text()
+    installer_text = (
+        repo_root() / ".github" / "scripts" / "install_sc_compose_cli.py"
+    ).read_text(encoding="utf-8")
+
+    install_step = "python3 .github/scripts/install_sc_compose_cli.py"
+    workspace_tests = "run: cargo test --workspace"
+    assert install_step in preflight_text
+    assert preflight_text.index(install_step) < preflight_text.index(workspace_tests)
+    assert "SC_COMPOSE_INSTALL" in installer_text
+    assert "sc_compose_dependency" in installer_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_python_receipt.py
+++ b/.github/scripts/tests/test_release_python_receipt.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / ".github" / "scripts"))
+from release_python_receipt import create_receipt  # noqa: E402
+
+
+def test_receipt_binds_source_manifest_version_and_checksums(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = true
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture-1.4.3-py3-none-any.whl", "w") as wheel:
+        wheel.writestr("fixture-1.4.3.dist-info/METADATA", "Name: fixture\nVersion: 1.4.3\n")
+    with tarfile.open(assets / "fixture-1.4.3.tar.gz", "w:gz") as sdist:
+        metadata = b"Name: fixture\nVersion: 1.4.3\n"
+        info = tarfile.TarInfo("fixture-1.4.3/PKG-INFO")
+        info.size = len(metadata)
+        sdist.addfile(info, io.BytesIO(metadata))
+
+    receipt = create_receipt(manifest, assets, "1.4.3", "a" * 40)
+
+    assert receipt["source_commit"] == "a" * 40
+    assert receipt["version"] == "1.4.3"
+    assert len(receipt["manifest_sha256"]) == 64
+    assert {item["filename"] for item in receipt["artifacts"]} == {
+        "fixture-1.4.3-py3-none-any.whl",
+        "fixture-1.4.3.tar.gz",
+    }
+
+
+def test_receipt_rejects_version_drift(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = false
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture.whl", "w") as wheel:
+        wheel.writestr("fixture.dist-info/METADATA", "Name: fixture\nVersion: 1.4.2\n")
+
+    with pytest.raises(SystemExit, match="expected version 1.4.3"):
+        create_receipt(manifest, assets, "1.4.3", "a" * 40)
+
+
+def test_receipt_rejects_incomplete_manifest_asset_set(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = true
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture.whl", "w") as wheel:
+        wheel.writestr("fixture.dist-info/METADATA", "Name: fixture\nVersion: 1.4.3\n")
+
+    with pytest.raises(SystemExit, match="Python artifact set mismatch"):
+        create_receipt(manifest, assets, "1.4.3", "a" * 40)

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -74,6 +74,24 @@ jobs:
             --manifest release/publish-artifacts.toml \
             --asset-dir release-assets \
             --copy-to dist
+      - name: Record source-bound Python artifact receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.tag }}"
+          version="${version#v}"
+          python3 .github/scripts/release_python_receipt.py \
+            --manifest release/publish-artifacts.toml \
+            --asset-dir dist \
+            --version "${version}" \
+            --source-commit "$(git rev-parse HEAD)" \
+            --output pypi-release-receipt.json
+      - name: Store Python artifact receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-release-receipt-${{ inputs.tag }}
+          path: pypi-release-receipt.json
+          if-no-files-found: error
       - name: Select configured Python repository
         shell: bash
         env:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -393,6 +393,7 @@ jobs:
           BOUNDARY_LINT: ${{ steps.boundary_lint.outcome }}
           FORMATTING: ${{ steps.formatting.outcome }}
           CLIPPY: ${{ steps.clippy.outcome }}
+          SC_COMPOSE_CLI: ${{ steps.sc_compose_cli.outcome }}
           WORKSPACE_TESTS: ${{ steps.workspace_tests.outcome }}
           MANIFEST: ${{ steps.manifest.outcome }}
           PUBLISH_ORDER: ${{ steps.publish_order.outcome }}
@@ -425,6 +426,7 @@ jobs:
           record boundary-lint "${BOUNDARY_LINT}"
           record formatting "${FORMATTING}"
           record clippy "${CLIPPY}"
+          record sc-compose-cli "${SC_COMPOSE_CLI}"
           record workspace-tests "${WORKSPACE_TESTS}"
           record manifest "${MANIFEST}"
           record publish-order "${PUBLISH_ORDER}"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -159,12 +159,24 @@ jobs:
 
       - name: Set up lint toolchain
         uses: ./.github/actions/setup-lint-toolchain
+        with:
+          # Boundary inventory validation must use this checkout's analyzer.
+          # The externally released sc-lint bundle can lag ATM's owned schema.
+          include-sc-lint: "false"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.94.1
           components: rustfmt, clippy
+
+      - id: boundary_lint
+        name: Validate boundary inventory with workspace source
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo run -p sc-lint-boundary --release -- analyze --root . --format json
 
       - name: Normalize version input
         id: meta
@@ -372,6 +384,7 @@ jobs:
           CREDENTIAL_LIVENESS: ${{ steps.credential_liveness.outcome }}
           REGISTRY_STATE: ${{ steps.registry_state.outcome }}
           META: ${{ steps.meta.outcome }}
+          BOUNDARY_LINT: ${{ steps.boundary_lint.outcome }}
           FORMATTING: ${{ steps.formatting.outcome }}
           CLIPPY: ${{ steps.clippy.outcome }}
           WORKSPACE_TESTS: ${{ steps.workspace_tests.outcome }}
@@ -403,6 +416,7 @@ jobs:
           record credential-liveness "${CREDENTIAL_LIVENESS}"
           record registry-state "${REGISTRY_STATE}"
           record version-input "${META}"
+          record boundary-lint "${BOUNDARY_LINT}"
           record formatting "${FORMATTING}"
           record clippy "${CLIPPY}"
           record workspace-tests "${WORKSPACE_TESTS}"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -205,6 +205,11 @@ jobs:
         continue-on-error: true
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - id: sc_compose_cli
+        name: Install pinned sc-compose CLI for parity tests
+        continue-on-error: true
+        run: python3 .github/scripts/install_sc_compose_cli.py
+
       - id: workspace_tests
         name: Run workspace tests
         continue-on-error: true

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -176,7 +176,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo run -p sc-lint-boundary --release -- analyze --root . --format json
+          cargo run -p sc-lint-boundary --release -- analyze --root . --format json > boundary-lint.json
+          python3 .github/scripts/check_boundary_lint_status.py boundary-lint.json
 
       - name: Normalize version input
         id: meta

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.4.3
+PackageVersion: 1.4.4
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.3/atm_1.4.3_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.4/atm_1.4.4_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.4.3
+ManifestVersion: 1.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.4
+
+- prepare the first authorized production-PyPI cut for `hermes-atm` and
+  `atm-graft`, with the ADR-049 first-public-release disclosure and the
+  manifest-driven Python distribution contract; publication remains pending
+  explicit authorization
+- make release preflight install and gate the repository-pinned `sc-compose`
+  CLI before workspace parity tests, preventing a missing local executable
+  from being mistaken for a successful release check
+
 ## 1.4.3
 
 - recovery release: `v1.4.2` was abandoned as a release tag/GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -328,14 +328,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-attributes"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-error = { path = "../atm-error", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/bin/atm-daemon-benchmark.rs"
 required-features = ["benchmark-harness"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3" }
-atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4" }
+atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.4" }
 tokio.workspace = true
 fs4 = "0.13"
 serde_json.workspace = true

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
@@ -20,5 +20,5 @@ tracing = "0.1"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -17,8 +17,8 @@ sc-observability-types.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.4" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -5,7 +5,7 @@ name = "atm-graft-python"
 publish = false
 # Maturin consumes this crate's Cargo version as Python package metadata; keep
 # it equivalent to the workspace release while using PEP 440-compatible form.
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,12 +27,12 @@ abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.3" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-graft = { path = "../atm-graft", version = "1.4.4" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 pyo3 = "0.29"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-graft = { path = "../atm-graft", version = "1.4.3", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.4", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,14 +13,14 @@ homepage.workspace = true
 test-support = ["atm-core/test-utils"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.4" }
 async-trait.workspace = true
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
 tracing.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
@@ -29,8 +29,8 @@ ulid.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -12,8 +12,8 @@ homepage.workspace = true
 description = "Provisioning and bounded curl mTLS interoperability fixture for ATM."
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 rustls.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atm-query-python"
 # This local analyst binding is not part of the current public release surface.
 publish = false
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -24,9 +24,9 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4" }
 
 [dev-dependencies]
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3", features = ["test-support"] }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,8 +16,8 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Shared audited storage contract and canonical domain types for ATM."
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.3" }
+atm-error = { path = "../atm-error", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/atm-template-sc-compose/Cargo.toml
+++ b/crates/atm-template-sc-compose/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace = true
 name = "atm_template_sc_compose"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 sc-composer = "=1.4.1"
 sc-sha = "=1.4.1"
 serde_json.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,11 +33,11 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.4" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -53,8 +53,8 @@ async-trait.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.3", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.4", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -6,6 +6,11 @@ through the public `GatewayRunner.inject_internal_message(..., mode="queue")`
 API. It does not open an ATM database, select a Hermes adapter, or require any
 post-install source edits.
 
+> **First public PyPI release.** `hermes-atm` and its `atm-graft` dependency
+> begin public distribution at the project's existing 1.x workspace version.
+> Earlier 1.x development was internal rather than a missing public release
+> history; both packages remain version-locked to ATM's workspace release.
+
 ## Required settings
 
 Collect these values before installation. Keep the chat identifier in local

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.4.3"
+version = "1.4.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/docs/plans/phase-as/AS.1-overlay-contract.md
+++ b/docs/plans/phase-as/AS.1-overlay-contract.md
@@ -162,7 +162,12 @@ python3 "$PUBLISH_KIT_SOURCE/plugins/sc-publish/install.py" --help
 | `sc-publish` #12 — `extra_validations` runner/evidence | safety-load-bearing | Must be accepted and synchronized before AS.3. |
 | `sc-publish` #13 — Cargo-derived dynamic PEP 621 validation | safety-load-bearing | Must be accepted and synchronized before AS.3. |
 | `sc-publish` #14 — generic release-version wiring | safety-load-bearing | Atomic sync revealed that ATM's legacy version check inspects an ATM-only workflow job. The generic manifest/workflow contract must replace that assertion before AS.3. |
-| Explicit installer input / generated-manifest parity | blocked | PR #7 at `240fd52` supplies explicit input and PR #15 at `5e49b6ac` closes the source-layout defect. PR #16 fixes the `[[crates]]` entry shape. The remaining complete-schema gap — rendered `[project]`, channel, and Python-distribution fields required by the canonical validators — is tracked by [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17) and the consolidated report to its maintainer. AS.2 owns ATM's complete declared input; no local adapter is permitted. |
+| Explicit installer input / generated-manifest parity | accepted upstream; execution proof pending | PR #7 at `240fd52` supplies explicit input, PR #15 at `5e49b6ac` closes the source-layout defect, and PR #24 at `68c06f97` closes [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17) (closed 2026-08-18T16:30:53Z). AS.3 still owns ATM's unchanged-sync execution proof; no local adapter is permitted. |
+
+Verified against `randlee/sc-publish` on 2026-08-18: #6, #9, #10, #11,
+#12, #13, and #14 remain open safety-load-bearing items. #17 is closed by
+PR #24 at `68c06f97a98f845f0b61f940b4616e0c214bece3`; it must not remain
+represented as an open upstream blocker.
 
 The safety items are intentionally **not** represented as closed by their
 issue creation. AS.3 remains blocked until the stated upstream implementation

--- a/docs/plans/phase-as/AS.2-consumer-manifest-contract.md
+++ b/docs/plans/phase-as/AS.2-consumer-manifest-contract.md
@@ -112,10 +112,11 @@ evidence and must not silently add schema behavior.
   consumer’s supplied manifest input.
 - Installing from the ATM JSON produces every package-owned shared file and
   both rendered release manifests; byte/source parity and semantic manifest
-  equality are checked before the clean dry-run proof. The terminal rendered
-  manifest equality gate remains blocked on
-  [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17); no
-  ATM-side translation or workaround is permitted.
+  equality are checked before the clean dry-run proof. The source-layout and
+  complete-schema item formerly tracked by
+  [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17) closed
+  through PR #24 at `68c06f97`; AS.3 owns the resulting unchanged-sync
+  execution proof. No ATM-side translation or workaround is permitted.
 - PF-1, PF-2, and PF-3 use existing canonical solutions as defined above.
 - Each released Python distribution is locked to the workspace release base:
   both Maturin packages use their supported Cargo-derived path, while the pure
@@ -186,7 +187,7 @@ complete schema is available.
 | PF-1 credential/configuration preflight | `release-preflight.yml` invokes the shared non-disclosing `preflight-secret-plan`; channel contracts carry names and liveness kinds, never values. | Use unchanged. |
 | PF-2 registry state | `public-registry-check-plan` provides the fenced crates.io JSON inquiry plan for every declared crate. | Use unchanged; retain each artifact’s version, last-publish timestamp, classification, and planned action in the receipt. |
 | PF-3 partial state | Existing registry classification distinguishes missing, already-at-target, and true-conflict artifacts. | Publish missing targets, skip already-at-target targets, and block conflicts; a version bump is an explicit release decision. |
-| Full installer schema and render/validate parity | [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17) | Blocked upstream: installer input must render `[project]`, channel configuration, and Python package/distribution fields before ATM creates the final consumer JSON or synchronizes the generated outputs. |
+| Full installer schema and render/validate parity | [`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17), closed by PR #24 `68c06f97` | Accepted upstream; AS.3 must prove the unchanged installer renders `[project]`, channel configuration, and Python package/distribution fields before release dispatch. |
 | Generic Maturin/Python version-model contract | [`sc-publish` #13](https://github.com/randlee/sc-publish/issues/13) | The broader contract is Maturin `dynamic = ["version"]` from an explicit Cargo source, alongside literal-version pure setuptools packages. ATM declares both shapes; the two concrete validator paths below remain separately tracked. |
 | `validate-manifest` dynamic-version resolution | [`sc-publish` #20](https://github.com/randlee/sc-publish/issues/20) | Blocked upstream until the canonical `[[python_packages]]` validation resolves a Maturin dynamic version from its declared Cargo source. This is distinct from #13's broader contract and from #21's Cargo lockstep path. |
 | `verify-version-lockstep` literal bridge-version allowance | [`sc-publish` #21](https://github.com/randlee/sc-publish/issues/21) | Blocked upstream until canonical lockstep accepts an intentionally literal Maturin bridge version when it equals the documented workspace release base. This is distinct from #20's PEP 621 validation path. |
@@ -210,9 +211,10 @@ consumer document: the shared template currently renders wheel entries as
 `[[python_packages]]` and `[[python_distributions]]`. The current canonical
 installer also rejects ATM's explicit non-published bridge crates because their
 `publish_order = 0` values are not yet an accepted generic input shape. Both
-the shape and rendered-manifest parity are tracked by
-[`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17). No
-ATM-side translation or workaround is permitted.
+the shape and rendered-manifest parity were closed by
+[`sc-publish` #17](https://github.com/randlee/sc-publish/issues/17) through
+PR #24 at `68c06f97`. AS.3 owns unchanged-sync execution proof; no ATM-side
+translation or workaround is permitted.
 
 `python3 .just/tests/test_as2_consumer_contract.py` prevents ATM-owned input
 drift: every declared crate must still resolve to its stated Cargo package,

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -120,6 +120,19 @@ PyPI path writes a source-commit, manifest-SHA-256, version, and per-artifact
 SHA-256 receipt before upload. No upstream `sc-lint` or `sc-publish` merge is
 required for those checks.
 
+**Boundary-lint triage (2026-08-18):** The workspace analyzer reports
+`status: fail` with 21 findings on both the AS.3 baseline commit
+`3f5f2db474dc66b34be38d60193ba259fe8e78e4` and this AS.4 branch: seven
+`SCB-CYCLE-001` multi-owner architectural cycles, nine `SCB-CYCLE-002`
+type/method self-loops, and five `SCB-CYCLE-003` trait-implementation
+self-loops. The seven multi-owner cycles are pre-existing hard failures under
+the analyzer's `finding_is_failure` policy; the self-loop categories are
+reported advisory findings. They are neither introduced by AS.4 nor accepted
+as clean, and AS.4 does not suppress or reclassify them. The preflight gate
+therefore captures the analyzer JSON and exits nonzero unless its status is
+`pass`, while retaining `continue-on-error` so the final receipt records the
+real boundary-lint failure rather than aborting all remaining evidence.
+
 The immutable tag also fails ADR-049's publication-disclosure prerequisite:
 neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
 states that this is the first public release and explains the internal 1.x

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -189,6 +189,19 @@ a new immutable release containing the ADR-049 disclosure and current release
 manifest, followed by the local AS.3 validation receipt and the PyPI-only
 channel. No rebuild or upload is authorized for the blocked v1.4.3 set.
 
+### 1.4.4 preflight re-runs
+
+The fresh `1.4.4` cut was prepared in `a22168eec` and the preflight workspace
+test bootstrap was added in `df54f34f7`. Release-preflight run
+[`32169019885`](https://github.com/randlee/atm-core/actions/runs/32169019885)
+was the first `1.4.4` attempt and exposed that `compose_passthrough` needs the
+`sc-compose` executable, not only Python bindings. Run
+[`32169985864`](https://github.com/randlee/atm-core/actions/runs/32169985864)
+re-ran after that pinned CLI bootstrap and passed the workspace checks; its
+remaining channel-only failure was the rejected `CARGO_REGISTRY_TOKEN` for
+crates.io. That credential decision remains pending Rand and does not
+authorize a PyPI upload.
+
 ### Draft v1.4.3 GitHub release note
 
 > **First public PyPI release:** `hermes-atm` and `atm-graft` begin public

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -6,7 +6,7 @@ phase: AS
 sprint: AS.4
 worktree: main immutable release assets; canonical publisher agents from AS worktree
 branch: main
-status: proposed
+status: blocked
 estimated_scope: one authorized production channel
 ```
 
@@ -95,3 +95,50 @@ python3 -m pip install --only-binary=:all: hermes-atm==1.4.3
 
 Existing target versions must be classified with PF-3 semantics; do not treat
 an already-published version as permission to rebuild or overwrite it.
+
+## Execution Receipt — 2026-08-18
+
+**Outcome: blocked before production upload.** The AS.4 forward branch is
+`feature/pas-s4-authorized-pypi-1.4.3`, stacked from AS.3 evidence commit
+`3f5f2db474dc66b34be38d60193ba259fe8e78e4`. The immutable release source is
+`main`/`v1.4.3` commit `fa6066468f8e638893bedd686244cffa2a43dbdf`.
+
+The prerequisite receipt is not acceptable: Release Preflight run
+[`32159872873`](https://github.com/randlee/atm-core/actions/runs/32159872873)
+failed because `sc-lint` 0.4.0 rejected ATM's `trait` boundary field. The
+sc-lint correction is awaiting merge in
+[randlee/sc-lint#115](https://github.com/randlee/sc-lint/pull/115), and the
+resolved-receipt workflow is awaiting merge in
+[randlee/sc-publish#25](https://github.com/randlee/sc-publish/pull/25).
+
+The immutable tag also fails ADR-049's publication-disclosure prerequisite:
+neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
+states that this is the first public release and explains the internal 1.x
+history. That cannot be corrected without a new immutable release; AS.4
+therefore must not upload these artifacts.
+
+At the time of this receipt, both public registry endpoints returned 404 for
+`hermes-atm` and `atm-graft`; no public PyPI artifacts exist. The prior
+workflow run [`32081875532`](https://github.com/randlee/atm-core/actions/runs/32081875532)
+successfully uploaded only to TestPyPI; its production-PyPI job was skipped.
+Its immutable staged artifact SHA-256 values were:
+
+- `hermes_atm-1.4.3-py3-none-any.whl` —
+  `041311b7806d43acd2326c6532076b614f6df9af930f6102d4c8485aa936b2f7`
+- `atm_graft-1.4.3.tar.gz` —
+  `c9d6f532d6606f9f1cbc90e8970e7817ce1444dc75e44906ed4ad5b688f880ab`
+- `atm_graft-1.4.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` —
+  `3344cabb6c1f0b1c02e9df0174b28dd72577021e92d784fc307dae693adfc26b`
+- `atm_graft-1.4.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` —
+  `11aa4d7059a94854d8acec11df2200359e660226176907397d3961464f0d7337`
+- `atm_graft-1.4.3-cp311-abi3-musllinux_1_2_x86_64.whl` —
+  `32b713a0cf4508dbffe2a865194c471e1836ec6d7a744938c1be7e7a64f9e83e`
+- `atm_graft-1.4.3-cp311-abi3-macosx_11_0_arm64.whl` —
+  `23da2aa35fef045c9899063d00495a384506d0ff995d4728d378962fb3b9aeac`
+- `atm_graft-1.4.3-cp311-abi3-win_amd64.whl` —
+  `f9963df87f5d4e04377583200e79227b8c1db9f22a507b37bff3de43c6e2112a`
+
+Required remediation: merge the two upstream fixes, create a new immutable
+release containing the ADR-049 disclosure, obtain a matching AS.3 receipt,
+and then run the PyPI-only channel against that release. No rebuild or upload
+is authorized for the blocked v1.4.3 set.

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -111,13 +111,14 @@ an already-published version as permission to rebuild or overwrite it.
 `3f5f2db474dc66b34be38d60193ba259fe8e78e4`. The immutable release source is
 `main`/`v1.4.3` commit `fa6066468f8e638893bedd686244cffa2a43dbdf`.
 
-The prerequisite receipt is not acceptable: Release Preflight run
+Release Preflight run
 [`32159872873`](https://github.com/randlee/atm-core/actions/runs/32159872873)
-failed because `sc-lint` 0.4.0 rejected ATM's `trait` boundary field. The
-sc-lint correction is awaiting merge in
-[randlee/sc-lint#115](https://github.com/randlee/sc-lint/pull/115), and the
-resolved-receipt workflow is awaiting merge in
-[randlee/sc-publish#25](https://github.com/randlee/sc-publish/pull/25).
+failed because external `sc-lint` 0.4.0 rejected ATM's legitimate `trait`
+boundary field. This was superseded locally in AS.4: preflight now runs
+ATM's workspace-source `sc-lint-boundary` analyzer directly, and the local
+PyPI path writes a source-commit, manifest-SHA-256, version, and per-artifact
+SHA-256 receipt before upload. No upstream `sc-lint` or `sc-publish` merge is
+required for those checks.
 
 The immutable tag also fails ADR-049's publication-disclosure prerequisite:
 neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
@@ -146,7 +147,16 @@ Its immutable staged artifact SHA-256 values were:
 - `atm_graft-1.4.3-cp311-abi3-win_amd64.whl` —
   `f9963df87f5d4e04377583200e79227b8c1db9f22a507b37bff3de43c6e2112a`
 
-Required remediation: merge the two upstream fixes, create a new immutable
-release containing the ADR-049 disclosure, obtain a matching AS.3 receipt,
-and then run the PyPI-only channel against that release. No rebuild or upload
-is authorized for the blocked v1.4.3 set.
+The immutable v1.4.3 release manifest also predates the current
+`[[python_distributions]]` contract, so it cannot produce a contract-matching
+receipt through the current PyPI workflow. Required remediation is therefore
+a new immutable release containing the ADR-049 disclosure and current release
+manifest, followed by the local AS.3 validation receipt and the PyPI-only
+channel. No rebuild or upload is authorized for the blocked v1.4.3 set.
+
+### Draft v1.4.3 GitHub release note
+
+> **First public PyPI release:** `hermes-atm` and `atm-graft` begin public
+> distribution at ATM's existing 1.x workspace version. Earlier 1.x
+> development was internal, not a missing public release history; the Python
+> packages remain version-locked to the ATM workspace release.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1308,8 +1308,8 @@ Sprint line:
   release-version contract
 - `AS.3` `AS.3-worktree-preflight-proof.md` — canonical worktree preflight
   proof
-- `AS.4` `AS.4-authorized-pypi-1.4.3.md` — separately authorized immutable
-  main PyPI release
+- `AS.4` `AS.4-authorized-pypi-1.4.3.md` — separately authorized, fresh
+  `1.4.4` PyPI-only release
 - `AS.5` `AS.5-main-migration-merge.md` — verified migration promotion from
   `develop` to `main`
 - `AS.6` `AS.6-full-1.4.4-release.md` — first full canonical release

--- a/docs/user-documents/README.md
+++ b/docs/user-documents/README.md
@@ -1,7 +1,7 @@
 ---
 title: ATM User Guide
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # ATM User Guide

--- a/docs/user-documents/doctor-and-log.md
+++ b/docs/user-documents/doctor-and-log.md
@@ -1,7 +1,7 @@
 ---
 title: Doctor And Log
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Doctor And Log

--- a/docs/user-documents/examples/quickstart/install-paths.json
+++ b/docs/user-documents/examples/quickstart/install-paths.json
@@ -1,8 +1,8 @@
 {
-  "install_root": "~/.local/atm/1.4.3",
-  "binary_path": "~/.local/atm/1.4.3/bin/atm",
-  "daemon_binary_path": "~/.local/atm/1.4.3/bin/atm-daemon",
-  "doc_root": "~/.local/atm/1.4.3/share/doc/atm",
-  "doc_entrypoint": "~/.local/atm/1.4.3/share/doc/atm/README.md",
+  "install_root": "~/.local/atm/1.4.4",
+  "binary_path": "~/.local/atm/1.4.4/bin/atm",
+  "daemon_binary_path": "~/.local/atm/1.4.4/bin/atm-daemon",
+  "doc_root": "~/.local/atm/1.4.4/share/doc/atm",
+  "doc_entrypoint": "~/.local/atm/1.4.4/share/doc/atm/README.md",
   "runtime_state_root": "~/.atm"
 }

--- a/docs/user-documents/hermes-atm.md
+++ b/docs/user-documents/hermes-atm.md
@@ -1,7 +1,7 @@
 ---
 title: Hermes Gateway Integration
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Hermes Gateway Integration

--- a/docs/user-documents/hermes-atm.md
+++ b/docs/user-documents/hermes-atm.md
@@ -13,9 +13,10 @@ access, source edits, or a hand-written hook.
 
 ## Release Status
 
-Version `1.4.2` is currently available on TestPyPI. Production PyPI publication
-is pending. Use the TestPyPI command below until the production release is
-announced; then use the ordinary PyPI command instead.
+Version `1.4.4` is prepared but is not yet published to PyPI or TestPyPI.
+Production publication remains pending this sprint's authorization. Do not
+install an earlier TestPyPI candidate as a substitute; wait for the published
+`1.4.4` release announcement.
 
 `hermes-atm` supports CPython 3.11 through 3.14. It installs the matching
 typed `atm-graft` client as a dependency.
@@ -48,19 +49,10 @@ the receiver correctly fails closed instead of injecting the nudge.
 
 ## Install
 
-For the current TestPyPI release, run this with the gateway's Python:
+After production PyPI publication, install the announced release with:
 
 ```bash
-python -m pip install --upgrade \
-  --index-url https://test.pypi.org/simple \
-  --extra-index-url https://pypi.org/simple \
-  "hermes-atm==1.4.2"
-```
-
-After production PyPI publication, install the current release with:
-
-```bash
-python -m pip install --upgrade hermes-atm
+python -m pip install --upgrade "hermes-atm==1.4.4"
 ```
 
 Register the profile with ATM before installing the receiver. Use the profile's

--- a/docs/user-documents/hooks.md
+++ b/docs/user-documents/hooks.md
@@ -1,7 +1,7 @@
 ---
 title: Hooks
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Hooks

--- a/docs/user-documents/identity-and-team.md
+++ b/docs/user-documents/identity-and-team.md
@@ -1,7 +1,7 @@
 ---
 title: Identity And Team
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Identity And Team

--- a/docs/user-documents/install-layout.md
+++ b/docs/user-documents/install-layout.md
@@ -1,7 +1,7 @@
 ---
 title: Install Layout
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Install Layout
@@ -21,7 +21,7 @@ Long-form user docs live under `share/doc/atm/`.
 A typical local install layout looks like this:
 
 ```text
-~/.local/atm/1.4.3/
+~/.local/atm/1.4.4/
   bin/
     atm
     atm-daemon

--- a/docs/user-documents/mailbox-workflows.md
+++ b/docs/user-documents/mailbox-workflows.md
@@ -1,7 +1,7 @@
 ---
 title: Mailbox Workflows
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Mailbox Workflows

--- a/docs/user-documents/nudge-templates.md
+++ b/docs/user-documents/nudge-templates.md
@@ -1,7 +1,7 @@
 ---
 title: Nudge Templates
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Nudge Templates

--- a/docs/user-documents/quickstart.md
+++ b/docs/user-documents/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Quickstart
@@ -57,11 +57,11 @@ not rely on direct database access or private files under `~/.atm/`.
 
 If the installed ATM binary is at:
 
-- `~/.local/atm/1.4.3/bin/atm`
+- `~/.local/atm/1.4.4/bin/atm`
 
 then the installed long-form doc entrypoint is:
 
-- `~/.local/atm/1.4.3/share/doc/atm/README.md`
+- `~/.local/atm/1.4.4/share/doc/atm/README.md`
 
 ## Next Documents
 

--- a/docs/user-documents/troubleshooting.md
+++ b/docs/user-documents/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Troubleshooting

--- a/install.py
+++ b/install.py
@@ -7,7 +7,6 @@ import argparse
 import difflib
 import json
 import shutil
-import subprocess
 import sys
 import tempfile
 import tomllib
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
+SOURCE_ROOT_MARKER = ".sc-publish-source-root"
 TEMPLATES = {
     Path("release/publish-channel-contracts.toml.j2"): Path(
         "release/publish-channel-contracts.toml"
@@ -26,114 +26,7 @@ TEMPLATES = {
     Path("release/publish-artifacts.toml.j2"): Path("release/publish-artifacts.toml"),
 }
 
-CHANNEL_NAMES = (
-    "github_release",
-    "crates_io",
-    "pypi",
-    "homebrew",
-    "scoop",
-    "winget",
-)
-
-
-def discover_crates(consumer: Path) -> list[dict[str, str]]:
-    """Return publishable Cargo package name/manifest pairs, example use only."""
-    if not (consumer / "Cargo.toml").is_file():
-        return []
-    result = subprocess.run(
-        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
-        cwd=consumer,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    metadata = json.loads(result.stdout)
-    return [
-        {
-            "name": package["name"],
-            "cargo_toml": str(Path(package["manifest_path"]).relative_to(consumer)),
-        }
-        for package in metadata["packages"]
-        if package.get("publish") != []
-    ]
-
-
-def discover_binaries(consumer: Path) -> list[str]:
-    """Return Cargo binary target names for an example input only."""
-    if not (consumer / "Cargo.toml").is_file():
-        return []
-    result = subprocess.run(
-        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
-        cwd=consumer,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    metadata = json.loads(result.stdout)
-    return sorted(
-        {
-            target["name"]
-            for package in metadata["packages"]
-            if package.get("publish") != []
-            for target in package.get("targets", [])
-            if "bin" in target.get("kind", [])
-        }
-    )
-
-
-def discover_wheels(consumer: Path) -> list[str]:
-    """Return Python project names without reading release metadata."""
-    excluded = {".git", "target", ".venv", "venv"}
-    wheels = []
-    for manifest in sorted(consumer.rglob("pyproject.toml")):
-        if any(part in excluded for part in manifest.parts):
-            continue
-        with manifest.open("rb") as file:
-            project = tomllib.load(file).get("project", {})
-        name = project.get("name")
-        if isinstance(name, str):
-            wheels.append(name)
-    return wheels
-
-
-def example_values(consumer: Path) -> dict[str, object]:
-    """Return a source-discovered starting point; never use it for installation."""
-    crates = discover_crates(consumer)
-    wheels = discover_wheels(consumer)
-    binaries = discover_binaries(consumer)
-    has_binaries = bool(binaries)
-    return {
-        "release": {"version_source": "Cargo.toml", "tag_prefix": "v"},
-        "artifacts": {
-            "crates": [
-                {
-                    "artifact": crate["name"],
-                    "package": crate["name"],
-                    "cargo_toml": crate["cargo_toml"],
-                    "required": True,
-                    "publish": True,
-                    "publish_order": position,
-                    "preflight_check": "full",
-                    "wait_after_publish_seconds": 0,
-                    "verify_install": False,
-                }
-                for position, crate in enumerate(crates, start=1)
-            ],
-            "wheels": [
-                {"package": name, "python_package": name.replace("-", "_")}
-                for name in wheels
-            ],
-            "binaries": binaries,
-        },
-        "channels": {
-            "github_release": {"enabled": has_binaries},
-            "crates_io": {"enabled": bool(crates)},
-            "pypi": {"enabled": bool(wheels), "workflow": "pypi-publish.yml"},
-            "homebrew": {"enabled": has_binaries},
-            "scoop": {"enabled": has_binaries},
-            "winget": {"enabled": has_binaries},
-        },
-    }
+CHANNEL_NAMES = ("pypi", "homebrew", "scoop", "winget")
 
 
 def _require_mapping(value: object, label: str) -> dict[str, Any]:
@@ -148,8 +41,52 @@ def _require_string(value: object, label: str) -> str:
     return value
 
 
+def _require_array(value: object, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise argparse.ArgumentTypeError(f"{label} must be an array")
+    return value
+
+
+def _require_boolean(value: object, label: str) -> bool:
+    if type(value) is not bool:
+        raise argparse.ArgumentTypeError(f"{label} must be a boolean")
+    return value
+
+
+def _require_non_negative_integer(value: object, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise argparse.ArgumentTypeError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _require_string_array(value: object, label: str) -> list[str]:
+    entries = _require_array(value, label)
+    for position, entry in enumerate(entries, start=1):
+        _require_string(entry, f"{label}[{position}]")
+    return entries
+
+
+def _require_string_mapping(value: object, label: str) -> dict[str, str]:
+    mapping = _require_mapping(value, label)
+    for key, entry in mapping.items():
+        _require_string(key, f"{label} key")
+        _require_string(entry, f"{label}.{key}")
+    return mapping
+
+
+def _require_entries(
+    values: object, label: str, required_fields: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    entries = _require_array(values, label)
+    for position, entry in enumerate(entries, start=1):
+        mapping = _require_mapping(entry, f"{label}[{position}]")
+        for field in required_fields:
+            _require_string(mapping.get(field), f"{label}[{position}].{field}")
+    return entries
+
+
 def load_install_values(path: Path) -> dict[str, object]:
-    """Load the complete, caller-declared install contract without inference."""
+    """Load the complete, caller-declared publish manifest contract."""
     try:
         values = _require_mapping(json.loads(path.read_text(encoding="utf-8")), "install input")
     except OSError as error:
@@ -157,58 +94,110 @@ def load_install_values(path: Path) -> dict[str, object]:
     except json.JSONDecodeError as error:
         raise argparse.ArgumentTypeError(f"--input must contain JSON: {error}") from error
 
-    release = _require_mapping(values.get("release"), "release")
-    _require_string(release.get("version_source"), "release.version_source")
-    _require_string(release.get("tag_prefix"), "release.tag_prefix")
-    artifacts = _require_mapping(values.get("artifacts"), "artifacts")
-    for key in ("crates", "wheels", "binaries"):
-        if not isinstance(artifacts.get(key), list):
-            raise argparse.ArgumentTypeError(f"artifacts.{key} must be an array")
+    if values.get("schema_version") != 1:
+        raise argparse.ArgumentTypeError("schema_version must be 1")
+
+    project = _require_mapping(values.get("project"), "project")
+    for field in ("name", "archive_prefix", "description", "homepage", "license"):
+        _require_string(project.get(field), f"project.{field}")
+    if "readme_dependency_crate" in project:
+        _require_string(project["readme_dependency_crate"], "project.readme_dependency_crate")
+
+    release_targets = _require_entries(
+        values.get("release_targets"), "release_targets", ("target", "os", "archive")
+    )
+    if not release_targets:
+        raise argparse.ArgumentTypeError("release_targets must not be empty")
+
+    crates = _require_array(values.get("crates"), "crates")
     publish_orders: set[int] = set()
-    for position, crate in enumerate(artifacts["crates"], start=1):
-        crate_value = _require_mapping(crate, f"artifacts.crates[{position}]")
-        _require_string(crate_value.get("artifact"), f"artifacts.crates[{position}].artifact")
-        _require_string(crate_value.get("package"), f"artifacts.crates[{position}].package")
-        _require_string(crate_value.get("cargo_toml"), f"artifacts.crates[{position}].cargo_toml")
+    for position, crate in enumerate(crates, start=1):
+        crate_value = _require_mapping(crate, f"crates[{position}]")
+        _require_string(crate_value.get("artifact"), f"crates[{position}].artifact")
+        _require_string(crate_value.get("package"), f"crates[{position}].package")
+        _require_string(crate_value.get("cargo_toml"), f"crates[{position}].cargo_toml")
         _require_string(
-            crate_value.get("preflight_check"), f"artifacts.crates[{position}].preflight_check"
+            crate_value.get("preflight_check"), f"crates[{position}].preflight_check"
         )
-        if type(crate_value.get("required")) is not bool:
+        _require_boolean(crate_value.get("required"), f"crates[{position}].required")
+        publish = _require_boolean(crate_value.get("publish"), f"crates[{position}].publish")
+        _require_boolean(crate_value.get("verify_install"), f"crates[{position}].verify_install")
+        _require_non_negative_integer(
+            crate_value.get("wait_after_publish_seconds"),
+            f"crates[{position}].wait_after_publish_seconds",
+        )
+        publish_order = _require_non_negative_integer(
+            crate_value.get("publish_order"), f"crates[{position}].publish_order"
+        )
+        if publish and publish_order == 0:
             raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].required must be a boolean"
+                f"crates[{position}].publish_order must be positive when publish is true"
             )
-        if type(crate_value.get("publish")) is not bool:
+        if not publish and publish_order != 0:
             raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].publish must be a boolean"
+                f"crates[{position}].publish_order must be zero when publish is false"
             )
-        if type(crate_value.get("verify_install")) is not bool:
-            raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].verify_install must be a boolean"
-            )
-        wait_after_publish_seconds = crate_value.get("wait_after_publish_seconds")
-        if type(wait_after_publish_seconds) is not int or wait_after_publish_seconds < 0:
-            raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].wait_after_publish_seconds must be a"
-                " non-negative integer"
-            )
-        publish_order = crate_value.get("publish_order")
-        if type(publish_order) is not int or publish_order <= 0:
-            raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].publish_order must be a positive integer"
-            )
+        if not publish:
+            continue
         if publish_order in publish_orders:
             raise argparse.ArgumentTypeError(
-                f"artifacts.crates[{position}].publish_order must be unique"
+                f"crates[{position}].publish_order must be unique"
             )
         publish_orders.add(publish_order)
-    for position, wheel in enumerate(artifacts["wheels"], start=1):
-        wheel_value = _require_mapping(wheel, f"artifacts.wheels[{position}]")
-        _require_string(wheel_value.get("package"), f"artifacts.wheels[{position}].package")
-        _require_string(
-            wheel_value.get("python_package"), f"artifacts.wheels[{position}].python_package"
-        )
-    if not all(isinstance(binary, str) and binary for binary in artifacts["binaries"]):
-        raise argparse.ArgumentTypeError("artifacts.binaries must be an array of non-empty strings")
+
+    release_binaries = _require_entries(values.get("release_binaries"), "release_binaries", ("name",))
+    for position, binary in enumerate(release_binaries, start=1):
+        if "bundled_paths" not in binary:
+            continue
+        for path_position, bundled_path in enumerate(
+            _require_array(binary["bundled_paths"], f"release_binaries[{position}].bundled_paths"),
+            start=1,
+        ):
+            bundled = _require_mapping(
+                bundled_path, f"release_binaries[{position}].bundled_paths[{path_position}]"
+            )
+            _require_string(bundled.get("source"), "bundled_paths.source")
+            _require_string(bundled.get("destination"), "bundled_paths.destination")
+            _require_string_array(
+                bundled.get("homebrew_destination_components"),
+                "bundled_paths.homebrew_destination_components",
+            )
+
+    if "installed_docs" in values:
+        installed_docs = _require_mapping(values["installed_docs"], "installed_docs")
+        for field in ("source_root", "install_root", "entrypoint"):
+            _require_string(installed_docs.get(field), f"installed_docs.{field}")
+
+    _require_entries(
+        values.get("python_packages"),
+        "python_packages",
+        ("artifact", "package", "manifest", "module", "publish"),
+    )
+    distributions = _require_entries(
+        values.get("python_distributions"),
+        "python_distributions",
+        ("name", "source", "module_path"),
+    )
+    for position, distribution in enumerate(distributions, start=1):
+        _require_boolean(distribution.get("sdist"), f"python_distributions[{position}].sdist")
+        _require_string_array(distribution.get("wheels"), f"python_distributions[{position}].wheels")
+        cargo_manifest = distribution.get("cargo_manifest")
+        build_system = distribution.get("build_system")
+        if cargo_manifest is None and build_system is None:
+            raise argparse.ArgumentTypeError(
+                f"python_distributions[{position}] requires cargo_manifest or build_system"
+            )
+        if cargo_manifest is not None and build_system is not None:
+            raise argparse.ArgumentTypeError(
+                f"python_distributions[{position}] must not set both cargo_manifest and build_system"
+            )
+        if cargo_manifest is not None:
+            _require_string(cargo_manifest, f"python_distributions[{position}].cargo_manifest")
+        if build_system is not None:
+            if _require_string(build_system, f"python_distributions[{position}].build_system") != "setuptools":
+                raise argparse.ArgumentTypeError(
+                    f"python_distributions[{position}].build_system must be setuptools"
+                )
 
     channels = _require_mapping(values.get("channels"), "channels")
     missing_channels = [name for name in CHANNEL_NAMES if name not in channels]
@@ -218,10 +207,149 @@ def load_install_values(path: Path) -> dict[str, object]:
         )
     for name in CHANNEL_NAMES:
         channel = _require_mapping(channels[name], f"channels.{name}")
-        if not isinstance(channel.get("enabled"), bool):
-            raise argparse.ArgumentTypeError(f"channels.{name}.enabled must be true or false")
-    _require_string(_require_mapping(channels["pypi"], "channels.pypi").get("workflow"), "channels.pypi.workflow")
+        _require_string(channel.get("workflow"), f"channels.{name}.workflow")
+        _require_string_mapping(channel.get("dispatch_inputs"), f"channels.{name}.dispatch_inputs")
+    pypi = _require_mapping(channels["pypi"], "channels.pypi")
+    _require_string_mapping(pypi.get("credential_rehearsal_inputs", {}), "channels.pypi.credential_rehearsal_inputs")
+    for field in ("test_repository", "production_repository"):
+        _require_string(pypi.get(field), f"channels.pypi.{field}")
+    homebrew = _require_mapping(channels["homebrew"], "channels.homebrew")
+    for field in ("tap_repository", "renderer_target"):
+        _require_string(homebrew.get(field), f"channels.homebrew.{field}")
+    for formula_position, formula in enumerate(
+        _require_array(homebrew.get("formulas"), "channels.homebrew.formulas"), start=1
+    ):
+        formula_value = _require_mapping(formula, f"channels.homebrew.formulas[{formula_position}]")
+        for field in ("path", "template", "class", "test_command", "test_output", "release_track"):
+            _require_string(formula_value.get(field), f"channels.homebrew.formulas[{formula_position}].{field}")
+        _require_string_array(formula_value.get("binaries"), f"channels.homebrew.formulas[{formula_position}].binaries")
+    _require_entries(homebrew.get("assets"), "channels.homebrew.assets", ("key", "target"))
+    for name, fields in {
+        "winget": ("identifier", "installer_target"),
+        "scoop": (
+            "bucket_repository",
+            "manifest_path",
+            "manifest_template",
+            "installer_target",
+            "binary",
+            "renderer_target",
+        ),
+    }.items():
+        channel = _require_mapping(channels[name], f"channels.{name}")
+        for field in fields:
+            _require_string(channel.get(field), f"channels.{name}.{field}")
+
+    if "homebrew" in channels or "scoop" in channels:
+        _require_string(project.get("renderer_archive_path"), "project.renderer_archive_path")
     return values
+
+
+def _toml_literal(value: object) -> str:
+    """Return a TOML literal for JSON-compatible manifest values."""
+    if isinstance(value, str):
+        return json.dumps(value)
+    if type(value) is bool:
+        return "true" if value else "false"
+    if type(value) is int:
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_literal(entry) for entry in value) + "]"
+    if isinstance(value, dict):
+        entries = []
+        for key, entry in value.items():
+            key_text = key if key.replace("_", "").replace("-", "").isalnum() else json.dumps(key)
+            entries.append(f"{key_text} = {_toml_literal(entry)}")
+        return "{ " + ", ".join(entries) + " }"
+    raise TypeError(f"unsupported TOML literal value: {type(value).__name__}")
+
+
+def _toml_scalars(mapping: dict[str, Any], literal_lists: tuple[str, ...] = ()) -> dict[str, Any]:
+    """Serialize scalar template fields while retaining table-array structure."""
+    converted: dict[str, Any] = {}
+    for key, value in mapping.items():
+        if key in literal_lists:
+            converted[key] = _toml_literal(value)
+        elif isinstance(value, (str, bool, int)):
+            converted[key] = _toml_literal(value)
+        else:
+            converted[key] = value
+    return converted
+
+
+def template_values(values: dict[str, object]) -> dict[str, object]:
+    """Convert validated JSON values to TOML-safe values for the Jinja template."""
+    project = _require_mapping(values["project"], "project")
+    channels = _require_mapping(values["channels"], "channels")
+    converted_channels: dict[str, Any] = {}
+    for name, channel_value in channels.items():
+        channel = _require_mapping(channel_value, f"channels.{name}")
+        converted = _toml_scalars(
+            channel,
+            ("dispatch_inputs", "credential_rehearsal_inputs"),
+        )
+        if name == "homebrew":
+            converted["formulas"] = [
+                _toml_scalars(
+                    _require_mapping(formula, "channels.homebrew.formulas entry"), ("binaries",)
+                )
+                for formula in _require_array(channel["formulas"], "channels.homebrew.formulas")
+            ]
+            converted["assets"] = [
+                _toml_scalars(_require_mapping(asset, "channels.homebrew.assets entry"))
+                for asset in _require_array(channel["assets"], "channels.homebrew.assets")
+            ]
+        converted_channels[name] = converted
+
+    release_binaries = []
+    for binary_value in _require_array(values["release_binaries"], "release_binaries"):
+        binary = _require_mapping(binary_value, "release_binaries entry")
+        converted = _toml_scalars(binary, ("bundled_paths",))
+        converted["has_bundled_paths"] = "bundled_paths" in binary
+        release_binaries.append(converted)
+
+    distributions = []
+    for distribution_value in _require_array(values["python_distributions"], "python_distributions"):
+        distribution = _toml_scalars(
+            _require_mapping(distribution_value, "python_distributions entry"), ("wheels",)
+        )
+        # Both build systems use one template. Empty sentinels keep the other
+        # branch defined under strict-undeclared-variable rendering.
+        distribution.setdefault("cargo_manifest", "")
+        distribution.setdefault("build_system", "")
+        distributions.append(distribution)
+
+    template_project = _toml_scalars(project)
+    template_project.setdefault("readme_dependency_crate", "")
+    template_project.setdefault("renderer_archive_path", "")
+    installed_docs = _toml_scalars(
+        _require_mapping(values.get("installed_docs", {}), "installed_docs")
+    )
+    for field in ("source_root", "install_root", "entrypoint"):
+        installed_docs.setdefault(field, "")
+
+    return {
+        "schema_version": _toml_literal(values["schema_version"]),
+        "project": template_project,
+        "release_targets": [
+            _toml_scalars(_require_mapping(target, "release_targets entry"))
+            for target in _require_array(values["release_targets"], "release_targets")
+        ],
+        "crates": [
+            _toml_scalars(_require_mapping(crate, "crates entry"))
+            for crate in _require_array(values["crates"], "crates")
+        ],
+        "release_binaries": release_binaries,
+        "installed_docs": installed_docs,
+        "has_installed_docs": "installed_docs" in values,
+        "python_packages": [
+            _toml_scalars(_require_mapping(package, "python_packages entry"))
+            for package in _require_array(values["python_packages"], "python_packages")
+        ],
+        "python_distributions": distributions,
+        "channels": converted_channels,
+        "has_readme_dependency_crate": "readme_dependency_crate" in project,
+        "has_renderer_archive_path": "renderer_archive_path" in project,
+    }
 
 
 def package_files() -> list[Path]:
@@ -230,6 +358,7 @@ def package_files() -> list[Path]:
         path
         for path in PACKAGE_ROOT.rglob("*")
         if path.is_file()
+        and path.name != SOURCE_ROOT_MARKER
         and "__pycache__" not in path.parts
         and path.suffix != ".pyc"
     )
@@ -261,7 +390,7 @@ def render_template(template: Path, values: dict[str, object], output: Path) -> 
     request: ComposeRequest = sc_compose.ComposeRequest(
         root=PACKAGE_ROOT,
         mode=sc_compose.ComposeMode.file(str(template_path.relative_to(PACKAGE_ROOT))),
-        vars_input=values,
+        vars_input=template_values(values),
         policy=sc_compose.ComposePolicy(strict_undeclared_variables=True),
     )
     rendered = sc_compose.compose_file(request).rendered_text
@@ -274,13 +403,13 @@ def main() -> int:
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""workflow:
-  1. Generate a reviewable input: --example-json install.json REPOSITORY
-  2. Confirm artifact names, publish order, and enabled channels in install.json.
+  1. Create a complete, reviewable JSON manifest contract for this repository.
+  2. Confirm artifact names, publish order, targets, package distributions, and channels.
   3. Install: --input install.json REPOSITORY
   4. Verify a repeat install without changing files: --dry-run --input install.json REPOSITORY
 
 All installed package assets are shared verbatim. Only the two release manifests
-are rendered from the caller-owned JSON input. Exit 0 means clean/success; a
+are rendered from the caller-owned complete JSON input. Exit 0 means clean/success; a
 dry-run returns 1 when consumer files would change.""",
     )
     parser.add_argument(
@@ -296,20 +425,11 @@ dry-run returns 1 when consumer files would change.""",
         metavar="REPOSITORY",
         help="consumer repository (default: current directory)",
     )
-    input_mode = parser.add_mutually_exclusive_group()
-    input_mode.add_argument(
+    parser.add_argument(
         "--input",
         type=Path,
         metavar="INSTALL.json",
-        help="required JSON file declaring release artifacts, explicit order, and channel activation",
-    )
-    input_mode.add_argument(
-        "--example-json",
-        nargs="?",
-        type=Path,
-        metavar="INSTALL.json",
-        const=Path("-"),
-        help="print or write a source-discovered starting JSON document and exit; never installs",
+        help="required complete JSON file declaring the release manifest contract",
     )
     if len(sys.argv) == 1:
         parser.print_help()
@@ -319,21 +439,8 @@ dry-run returns 1 when consumer files would change.""",
     consumer = args.consumer_repository.resolve()
     if not consumer.is_dir():
         parser.error(f"consumer repository does not exist: {consumer}")
-    if args.example_json is not None:
-        try:
-            example = f"{json.dumps(example_values(consumer), indent=2)}\n"
-            if args.example_json == Path("-"):
-                print(example, end="")
-            else:
-                if args.example_json.exists():
-                    parser.error(f"refusing to overwrite existing example input: {args.example_json}")
-                args.example_json.write_text(example, encoding="utf-8")
-                print(f"wrote reviewable install input: {args.example_json}")
-        except (OSError, subprocess.CalledProcessError, tomllib.TOMLDecodeError) as error:
-            parser.error(str(error))
-        return 0
     if args.input is None:
-        parser.error("--input is required for installation; use --example-json only to draft it")
+        parser.error("--input is required for installation")
     try:
         values = load_install_values(args.input)
     except argparse.ArgumentTypeError as error:

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -13,25 +13,20 @@ renderer_archive_path = "bin/atm"
 target = "x86_64-unknown-linux-gnu"
 os = "ubuntu-latest"
 archive = "tar.gz"
-
 [[release_targets]]
 target = "x86_64-apple-darwin"
 os = "macos-latest"
 archive = "tar.gz"
-
 [[release_targets]]
 target = "aarch64-apple-darwin"
 os = "macos-latest"
 archive = "tar.gz"
-
 [[release_targets]]
 target = "x86_64-pc-windows-msvc"
 os = "windows-latest"
 archive = "zip"
 
 [[crates]]
-# This Maturin package is published to PyPI as `atm-graft`, not to crates.io.
-# Keep it in the release inventory so validation cannot silently omit it.
 artifact = "atm-graft-python"
 package = "atm-graft-python"
 cargo_toml = "crates/atm-graft-python/Cargo.toml"
@@ -41,10 +36,7 @@ publish_order = 0
 preflight_check = "locked"
 wait_after_publish_seconds = 0
 verify_install = true
-
 [[crates]]
-# This Maturin package is published to PyPI as `atm-query`, not to crates.io.
-# Keep it in the release inventory so validation cannot silently omit it.
 artifact = "atm-query-python"
 package = "atm-query-python"
 cargo_toml = "crates/atm-query-python/Cargo.toml"
@@ -54,7 +46,6 @@ publish_order = 0
 preflight_check = "locked"
 wait_after_publish_seconds = 0
 verify_install = true
-
 [[crates]]
 artifact = "atm-error"
 package = "atm-error"
@@ -65,7 +56,6 @@ publish_order = 1
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-storage"
 package = "atm-storage"
@@ -76,7 +66,6 @@ publish_order = 2
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "agent-team-mail-core"
 package = "agent-team-mail-core"
@@ -87,7 +76,6 @@ publish_order = 3
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-storage-rusqlite"
 package = "atm-storage-rusqlite"
@@ -98,7 +86,6 @@ publish_order = 4
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-http-runtime"
 package = "atm-http-runtime"
@@ -109,7 +96,6 @@ publish_order = 5
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-daemon-client"
 package = "atm-daemon-client"
@@ -120,7 +106,6 @@ publish_order = 6
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-runtime"
 package = "atm-runtime"
@@ -131,7 +116,6 @@ publish_order = 7
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-template-sc-compose"
 package = "atm-template-sc-compose"
@@ -142,7 +126,6 @@ publish_order = 8
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-daemon-bootstrap"
 package = "atm-daemon-bootstrap"
@@ -153,7 +136,6 @@ publish_order = 9
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-daemon"
 package = "atm-daemon"
@@ -164,7 +146,6 @@ publish_order = 10
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "atm-graft"
 package = "atm-graft"
@@ -175,7 +156,6 @@ publish_order = 11
 preflight_check = "locked"
 wait_after_publish_seconds = 30
 verify_install = false
-
 [[crates]]
 artifact = "agent-team-mail"
 package = "agent-team-mail"
@@ -190,7 +170,6 @@ verify_install = true
 [[release_binaries]]
 name = "atm"
 bundled_paths = [{ source = "docs/user-documents", destination = "share/doc/atm", homebrew_destination_components = ["pkgshare"] }]
-
 [[release_binaries]]
 name = "atm-daemon"
 
@@ -205,14 +184,12 @@ package = "atm-graft"
 manifest = "crates/atm-graft-python/pyproject.toml"
 module = "atm_graft"
 publish = "pypi"
-
 [[python_packages]]
 artifact = "atm-query-wheel"
 package = "atm-query"
 manifest = "crates/atm-query-python/pyproject.toml"
 module = "atm_query"
 publish = "pypi"
-
 [[python_packages]]
 artifact = "hermes-atm"
 package = "hermes-atm"
@@ -227,7 +204,6 @@ cargo_manifest = "crates/atm-graft-python/Cargo.toml"
 module_path = "crates/atm-graft-python/python/atm_graft"
 sdist = true
 wheels = ["ubuntu-latest", "macos-latest", "windows-latest"]
-
 [[python_distributions]]
 name = "atm-query"
 source = "crates/atm-query-python"
@@ -235,7 +211,6 @@ cargo_manifest = "crates/atm-query-python/Cargo.toml"
 module_path = "crates/atm-query-python"
 sdist = true
 wheels = ["ubuntu-latest", "macos-latest", "windows-latest"]
-
 [[python_distributions]]
 name = "hermes-atm"
 source = "crates/hermes-atm"
@@ -253,7 +228,7 @@ production_repository = "pypi"
 
 [channels.homebrew]
 workflow = "homebrew-publish.yml"
-dispatch_inputs = {}
+dispatch_inputs = {  }
 tap_repository = "randlee/homebrew-tap"
 renderer_target = "x86_64-unknown-linux-gnu"
 
@@ -265,7 +240,6 @@ binaries = ["atm", "atm-daemon"]
 test_command = "--help"
 test_output = "CLI for local agent team mail workflows"
 release_track = "stable"
-
 [[channels.homebrew.formulas]]
 path = "Formula/atm.rb"
 template = "release/homebrew/formula.rb.j2"
@@ -274,7 +248,6 @@ binaries = ["atm", "atm-daemon"]
 test_command = "--help"
 test_output = "CLI for local agent team mail workflows"
 release_track = "stable"
-
 [[channels.homebrew.formulas]]
 path = "Formula/atm-beta.rb"
 template = "release/homebrew/formula.rb.j2"
@@ -287,24 +260,22 @@ release_track = "prerelease"
 [[channels.homebrew.assets]]
 key = "macos_arm"
 target = "aarch64-apple-darwin"
-
 [[channels.homebrew.assets]]
 key = "macos_intel"
 target = "x86_64-apple-darwin"
-
 [[channels.homebrew.assets]]
 key = "linux"
 target = "x86_64-unknown-linux-gnu"
 
 [channels.winget]
 workflow = "winget-publish.yml"
-dispatch_inputs = {}
+dispatch_inputs = {  }
 identifier = "randlee.agent-team-mail"
 installer_target = "x86_64-pc-windows-msvc"
 
 [channels.scoop]
 workflow = "scoop-publish.yml"
-dispatch_inputs = {}
+dispatch_inputs = {  }
 bucket_repository = "randlee/scoop-bucket"
 manifest_path = "bucket/atm.json"
 manifest_template = "release/scoop/manifest.json.j2"

--- a/release/publish-artifacts.toml.j2
+++ b/release/publish-artifacts.toml.j2
@@ -1,76 +1,168 @@
 ---
 name: publish-artifacts
 version: 0.1.0
-description: Render a repository-specific release-artifact manifest.
+description: Render a complete repository-specific release-artifact manifest.
 format: toml
 required_variables:
-  - release.version_source
-  - release.tag_prefix
-  - artifacts.crates
-  - artifacts.crates.artifact
-  - artifacts.crates.package
-  - artifacts.crates.cargo_toml
-  - artifacts.crates.required
-  - artifacts.crates.publish
-  - artifacts.crates.publish_order
-  - artifacts.crates.preflight_check
-  - artifacts.crates.wait_after_publish_seconds
-  - artifacts.crates.verify_install
-  - artifacts.wheels
-  - artifacts.wheels.package
-  - artifacts.wheels.python_package
-  - artifacts.binaries
-  - channels.github_release.enabled
-  - channels.crates_io.enabled
-  - channels.pypi.enabled
+  - schema_version
+  - project.name
+  - project.archive_prefix
+  - project.description
+  - project.homepage
+  - project.license
+  - project.readme_dependency_crate
+  - project.renderer_archive_path
+  - release_targets
+  - crates
+  - release_binaries
+  - installed_docs.source_root
+  - installed_docs.install_root
+  - installed_docs.entrypoint
+  - python_packages
+  - python_distributions
   - channels.pypi.workflow
-  - channels.homebrew.enabled
-  - channels.scoop.enabled
-  - channels.winget.enabled
+  - channels.pypi.dispatch_inputs
+  - channels.pypi.credential_rehearsal_inputs
+  - channels.pypi.test_repository
+  - channels.pypi.production_repository
+  - channels.homebrew.workflow
+  - channels.homebrew.dispatch_inputs
+  - channels.homebrew.tap_repository
+  - channels.homebrew.renderer_target
+  - channels.homebrew.formulas
+  - channels.homebrew.assets
+  - channels.scoop.workflow
+  - channels.scoop.dispatch_inputs
+  - channels.scoop.bucket_repository
+  - channels.scoop.manifest_path
+  - channels.scoop.manifest_template
+  - channels.scoop.installer_target
+  - channels.scoop.binary
+  - channels.scoop.renderer_target
+  - channels.winget.workflow
+  - channels.winget.dispatch_inputs
+  - channels.winget.identifier
+  - channels.winget.installer_target
+  - has_readme_dependency_crate
+  - has_renderer_archive_path
+  - has_installed_docs
 ---
-[release]
-version_source = "{{ release.version_source }}"
-tag_prefix = "{{ release.tag_prefix }}"
+schema_version = {{ schema_version }}
 
-{% for crate in artifacts.crates %}
+[project]
+name = {{ project.name }}
+archive_prefix = {{ project.archive_prefix }}
+description = {{ project.description }}
+homepage = {{ project.homepage }}
+license = {{ project.license }}
+{% if has_readme_dependency_crate %}
+readme_dependency_crate = {{ project.readme_dependency_crate }}
+{% endif %}
+{% if has_renderer_archive_path %}
+renderer_archive_path = {{ project.renderer_archive_path }}
+{% endif %}
+
+{% for target in release_targets %}
+[[release_targets]]
+target = {{ target.target }}
+os = {{ target.os }}
+archive = {{ target.archive }}
+{% endfor %}
+
+{% for crate in crates %}
 [[crates]]
-artifact = "{{ crate.artifact }}"
-package = "{{ crate.package }}"
-cargo_toml = "{{ crate.cargo_toml }}"
+artifact = {{ crate.artifact }}
+package = {{ crate.package }}
+cargo_toml = {{ crate.cargo_toml }}
 required = {{ crate.required }}
 publish = {{ crate.publish }}
 publish_order = {{ crate.publish_order }}
-preflight_check = "{{ crate.preflight_check }}"
+preflight_check = {{ crate.preflight_check }}
 wait_after_publish_seconds = {{ crate.wait_after_publish_seconds }}
 verify_install = {{ crate.verify_install }}
 {% endfor %}
 
-{% for wheel in artifacts.wheels %}
-[[artifacts.wheels]]
-package = "{{ wheel.package }}"
-python_package = "{{ wheel.python_package }}"
-{% endfor %}
-
-{% for binary in artifacts.binaries %}
+{% for binary in release_binaries %}
 [[release_binaries]]
-name = "{{ binary }}"
+name = {{ binary.name }}
+{% if binary.has_bundled_paths %}
+bundled_paths = {{ binary.bundled_paths }}
+{% endif %}
 {% endfor %}
 
-[channels.github_release]
-enabled = {{ channels.github_release.enabled }}
+{% if has_installed_docs %}
+[installed_docs]
+source_root = {{ installed_docs.source_root }}
+install_root = {{ installed_docs.install_root }}
+entrypoint = {{ installed_docs.entrypoint }}
+{% endif %}
 
-[channels.crates_io]
-enabled = {{ channels.crates_io.enabled }}
+{% for package in python_packages %}
+[[python_packages]]
+artifact = {{ package.artifact }}
+package = {{ package.package }}
+manifest = {{ package.manifest }}
+module = {{ package.module }}
+publish = {{ package.publish }}
+{% endfor %}
+
+{% for distribution in python_distributions %}
+[[python_distributions]]
+name = {{ distribution.name }}
+source = {{ distribution.source }}
+{% if distribution.cargo_manifest %}
+cargo_manifest = {{ distribution.cargo_manifest }}
+{% endif %}
+{% if distribution.build_system %}
+build_system = {{ distribution.build_system }}
+{% endif %}
+module_path = {{ distribution.module_path }}
+sdist = {{ distribution.sdist }}
+wheels = {{ distribution.wheels }}
+{% endfor %}
 
 [channels.pypi]
-enabled = {{ channels.pypi.enabled }}
-workflow = "{{ channels.pypi.workflow }}"
+workflow = {{ channels.pypi.workflow }}
+dispatch_inputs = {{ channels.pypi.dispatch_inputs }}
+credential_rehearsal_inputs = {{ channels.pypi.credential_rehearsal_inputs }}
+test_repository = {{ channels.pypi.test_repository }}
+production_repository = {{ channels.pypi.production_repository }}
 
 [channels.homebrew]
-enabled = {{ channels.homebrew.enabled }}
+workflow = {{ channels.homebrew.workflow }}
+dispatch_inputs = {{ channels.homebrew.dispatch_inputs }}
+tap_repository = {{ channels.homebrew.tap_repository }}
+renderer_target = {{ channels.homebrew.renderer_target }}
 
-[channels.scoop]
-enabled = {{ channels.scoop.enabled }}
+{% for formula in channels.homebrew.formulas %}
+[[channels.homebrew.formulas]]
+path = {{ formula.path }}
+template = {{ formula.template }}
+class = {{ formula.class }}
+binaries = {{ formula.binaries }}
+test_command = {{ formula.test_command }}
+test_output = {{ formula.test_output }}
+release_track = {{ formula.release_track }}
+{% endfor %}
+
+{% for asset in channels.homebrew.assets %}
+[[channels.homebrew.assets]]
+key = {{ asset.key }}
+target = {{ asset.target }}
+{% endfor %}
 
 [channels.winget]
-enabled = {{ channels.winget.enabled }}
+workflow = {{ channels.winget.workflow }}
+dispatch_inputs = {{ channels.winget.dispatch_inputs }}
+identifier = {{ channels.winget.identifier }}
+installer_target = {{ channels.winget.installer_target }}
+
+[channels.scoop]
+workflow = {{ channels.scoop.workflow }}
+dispatch_inputs = {{ channels.scoop.dispatch_inputs }}
+bucket_repository = {{ channels.scoop.bucket_repository }}
+manifest_path = {{ channels.scoop.manifest_path }}
+manifest_template = {{ channels.scoop.manifest_template }}
+installer_target = {{ channels.scoop.installer_target }}
+binary = {{ channels.scoop.binary }}
+renderer_target = {{ channels.scoop.renderer_target }}

--- a/release/sc-publish-consumer-input.json
+++ b/release/sc-publish-consumer-input.json
@@ -1,0 +1,360 @@
+{
+  "schema_version": 1,
+  "project": {
+    "name": "agent-team-mail",
+    "archive_prefix": "atm",
+    "description": "CLI for local agent team mail workflows",
+    "homepage": "https://github.com/randlee/atm-core",
+    "license": "MIT OR Apache-2.0",
+    "readme_dependency_crate": "agent-team-mail-core",
+    "renderer_archive_path": "bin/atm"
+  },
+  "release_targets": [
+    {
+      "target": "x86_64-unknown-linux-gnu",
+      "os": "ubuntu-latest",
+      "archive": "tar.gz"
+    },
+    {
+      "target": "x86_64-apple-darwin",
+      "os": "macos-latest",
+      "archive": "tar.gz"
+    },
+    {
+      "target": "aarch64-apple-darwin",
+      "os": "macos-latest",
+      "archive": "tar.gz"
+    },
+    {
+      "target": "x86_64-pc-windows-msvc",
+      "os": "windows-latest",
+      "archive": "zip"
+    }
+  ],
+  "crates": [
+    {
+      "artifact": "atm-graft-python",
+      "package": "atm-graft-python",
+      "cargo_toml": "crates/atm-graft-python/Cargo.toml",
+      "required": true,
+      "publish": false,
+      "publish_order": 0,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 0,
+      "verify_install": true
+    },
+    {
+      "artifact": "atm-query-python",
+      "package": "atm-query-python",
+      "cargo_toml": "crates/atm-query-python/Cargo.toml",
+      "required": true,
+      "publish": false,
+      "publish_order": 0,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 0,
+      "verify_install": true
+    },
+    {
+      "artifact": "atm-error",
+      "package": "atm-error",
+      "cargo_toml": "crates/atm-error/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 1,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-storage",
+      "package": "atm-storage",
+      "cargo_toml": "crates/atm-storage/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 2,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "agent-team-mail-core",
+      "package": "agent-team-mail-core",
+      "cargo_toml": "crates/atm-core/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 3,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-storage-rusqlite",
+      "package": "atm-storage-rusqlite",
+      "cargo_toml": "crates/atm-storage-rusqlite/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 4,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-http-runtime",
+      "package": "atm-http-runtime",
+      "cargo_toml": "crates/atm-http-runtime/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 5,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-daemon-client",
+      "package": "atm-daemon-client",
+      "cargo_toml": "crates/atm-daemon-client/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 6,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-runtime",
+      "package": "atm-runtime",
+      "cargo_toml": "crates/atm-runtime/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 7,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-template-sc-compose",
+      "package": "atm-template-sc-compose",
+      "cargo_toml": "crates/atm-template-sc-compose/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 8,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-daemon-bootstrap",
+      "package": "atm-daemon-bootstrap",
+      "cargo_toml": "crates/atm-daemon-bootstrap/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 9,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-daemon",
+      "package": "atm-daemon",
+      "cargo_toml": "crates/atm-daemon/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 10,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "atm-graft",
+      "package": "atm-graft",
+      "cargo_toml": "crates/atm-graft/Cargo.toml",
+      "required": false,
+      "publish": true,
+      "publish_order": 11,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 30,
+      "verify_install": false
+    },
+    {
+      "artifact": "agent-team-mail",
+      "package": "agent-team-mail",
+      "cargo_toml": "crates/atm/Cargo.toml",
+      "required": true,
+      "publish": true,
+      "publish_order": 12,
+      "preflight_check": "locked",
+      "wait_after_publish_seconds": 0,
+      "verify_install": true
+    }
+  ],
+  "release_binaries": [
+    {
+      "name": "atm",
+      "bundled_paths": [
+        {
+          "source": "docs/user-documents",
+          "destination": "share/doc/atm",
+          "homebrew_destination_components": [
+            "pkgshare"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "atm-daemon"
+    }
+  ],
+  "installed_docs": {
+    "source_root": "docs/user-documents",
+    "install_root": "share/doc/atm",
+    "entrypoint": "share/doc/atm/README.md"
+  },
+  "python_packages": [
+    {
+      "artifact": "atm-graft-wheel",
+      "package": "atm-graft",
+      "manifest": "crates/atm-graft-python/pyproject.toml",
+      "module": "atm_graft",
+      "publish": "pypi"
+    },
+    {
+      "artifact": "atm-query-wheel",
+      "package": "atm-query",
+      "manifest": "crates/atm-query-python/pyproject.toml",
+      "module": "atm_query",
+      "publish": "pypi"
+    },
+    {
+      "artifact": "hermes-atm",
+      "package": "hermes-atm",
+      "manifest": "crates/hermes-atm/pyproject.toml",
+      "module": "hermes_atm",
+      "publish": "pypi"
+    }
+  ],
+  "python_distributions": [
+    {
+      "name": "atm-graft",
+      "source": "crates/atm-graft-python",
+      "cargo_manifest": "crates/atm-graft-python/Cargo.toml",
+      "module_path": "crates/atm-graft-python/python/atm_graft",
+      "sdist": true,
+      "wheels": [
+        "ubuntu-latest",
+        "macos-latest",
+        "windows-latest"
+      ]
+    },
+    {
+      "name": "atm-query",
+      "source": "crates/atm-query-python",
+      "cargo_manifest": "crates/atm-query-python/Cargo.toml",
+      "module_path": "crates/atm-query-python",
+      "sdist": true,
+      "wheels": [
+        "ubuntu-latest",
+        "macos-latest",
+        "windows-latest"
+      ]
+    },
+    {
+      "name": "hermes-atm",
+      "source": "crates/hermes-atm",
+      "build_system": "setuptools",
+      "module_path": "crates/hermes-atm/src/hermes_atm",
+      "sdist": true,
+      "wheels": [
+        "ubuntu-latest",
+        "macos-latest",
+        "windows-latest"
+      ]
+    }
+  ],
+  "channels": {
+    "pypi": {
+      "workflow": "pypi-publish.yml",
+      "dispatch_inputs": {
+        "target": "production"
+      },
+      "credential_rehearsal_inputs": {
+        "target": "testpypi"
+      },
+      "test_repository": "testpypi",
+      "production_repository": "pypi"
+    },
+    "homebrew": {
+      "workflow": "homebrew-publish.yml",
+      "dispatch_inputs": {},
+      "tap_repository": "randlee/homebrew-tap",
+      "renderer_target": "x86_64-unknown-linux-gnu",
+      "formulas": [
+        {
+          "path": "Formula/agent-team-mail.rb",
+          "template": "release/homebrew/formula.rb.j2",
+          "class": "AgentTeamMail",
+          "binaries": [
+            "atm",
+            "atm-daemon"
+          ],
+          "test_command": "--help",
+          "test_output": "CLI for local agent team mail workflows",
+          "release_track": "stable"
+        },
+        {
+          "path": "Formula/atm.rb",
+          "template": "release/homebrew/formula.rb.j2",
+          "class": "Atm",
+          "binaries": [
+            "atm",
+            "atm-daemon"
+          ],
+          "test_command": "--help",
+          "test_output": "CLI for local agent team mail workflows",
+          "release_track": "stable"
+        },
+        {
+          "path": "Formula/atm-beta.rb",
+          "template": "release/homebrew/formula.rb.j2",
+          "class": "AtmBeta",
+          "binaries": [
+            "atm",
+            "atm-daemon"
+          ],
+          "test_command": "--help",
+          "test_output": "CLI for local agent team mail workflows",
+          "release_track": "prerelease"
+        }
+      ],
+      "assets": [
+        {
+          "key": "macos_arm",
+          "target": "aarch64-apple-darwin"
+        },
+        {
+          "key": "macos_intel",
+          "target": "x86_64-apple-darwin"
+        },
+        {
+          "key": "linux",
+          "target": "x86_64-unknown-linux-gnu"
+        }
+      ]
+    },
+    "winget": {
+      "workflow": "winget-publish.yml",
+      "dispatch_inputs": {},
+      "identifier": "randlee.agent-team-mail",
+      "installer_target": "x86_64-pc-windows-msvc"
+    },
+    "scoop": {
+      "workflow": "scoop-publish.yml",
+      "dispatch_inputs": {},
+      "bucket_repository": "randlee/scoop-bucket",
+      "manifest_path": "bucket/atm.json",
+      "manifest_template": "release/scoop/manifest.json.j2",
+      "installer_target": "x86_64-pc-windows-msvc",
+      "binary": "bin/atm.exe",
+      "renderer_target": "x86_64-unknown-linux-gnu"
+    }
+  }
+}


### PR DESCRIPTION
AS.3 proof: installs the exact sc-publish branch overlay into an isolated ATM worktree; renders the complete manifest from the consumer input; confirms installer idempotence with dry-run; just lint and just test pass locally. Release Preflight: https://github.com/randlee/atm-core/actions/runs/32159872873. Shared publish-kit files are copied without local modifications.