### PR TITLE
Add canonical SC website (site/ + announcements/)

### DIFF
--- a/site/announcements/index.html
+++ b/site/announcements/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Announcements · atm-core</title>
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; max-width: 52rem; margin: 3rem auto; padding: 0 1.5rem; line-height: 1.6; color: #1a1a2e; }
+    nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <nav><a href="../">&#8592; atm-core home</a></nav>
+  <h1>Announcements</h1>
+  <p>Press releases and release announcements for atm-core.</p>
+  <ul>
+    <!-- one <li> per release, added by the press-release workflow -->
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
Canonical SC website scaffold: site/ with index.html + announcements/ folder, and a GitHub Pages workflow. Reference structure: https://github.com/randlee/sc-compose