### PR TITLE
AO2.1: Peer-wire policy and plain-pipeline baseline

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -125,6 +125,11 @@ owner_manifest_path = "crates/atm-core/Cargo.toml"
 allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "getrandom", "interprocess", "libc", "parking_lot", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
+owner_manifest_path = "crates/atm-error/Cargo.toml"
+boundary_record_path = "boundaries/atm-error/error-codes.toml"
+allowed_dependencies = ["serde", "serde_json"]
+
+[[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
 allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "serde_json", "tempfile", "tokio", "ulid"]
 

--- a/boundaries/atm-core/peer-wire-mode.toml
+++ b/boundaries/atm-core/peer-wire-mode.toml
@@ -1,0 +1,47 @@
+boundary_id = "BOUNDARY-PeerWireMode"
+owner_package = "atm-core"
+owner_crate_path = "atm_core"
+name = "PeerWireMode"
+
+[public]
+facade = "PeerWireMode"
+notes = "Transport-neutral daemon peer-wire policy types; no TLS implementation, configuration, or runtime selection."
+
+[implementation]
+type = "PeerWireMode"
+module = "atm_core::peer_wire"
+visibility = "public"
+constructor = "public"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["peer_wire_policy_vocabulary"]
+io_forbidden = ["socket_io", "tls_adapter", "sqlite", "daemon_lifecycle", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-http-runtime", "atm-peer-tls-interop"]
+allowed_dependencies = []
+forbidden_edges = ["atm-core -> atm-daemon", "atm-core -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["PeerWireSecurity"]
+response_types = ["PeerWireMode"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["environment_mode_selection", "adapter_availability_inference"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-PEER-WIRE-MODE"]
+review_gates = ["mode_selected_once_at_daemon_launch", "no_tls_types_in_policy", "no_environment_or_durable_mode_source"]
+
+[status]
+state = "concrete_landed"
+notes = ["AO2.1 owns the typed policy contract; AO2.3 owns daemon argument parsing and runtime mode wiring."]

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -17,7 +17,7 @@ constructor = "public"
 roots = ["atm_daemon_bootstrap::run_replacement_daemon"]
 
 [ownership]
-io_owns = ["singleton_owner_lock", "concrete_backend_selection", "receiver_hook_harness_selection", "shutdown_signal_wait"]
+io_owns = ["singleton_owner_lock", "concrete_backend_selection", "receiver_hook_harness_selection", "shutdown_signal_wait", "daemon_launch_peer_wire_mode_selection"]
 io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "graft_crate_dependency", "replay_or_resend", "tls_adapter"]
 
 [dependencies]
@@ -33,7 +33,7 @@ forbidden = []
 request_types = ["core RuntimeAssembly inputs", "core sealed MessageReceivedHookSelector"]
 response_types = ["typed runtime lifecycle outcome"]
 error_types = ["AtmError"]
-notes = ["The concrete storage factory is legal only at this composition boundary; atm-daemon and atm-http-runtime remain backend-neutral."]
+notes = ["The concrete storage factory is legal only at this composition boundary; atm-daemon and atm-http-runtime remain backend-neutral.", "AO2.3 parses the one explicit daemon launch argument into the core PeerWireMode; environment, durable settings, and TLS availability never select it."]
 
 [testing]
 allowed_test_double_paths = []

--- a/boundaries/atm-error/error-codes.toml
+++ b/boundaries/atm-error/error-codes.toml
@@ -22,7 +22,7 @@ io_forbidden = ["socket_io", "tls_adapter", "sqlite", "process_spawn", "daemon_l
 
 [dependencies]
 allowed_dependents = ["atm-storage", "atm-core"]
-allowed_dependencies = ["serde"]
+allowed_dependencies = ["serde", "serde_json"]
 forbidden_edges = ["atm-error -> atm-core", "atm-error -> atm-storage-rusqlite"]
 
 [references]

--- a/boundaries/atm-error/error-codes.toml
+++ b/boundaries/atm-error/error-codes.toml
@@ -1,0 +1,47 @@
+boundary_id = "BOUNDARY-AtmErrorCodes"
+owner_package = "atm-error"
+owner_crate_path = "atm_error"
+name = "AtmErrorCodes"
+
+[public]
+facade = "AtmErrorCode"
+notes = "Single dependency-light registry for stable ATM-owned error identities."
+
+[implementation]
+type = "AtmErrorCode"
+module = "atm_error::error_codes"
+visibility = "public"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["stable_error_code_registry"]
+io_forbidden = ["socket_io", "tls_adapter", "sqlite", "process_spawn", "daemon_lifecycle"]
+
+[dependencies]
+allowed_dependents = ["atm-storage", "atm-core"]
+allowed_dependencies = ["serde"]
+forbidden_edges = ["atm-error -> atm-core", "atm-error -> atm-storage-rusqlite"]
+
+[references]
+scope = "global"
+forbidden = []
+
+[contracts]
+request_types = ["stable wire-code string"]
+response_types = ["AtmErrorCode"]
+error_types = ["UnknownAtmErrorCode"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["local_error_enum", "ad_hoc_error_code_string"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-ATM-ERROR-CODES"]
+review_gates = ["one_registry", "stable_wire_round_trip"]
+
+[status]
+state = "concrete_landed"
+notes = ["AO2.1 adds peer-wire policy errors here so later adapter work cannot mint local transport error enums."]

--- a/boundaries/atm-http-runtime/http-runtime.toml
+++ b/boundaries/atm-http-runtime/http-runtime.toml
@@ -5,7 +5,7 @@ name = "HttpRuntime"
 
 [public]
 facade = "HttpRuntime"
-notes = "Tokio/Axum lifecycle facade. HttpRuntimeClient is the one connector-neutral async client translation; AL.9 adds an optional explicit plain-TCP direct-peer adapter that retains the canonical WriteRequest route and handler. TLS remains isolated and deferred."
+notes = "Tokio/Axum lifecycle facade. HttpRuntimeClient is the one connector-neutral async client translation; the explicit plain-TCP direct-peer adapter retains the canonical WriteRequest route and handler. AO2 keeps TLS as an outer stream adapter, so selected plaintext remains the preserved direct path."
 
 [implementation]
 type = "HttpRuntimeClient"
@@ -50,4 +50,4 @@ review_gates = ["core_contracts_only", "typestate_lifecycle", "all_routes_from_c
 
 [status]
 state = "active"
-notes = ["AL.1 introduced the construction facade and its dependency boundary.", "AL.8 makes this the active daemon runtime with framework-managed UDS and loopback adapters; the legacy daemon server is reference-only until AM deletion.", "AL.9 permits atm and atm-graft to consume the runtime-owned preferred local client for write paths only; the runtime remains independent of both consumers.", "AL.9's optional direct-peer adapter is an explicit plain-TCP connector/listener pair for documented M5 evidence reruns only; it shares the existing WriteRequest encoder, POST route, canonical router, storage boundary, and received-hook path, and authorizes no peer DTO, peer route, resend, replay, or TLS surface."]
+notes = ["AL.1 introduced the construction facade and its dependency boundary.", "AL.8 makes this the active daemon runtime with framework-managed UDS and loopback adapters; the legacy daemon server is reference-only until AM deletion.", "AL.9 permits atm and atm-graft to consume the runtime-owned preferred local client for write paths only; the runtime remains independent of both consumers.", "The direct-peer adapter is one plain-TCP connector/listener pair for explicitly selected plaintext-test evidence only; it shares the existing WriteRequest encoder, POST route, canonical router, storage boundary, and received-hook path, and authorizes no peer DTO, peer route, resend, replay, or TLS surface.", "ADR-047 requires any later mTLS stream adapter to preserve this direct pipeline when plaintext-test is selected."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -129,6 +129,134 @@ fn daemon_must_not_read_caller_workspace_config() {
 }
 
 #[test]
+fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
+    let root = workspace_root();
+    let bootstrap = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
+    let runtime = read_source(&root.join("crates/atm-http-runtime/src/lib.rs"));
+    let client = read_source(&root.join("crates/atm-http-runtime/src/client.rs"));
+    let policy = read_source(&root.join("crates/atm-core/src/peer_wire.rs"));
+
+    let bootstrap_direct_setup = bootstrap
+        .split("async fn run_replacement_daemon_with_selector")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("/// Emit the benchmark/supervisor marker")
+                .next()
+        })
+        .expect("replacement bootstrap direct-peer setup");
+    let direct_listener = runtime
+        .split("async fn bind_configured_direct_peer_listener")
+        .nth(1)
+        .and_then(|source| source.split("async fn bind_loopback_listener").next())
+        .expect("direct-peer listener implementation");
+    let direct_connector = client
+        .split("impl DirectPeerTcpConnector")
+        .nth(1)
+        .and_then(|source| source.split("impl LoopbackTcpConnector").next())
+        .expect("direct-peer connector implementation");
+
+    assert!(
+        bootstrap_direct_setup.contains("DirectPeerTcpConfig::standard()"),
+        "AO2 plaintext characterization must retain the existing standard direct-peer configuration"
+    );
+    assert!(
+        client.contains("struct DirectPeerTcpConnector")
+            && client.contains("pub fn direct_peer_tcp_client")
+            && direct_connector.contains("execute_reqwest_request"),
+        "AO2 plaintext characterization must retain the shared direct-peer connector and HTTP exchange"
+    );
+    assert!(
+        direct_listener.contains("TcpListener::bind")
+            && runtime.contains("canonical_api_router(")
+            && runtime.contains("AuthenticatedConnector::peer_socket()"),
+        "AO2 plaintext listener must enter the ordinary canonical router"
+    );
+    for (scope, source) in [
+        ("bootstrap direct-peer setup", bootstrap_direct_setup),
+        ("direct-peer listener", direct_listener),
+        ("direct-peer connector", direct_connector),
+    ] {
+        for forbidden in [
+            "peer_tls",
+            "rustls",
+            "PeerConfigStore",
+            "certificate",
+            "adapter availability",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "AO2 plaintext {scope} must not inspect TLS/configuration/adapter state `{forbidden}`"
+            );
+        }
+    }
+    for forbidden in [
+        "std::env",
+        "rustls",
+        "PeerConfigStore",
+        "TlsConnector",
+        "TlsAcceptor",
+    ] {
+        assert!(
+            !policy.contains(forbidden),
+            "AO2 peer-wire policy must remain transport-neutral and reject `{forbidden}`"
+        );
+    }
+    assert!(
+        policy.contains("pub enum PeerWireSecurity")
+            && policy.contains("Mtls")
+            && policy.contains("PlaintextTest")
+            && policy.contains("pub struct PeerWireMode")
+            && policy.contains("pub const fn mtls()"),
+        "AO2 needs a typed mode vocabulary whose normal policy is mTLS"
+    );
+}
+
+#[test]
+fn ao2_peer_wire_policy_keeps_one_error_registry_and_one_http_pipeline() {
+    let root = workspace_root();
+    let error_registry = read_source(&root.join("crates/atm-error/src/error_codes.rs"));
+    let error_catalog = read_source(&root.join("crates/atm-storage/src/error_catalog.rs"));
+    let adr = read_source(&root.join("docs/adr/ADR-047-layered-peer-wire-security.md"));
+    let requirements = read_source(&root.join("docs/requirements.md"));
+    let daemon_requirements = read_source(&root.join("docs/atm-daemon/requirements.md"));
+
+    for (code, variant) in [
+        ("ATM_PEER_WIRE_MODE_INVALID", "PeerWireModeInvalid"),
+        (
+            "ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN",
+            "PeerWireModeSourceForbidden",
+        ),
+        (
+            "ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED",
+            "PeerWirePlaintextAuthenticationRequired",
+        ),
+    ] {
+        assert!(
+            error_registry.contains(code) && error_catalog.contains(variant),
+            "AO2 peer-wire failure `{code}` must use the central registry and catalog recovery"
+        );
+    }
+    for required in [
+        "PeerWireMode` launch policy",
+        "It does not select an HTTP",
+        "never falls back to plaintext",
+        "Plaintext-test evidence cannot satisfy",
+    ] {
+        assert!(
+            adr.contains(required),
+            "ADR-047 must retain the AO2 policy guarantee `{required}`"
+        );
+    }
+    assert!(
+        requirements
+            .contains("Mode ownership and the layered-stream constraint are defined by ADR-047.")
+            && daemon_requirements.contains("ADR-047 owns the typed launch-mode selection"),
+        "both core and daemon requirements must cite the accepted ADR-047 policy"
+    );
+}
+
+#[test]
 fn acknowledgement_cannot_restore_a_second_write_pipeline() {
     let root = workspace_root();
     let send = fs::read_to_string(root.join("crates/atm-core/src/send/mod.rs"))

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -257,6 +257,27 @@ fn ao2_peer_wire_policy_keeps_one_error_registry_and_one_http_pipeline() {
 }
 
 #[test]
+fn ao2_benchmark_harness_cannot_introduce_a_second_daemon_pipeline() {
+    let root = workspace_root();
+    let bootstrap = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
+    let benchmark_entrypoint =
+        read_source(&root.join("crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs"));
+
+    assert!(
+        bootstrap.contains("#[cfg(feature = \"benchmark-harness\")]")
+            && bootstrap.contains("pub async fn run_benchmark_daemon")
+            && bootstrap.contains("run_replacement_daemon_with_selector("),
+        "the retained benchmark harness must stay feature-gated and reuse the replacement daemon"
+    );
+    assert!(
+        benchmark_entrypoint.contains("atm_daemon_bootstrap::run_benchmark_daemon(mode).await")
+            && !benchmark_entrypoint.contains("canonical_api_router(")
+            && !benchmark_entrypoint.contains("TcpListener::bind"),
+        "the benchmark entrypoint must not create a second HTTP route or listener pipeline"
+    );
+}
+
+#[test]
 fn acknowledgement_cannot_restore_a_second_write_pipeline() {
     let root = workspace_root();
     let send = fs::read_to_string(root.join("crates/atm-core/src/send/mod.rs"))

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -78,6 +78,24 @@ const AI11_RETIRED_WINDOWS_TRANSPORT_DEPENDENCIES: &[&str] = &[
     "windows-named-pipe",
 ];
 
+fn contains_adapter_availability_inference(source: &str) -> bool {
+    const ADAPTER_TERMS: &[&str] = &["adapter", "peer-wire", "peer_wire", "transport"];
+    const AVAILABILITY_TERMS: &[&str] = &[
+        "availability",
+        "available",
+        "enabled",
+        "present",
+        "supported",
+        "configured",
+    ];
+
+    source.lines().any(|line| {
+        let line = line.to_ascii_lowercase();
+        ADAPTER_TERMS.iter().any(|term| line.contains(term))
+            && AVAILABILITY_TERMS.iter().any(|term| line.contains(term))
+    })
+}
+
 #[test]
 fn daemon_must_not_read_caller_workspace_config() {
     let root = workspace_root();
@@ -177,18 +195,16 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         ("direct-peer listener", direct_listener),
         ("direct-peer connector", direct_connector),
     ] {
-        for forbidden in [
-            "peer_tls",
-            "rustls",
-            "PeerConfigStore",
-            "certificate",
-            "adapter availability",
-        ] {
+        for forbidden in ["peer_tls", "rustls", "PeerConfigStore", "certificate"] {
             assert!(
                 !source.contains(forbidden),
                 "AO2 plaintext {scope} must not inspect TLS/configuration/adapter state `{forbidden}`"
             );
         }
+        assert!(
+            !contains_adapter_availability_inference(source),
+            "AO2 plaintext {scope} must not infer its mode from adapter availability or synonyms"
+        );
     }
     for forbidden in [
         "std::env",

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -457,27 +457,73 @@ fn ak2_peer_worker_symbols_are_absent_from_production() {
         "crates/atm-storage/src/contract.rs",
         "crates/atm-storage-rusqlite/src/peer_config_store.rs",
     ];
-    let retired_symbols = [
-        "PeerDeliveryCoordinator",
-        "PeerDrainCoordinator",
-        "PeerPostCommitWorkQueue",
-        "PostCommitWorkKey::PeerDelivery",
-        "PeerSyncPolicy",
-        "PeerSyncRequest",
-        "PeerSyncOutcome",
-        "PeerLinkStatus",
-        "PeerWireSecurity",
-        "HttpsTransport",
-    ];
     for source in production_sources {
         let contents = read_source(&root.join(source));
-        for symbol in retired_symbols {
-            assert!(
-                !contents.contains(symbol),
-                "AK.2 production source `{source}` must not retain `{symbol}`"
-            );
-        }
+        let retired = retired_peer_worker_symbols_in_source(&contents);
+        assert!(
+            retired.is_empty(),
+            "AK.2 production source `{source}` must not retain retired symbols {retired:?}"
+        );
     }
+}
+
+fn retired_peer_worker_symbols_in_source(source: &str) -> BTreeSet<String> {
+    let syntax = syn::parse_file(source).expect("production source must parse for AK.2 guard");
+    let mut visitor = RetiredPeerWorkerSymbolVisitor::default();
+    visitor.visit_file(&syntax);
+    visitor.found
+}
+
+#[derive(Default)]
+struct RetiredPeerWorkerSymbolVisitor {
+    found: BTreeSet<String>,
+}
+
+impl<'ast> Visit<'ast> for RetiredPeerWorkerSymbolVisitor {
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        const RETIRED_TERMINALS: &[&str] = &[
+            "PeerDeliveryCoordinator",
+            "PeerDrainCoordinator",
+            "PeerPostCommitWorkQueue",
+            "PeerSyncPolicy",
+            "PeerSyncRequest",
+            "PeerSyncOutcome",
+            "PeerLinkStatus",
+            "HttpsTransport",
+        ];
+
+        let segments: Vec<_> = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect();
+        if let Some(terminal) = segments.last()
+            && RETIRED_TERMINALS.contains(&terminal.as_str())
+        {
+            self.found.insert(terminal.clone());
+        }
+        if segments
+            .windows(2)
+            .any(|pair| matches!(pair, [first, second] if first == "PostCommitWorkKey" && second == "PeerDelivery"))
+        {
+            self.found
+                .insert("PostCommitWorkKey::PeerDelivery".to_owned());
+        }
+        syn::visit::visit_path(self, path);
+    }
+}
+
+#[test]
+fn ak2_retirement_guard_matches_symbols_not_substrings() {
+    assert!(
+        retired_peer_worker_symbols_in_source("pub struct PeerWireSecurity;").is_empty(),
+        "AO2's PeerWireSecurity vocabulary must not collide with retired AK.2 identifiers"
+    );
+    assert_eq!(
+        retired_peer_worker_symbols_in_source("fn f(_: PeerSyncPolicy) {}"),
+        BTreeSet::from(["PeerSyncPolicy".to_owned()]),
+        "the AK.2 guard must still reject an exact retired symbol"
+    );
 }
 
 #[test]

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -45,6 +45,8 @@ pub(crate) mod mailbox;
 pub(crate) mod model_registry;
 /// Observability adapter traits and event payload types.
 pub mod observability;
+/// Transport-neutral peer-wire policy vocabulary selected at daemon launch.
+pub mod peer_wire;
 /// Internal atomic persistence helpers for shared mutable state files.
 pub(crate) mod persistence;
 /// Hidden process-liveness helpers shared across lock implementations.

--- a/crates/atm-core/src/peer_wire.rs
+++ b/crates/atm-core/src/peer_wire.rs
@@ -1,0 +1,84 @@
+//! Transport-neutral peer-wire policy vocabulary.
+//!
+//! This module owns the typed mode selected at the daemon launch boundary. It
+//! deliberately carries no TLS adapter, certificate, environment, or runtime
+//! availability detail: those are implementation concerns of later adapters.
+
+/// The security policy selected for the daemon's peer-wire adapter.
+///
+/// `Mtls` is the normal process mode. `PlaintextTest` is an explicit,
+/// non-durable diagnostic and benchmark mode; it never represents peer
+/// authentication or authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PeerWireSecurity {
+    /// Normal cross-host transport: mutual TLS and exact peer authorization.
+    #[default]
+    Mtls,
+    /// Explicit untrusted diagnostic mode using the preserved direct TCP path.
+    PlaintextTest,
+}
+
+impl PeerWireSecurity {
+    /// Stable daemon-launch spelling for this security mode.
+    #[must_use]
+    pub const fn as_launch_value(self) -> &'static str {
+        match self {
+            Self::Mtls => "mutual-tls",
+            Self::PlaintextTest => "plaintext-test",
+        }
+    }
+}
+
+/// The complete transport-neutral peer-wire policy chosen for one daemon run.
+///
+/// AO.3 owns parsing this value from `atm-daemon --peer-wire-security`; this
+/// contract intentionally has no environment or configuration constructor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PeerWireMode {
+    /// The selected wire-security policy.
+    pub security: PeerWireSecurity,
+}
+
+impl PeerWireMode {
+    /// Returns the normal daemon policy for an invocation with no explicit
+    /// launch-mode override.
+    #[must_use]
+    pub const fn mtls() -> Self {
+        Self {
+            security: PeerWireSecurity::Mtls,
+        }
+    }
+
+    /// Returns the explicit untrusted diagnostic/benchmark policy.
+    #[must_use]
+    pub const fn plaintext_test() -> Self {
+        Self {
+            security: PeerWireSecurity::PlaintextTest,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PeerWireMode, PeerWireSecurity};
+
+    #[test]
+    fn normal_mode_defaults_to_mutual_tls() {
+        assert_eq!(PeerWireMode::default(), PeerWireMode::mtls());
+        assert_eq!(PeerWireSecurity::default(), PeerWireSecurity::Mtls);
+    }
+
+    #[test]
+    fn mode_vocabulary_has_stable_daemon_launch_spellings() {
+        assert_eq!(PeerWireSecurity::Mtls.as_launch_value(), "mutual-tls");
+        assert_eq!(
+            PeerWireSecurity::PlaintextTest.as_launch_value(),
+            "plaintext-test"
+        );
+    }
+
+    #[test]
+    fn plaintext_test_remains_an_explicit_distinct_mode() {
+        assert_ne!(PeerWireMode::plaintext_test(), PeerWireMode::mtls());
+    }
+}

--- a/crates/atm-core/src/peer_wire.rs
+++ b/crates/atm-core/src/peer_wire.rs
@@ -36,7 +36,7 @@ impl PeerWireSecurity {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PeerWireMode {
     /// The selected wire-security policy.
-    pub security: PeerWireSecurity,
+    security: PeerWireSecurity,
 }
 
 impl PeerWireMode {
@@ -55,6 +55,13 @@ impl PeerWireMode {
         Self {
             security: PeerWireSecurity::PlaintextTest,
         }
+    }
+
+    /// Returns the selected wire-security policy without permitting callers
+    /// to construct an arbitrary mode.
+    #[must_use]
+    pub const fn security(self) -> PeerWireSecurity {
+        self.security
     }
 }
 
@@ -80,5 +87,9 @@ mod tests {
     #[test]
     fn plaintext_test_remains_an_explicit_distinct_mode() {
         assert_ne!(PeerWireMode::plaintext_test(), PeerWireMode::mtls());
+        assert_eq!(
+            PeerWireMode::plaintext_test().security(),
+            PeerWireSecurity::PlaintextTest
+        );
     }
 }

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -42,6 +42,12 @@ pub enum AtmErrorCode {
     DaemonAutoStartFailed,
     DaemonConnectionSaturated,
     RemoteDeliveryUnconfirmed,
+    /// The daemon launch argument did not name a supported peer-wire mode.
+    PeerWireModeInvalid,
+    /// A non-launch source attempted to select the daemon peer-wire mode.
+    PeerWireModeSourceForbidden,
+    /// Plaintext diagnostic mode was asked to satisfy authenticated peer work.
+    PeerWirePlaintextAuthenticationRequired,
     PeerConfigValidationFailed,
     CertificateOperationFailed,
     BindPreflightFailed,
@@ -180,6 +186,11 @@ impl AtmErrorCode {
             Self::DaemonAutoStartFailed => "ATM_DAEMON_AUTO_START_FAILED",
             Self::DaemonConnectionSaturated => "ATM_DAEMON_CONNECTION_SATURATED",
             Self::RemoteDeliveryUnconfirmed => "REMOTE_DELIVERY_UNCONFIRMED",
+            Self::PeerWireModeInvalid => "ATM_PEER_WIRE_MODE_INVALID",
+            Self::PeerWireModeSourceForbidden => "ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN",
+            Self::PeerWirePlaintextAuthenticationRequired => {
+                "ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED"
+            }
             Self::PeerConfigValidationFailed => "ATM_PEER_CONFIG_VALIDATION_FAILED",
             Self::CertificateOperationFailed => "ATM_CERTIFICATE_OPERATION_FAILED",
             Self::BindPreflightFailed => "ATM_BIND_PREFLIGHT_FAILED",
@@ -338,6 +349,11 @@ fn parse_daemon_or_address_code(value: &str) -> Option<AtmErrorCode> {
         "ATM_DAEMON_AUTO_START_FAILED" => AtmErrorCode::DaemonAutoStartFailed,
         "ATM_DAEMON_CONNECTION_SATURATED" => AtmErrorCode::DaemonConnectionSaturated,
         "REMOTE_DELIVERY_UNCONFIRMED" => AtmErrorCode::RemoteDeliveryUnconfirmed,
+        "ATM_PEER_WIRE_MODE_INVALID" => AtmErrorCode::PeerWireModeInvalid,
+        "ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN" => AtmErrorCode::PeerWireModeSourceForbidden,
+        "ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED" => {
+            AtmErrorCode::PeerWirePlaintextAuthenticationRequired
+        }
         "ATM_PEER_CONFIG_VALIDATION_FAILED" => AtmErrorCode::PeerConfigValidationFailed,
         "ATM_CERTIFICATE_OPERATION_FAILED" => AtmErrorCode::CertificateOperationFailed,
         "ATM_BIND_PREFLIGHT_FAILED" => AtmErrorCode::BindPreflightFailed,

--- a/crates/atm-error/src/lib.rs
+++ b/crates/atm-error/src/lib.rs
@@ -24,6 +24,27 @@ mod tests {
     }
 
     #[test]
+    fn peer_wire_policy_error_codes_keep_their_stable_wire_spellings() {
+        for (code, wire) in [
+            (
+                AtmErrorCode::PeerWireModeInvalid,
+                "ATM_PEER_WIRE_MODE_INVALID",
+            ),
+            (
+                AtmErrorCode::PeerWireModeSourceForbidden,
+                "ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN",
+            ),
+            (
+                AtmErrorCode::PeerWirePlaintextAuthenticationRequired,
+                "ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED",
+            ),
+        ] {
+            assert_eq!(code.as_str(), wire);
+            assert_eq!(wire.parse::<AtmErrorCode>(), Ok(code));
+        }
+    }
+
+    #[test]
     fn error_codes_round_trip_through_json() {
         let code = AtmErrorCode::MessageValidationFailed;
         let encoded = serde_json::to_string(&code).expect("serialize error code");

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -71,7 +71,13 @@ impl AtmError {
 
     #[must_use]
     pub fn is_validation(&self) -> bool {
-        self.code == AtmErrorCode::MessageValidationFailed
+        matches!(
+            self.code,
+            AtmErrorCode::MessageValidationFailed
+                | AtmErrorCode::PeerWireModeInvalid
+                | AtmErrorCode::PeerWireModeSourceForbidden
+                | AtmErrorCode::PeerWirePlaintextAuthenticationRequired
+        )
     }
 
     #[must_use]
@@ -159,6 +165,25 @@ impl AtmError {
     /// write before the caller's shared deadline. Retrying uses the same ULID.
     pub fn remote_delivery_unconfirmed(message: impl Into<String>) -> Self {
         Self::new(AtmErrorCode::RemoteDeliveryUnconfirmed, message)
+    }
+
+    /// Reports an unsupported daemon peer-wire launch argument.
+    pub fn peer_wire_mode_invalid(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::PeerWireModeInvalid, message)
+    }
+
+    /// Reports an unsupported durable or environment peer-wire selector.
+    pub fn peer_wire_mode_source_forbidden(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::PeerWireModeSourceForbidden, message)
+    }
+
+    /// Reports an attempt to treat untrusted plaintext diagnostics as
+    /// authenticated peer transport.
+    pub fn peer_wire_plaintext_authentication_required(message: impl Into<String>) -> Self {
+        Self::new(
+            AtmErrorCode::PeerWirePlaintextAuthenticationRequired,
+            message,
+        )
     }
 
     pub fn peer_config_validation(message: impl Into<String>) -> Self {
@@ -530,6 +555,41 @@ mod tests {
             "REMOTE_DELIVERY_UNCONFIRMED".parse::<AtmErrorCode>(),
             Ok(AtmErrorCode::RemoteDeliveryUnconfirmed)
         ));
+    }
+
+    #[test]
+    fn peer_wire_policy_errors_keep_structured_codes_and_actionable_recovery() {
+        let cases = [
+            (
+                AtmError::peer_wire_mode_invalid("unsupported value"),
+                "ATM_PEER_WIRE_MODE_INVALID",
+                "mutual-tls",
+            ),
+            (
+                AtmError::peer_wire_mode_source_forbidden("ATM_PEER_WIRE_SECURITY"),
+                "ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN",
+                "daemon launch argument",
+            ),
+            (
+                AtmError::peer_wire_plaintext_authentication_required("authenticated proof"),
+                "ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED",
+                "mutual-TLS mode",
+            ),
+        ];
+
+        for (error, code, recovery) in cases {
+            assert_eq!(error.code().as_str(), code);
+            assert!(
+                error.is_validation(),
+                "peer-wire policy errors are launch validation failures"
+            );
+            assert!(error.message().contains(recovery));
+            assert!(
+                serde_json::to_string(&error)
+                    .expect("serialize structured peer-wire error")
+                    .contains(code)
+            );
+        }
     }
 
     #[test]

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -116,6 +116,15 @@ const fn daemon_guidance(code: AtmErrorCode) -> Option<&'static str> {
         AtmErrorCode::DaemonConnectionSaturated => {
             Some("Wait for the daemon to finish an in-flight request, then retry.")
         }
+        AtmErrorCode::PeerWireModeInvalid => Some(
+            "Use `mutual-tls` or `plaintext-test` with --peer-wire-security, then restart the daemon.",
+        ),
+        AtmErrorCode::PeerWireModeSourceForbidden => Some(
+            "Remove the environment or durable peer-wire setting and use the documented daemon launch argument.",
+        ),
+        AtmErrorCode::PeerWirePlaintextAuthenticationRequired => Some(
+            "Restart in mutual-TLS mode and verify the enabled peer identity, certificate, and exact trust record.",
+        ),
         _ => None,
     }
 }

--- a/docs/adr/ADR-034-minimal-cross-host-https-transport.md
+++ b/docs/adr/ADR-034-minimal-cross-host-https-transport.md
@@ -1,5 +1,9 @@
 # ADR-034 — Minimal Cross-Host HTTPS Transport
 
+> **Forward reconciliation:** ADR-047 partially supersedes this ADR's
+> peer-wire mode-selection wording. Its single-router, canonical-request, and
+> stream-adapter constraints remain in force.
+
 | Field | Value |
 | --- | --- |
 | ID | ADR-034 |

--- a/docs/adr/ADR-040-peer-authority-resolution.md
+++ b/docs/adr/ADR-040-peer-authority-resolution.md
@@ -1,5 +1,9 @@
 # ADR-040 — Peer Authority Resolution
 
+> **Forward reconciliation:** ADR-047 partially supersedes this ADR's
+> peer-wire mode-selection wording. Its authority-resolution, hostname, pin,
+> and allowlist rules remain in force.
+
 | Field | Value |
 | --- | --- |
 | ID | ADR-040 |

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -1,0 +1,50 @@
+# ADR-047 — Layered Peer-Wire Security
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-047 |
+| Status | Accepted |
+| Scope | Repository-wide |
+| Relates to | ADR-033, ADR-034, ADR-035, ADR-040; REQ-CORE-TRANSPORT-002B1; REQ-DAEMON-TRANSPORT-002B1; Phase AO |
+
+## Decision
+
+Peer-wire security is selected once for each daemon process by the typed
+`PeerWireMode` launch policy. `PeerWireSecurity::Mtls` is the default and
+normal mode. `PeerWireSecurity::PlaintextTest` is available only through the
+explicit non-durable daemon launch argument
+`--peer-wire-security plaintext-test` for bounded diagnostics and benchmarks.
+It is untrusted test provenance, never authentication or authorization.
+
+The mode is an outer stream-adapter decision. It does not select an HTTP
+resource, request DTO, canonical write handler, persistence operation,
+acknowledgement sender, post-write hook, or benchmark-only daemon. Plaintext
+mode uses the preserved `DirectPeerTcpConfig::standard`,
+`DirectPeerTcpConnector`, direct-peer listener, and ordinary router pipeline.
+The mTLS adapter wraps that same pipeline at the stream boundary only.
+
+No environment variable, durable setting, TLS adapter availability check, or
+TLS/certificate/allowlist failure may choose or change the selected mode. A
+normal restart selects mTLS; mTLS never falls back to plaintext. In particular,
+the plaintext pipeline remains direct and unchanged even when mTLS support is
+compiled into the same binary, so an enabled TLS feature cannot impose work on
+the plaintext hot path.
+
+Only daemon-launch parsing may construct a process mode from user input. An
+unknown mode returns `ATM_PEER_WIRE_MODE_INVALID`; durable or environment
+selection returns `ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN`. Work that requires
+authenticated peer evidence fails closed with
+`ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED` when plaintext-test is
+selected.
+
+## Consequences
+
+ADR-034's transport-security sequencing and ADR-040's authority-resolution
+wording are superseded by this mode-layering decision, while their endpoint,
+pinning, and authority rules remain in force. ADR-035 remains the active
+canonical ingress decision; this ADR supersedes only its peer-wire transport
+wording. ADR-033's one-router contract remains unchanged.
+
+Doctor, retained diagnostics, smoke JSON/XHTML, and benchmark evidence must
+record the active peer-wire mode. Plaintext-test evidence cannot satisfy any
+mTLS or peer-allowlist acceptance criterion.

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -18,8 +18,10 @@ It is untrusted test provenance, never authentication or authorization.
 
 The mode is an outer stream-adapter decision. It does not select an HTTP
 resource, request DTO, canonical write handler, persistence operation,
-acknowledgement sender, post-write hook, or benchmark-only daemon. Plaintext
-mode uses the preserved `DirectPeerTcpConfig::standard`,
+acknowledgement sender, or post-write hook. The retained, feature-gated
+`atm-daemon-benchmark` harness invokes the same replacement daemon with an
+explicit benchmark hook selector; it is guarded against creating a second
+listener or HTTP pipeline. Plaintext mode uses the preserved `DirectPeerTcpConfig::standard`,
 `DirectPeerTcpConnector`, direct-peer listener, and ordinary router pipeline.
 The mTLS adapter wraps that same pipeline at the stream boundary only.
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -54,6 +54,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-044 — Public Verification Report Classification](./ADR-044-public-verification-report-classification.md)
 - [ADR-045 — Runtime Observation Attribution](./ADR-045-runtime-observation-attribution.md)
 - [ADR-046 — Template-Declared Workflow Metadata And Admission Snapshots](./ADR-046-template-declared-workflow-metadata.md)
+- [ADR-047 — Layered Peer-Wire Security](./ADR-047-layered-peer-wire-security.md)
 - [ADR-049 — hermes-atm/atm-graft First Public PyPI Release Versioning](./ADR-049-hermes-atm-first-public-pypi-release-versioning.md)
 - [ADR-050 — Shared Publish-Kit Ownership](./ADR-050-shared-publish-kit-ownership.md)
 - [ADR-051 — Permissive Declared Sender Identity and Roster Advisory](./ADR-051-permissive-declared-sender-identity.md)

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -178,7 +178,8 @@ Initial crate requirement IDs:
   changing HTTP routing, canonical writes, persistence, or post-write routing;
   declared source-host data is untrusted smoke provenance. Normal startup is
   mTLS, never falls back to plaintext, and doctor/logs must expose the active
-  mode. Satisfies: `REQ-CORE-TRANSPORT-002B1`.
+  mode. ADR-047 owns the typed launch-mode selection and isolated stream
+  layering. Satisfies: `REQ-CORE-TRANSPORT-002B1`.
 - `REQ-DAEMON-TRANSPORT-002C` localhost and a daemon's own advertised address
   are ordinary HTTPS peer targets; no loopback-only transport branch exists.
   Satisfies:

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -68,6 +68,18 @@ Error codes should describe the failure class, not a specific prose message.
 - `ATM_TEAM_NOT_FOUND`
 - `ATM_AGENT_NOT_FOUND`
 
+### 5.2.1 Peer-Wire Policy
+
+- `ATM_PEER_WIRE_MODE_INVALID` — `--peer-wire-security` did not name
+  `mutual-tls` or `plaintext-test`; correct the daemon launch argument and
+  restart.
+- `ATM_PEER_WIRE_MODE_SOURCE_FORBIDDEN` — an environment variable or durable
+  setting attempted to select peer-wire mode; remove it and use the one daemon
+  launch argument.
+- `ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED` — untrusted
+  `plaintext-test` was asked to satisfy authenticated peer work; restart in
+  normal mutual-TLS mode and verify peer configuration.
+
 ### 5.3 Mailbox And Message Validation
 
 - `ATM_MAILBOX_READ_FAILED`

--- a/docs/peer-pair-smoke.md
+++ b/docs/peer-pair-smoke.md
@@ -139,6 +139,8 @@ interface only to the private test overlay address used by the participating
 hosts. The profile disables TLS, certificate pinning, and the peer allowlist;
 it is never safe to bind it to a public or shared network interface. Restart
 without `--peer-wire-security plaintext-test` before any non-diagnostic use.
+It remains the ordinary direct-peer HTTP pipeline; its evidence must be labeled
+`plaintext-test` and never used to claim mTLS or peer-allowlist coverage (ADR-047).
 
 The runner prints one `PASS` or `FAIL` line for local doctor, each peer doctor,
 each peer send/read pair, and the evidence path. It exits zero only when every

--- a/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
+++ b/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
@@ -70,7 +70,7 @@ can introduce an mTLS dependency.
    pub enum PeerWireSecurity { Mtls, PlaintextTest }
 
    pub struct PeerWireMode {
-       pub security: PeerWireSecurity,
+       security: PeerWireSecurity,
    }
    ```
 

--- a/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
+++ b/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
@@ -1,6 +1,6 @@
 ---
 title: AO.1 — Peer-Wire Policy and Plain-Pipeline Baseline
-status: planned
+status: complete
 branch: feature/pao-s1-peer-wire-policy
 target: integrate/phase-ao2
 worktree: ../atm-core-worktrees/feature/pao-s1-peer-wire-policy

--- a/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
+++ b/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
@@ -122,7 +122,7 @@ Deliverable 3.
 
 ## Required Validation
 
-- `cargo test -p atm-core -p atm-http-runtime -p atm-daemon-bootstrap`
+- `cargo test -p agent-team-mail-core -p atm-http-runtime -p atm-daemon-bootstrap`
 - `cargo test -p atm-architecture --test boundary_enforcement`
 - `just lint`
 - `just test`

--- a/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
+++ b/docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md
@@ -88,6 +88,26 @@ can introduce an mTLS dependency.
    The same guards must reject a second HTTP route, DTO, ACK sender,
    persistence path, hook path, or benchmark-only daemon.
 
+### Existing plaintext characterization matrix
+
+AO.1 does not duplicate the pre-existing, live direct-peer characterization
+suite. The following tests are the retained oracle that the AO.1 policy and
+guard work must continue to pass; together they cover every behavior named in
+Deliverable 3.
+
+| Behavior | Existing test evidence |
+| --- | --- |
+| Bind and readiness | `crates/atm-http-runtime/src/lib.rs` — `runtime_health_becomes_ready_only_after_all_enabled_binds_and_not_ready_during_drain` |
+| Host-qualified outbound selection | `crates/atm-http-runtime/src/lib.rs` — `direct_peer_listener_uses_the_canonical_router_and_normalizes_provenance` (host-qualified recipient over the direct peer client) |
+| Canonical `WriteRequest` encoding | `crates/atm-http-runtime/src/lib.rs` — `direct_peer_listener_uses_the_canonical_router_and_normalizes_provenance` (a `RequestEnvelope::Write` is carried by the real direct peer client) |
+| Router provenance | `crates/atm-http-runtime/src/lib.rs` — `direct_peer_listener_uses_the_canonical_router_and_normalizes_provenance` |
+| Durable write | `crates/atm-http-runtime/src/storage_and_nudge_router.rs` — `direct_peer_runtime_reaches_storage_once_and_skips_duplicate_hook` |
+| Hook warning | `crates/atm-http-runtime/src/storage_and_nudge_router.rs` — `direct_peer_hook_failure_keeps_the_write_successful_with_a_warning` |
+| Acknowledgement | `crates/atm-http-runtime/src/storage_and_nudge_router.rs` — `local_ack_routes_to_the_received_peer_and_peer_receipt_does_not_reacknowledge` |
+| Duplicate behavior | `crates/atm-http-runtime/src/storage_and_nudge_router.rs` — `direct_peer_runtime_reaches_storage_once_and_skips_duplicate_hook` |
+| Typed connection failure | `crates/atm-http-runtime/src/client.rs` — `direct_peer_connection_failure_names_the_remote_authority` |
+| Shutdown/readiness behavior | `crates/atm-http-runtime/src/lib.rs` — `loopback_shutdown_drains_an_in_flight_canonical_request_before_record_cleanup` and `runtime_health_becomes_ready_only_after_all_enabled_binds_and_not_ready_during_drain` |
+
 ## Acceptance Criteria
 
 - The accepted records consistently distinguish normal mTLS from explicitly

--- a/docs/plans/phase-ao/sprint-AO2-isolated-mtls-stream-adapter.md
+++ b/docs/plans/phase-ao/sprint-AO2-isolated-mtls-stream-adapter.md
@@ -107,7 +107,7 @@ AO.1 development pushed; AO.1 PR merged before AO.2 PR completion.
 
 ## Required Validation
 
-- `cargo test -p peer-tls -p atm-core -p atm-storage`
+- `cargo test -p peer-tls -p agent-team-mail-core -p atm-storage`
 - `cargo test -p atm-architecture --test boundary_enforcement`
 - `just lint`
 - `just test`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1306,6 +1306,19 @@ integrates through `integrate/phase-ao2`; the earlier AO plan is retained only
 as [archived reference](./archive/phase-ao/).  The authoritative plan is
 [Phase AO plan](./plans/phase-ao/plan-phase-ao.md).
 
+Sprint line:
+- `AO.1` `feature/pao-s1-peer-wire-policy` [COMPLETE] — ADR-047, typed
+  `PeerWireMode` (mTLS default), peer-wire error/recovery contracts, boundary
+  records, and executable guards proving the plaintext arm stays on the
+  existing direct-peer canonical HTTP pipeline
+- `AO.2` `feature/pao-s2-isolated-mtls-stream-adapter` — bounded `peer-tls`
+  adapter with positive and negative stream evidence
+- `AO.3` `feature/pao-s3-runtime-peer-wire-mode` — one daemon build selects
+  the original plaintext or mTLS stream establishment without application
+  drift
+- `AO.4` `feature/pao-s4-peer-wire-proof` — shipped-daemon plaintext/mTLS
+  proof and compatible-baseline performance evidence
+
 ## 47. Phase AP — Outbound-Only Corporate Network Peer Connectivity [PROPOSED]
 
 Phase AP investigates support for a firewalled daemon that may initiate an

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3957,6 +3957,8 @@ mail correctness.
 - `REQ-CORE-TRANSPORT-002B1` A daemon may run an explicit, process-local
   plaintext peer-wire profile only for debug/smoke diagnosis.
 
+  Mode ownership and the layered-stream constraint are defined by ADR-047.
+
   Required behavior:
   - default and every normal release invocation use mTLS plus the exact peer
     allowlist; no TLS, certificate, or allowlist failure may fall back to

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -27,6 +27,9 @@ replacement for functional smoke coverage. Each successful run writes its
 immutable JSON, its XHTML panel, and the aggregate report beneath
 `site/reports/`; the recipe rebuilds the report automatically. Use
 `just benchmark-report` only to rebuild or inspect already-published evidence.
+Peer-wire evidence must record the active ADR-047 security mode. Normal
+benchmark and release evidence is mutual TLS; `plaintext-test` is explicit
+diagnostic evidence only and cannot satisfy mTLS or peer-allowlist criteria.
 
 The routed smoke implementations are deliberately not independent public
 commands:


### PR DESCRIPTION
## Summary
- Implements sprint AO.1 (docs/plans/phase-ao/sprint-AO1-policy-and-plain-baseline.md)
- Adds ADR-047, typed `PeerWireMode` (mTLS default), central peer-wire error/recovery contracts, boundary records
- Executable guards prove the plaintext arm stays on the existing direct-peer canonical HTTP pipeline without TLS/config inference

## Test plan
- [x] cargo targeted suites
- [x] boundary enforcement
- [x] just lint
- [x] just test (full)

Part of the Phase AO2 TLS replan (graph-orchestration cursor AO2.1).