### PR TITLE
fix(ci): centralize sc-compose revision pins

### DIFF
--- a/.github/scripts/install_sc_compose_cli.py
+++ b/.github/scripts/install_sc_compose_cli.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Install the repository-pinned sc-compose CLI for passthrough parity tests."""
+"""Install a repository-pinned sc-compose CLI for default or parity tests."""
 
 from __future__ import annotations
 
+import argparse
 import shlex
 import subprocess
 import sys
@@ -12,11 +13,23 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPOSITORY_ROOT / ".claude"))
 
-from lib.sc_compose_dependency import SC_COMPOSE_PARITY_INSTALL  # noqa: E402
+from lib.sc_compose_dependency import (  # noqa: E402
+    SC_COMPOSE_INSTALL,
+    SC_COMPOSE_PARITY_INSTALL,
+)
 
 
-def main() -> int:
-    return subprocess.run(shlex.split(SC_COMPOSE_PARITY_INSTALL), check=False).returncode
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--purpose",
+        choices=("default", "parity"),
+        default="parity",
+        help="select the repository-pinned CLI revision",
+    )
+    args = parser.parse_args(argv)
+    install = SC_COMPOSE_PARITY_INSTALL if args.purpose == "parity" else SC_COMPOSE_INSTALL
+    return subprocess.run(shlex.split(install), check=False).returncode
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_install_sc_compose_cli.py
+++ b/.github/scripts/tests/test_install_sc_compose_cli.py
@@ -1,0 +1,30 @@
+"""Unit tests for the canonical sc-compose CLI installer selector."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+INSTALLER_PATH = Path(__file__).resolve().parents[1] / "install_sc_compose_cli.py"
+SPEC = importlib.util.spec_from_file_location("install_sc_compose_cli", INSTALLER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+INSTALLER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(INSTALLER)
+
+
+def test_default_purpose_uses_the_released_template_cli_revision() -> None:
+    completed = Mock(returncode=0)
+    with patch.object(INSTALLER.subprocess, "run", return_value=completed) as run:
+        assert INSTALLER.main(["--purpose", "default"]) == 0
+
+    assert run.call_args.args[0] == INSTALLER.shlex.split(INSTALLER.SC_COMPOSE_INSTALL)
+
+
+def test_parity_purpose_uses_the_passthrough_cli_revision() -> None:
+    completed = Mock(returncode=0)
+    with patch.object(INSTALLER.subprocess, "run", return_value=completed) as run:
+        assert INSTALLER.main(["--purpose", "parity"]) == 0
+
+    assert run.call_args.args[0] == INSTALLER.shlex.split(INSTALLER.SC_COMPOSE_PARITY_INSTALL)

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -1679,6 +1679,7 @@ def test_release_preflight_installs_the_pinned_sc_compose_cli_before_workspace_t
     assert install_step in preflight_text
     assert preflight_text.index(install_step) < preflight_text.index(workspace_tests)
     assert "SC_COMPOSE_PARITY_INSTALL" in installer_text
+    assert "SC_COMPOSE_INSTALL" in installer_text
     assert "sc_compose_dependency" in installer_text
 
 
@@ -1687,6 +1688,16 @@ def test_release_preflight_denies_a_failed_sc_compose_cli_install() -> None:
 
     assert "SC_COMPOSE_CLI: ${{ steps.sc_compose_cli.outcome }}" in preflight_text
     assert 'record sc-compose-cli "${SC_COMPOSE_CLI}"' in preflight_text
+
+
+def test_ci_derives_both_sc_compose_installs_from_the_canonical_installer() -> None:
+    ci_text = (repo_root() / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    installer = "python3 .github/scripts/install_sc_compose_cli.py"
+
+    assert f"{installer} --purpose default" in ci_text
+    assert f"{installer} --purpose parity" in ci_text
+    assert "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661" not in ci_text
+    assert "113729e60e3409ad8c651a74956ffa5c167dd1b6" not in ci_text
 
 
 def test_release_workflow_collects_wheels_without_redundant_zip_sweep() -> None:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install sc-compose CLI
         # Template JSON escaping requires the released sc-compose 1.4.0 API.
         # Keep this pin aligned with .claude/lib/sc_compose_dependency.py.
-        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+        run: python3 .github/scripts/install_sc_compose_cli.py --purpose default
 
       - name: Expose Cargo binaries on PATH
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
@@ -199,10 +199,9 @@ jobs:
 
       - name: Install sc-compose CLI for passthrough parity tests
         # The AN.7 process-level tests compare the ATM command with the
-        # pinned upstream CLI on every platform, so the test lane needs the
-        # same source revision already used by just-lint.
+        # pinned upstream CLI on every platform.
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
+        run: python3 .github/scripts/install_sc_compose_cli.py --purpose parity
 
       - name: Cache cargo registry
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
+++ b/docs/plans/phase-as/AS.4-authorized-pypi-1.4.3.md
@@ -202,7 +202,7 @@ remaining channel-only failure was the rejected `CARGO_REGISTRY_TOKEN` for
 crates.io. That credential decision remains pending Rand and does not
 authorize a PyPI upload.
 
-### Draft v1.4.3 GitHub release note
+### Draft v1.4.4 GitHub release note
 
 > **First public PyPI release:** `hermes-atm` and `atm-graft` begin public
 > distribution at ATM's existing 1.x workspace version. Earlier 1.x


### PR DESCRIPTION
Closes the AS4 QA-2 non-blocking cleanup: CI derives both intentional sc-compose revisions from the canonical Python owner; installer selector unit tests and workflow drift checks prevent silent divergence; stale AS.4 1.4.3 release-note heading corrected.