### PR TITLE
fix(sprint-report): don't gate in-progress sprints as data gaps

### DIFF
--- a/.claude/skills/sprint-report/SKILL.md
+++ b/.claude/skills/sprint-report/SKILL.md
@@ -65,7 +65,7 @@ The template path is relative - must run from the **main repo root** (not a work
 
 ```bash
 cd "${CLAUDE_PROJECT_DIR:-$(git worktree list | head -1 | awk '{print $1}')}"
-sc-compose render .claude/skills/sprint-report/report.md.j2 --var-file /tmp/sprint-report.json
+sc-compose render --file .claude/skills/sprint-report/report.md.j2 --var-file /tmp/sprint-report.json
 ```
 
 ## --table (default)

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -966,7 +966,12 @@ def build_report(
                 "diagnostics": row_diagnostics,
             }
         )
-        if run is None and qa_data is not None:
+        if run is None and qa_data is not None and dev_done:
+            # QA only ever runs after dev sends a Completion. A sprint that
+            # is merely assigned (in progress, not yet completed) has no QA
+            # run to be missing -- that is the normal "in flight" state, not
+            # lost evidence. Only a completed sprint with no recorded
+            # verdict is a real gap.
             problem = f"{sid}: no authoritative QA run"
             data_gaps.append(problem)
             remediations.append(
@@ -996,7 +1001,13 @@ def build_report(
                     sprint_id=sid,
                 )
             )
-        elif github_repo is not None:
+        elif github_repo is not None and dev_done:
+            # Same rationale as the QA-run carve-out above: a sprint that is
+            # merely assigned (dev in progress, not yet pushed/completed)
+            # has no PR/CI state to observe yet. Fabricating one would
+            # violate the no-invented-GitHub-state rule in
+            # docs/triage/ttl-repair.md, so only demand real GitHub state
+            # once dev work has actually completed (dev_done).
             for field in ("head_sha", "target_branch", "pr_number", "pr_url", "ci_status", "merged"):
                 if item.get(field) is None:
                     problem = f"{sid}: GitHub {field} is missing or unknown"

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -139,6 +139,58 @@ def test_missing_qa_snapshot_does_not_hide_live_sprint_counts(tmp_path):
     assert "QA evidence master not found" in report["data_gaps"][0]
 
 
+def test_in_progress_sprint_with_no_pr_yet_is_not_a_data_gap(tmp_path, monkeypatch):
+    """An assigned-but-not-completed sprint has no QA run or PR/CI state to
+    observe yet -- that is the normal in-flight state, not lost evidence, and
+    must not block the report or invent GitHub data to fill it in."""
+    root, qa = _inputs(tmp_path)
+    structure_path = root / ".sprints" / "AICH" / "structure.ttl"
+    structure_path.write_text(
+        structure_path.read_text()
+        + "triage:AICH-S3 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 3 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-23.md\" ; triage:branch \"feature/s3\" .\n"
+    )
+    events_path = root / ".sprints" / "AICH" / "events.ttl"
+    events_path.write_text(
+        events_path.read_text()
+        + "triage:a3 a triage:Assignment ; triage:ofSprint triage:AICH-S3 ; triage:assignedAt \"2026-07-25T06:00:00Z\"^^xsd:dateTime .\n"
+    )
+
+    def _sparse_github_state(_root, sprints):
+        state = {}
+        for sprint in sprints:
+            if sprint["id"] == "AICH-S3":
+                state[sprint["id"]] = {
+                    "branch": sprint["branch"],
+                    "head_sha": None,
+                    "target_branch": None,
+                    "pr_number": None,
+                    "pr_url": None,
+                    "ci_status": None,
+                    "merged": None,
+                    "delivery_attempts": [],
+                }
+            else:
+                state[sprint["id"]] = {
+                    "branch": sprint["branch"],
+                    "head_sha": f"{sprint['id']}-sha",
+                    "target_branch": "integrate/phase-ai",
+                    "pr_number": sprint["order"],
+                    "pr_url": f"https://example.test/pr/{sprint['order']}",
+                    "ci_status": "pass",
+                    "merged": sprint["order"] == 1,
+                    "delivery_attempts": [],
+                }
+        return state, "example/test"
+
+    monkeypatch.setattr(triage_report, "_github_state", _sparse_github_state)
+    report = triage_report.build_report(root, "AICH", qa)
+    third = report["rows"][2]
+    assert third["dev_status"] == "in_progress"
+    assert third["qa"]["run_id"] is None
+    assert third["pr_number"] is None
+    assert not any(gap.startswith("AICH-S3:") for gap in report["data_gaps"])
+
+
 def test_report_ignores_unrelated_project_phase_findings(tmp_path):
     """A historical malformed phase cannot block the current phase report."""
     root, qa = _inputs(tmp_path)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,10 +111,9 @@ Every sprint follows this pattern:
 5. **Commit/Push/PR** to phase integration branch
 6. **Agent-teams review** documenting what worked/didn't
 
-**PR/QA is immediate, CI is a merge gate only — never a dispatch gate:**
-- Open the PR and dispatch `quality-mgr` for review the instant dev pushes. Do NOT hold off sending a task to `quality-mgr` to wait for CI to run or finish.
-- Never poll or watch CI runs yourself. CI checks a completely different thing than `quality-mgr` reviews (build/lint/test infra vs. architecture/requirements/boundary/best-practices) — a CI run in progress or even red is not a reason to delay QA.
-- The only thing to check for on a PR before/independent of QA is `mergeable == false` (a real merge conflict) — that needs action (rebase/resolve). A pending or failing CI check on its own needs no action and blocks nothing except the final merge.
+** team-lead - PR/QA is immediate, CI is a merge gate only — never a dispatch gate:**
+- Open the PR and dispatch `quality-mgr` for review immediately when dev pushes. Do NOT hold off sending j2 task to `quality-mgr` to wait for CI.
+- The only thing to check for on a PR before/independent of QA is `mergeable == false` (a real merge conflict) — that needs action (rebase/resolve). A failing CI check on its own must be addressed by idle or background agent, do not interrupt dev agent mid task to fix ci.
 - CI green is required only at actual merge time, never as a precondition for opening a PR or dispatching QA.
 
 ### Phase Integration Branch Strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Every sprint follows this pattern:
 5. **Commit/Push/PR** to phase integration branch
 6. **Agent-teams review** documenting what worked/didn't
 
-** team-lead - PR/QA is immediate, CI is a merge gate only — never a dispatch gate:**
+** team-lead only - PR/QA is immediate, CI is a merge gate only — never a dispatch gate:**
 - Open the PR and dispatch `quality-mgr` for review immediately when dev pushes. Do NOT hold off sending j2 task to `quality-mgr` to wait for CI.
 - The only thing to check for on a PR before/independent of QA is `mergeable == false` (a real merge conflict) — that needs action (rebase/resolve). A failing CI check on its own must be addressed by idle or background agent, do not interrupt dev agent mid task to fix ci.
 - CI green is required only at actual merge time, never as a precondition for opening a PR or dispatching QA.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ Every sprint follows this pattern:
 5. **Commit/Push/PR** to phase integration branch
 6. **Agent-teams review** documenting what worked/didn't
 
+**PR/QA is immediate, CI is a merge gate only — never a dispatch gate:**
+- Open the PR and dispatch `quality-mgr` for review the instant dev pushes. Do NOT hold off sending a task to `quality-mgr` to wait for CI to run or finish.
+- Never poll or watch CI runs yourself. CI checks a completely different thing than `quality-mgr` reviews (build/lint/test infra vs. architecture/requirements/boundary/best-practices) — a CI run in progress or even red is not a reason to delay QA.
+- The only thing to check for on a PR before/independent of QA is `mergeable == false` (a real merge conflict) — that needs action (rebase/resolve). A pending or failing CI check on its own needs no action and blocks nothing except the final merge.
+- CI green is required only at actual merge time, never as a precondition for opening a PR or dispatching QA.
+
 ### Phase Integration Branch Strategy
 
 Each phase gets a dedicated integration branch off `develop`:


### PR DESCRIPTION
## Summary
- `triage_report.py` was demanding a QA run and full GitHub PR/CI state as soon as a sprint's TTL declared a `triage:branch`, regardless of whether dev had even finished. That fires unconditionally for every in-flight sprint (assigned but not yet completed), because `triage:branch` is declared for all sprints upfront in `structure.ttl`, not just the ones dev has pushed.
- Gated both `TTL.QA_RUN_MISSING` and `GITHUB.SPRINT_STATE_UNAVAILABLE` on `dev_done` (Completion timestamp >= Assignment timestamp) instead of firing unconditionally — QA only ever runs after a dev Completion, and PR/CI state only exists after dev pushes, so this reflects the real lifecycle rather than loosening a correctness check.
- Fixed the stale `sc-compose render` invocation in `sprint-report/SKILL.md` (positional template arg no longer accepted; requires `--file`).
- Verified against live phase-ao2 data: report now renders correctly for AO2.1 (merged, PASS) and AO2.2 (in-progress, no invented PR/CI data), with AO2.3/AO2.4 correctly shown not-started.

## Test plan
- [x] `python3 -m pytest .claude/skills/triage-report/tests/test_triage_report.py -q` — 25 passed (24 pre-existing + 1 new regression test for the in-progress carve-out)
- [x] Manually rendered `/sprint-report` end-to-end against `integrate/phase-ao2` — clean zero-exit result, correct table output