### PR TITLE
docs(as4): record blocked PyPI publication receipt

### DIFF
--- a/.claude/lib/sc_compose_dependency.py
+++ b/.claude/lib/sc_compose_dependency.py
@@ -6,6 +6,7 @@ import re
 
 
 SC_COMPOSE_SOURCE_REV = "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661"
+SC_COMPOSE_PARITY_SOURCE_REV = "113729e60e3409ad8c651a74956ffa5c167dd1b6"
 MIN_SC_COMPOSE = (1, 4, 0)
 MIN_SC_COMPOSE_TEXT = (
     ">= 1.4.0 (released v1.4.0 source revision "
@@ -16,6 +17,10 @@ MIN_SC_COMPOSE_BINDING_TEXT = ">= 1.2.0"
 SC_COMPOSE_INSTALL = (
     "cargo install --git https://github.com/randlee/sc-compose.git "
     f"--rev {SC_COMPOSE_SOURCE_REV} --locked --bin sc-compose"
+)
+SC_COMPOSE_PARITY_INSTALL = (
+    "cargo install --git https://github.com/randlee/sc-compose.git "
+    f"--rev {SC_COMPOSE_PARITY_SOURCE_REV} --locked --bin sc-compose"
 )
 SC_COMPOSE_BINDING_INSTALL = (
     "python3 -m pip install --user --break-system-packages "

--- a/.github/actions/setup-lint-toolchain/action.yml
+++ b/.github/actions/setup-lint-toolchain/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Released sc-lint version to install
     required: false
     default: "0.4.0"
+  include-sc-lint:
+    description: Install the externally released sc-lint bundle
+    required: false
+    default: "true"
   cargo-deny-version:
     description: Pinned cargo-deny version
     required: false
@@ -21,6 +25,7 @@ runs:
   using: composite
   steps:
     - name: Set up sc-lint
+      if: inputs.include-sc-lint == 'true'
       uses: ./.github/actions/setup-sc-lint
       with:
         version: ${{ inputs.sc-lint-version }}

--- a/.github/scripts/check_boundary_lint_status.py
+++ b/.github/scripts/check_boundary_lint_status.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Translate a sc-lint-boundary JSON report into a process exit status."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_boundary_lint_status.py <report.json>", file=sys.stderr)
+        return 2
+
+    report_path = Path(argv[1])
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"failed to read boundary-lint report {report_path}: {error}", file=sys.stderr)
+        return 2
+
+    status = report.get("status") if isinstance(report, dict) else None
+    if status == "pass":
+        return 0
+    if status == "fail":
+        return 1
+
+    print(
+        f"boundary-lint report {report_path} has invalid status: {status!r}",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the repository-pinned sc-compose CLI for parity tests."""
+"""Install the repository-pinned sc-compose CLI for release-preflight tests."""
 
 from __future__ import annotations
 

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Install the repository-pinned sc-compose CLI for parity tests."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPOSITORY_ROOT / ".claude"))
+
+from lib.sc_compose_dependency import SC_COMPOSE_INSTALL  # noqa: E402
+
+
+def main() -> int:
+    return subprocess.run(shlex.split(SC_COMPOSE_INSTALL), check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the repository-pinned sc-compose CLI for release-preflight tests."""
+"""Install the repository-pinned sc-compose CLI for passthrough parity tests."""
 
 from __future__ import annotations
 
@@ -12,11 +12,11 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPOSITORY_ROOT / ".claude"))
 
-from lib.sc_compose_dependency import SC_COMPOSE_INSTALL  # noqa: E402
+from lib.sc_compose_dependency import SC_COMPOSE_PARITY_INSTALL  # noqa: E402
 
 
 def main() -> int:
-    return subprocess.run(shlex.split(SC_COMPOSE_INSTALL), check=False).returncode
+    return subprocess.run(shlex.split(SC_COMPOSE_PARITY_INSTALL), check=False).returncode
 
 
 if __name__ == "__main__":

--- a/.github/scripts/release_python_receipt.py
+++ b/.github/scripts/release_python_receipt.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Emit a source-bound SHA-256 receipt for manifest-selected Python assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+import zipfile
+from email import message_from_bytes
+from pathlib import Path
+
+from release_manifest import load_manifest
+
+
+def distribution_metadata(path: Path) -> tuple[str, str]:
+    """Read the normalized distribution name and version from one artifact."""
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(members) != 1:
+                raise SystemExit(f"{path}: expected exactly one wheel METADATA file")
+            metadata = message_from_bytes(archive.read(members[0]))
+    elif path.name.endswith(".tar.gz"):
+        with tarfile.open(path, "r:gz") as archive:
+            members = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+            if len(members) != 1:
+                raise SystemExit(f"{path}: expected exactly one sdist PKG-INFO file")
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise SystemExit(f"{path}: unable to read sdist PKG-INFO")
+            metadata = message_from_bytes(extracted.read())
+    else:
+        raise SystemExit(f"{path}: unsupported Python artifact")
+    name, version = metadata.get("Name"), metadata.get("Version")
+    if not name or not version:
+        raise SystemExit(f"{path}: package metadata must provide Name and Version")
+    return name, version
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_receipt(manifest_path: Path, asset_dir: Path, version: str, source_commit: str) -> dict[str, object]:
+    manifest = load_manifest(manifest_path)
+    expected = {
+        entry["name"]: {"wheel": len(entry["wheels"]), "sdist": int(entry["sdist"])}
+        for entry in manifest["python_distributions"]
+    }
+    if not expected:
+        raise SystemExit("manifest must define [[python_distributions]]")
+    found = {name: {"wheel": 0, "sdist": 0} for name in expected}
+    artifacts: list[dict[str, str]] = []
+    for path in sorted(asset_dir.iterdir()):
+        if not path.is_file() or (path.suffix != ".whl" and not path.name.endswith(".tar.gz")):
+            continue
+        name, actual_version = distribution_metadata(path)
+        if name not in expected:
+            raise SystemExit(f"{path}: unexpected Python distribution {name!r}")
+        if actual_version != version:
+            raise SystemExit(f"{path}: expected version {version}, found {actual_version}")
+        found[name]["wheel" if path.suffix == ".whl" else "sdist"] += 1
+        artifacts.append({"filename": path.name, "package": name, "sha256": sha256(path)})
+    if not artifacts:
+        raise SystemExit(f"no Python artifacts found in {asset_dir}")
+    if found != expected:
+        raise SystemExit(f"Python artifact set mismatch: expected {expected}, found {found}")
+    return {
+        "source_commit": source_commit,
+        "manifest_sha256": sha256(manifest_path),
+        "version": version,
+        "artifacts": artifacts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--asset-dir", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    receipt = create_receipt(args.manifest, args.asset_dir, args.version, args.source_commit)
+    args.output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_check_boundary_lint_status.py
+++ b/.github/scripts/tests/test_check_boundary_lint_status.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "check_boundary_lint_status.py"
+)
+
+
+def run_status_check(report_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(report_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_boundary_lint_status_check_passes_only_a_pass_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(json.dumps({"status": "pass", "findings": []}), encoding="utf-8")
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 0
+
+
+def test_boundary_lint_status_check_fails_a_report_with_findings(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(
+        json.dumps({"status": "fail", "findings": [{"rule_id": "SCB-CYCLE-001"}]}),
+        encoding="utf-8",
+    )
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 1
+
+
+def test_boundary_lint_status_check_rejects_a_malformed_status(tmp_path: Path) -> None:
+    report_path = tmp_path / "boundary-lint.json"
+    report_path.write_text(json.dumps({"status": "unknown"}), encoding="utf-8")
+
+    result = run_status_check(report_path)
+
+    assert result.returncode == 2
+    assert "invalid status" in result.stderr

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1171,6 +1171,8 @@ def test_release_workflow_enforces_python_release_invariants() -> None:
     assert "release_tag: ${{ inputs.tag }}" in pypi_text
     assert "gh release download" in pypi_text
     assert "verify-python-release-assets" in pypi_text
+    assert "release_python_receipt.py" in pypi_text
+    assert "pypi-release-receipt-${{ inputs.tag }}" in pypi_text
     assert "maturin build" not in pypi_text
     assert "maturin sdist" not in pypi_text
     assert "name: Publish manifest-declared wheels and sdists to TestPyPI" in pypi_text

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1651,6 +1651,19 @@ def test_release_preflight_collects_independent_failures_before_denial() -> None
     assert "REGISTRY_STATE" in preflight_text
 
 
+def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
+    preflight_text = release_preflight_workflow_text()
+    toolchain_text = (
+        repo_root() / ".github" / "actions" / "setup-lint-toolchain" / "action.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'include-sc-lint: "false"' in preflight_text
+    assert "cargo run -p sc-lint-boundary --release -- analyze --root . --format json" in preflight_text
+    assert "BOUNDARY_LINT" in preflight_text
+    assert "include-sc-lint:" in toolchain_text
+    assert "if: inputs.include-sc-lint == 'true'" in toolchain_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1661,6 +1661,8 @@ def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
 
     assert 'include-sc-lint: "false"' in preflight_text
     assert "cargo run -p sc-lint-boundary --release -- analyze --root . --format json" in preflight_text
+    assert "> boundary-lint.json" in preflight_text
+    assert "python3 .github/scripts/check_boundary_lint_status.py boundary-lint.json" in preflight_text
     assert "BOUNDARY_LINT" in preflight_text
     assert "include-sc-lint:" in toolchain_text
     assert "if: inputs.include-sc-lint == 'true'" in toolchain_text

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1682,6 +1682,13 @@ def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_t
     assert "sc_compose_dependency" in installer_text
 
 
+def test_release_preflight_denies_a_failed_sc_compose_cli_install() -> None:
+    preflight_text = release_preflight_workflow_text()
+
+    assert "SC_COMPOSE_CLI: ${{ steps.sc_compose_cli.outcome }}" in preflight_text
+    assert 'record sc-compose-cli "${SC_COMPOSE_CLI}"' in preflight_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1678,7 +1678,7 @@ def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_t
     workspace_tests = "run: cargo test --workspace"
     assert install_step in preflight_text
     assert preflight_text.index(install_step) < preflight_text.index(workspace_tests)
-    assert "SC_COMPOSE_INSTALL" in installer_text
+    assert "SC_COMPOSE_PARITY_INSTALL" in installer_text
     assert "sc_compose_dependency" in installer_text
 
 

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1668,6 +1668,20 @@ def test_release_preflight_uses_atm_workspace_boundary_analyzer() -> None:
     assert "if: inputs.include-sc-lint == 'true'" in toolchain_text
 
 
+def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_tests() -> None:
+    preflight_text = release_preflight_workflow_text()
+    installer_text = (
+        repo_root() / ".github" / "scripts" / "install_sc_compose_cli.py"
+    ).read_text(encoding="utf-8")
+
+    install_step = "python3 .github/scripts/install_sc_compose_cli.py"
+    workspace_tests = "run: cargo test --workspace"
+    assert install_step in preflight_text
+    assert preflight_text.index(install_step) < preflight_text.index(workspace_tests)
+    assert "SC_COMPOSE_INSTALL" in installer_text
+    assert "sc_compose_dependency" in installer_text
+
+
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:
     text = release_workflow_text()
 

--- a/.github/scripts/tests/test_release_python_receipt.py
+++ b/.github/scripts/tests/test_release_python_receipt.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / ".github" / "scripts"))
+from release_python_receipt import create_receipt  # noqa: E402
+
+
+def test_receipt_binds_source_manifest_version_and_checksums(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = true
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture-1.4.3-py3-none-any.whl", "w") as wheel:
+        wheel.writestr("fixture-1.4.3.dist-info/METADATA", "Name: fixture\nVersion: 1.4.3\n")
+    with tarfile.open(assets / "fixture-1.4.3.tar.gz", "w:gz") as sdist:
+        metadata = b"Name: fixture\nVersion: 1.4.3\n"
+        info = tarfile.TarInfo("fixture-1.4.3/PKG-INFO")
+        info.size = len(metadata)
+        sdist.addfile(info, io.BytesIO(metadata))
+
+    receipt = create_receipt(manifest, assets, "1.4.3", "a" * 40)
+
+    assert receipt["source_commit"] == "a" * 40
+    assert receipt["version"] == "1.4.3"
+    assert len(receipt["manifest_sha256"]) == 64
+    assert {item["filename"] for item in receipt["artifacts"]} == {
+        "fixture-1.4.3-py3-none-any.whl",
+        "fixture-1.4.3.tar.gz",
+    }
+
+
+def test_receipt_rejects_version_drift(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = false
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture.whl", "w") as wheel:
+        wheel.writestr("fixture.dist-info/METADATA", "Name: fixture\nVersion: 1.4.2\n")
+
+    with pytest.raises(SystemExit, match="expected version 1.4.3"):
+        create_receipt(manifest, assets, "1.4.3", "a" * 40)
+
+
+def test_receipt_rejects_incomplete_manifest_asset_set(tmp_path: Path) -> None:
+    manifest = tmp_path / "publish-artifacts.toml"
+    manifest.write_text(
+        """[[crates]]
+artifact = "fixture"
+package = "fixture"
+publish_order = 1
+
+[[python_distributions]]
+name = "fixture"
+sdist = true
+wheels = ["ubuntu-latest"]
+""",
+        encoding="utf-8",
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    with zipfile.ZipFile(assets / "fixture.whl", "w") as wheel:
+        wheel.writestr("fixture.dist-info/METADATA", "Name: fixture\nVersion: 1.4.3\n")
+
+    with pytest.raises(SystemExit, match="Python artifact set mismatch"):
+        create_receipt(manifest, assets, "1.4.3", "a" * 40)

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -74,6 +74,24 @@ jobs:
             --manifest release/publish-artifacts.toml \
             --asset-dir release-assets \
             --copy-to dist
+      - name: Record source-bound Python artifact receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.tag }}"
+          version="${version#v}"
+          python3 .github/scripts/release_python_receipt.py \
+            --manifest release/publish-artifacts.toml \
+            --asset-dir dist \
+            --version "${version}" \
+            --source-commit "$(git rev-parse HEAD)" \
+            --output pypi-release-receipt.json
+      - name: Store Python artifact receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-release-receipt-${{ inputs.tag }}
+          path: pypi-release-receipt.json
+          if-no-files-found: error
       - name: Select configured Python repository
         shell: bash
         env:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -393,6 +393,7 @@ jobs:
           BOUNDARY_LINT: ${{ steps.boundary_lint.outcome }}
           FORMATTING: ${{ steps.formatting.outcome }}
           CLIPPY: ${{ steps.clippy.outcome }}
+          SC_COMPOSE_CLI: ${{ steps.sc_compose_cli.outcome }}
           WORKSPACE_TESTS: ${{ steps.workspace_tests.outcome }}
           MANIFEST: ${{ steps.manifest.outcome }}
           PUBLISH_ORDER: ${{ steps.publish_order.outcome }}
@@ -425,6 +426,7 @@ jobs:
           record boundary-lint "${BOUNDARY_LINT}"
           record formatting "${FORMATTING}"
           record clippy "${CLIPPY}"
+          record sc-compose-cli "${SC_COMPOSE_CLI}"
           record workspace-tests "${WORKSPACE_TESTS}"
           record manifest "${MANIFEST}"
           record publish-order "${PUBLISH_ORDER}"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -159,12 +159,24 @@ jobs:
 
       - name: Set up lint toolchain
         uses: ./.github/actions/setup-lint-toolchain
+        with:
+          # Boundary inventory validation must use this checkout's analyzer.
+          # The externally released sc-lint bundle can lag ATM's owned schema.
+          include-sc-lint: "false"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.94.1
           components: rustfmt, clippy
+
+      - id: boundary_lint
+        name: Validate boundary inventory with workspace source
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo run -p sc-lint-boundary --release -- analyze --root . --format json
 
       - name: Normalize version input
         id: meta
@@ -372,6 +384,7 @@ jobs:
           CREDENTIAL_LIVENESS: ${{ steps.credential_liveness.outcome }}
           REGISTRY_STATE: ${{ steps.registry_state.outcome }}
           META: ${{ steps.meta.outcome }}
+          BOUNDARY_LINT: ${{ steps.boundary_lint.outcome }}
           FORMATTING: ${{ steps.formatting.outcome }}
           CLIPPY: ${{ steps.clippy.outcome }}
           WORKSPACE_TESTS: ${{ steps.workspace_tests.outcome }}
@@ -403,6 +416,7 @@ jobs:
           record credential-liveness "${CREDENTIAL_LIVENESS}"
           record registry-state "${REGISTRY_STATE}"
           record version-input "${META}"
+          record boundary-lint "${BOUNDARY_LINT}"
           record formatting "${FORMATTING}"
           record clippy "${CLIPPY}"
           record workspace-tests "${WORKSPACE_TESTS}"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -205,6 +205,11 @@ jobs:
         continue-on-error: true
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - id: sc_compose_cli
+        name: Install pinned sc-compose CLI for parity tests
+        continue-on-error: true
+        run: python3 .github/scripts/install_sc_compose_cli.py
+
       - id: workspace_tests
         name: Run workspace tests
         continue-on-error: true

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -176,7 +176,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo run -p sc-lint-boundary --release -- analyze --root . --format json
+          cargo run -p sc-lint-boundary --release -- analyze --root . --format json > boundary-lint.json
+          python3 .github/scripts/check_boundary_lint_status.py boundary-lint.json
 
       - name: Normalize version input
         id: meta

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.4.3
+PackageVersion: 1.4.4
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.3/atm_1.4.3_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.4/atm_1.4.4_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.4.3
+ManifestVersion: 1.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.4
+
+- prepare the first authorized production-PyPI cut for `hermes-atm` and
+  `atm-graft`, with the ADR-049 first-public-release disclosure and the
+  manifest-driven Python distribution contract; publication remains pending
+  explicit authorization
+- make release preflight install and gate the repository-pinned `sc-compose`
+  CLI before workspace parity tests, preventing a missing local executable
+  from being mistaken for a successful release check
+
 ## 1.4.3
 
 - recovery release: `v1.4.2` was abandoned as a release tag/GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -328,14 +328,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-attributes"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-error = { path = "../atm-error", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/bin/atm-daemon-benchmark.rs"
 required-features = ["benchmark-harness"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3" }
-atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4" }
+atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.4" }
 tokio.workspace = true
 fs4 = "0.13"
 serde_json.workspace = true

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
@@ -20,5 +20,5 @@ tracing = "0.1"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -17,8 +17,8 @@ sc-observability-types.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.4" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -5,7 +5,7 @@ name = "atm-graft-python"
 publish = false
 # Maturin consumes this crate's Cargo version as Python package metadata; keep
 # it equivalent to the workspace release while using PEP 440-compatible form.
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,12 +27,12 @@ abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.3" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-graft = { path = "../atm-graft", version = "1.4.4" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 pyo3 = "0.29"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-graft = { path = "../atm-graft", version = "1.4.3", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.4", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,14 +13,14 @@ homepage.workspace = true
 test-support = ["atm-core/test-utils"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.4" }
 async-trait.workspace = true
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
 tracing.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
@@ -29,8 +29,8 @@ ulid.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -12,8 +12,8 @@ homepage.workspace = true
 description = "Provisioning and bounded curl mTLS interoperability fixture for ATM."
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 rustls.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atm-query-python"
 # This local analyst binding is not part of the current public release surface.
 publish = false
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -24,9 +24,9 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4" }
 
 [dev-dependencies]
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3", features = ["test-support"] }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.3", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.4.4" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,8 +16,8 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Shared audited storage contract and canonical domain types for ATM."
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.3" }
+atm-error = { path = "../atm-error", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/atm-template-sc-compose/Cargo.toml
+++ b/crates/atm-template-sc-compose/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace = true
 name = "atm_template_sc_compose"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 sc-composer = "=1.4.1"
 sc-sha = "=1.4.1"
 serde_json.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,11 +33,11 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.3" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.3" }
-atm-storage = { path = "../atm-storage", version = "1.4.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.4" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.4" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4" }
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -53,8 +53,8 @@ async-trait.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.3", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.3", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.4", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -6,6 +6,11 @@ through the public `GatewayRunner.inject_internal_message(..., mode="queue")`
 API. It does not open an ATM database, select a Hermes adapter, or require any
 post-install source edits.
 
+> **First public PyPI release.** `hermes-atm` and its `atm-graft` dependency
+> begin public distribution at the project's existing 1.x workspace version.
+> Earlier 1.x development was internal rather than a missing public release
+> history; both packages remain version-locked to ATM's workspace release.
+
 ## Required settings
 
 Collect these values before installation. Keep the chat identifier in local

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.4.3"
+version = "1.4.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -120,6 +120,19 @@ PyPI path writes a source-commit, manifest-SHA-256, version, and per-artifact
 SHA-256 receipt before upload. No upstream `sc-lint` or `sc-publish` merge is
 required for those checks.
 
+**Boundary-lint triage (2026-08-18):** The workspace analyzer reports
+`status: fail` with 21 findings on both the AS.3 baseline commit
+`3f5f2db474dc66b34be38d60193ba259fe8e78e4` and this AS.4 branch: seven
+`SCB-CYCLE-001` multi-owner architectural cycles, nine `SCB-CYCLE-002`
+type/method self-loops, and five `SCB-CYCLE-003` trait-implementation
+self-loops. The seven multi-owner cycles are pre-existing hard failures under
+the analyzer's `finding_is_failure` policy; the self-loop categories are
+reported advisory findings. They are neither introduced by AS.4 nor accepted
+as clean, and AS.4 does not suppress or reclassify them. The preflight gate
+therefore captures the analyzer JSON and exits nonzero unless its status is
+`pass`, while retaining `continue-on-error` so the final receipt records the
+real boundary-lint failure rather than aborting all remaining evidence.
+
 The immutable tag also fails ADR-049's publication-disclosure prerequisite:
 neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
 states that this is the first public release and explains the internal 1.x

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -189,6 +189,19 @@ a new immutable release containing the ADR-049 disclosure and current release
 manifest, followed by the local AS.3 validation receipt and the PyPI-only
 channel. No rebuild or upload is authorized for the blocked v1.4.3 set.
 
+### 1.4.4 preflight re-runs
+
+The fresh `1.4.4` cut was prepared in `a22168eec` and the preflight workspace
+test bootstrap was added in `df54f34f7`. Release-preflight run
+[`32169019885`](https://github.com/randlee/atm-core/actions/runs/32169019885)
+was the first `1.4.4` attempt and exposed that `compose_passthrough` needs the
+`sc-compose` executable, not only Python bindings. Run
+[`32169985864`](https://github.com/randlee/atm-core/actions/runs/32169985864)
+re-ran after that pinned CLI bootstrap and passed the workspace checks; its
+remaining channel-only failure was the rejected `CARGO_REGISTRY_TOKEN` for
+crates.io. That credential decision remains pending Rand and does not
+authorize a PyPI upload.
+
 ### Draft v1.4.3 GitHub release note
 
 > **First public PyPI release:** `hermes-atm` and `atm-graft` begin public

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -6,7 +6,7 @@ phase: AS
 sprint: AS.4
 worktree: main immutable release assets; canonical publisher agents from AS worktree
 branch: main
-status: proposed
+status: blocked
 estimated_scope: one authorized production channel
 ```
 
@@ -95,3 +95,50 @@ python3 -m pip install --only-binary=:all: hermes-atm==1.4.3
 
 Existing target versions must be classified with PF-3 semantics; do not treat
 an already-published version as permission to rebuild or overwrite it.
+
+## Execution Receipt — 2026-08-18
+
+**Outcome: blocked before production upload.** The AS.4 forward branch is
+`feature/pas-s4-authorized-pypi-1.4.3`, stacked from AS.3 evidence commit
+`3f5f2db474dc66b34be38d60193ba259fe8e78e4`. The immutable release source is
+`main`/`v1.4.3` commit `fa6066468f8e638893bedd686244cffa2a43dbdf`.
+
+The prerequisite receipt is not acceptable: Release Preflight run
+[`32159872873`](https://github.com/randlee/atm-core/actions/runs/32159872873)
+failed because `sc-lint` 0.4.0 rejected ATM's `trait` boundary field. The
+sc-lint correction is awaiting merge in
+[randlee/sc-lint#115](https://github.com/randlee/sc-lint/pull/115), and the
+resolved-receipt workflow is awaiting merge in
+[randlee/sc-publish#25](https://github.com/randlee/sc-publish/pull/25).
+
+The immutable tag also fails ADR-049's publication-disclosure prerequisite:
+neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
+states that this is the first public release and explains the internal 1.x
+history. That cannot be corrected without a new immutable release; AS.4
+therefore must not upload these artifacts.
+
+At the time of this receipt, both public registry endpoints returned 404 for
+`hermes-atm` and `atm-graft`; no public PyPI artifacts exist. The prior
+workflow run [`32081875532`](https://github.com/randlee/atm-core/actions/runs/32081875532)
+successfully uploaded only to TestPyPI; its production-PyPI job was skipped.
+Its immutable staged artifact SHA-256 values were:
+
+- `hermes_atm-1.4.3-py3-none-any.whl` —
+  `041311b7806d43acd2326c6532076b614f6df9af930f6102d4c8485aa936b2f7`
+- `atm_graft-1.4.3.tar.gz` —
+  `c9d6f532d6606f9f1cbc90e8970e7817ce1444dc75e44906ed4ad5b688f880ab`
+- `atm_graft-1.4.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` —
+  `3344cabb6c1f0b1c02e9df0174b28dd72577021e92d784fc307dae693adfc26b`
+- `atm_graft-1.4.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` —
+  `11aa4d7059a94854d8acec11df2200359e660226176907397d3961464f0d7337`
+- `atm_graft-1.4.3-cp311-abi3-musllinux_1_2_x86_64.whl` —
+  `32b713a0cf4508dbffe2a865194c471e1836ec6d7a744938c1be7e7a64f9e83e`
+- `atm_graft-1.4.3-cp311-abi3-macosx_11_0_arm64.whl` —
+  `23da2aa35fef045c9899063d00495a384506d0ff995d4728d378962fb3b9aeac`
+- `atm_graft-1.4.3-cp311-abi3-win_amd64.whl` —
+  `f9963df87f5d4e04377583200e79227b8c1db9f22a507b37bff3de43c6e2112a`
+
+Required remediation: merge the two upstream fixes, create a new immutable
+release containing the ADR-049 disclosure, obtain a matching AS.3 receipt,
+and then run the PyPI-only channel against that release. No rebuild or upload
+is authorized for the blocked v1.4.3 set.

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -39,15 +39,23 @@ and workflow source are pinned to immutable `main`.
 
 ## Prerequisites
 
-- AS.3 evidence accepted.
+- **Amended 2026-08-18** (see phase [README](README.md) governing-boundaries
+  amendment): AS.3 evidence is atm-core's own preflight validation, run via
+  the workspace-source `sc-lint-boundary` crate directly rather than gated on
+  the externally-released `sc-lint` binary's schema catching up (sc-lint#115)
+  or on `sc-publish`'s upstream fail-closed receipt PR (sc-publish#25)
+  merging first. Neither upstream PR is a blocking dependency for this
+  sprint.
 - Exact immutable `main` commit/tag and manifest-matching 1.4.3 artifacts.
 - Human production authorization.
 - ADR-049’s first-public-release disclosure is present in the package README
-  and GitHub release notes before the PyPI action.
+  and GitHub release notes before the PyPI action — an atm-core-owned doc fix,
+  not blocked on anything upstream.
 
 ## Hard Dependencies
 
-- `AS.3`: `must_follow`; receipt digest must match.
+- `AS.3`: `must_follow`; receipt digest must match an atm-core-owned
+  validation receipt (not an external `sc-publish` receipt PR).
 - `AS.5`: `must_follow`; migration merge waits for publication proof.
 
 ## Non-Goals

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -111,13 +111,14 @@ an already-published version as permission to rebuild or overwrite it.
 `3f5f2db474dc66b34be38d60193ba259fe8e78e4`. The immutable release source is
 `main`/`v1.4.3` commit `fa6066468f8e638893bedd686244cffa2a43dbdf`.
 
-The prerequisite receipt is not acceptable: Release Preflight run
+Release Preflight run
 [`32159872873`](https://github.com/randlee/atm-core/actions/runs/32159872873)
-failed because `sc-lint` 0.4.0 rejected ATM's `trait` boundary field. The
-sc-lint correction is awaiting merge in
-[randlee/sc-lint#115](https://github.com/randlee/sc-lint/pull/115), and the
-resolved-receipt workflow is awaiting merge in
-[randlee/sc-publish#25](https://github.com/randlee/sc-publish/pull/25).
+failed because external `sc-lint` 0.4.0 rejected ATM's legitimate `trait`
+boundary field. This was superseded locally in AS.4: preflight now runs
+ATM's workspace-source `sc-lint-boundary` analyzer directly, and the local
+PyPI path writes a source-commit, manifest-SHA-256, version, and per-artifact
+SHA-256 receipt before upload. No upstream `sc-lint` or `sc-publish` merge is
+required for those checks.
 
 The immutable tag also fails ADR-049's publication-disclosure prerequisite:
 neither `crates/hermes-atm/README.md` nor the v1.4.3 GitHub release notes
@@ -146,7 +147,16 @@ Its immutable staged artifact SHA-256 values were:
 - `atm_graft-1.4.3-cp311-abi3-win_amd64.whl` —
   `f9963df87f5d4e04377583200e79227b8c1db9f22a507b37bff3de43c6e2112a`
 
-Required remediation: merge the two upstream fixes, create a new immutable
-release containing the ADR-049 disclosure, obtain a matching AS.3 receipt,
-and then run the PyPI-only channel against that release. No rebuild or upload
-is authorized for the blocked v1.4.3 set.
+The immutable v1.4.3 release manifest also predates the current
+`[[python_distributions]]` contract, so it cannot produce a contract-matching
+receipt through the current PyPI workflow. Required remediation is therefore
+a new immutable release containing the ADR-049 disclosure and current release
+manifest, followed by the local AS.3 validation receipt and the PyPI-only
+channel. No rebuild or upload is authorized for the blocked v1.4.3 set.
+
+### Draft v1.4.3 GitHub release note
+
+> **First public PyPI release:** `hermes-atm` and `atm-graft` begin public
+> distribution at ATM's existing 1.x workspace version. Earlier 1.x
+> development was internal, not a missing public release history; the Python
+> packages remain version-locked to the ATM workspace release.

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -1,4 +1,4 @@
-# AS.4 — Authorized PyPI 1.4.3 publication
+# AS.4 — Authorized PyPI 1.4.4 publication
 
 ```yaml
 plan_type: sprint_plan
@@ -12,14 +12,28 @@ estimated_scope: one authorized production channel
 
 ## Goal
 
-Publish only the already-built `1.4.3` Python artifacts from immutable `main`
-through the canonical PyPI channel and retain a public verification receipt.
+**Amended 2026-08-18** (Rand, direct decision): the already-built immutable
+`1.4.3` artifacts predate both the ADR-049 first-public-release disclosure
+and the current `[[python_distributions]]` manifest contract, and AS.4's
+original Non-Goals forbid rebuilding/retagging `1.4.3` to fix that. Rather
+than fold this into AS.6, AS.4 now cuts and publishes a fresh, minimal
+version — `1.4.4`, PyPI channel only — with the disclosure and current
+manifest baked in from the start. This keeps AS.4 as the narrow,
+low-risk proof that the PyPI channel actually works end-to-end, ahead of
+AS.6's larger multi-channel release. Publish only the newly built `1.4.4`
+Python artifacts through the canonical PyPI channel and retain a public
+verification receipt. AS.6 remains the full multi-channel release; it may
+target a later version, or complete the remaining (non-PyPI) channels for
+`1.4.4` if versions line up — that call is made when AS.6 is dispatched, not
+here.
 
 ## Scope Summary
 
-This is an authorized production operation, not a rebuild or full release.
-The canonical agents may be launched from the Phase AS branch, but artifacts
-and workflow source are pinned to immutable `main`.
+This is an authorized production operation. Unlike the original AS.4 design,
+it does include a version bump and a fresh build/tag — narrowly scoped to
+carrying the ADR-049 disclosure and the current manifest contract, PyPI
+channel only. It is still not a full multi-channel release; that remains
+AS.6's job. The canonical agents may be launched from the Phase AS branch.
 
 ## Governing Requirements
 
@@ -46,7 +60,8 @@ and workflow source are pinned to immutable `main`.
   or on `sc-publish`'s upstream fail-closed receipt PR (sc-publish#25)
   merging first. Neither upstream PR is a blocking dependency for this
   sprint.
-- Exact immutable `main` commit/tag and manifest-matching 1.4.3 artifacts.
+- A freshly built, tagged `1.4.4` on immutable `main` with the ADR-049
+  disclosure and current manifest contract, and manifest-matching artifacts.
 - Human production authorization.
 - ADR-049’s first-public-release disclosure is present in the package README
   and GitHub release notes before the PyPI action — an atm-core-owned doc fix,
@@ -60,7 +75,12 @@ and workflow source are pinned to immutable `main`.
 
 ## Non-Goals
 
-- Rebuilding artifacts, recreating tags, publishing crates, or version bumping.
+- Publishing crates, GitHub Release binaries, Homebrew, Scoop, winget, or any
+  channel other than PyPI.
+- Rebuilding or republishing the now-superseded `1.4.3` immutable artifacts;
+  they stay as-is, unpublished, superseded by `1.4.4`.
+- Any version bump or unrelated change beyond the single `1.4.4` bump needed
+  to carry the ADR-049 disclosure and current manifest contract.
 
 ## Sub-Tasks
 
@@ -75,12 +95,14 @@ and workflow source are pinned to immutable `main`.
 
 ## Split Recommendation
 
-Keep this one-channel release separate from AS.6’s full 1.4.4 release.
+Keep this one-channel `1.4.4` PyPI release separate from AS.6, which remains
+the full multi-channel release (a later version, or the remaining non-PyPI
+channels for `1.4.4` — decided when AS.6 is dispatched).
 
 ## Acceptance Criteria
 
 - Only the authorized PyPI channel ran.
-- Public PyPI exposes the approved 1.4.3 artifacts.
+- Public PyPI exposes the approved 1.4.4 artifacts.
 - Python 3.11–3.14 verification succeeds.
 - Receipts prove immutable source/artifact identity and public availability.
 - The ADR-049 first-public-release disclosure is visible in the published
@@ -91,7 +113,7 @@ Keep this one-channel release separate from AS.6’s full 1.4.4 release.
 ```bash
 python3 .github/scripts/release_artifacts.py verify-python-release-assets \
   --manifest release/publish-artifacts.toml --asset-dir dist
-python3 -m pip install --only-binary=:all: hermes-atm==1.4.3
+python3 -m pip install --only-binary=:all: hermes-atm==1.4.4
 ```
 
 ## Required Document Updates

--- a/docs/plans/phase-as/README.md
+++ b/docs/plans/phase-as/README.md
@@ -80,7 +80,7 @@ must not recreate the retired script or patch the package locally.
 | [AS.1](AS.1-overlay-contract.md) | Freeze and justify the exact upstream overlay. | in_progress |
 | [AS.2](AS.2-consumer-manifest-contract.md) | Justify ATM consumer data and raise upstream gaps. | must_follow AS.1 |
 | [AS.3](AS.3-worktree-preflight-proof.md) | Prove canonical preflight from the exact sync worktree. | must_follow AS.2 |
-| [AS.4](AS.4-authorized-pypi-1.4.3.md) | Publish the already-built 1.4.3 PyPI artifacts from immutable `main`. | must_follow AS.3 |
+| [AS.4](AS.4-authorized-pypi-1.4.3.md) | Cut and publish a fresh `1.4.4` PyPI-only release (ADR-049 disclosure + current manifest baked in; the already-built `1.4.3` artifacts predate both and cannot be republished as-is). | must_follow AS.3 |
 | [AS.5](AS.5-main-migration-merge.md) | Promote the verified migration from `develop` to `main`. | must_follow AS.3 and AS.4 |
 | [AS.6](AS.6-full-1.4.4-release.md) | Execute and verify the first full canonical release. | must_follow AS.5 |
 

--- a/docs/plans/phase-as/README.md
+++ b/docs/plans/phase-as/README.md
@@ -16,20 +16,42 @@ release flow without reintroducing toolchain or validation drift.
 
 ## Governing boundaries
 
-- `sc-publish` is the sole source of shared workflows, actions, scripts,
-  agent prompts, and tests. ATM installs them only through the canonical
-  package installer, byte-for-byte.
-- ATM owns only repository data in its release manifest and explicitly
-  namespaced, non-shared validation data.
-- A shared-file defect is an upstream `sc-publish` issue/PR, never an ATM
-  overlay patch.
-- Preflight and publish consume one resolved manifest, toolchain, and
-  validation receipt. `source_commit`, `manifest_sha256`, `toolchain_sha256`,
-  and `validation_sha256` must agree; a digest mismatch blocks publication,
-  records an upstream escalation, and requires a fresh matching preflight only
-  after the upstream correction is accepted.
+- **Amended 2026-08-18 (Rand, relayed via quality-mgr):** the boundaries below
+  as originally written pushed atm-core-specific publish correctness into
+  `sc-publish`'s generic schema, turning every atm-core release nuance
+  (dynamic Maturin versioning, non-crates.io-published bridge crates,
+  publish-order, fail-closed receipts) into an upstream schema-growth request
+  and a blocking wait. That is reversed as of AS.4 onward:
+  - Pre-publish validation — version consistency, manifest correctness
+    (including `publish_order` and non-published bridge crates), and
+    release-receipt correctness — is atm-core DATA and atm-core's own concern.
+    It is implemented and run directly in atm-core, by atm-core-owned
+    scripts/workflows, and is never gated on a `sc-publish` schema change
+    landing upstream first.
+  - `sc-publish`'s installer/generator may still render a thin starter/scaffold
+    manifest shape, but it does not validate or gate atm-core-specific
+    correctness — that overreach (e.g. rejecting `publish_order = 0` for
+    non-published bridge crates) is what made AS.2/AS.3 block on upstream in
+    the first place.
+  - `sc-publish` remains the right place only for mechanics that are actually
+    generic across its 30+ consumers (e.g. how to talk to a registry given
+    credentials, credential-rehearsal patterns). "Is atm-core's release
+    correct" is never `sc-publish`'s business.
+  - A finding that atm-core's own validation/workflow logic is wrong is an
+    atm-core fix, fixed directly here, same-day — not an upstream ticket that
+    blocks the sprint.
+- `sc-publish` is the source of genuinely shared, generic release mechanics
+  installed through the canonical package installer, byte-for-byte — scoped
+  per the amendment above, not as the sole source of atm-core's publish
+  correctness.
+- Preflight and publish still consume one resolved manifest and toolchain, but
+  the validation receipt proving atm-core's release is correct is produced by
+  atm-core's own validation, not contingent on an external `sc-publish`
+  receipt-mechanism PR merging first.
 - Production publishing requires explicit authorization; planning or
   preflight does not grant it.
+- A blocking finding on one work item halts only that item; independent work
+  continues in parallel rather than idling the whole sprint.
 
 ## Phase delivery flow
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1308,8 +1308,8 @@ Sprint line:
   release-version contract
 - `AS.3` `AS.3-worktree-preflight-proof.md` — canonical worktree preflight
   proof
-- `AS.4` `AS.4-authorized-pypi-1.4.3.md` — separately authorized immutable
-  main PyPI release
+- `AS.4` `AS.4-authorized-pypi-1.4.3.md` — separately authorized, fresh
+  `1.4.4` PyPI-only release
 - `AS.5` `AS.5-main-migration-merge.md` — verified migration promotion from
   `develop` to `main`
 - `AS.6` `AS.6-full-1.4.4-release.md` — first full canonical release

--- a/docs/user-documents/README.md
+++ b/docs/user-documents/README.md
@@ -1,7 +1,7 @@
 ---
 title: ATM User Guide
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # ATM User Guide

--- a/docs/user-documents/doctor-and-log.md
+++ b/docs/user-documents/doctor-and-log.md
@@ -1,7 +1,7 @@
 ---
 title: Doctor And Log
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Doctor And Log

--- a/docs/user-documents/examples/quickstart/install-paths.json
+++ b/docs/user-documents/examples/quickstart/install-paths.json
@@ -1,8 +1,8 @@
 {
-  "install_root": "~/.local/atm/1.4.3",
-  "binary_path": "~/.local/atm/1.4.3/bin/atm",
-  "daemon_binary_path": "~/.local/atm/1.4.3/bin/atm-daemon",
-  "doc_root": "~/.local/atm/1.4.3/share/doc/atm",
-  "doc_entrypoint": "~/.local/atm/1.4.3/share/doc/atm/README.md",
+  "install_root": "~/.local/atm/1.4.4",
+  "binary_path": "~/.local/atm/1.4.4/bin/atm",
+  "daemon_binary_path": "~/.local/atm/1.4.4/bin/atm-daemon",
+  "doc_root": "~/.local/atm/1.4.4/share/doc/atm",
+  "doc_entrypoint": "~/.local/atm/1.4.4/share/doc/atm/README.md",
   "runtime_state_root": "~/.atm"
 }

--- a/docs/user-documents/hermes-atm.md
+++ b/docs/user-documents/hermes-atm.md
@@ -1,7 +1,7 @@
 ---
 title: Hermes Gateway Integration
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Hermes Gateway Integration

--- a/docs/user-documents/hermes-atm.md
+++ b/docs/user-documents/hermes-atm.md
@@ -13,9 +13,10 @@ access, source edits, or a hand-written hook.
 
 ## Release Status
 
-Version `1.4.2` is currently available on TestPyPI. Production PyPI publication
-is pending. Use the TestPyPI command below until the production release is
-announced; then use the ordinary PyPI command instead.
+Version `1.4.4` is prepared but is not yet published to PyPI or TestPyPI.
+Production publication remains pending this sprint's authorization. Do not
+install an earlier TestPyPI candidate as a substitute; wait for the published
+`1.4.4` release announcement.
 
 `hermes-atm` supports CPython 3.11 through 3.14. It installs the matching
 typed `atm-graft` client as a dependency.
@@ -48,19 +49,10 @@ the receiver correctly fails closed instead of injecting the nudge.
 
 ## Install
 
-For the current TestPyPI release, run this with the gateway's Python:
+After production PyPI publication, install the announced release with:
 
 ```bash
-python -m pip install --upgrade \
-  --index-url https://test.pypi.org/simple \
-  --extra-index-url https://pypi.org/simple \
-  "hermes-atm==1.4.2"
-```
-
-After production PyPI publication, install the current release with:
-
-```bash
-python -m pip install --upgrade hermes-atm
+python -m pip install --upgrade "hermes-atm==1.4.4"
 ```
 
 Register the profile with ATM before installing the receiver. Use the profile's

--- a/docs/user-documents/hooks.md
+++ b/docs/user-documents/hooks.md
@@ -1,7 +1,7 @@
 ---
 title: Hooks
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Hooks

--- a/docs/user-documents/identity-and-team.md
+++ b/docs/user-documents/identity-and-team.md
@@ -1,7 +1,7 @@
 ---
 title: Identity And Team
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Identity And Team

--- a/docs/user-documents/install-layout.md
+++ b/docs/user-documents/install-layout.md
@@ -1,7 +1,7 @@
 ---
 title: Install Layout
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Install Layout
@@ -21,7 +21,7 @@ Long-form user docs live under `share/doc/atm/`.
 A typical local install layout looks like this:
 
 ```text
-~/.local/atm/1.4.3/
+~/.local/atm/1.4.4/
   bin/
     atm
     atm-daemon

--- a/docs/user-documents/mailbox-workflows.md
+++ b/docs/user-documents/mailbox-workflows.md
@@ -1,7 +1,7 @@
 ---
 title: Mailbox Workflows
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Mailbox Workflows

--- a/docs/user-documents/nudge-templates.md
+++ b/docs/user-documents/nudge-templates.md
@@ -1,7 +1,7 @@
 ---
 title: Nudge Templates
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Nudge Templates

--- a/docs/user-documents/quickstart.md
+++ b/docs/user-documents/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Quickstart
@@ -57,11 +57,11 @@ not rely on direct database access or private files under `~/.atm/`.
 
 If the installed ATM binary is at:
 
-- `~/.local/atm/1.4.3/bin/atm`
+- `~/.local/atm/1.4.4/bin/atm`
 
 then the installed long-form doc entrypoint is:
 
-- `~/.local/atm/1.4.3/share/doc/atm/README.md`
+- `~/.local/atm/1.4.4/share/doc/atm/README.md`
 
 ## Next Documents
 

--- a/docs/user-documents/troubleshooting.md
+++ b/docs/user-documents/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 audience: end-user
-reviewed_for_release: 1.4.3
+reviewed_for_release: 1.4.4
 ---
 
 # Troubleshooting


### PR DESCRIPTION
## AS.4 forward branch\n\nStacks AS.4 on AS.3 evidence and records the production gate outcome.\n\n- no PyPI upload\n- v1.4.3 main/tag lacks the ADR-049 first-public-release disclosure\n- AS.3 preflight run 32159872873 is invalid because sc-lint rejected ATM boundary vocabulary\n- records source identity, prior TestPyPI-only run, public-PyPI absence, and staged artifact SHA-256 values\n\nUnblocks the audit trail; production remains intentionally blocked pending a new immutable release and matching receipt.