### PR TITLE
AO2.2: isolated mTLS peer-wire byte-stream adapter

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -159,7 +159,7 @@ allowed_dependencies = ["atm-core", "atm-storage", "serde_json", "tokio", "traci
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde", "serde_json", "sha2", "toml", "ulid", "x509-parser"]
+allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde", "serde_json", "sha2", "toml", "ulid", "x509-parser", "zeroize"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage-rusqlite/Cargo.toml"

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -159,11 +159,16 @@ allowed_dependencies = ["atm-core", "atm-storage", "serde_json", "tokio", "traci
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde", "serde_json", "sha2", "toml", "ulid"]
+allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde", "serde_json", "sha2", "toml", "ulid", "x509-parser"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage-rusqlite/Cargo.toml"
 allowed_dependencies = ["async-trait", "atm-storage", "chrono", "rusqlite", "serde", "serde_json", "tempfile", "tokio", "tracing"]
+
+[[boundaries.manifest_dependency_allowlists]]
+owner_manifest_path = "crates/peer-tls/Cargo.toml"
+boundary_record_path = "boundaries/peer-tls/mtls-peer-stream-adapter.toml"
+allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-template-sc-compose/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "toml",
  "ulid",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +348,7 @@ dependencies = [
  "sha2",
  "toml",
  "ulid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -356,6 +396,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -468,7 +531,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -478,6 +541,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -559,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +673,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +727,12 @@ name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "equivalent"
@@ -698,6 +798,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1103,6 +1209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1336,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1226,10 +1358,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1238,6 +1389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1273,6 +1433,18 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "peer-tls"
+version = "1.4.4"
+dependencies = [
+ "atm-storage",
+ "rcgen",
+ "rustls",
+ "tempfile",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1422,7 +1594,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -1444,7 +1616,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1641,6 +1813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1840,8 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1683,6 +1866,7 @@ version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1713,7 +1897,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar",
- "thiserror",
+ "thiserror 2.0.20",
  "time",
  "toml",
 ]
@@ -1762,7 +1946,7 @@ dependencies = [
  "sc-observability-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -1774,7 +1958,7 @@ checksum = "b3ddd83dc10e65f4fda4c8b392fb9cfb520c4007c5ee5d0cde3af75c463b98ab"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -2061,11 +2245,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2705,6 +2909,23 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ sc-observability-types = "1.2.0"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tokio-rustls = "0.26"
 x509-parser = "0.16"
+zeroize = "1"
 tokio = { version = "1.48", default-features = false, features = ["io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "server", "http1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/atm-daemon-bootstrap",
     "crates/atm-daemon-client",
     "crates/atm-peer-tls-interop",
+    "crates/peer-tls",
     "crates/atm-graft",
     "crates/atm-graft-python",
     "crates/atm-query-python",
@@ -43,7 +44,9 @@ cargo_metadata = "0.23"
 sc-observability = "1.2.0"
 sc-observability-types = "1.2.0"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tokio = { version = "1.48", default-features = false, features = ["macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
+tokio-rustls = "0.26"
+x509-parser = "0.16"
+tokio = { version = "1.48", default-features = false, features = ["io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "server", "http1"] }
 hyper-util = { version = "0.1", default-features = false, features = ["server", "service", "tokio"] }

--- a/boundaries/atm-storage/peer-config-store.toml
+++ b/boundaries/atm-storage/peer-config-store.toml
@@ -19,7 +19,7 @@ io_owns = ["https_interface_configuration", "certificate_reference_metadata", "t
 io_forbidden = ["socket_io", "tls_handshake", "message_delivery", "retry_queue", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-peer-tls-interop", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon-bootstrap", "atm-peer-tls-interop", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof", "peer-tls"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 
@@ -42,4 +42,4 @@ review_gates = ["no_transport_or_delivery_logic_in_configuration_store"]
 
 [status]
 state = "concrete_landed"
-notes = ["AI.8 establishes configuration only; AI.9 owns HTTPS listener and transport implementation"]
+notes = ["AI.8 establishes configuration only; AO2.2 authorizes peer-tls as the sole concrete mTLS byte-stream consumer. Storage retains no socket or handshake ownership."]

--- a/boundaries/atm-storage/tls.toml
+++ b/boundaries/atm-storage/tls.toml
@@ -22,7 +22,7 @@ io_forbidden = ["socket_io", "message_delivery", "recipient_routing", "retry_que
 
 [dependencies]
 allowed_dependents = ["atm-peer-tls-interop", "peer-tls"]
-allowed_dependencies = ["atm-error", "rustls", "sha2", "x509-parser"]
+allowed_dependencies = ["atm-error", "rustls", "sha2", "x509-parser", "zeroize"]
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 
 [references]

--- a/boundaries/atm-storage/tls.toml
+++ b/boundaries/atm-storage/tls.toml
@@ -21,8 +21,8 @@ io_owns = ["certificate_parsing", "certificate_fingerprint_normalization", "trus
 io_forbidden = ["socket_io", "message_delivery", "recipient_routing", "retry_queue", "nudge_emission", "background_work", "process_spawn", "daemon_lifecycle"]
 
 [dependencies]
-allowed_dependents = ["atm-peer-tls-interop"]
-allowed_dependencies = ["atm-error", "rustls", "sha2"]
+allowed_dependents = ["atm-peer-tls-interop", "peer-tls"]
+allowed_dependencies = ["atm-error", "rustls", "sha2", "x509-parser"]
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 
 [references]
@@ -44,4 +44,4 @@ review_gates = ["no_socket_or_delivery_capability", "one_canonical_fingerprint_h
 
 [status]
 state = "concrete_landed"
-notes = ["AK6 owns the shared TLS identity and protocol-verification surface, including TLS 1.2/1.3 signature checks; active daemon and interop callers are governed explicitly while the interop crate remains inactive for production delivery."]
+notes = ["AK6 owns the shared TLS identity and protocol-verification surface, including TLS 1.2/1.3 signature checks; AO2.2 authorizes peer-tls as the sole production stream consumer while the interop crate remains inactive for production delivery."]

--- a/boundaries/peer-tls/mtls-peer-stream-adapter.toml
+++ b/boundaries/peer-tls/mtls-peer-stream-adapter.toml
@@ -1,0 +1,47 @@
+boundary_id = "BOUNDARY-MtlsPeerStreamAdapter"
+owner_package = "peer-tls"
+owner_crate_path = "peer_tls"
+name = "MtlsPeerStreamAdapter"
+
+[public]
+facade = "MtlsPeerStreamAdapter"
+notes = "Concrete finite mTLS byte-stream wrapper; no public transport trait or HTTP contract."
+
+[implementation]
+type = "MtlsPeerStreamAdapter"
+module = "peer_tls"
+visibility = "public"
+constructor = "public"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["tokio_rustls_stream_wrapping", "peer_certificate_pin_verification", "mutual_tls_handshake"]
+io_forbidden = ["http_runtime", "message_delivery", "message_persistence", "receipt", "nudge_emission", "retry_queue", "daemon_lifecycle"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls"]
+forbidden_edges = ["atm-http-runtime -> peer-tls", "atm -> peer-tls", "atm-graft -> peer-tls", "atm-daemon -> peer-tls"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["TcpStream", "HostName"]
+response_types = ["AsyncRead+AsyncWrite byte stream"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = ["peer_tls::tests::TestStore"]
+forbidden_test_bypasses = ["plaintext_fallback", "http_router", "native_tls_sender"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-MTLS-PEER-STREAM-ADAPTER"]
+review_gates = ["one_concrete_tls_owner", "no_http_or_durable_message_types", "no_plaintext_fallback"]
+
+[status]
+state = "concrete_landed"
+notes = ["AO2.2 owns the only production Rustls/Tokio-Rustls byte-stream adapter."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1317,22 +1317,61 @@ fn ao2_mtls_stream_adapter_is_the_only_authorized_production_tls_consumer() {
         .expect("mTLS stream adapter boundary must be valid TOML");
     assert!(boundary.dependencies.allowed_dependents.is_empty());
     let source = read_source(&root.join("crates/peer-tls/src/lib.rs"));
-    for forbidden in [
-        "RequestEnvelope",
-        "canonical_api_router",
-        "MessageStore",
-        "PeerWireMode",
-    ] {
-        assert!(
-            !source.contains(forbidden),
-            "peer-tls must remain an mTLS byte-stream-only adapter and reject `{forbidden}`"
-        );
-    }
+    let syntax = syn::parse_file(&source).expect("peer-tls source must parse");
+    let mut visitor = PeerTlsSurfaceVisitor::default();
+    visitor.visit_file(&syntax);
     assert!(
-        source.contains("tokio_rustls")
-            && source.contains("MtlsPeerStreamAdapter")
-            && source.contains("PeerConfigStore"),
+        visitor.forbidden.is_empty(),
+        "peer-tls must remain an mTLS byte-stream-only adapter and reject {:?}",
+        visitor.forbidden
+    );
+    assert!(
+        visitor.required.contains("tokio_rustls")
+            && visitor.required.contains("MtlsPeerStreamAdapter")
+            && visitor.required.contains("PeerConfigStore"),
         "AO2 must retain one concrete Rustls/Tokio-Rustls adapter over configuration and byte streams"
+    );
+}
+
+#[derive(Default)]
+struct PeerTlsSurfaceVisitor {
+    forbidden: BTreeSet<String>,
+    required: BTreeSet<String>,
+}
+
+impl<'ast> Visit<'ast> for PeerTlsSurfaceVisitor {
+    fn visit_ident(&mut self, ident: &'ast syn::Ident) {
+        let name = ident.to_string();
+        if matches!(
+            name.as_str(),
+            "RequestEnvelope" | "canonical_api_router" | "MessageStore" | "PeerWireMode"
+        ) {
+            self.forbidden.insert(name.clone());
+        }
+        if matches!(
+            name.as_str(),
+            "tokio_rustls" | "MtlsPeerStreamAdapter" | "PeerConfigStore"
+        ) {
+            self.required.insert(name);
+        }
+        syn::visit::visit_ident(self, ident);
+    }
+}
+
+#[test]
+fn ao2_mtls_surface_guard_matches_ast_identifiers_not_comments_or_strings() {
+    let comment_only = syn::parse_file("// PeerWireMode\nconst NOTE: &str = \"MessageStore\";")
+        .expect("fixture must parse");
+    let mut comment_visitor = PeerTlsSurfaceVisitor::default();
+    comment_visitor.visit_file(&comment_only);
+    assert!(comment_visitor.forbidden.is_empty());
+
+    let forbidden_use = syn::parse_file("use crate::PeerWireMode;").expect("fixture must parse");
+    let mut forbidden_visitor = PeerTlsSurfaceVisitor::default();
+    forbidden_visitor.visit_file(&forbidden_use);
+    assert_eq!(
+        forbidden_visitor.forbidden,
+        BTreeSet::from(["PeerWireMode".to_owned()])
     );
 }
 

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1302,6 +1302,51 @@ fn storage_tls_boundary_lists_only_current_tls_consumers() {
 }
 
 #[test]
+fn tls_identity_scrubs_the_source_pem_buffer_after_parsing() {
+    let source = read_source(&workspace_root().join("crates/atm-storage/src/tls.rs"));
+    let syntax = syn::parse_file(&source).expect("storage TLS source must parse");
+    let mut visitor = PemScrubbingVisitor::default();
+    visitor.visit_file(&syntax);
+    assert!(
+        visitor.wraps_pem_in_zeroizing,
+        "TlsIdentity::load must retain its source PEM in Zeroizing so private-key bytes are scrubbed after parsing"
+    );
+}
+
+#[derive(Default)]
+struct PemScrubbingVisitor {
+    wraps_pem_in_zeroizing: bool,
+}
+
+impl<'ast> Visit<'ast> for PemScrubbingVisitor {
+    fn visit_local(&mut self, local: &'ast syn::Local) {
+        if let syn::Pat::Ident(binding) = &local.pat
+            && binding.ident == "pem"
+            && local.init.as_ref().is_some_and(|init| {
+                matches!(
+                    init.expr.as_ref(),
+                    syn::Expr::Call(call) if is_zeroizing_constructor(call)
+                )
+            })
+        {
+            self.wraps_pem_in_zeroizing = true;
+        }
+        syn::visit::visit_local(self, local);
+    }
+}
+
+fn is_zeroizing_constructor(call: &syn::ExprCall) -> bool {
+    let syn::Expr::Path(path) = call.func.as_ref() else {
+        return false;
+    };
+    path.path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .eq(["Zeroizing".to_owned(), "new".to_owned()])
+}
+
+#[test]
 fn ao2_mtls_stream_adapter_is_the_only_authorized_production_tls_consumer() {
     let root = workspace_root();
     for (source, target) in [

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1296,8 +1296,43 @@ fn storage_tls_boundary_lists_only_current_tls_consumers() {
         .expect("storage TLS boundary must be valid TOML");
     assert_eq!(
         boundary.dependencies.allowed_dependents,
-        vec!["atm-peer-tls-interop".to_string()],
+        vec!["atm-peer-tls-interop".to_string(), "peer-tls".to_string(),],
         "storage TLS helpers must name only crates that consume the TLS API"
+    );
+}
+
+#[test]
+fn ao2_mtls_stream_adapter_is_the_only_authorized_production_tls_consumer() {
+    let root = workspace_root();
+    for (source, target) in [
+        ("atm-http-runtime", "peer-tls"),
+        ("atm", "peer-tls"),
+        ("atm-graft", "peer-tls"),
+        ("atm-daemon", "peer-tls"),
+    ] {
+        assert_forbidden_edge_absent(source, target);
+    }
+    let boundary_path = root.join("boundaries/peer-tls/mtls-peer-stream-adapter.toml");
+    let boundary: BoundaryToml = toml::from_str(&read_source(&boundary_path))
+        .expect("mTLS stream adapter boundary must be valid TOML");
+    assert!(boundary.dependencies.allowed_dependents.is_empty());
+    let source = read_source(&root.join("crates/peer-tls/src/lib.rs"));
+    for forbidden in [
+        "RequestEnvelope",
+        "canonical_api_router",
+        "MessageStore",
+        "PeerWireMode",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "peer-tls must remain an mTLS byte-stream-only adapter and reject `{forbidden}`"
+        );
+    }
+    assert!(
+        source.contains("tokio_rustls")
+            && source.contains("MtlsPeerStreamAdapter")
+            && source.contains("PeerConfigStore"),
+        "AO2 must retain one concrete Rustls/Tokio-Rustls adapter over configuration and byte streams"
     );
 }
 

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -50,6 +50,8 @@ pub enum AtmErrorCode {
     PeerWirePlaintextAuthenticationRequired,
     PeerConfigValidationFailed,
     CertificateOperationFailed,
+    /// A configured peer did not satisfy exact mTLS hostname or pin authentication.
+    PeerAuthenticationFailed,
     BindPreflightFailed,
     ClientDaemonVersionIncompatible,
     DaemonAdvisorySessionAlreadyRegistered,
@@ -193,6 +195,7 @@ impl AtmErrorCode {
             }
             Self::PeerConfigValidationFailed => "ATM_PEER_CONFIG_VALIDATION_FAILED",
             Self::CertificateOperationFailed => "ATM_CERTIFICATE_OPERATION_FAILED",
+            Self::PeerAuthenticationFailed => "ATM_PEER_AUTHENTICATION_FAILED",
             Self::BindPreflightFailed => "ATM_BIND_PREFLIGHT_FAILED",
             Self::ClientDaemonVersionIncompatible => "ATM_CLIENT_DAEMON_VERSION_INCOMPATIBLE",
             Self::DaemonAdvisorySessionAlreadyRegistered => {
@@ -356,6 +359,7 @@ fn parse_daemon_or_address_code(value: &str) -> Option<AtmErrorCode> {
         }
         "ATM_PEER_CONFIG_VALIDATION_FAILED" => AtmErrorCode::PeerConfigValidationFailed,
         "ATM_CERTIFICATE_OPERATION_FAILED" => AtmErrorCode::CertificateOperationFailed,
+        "ATM_PEER_AUTHENTICATION_FAILED" => AtmErrorCode::PeerAuthenticationFailed,
         "ATM_BIND_PREFLIGHT_FAILED" => AtmErrorCode::BindPreflightFailed,
         "ATM_CLIENT_DAEMON_VERSION_INCOMPATIBLE" => AtmErrorCode::ClientDaemonVersionIncompatible,
         "ATM_DAEMON_ADVISORY_SESSION_ALREADY_REGISTERED" => {

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -52,6 +52,10 @@ pub enum AtmErrorCode {
     CertificateOperationFailed,
     /// A configured peer did not satisfy exact mTLS hostname or pin authentication.
     PeerAuthenticationFailed,
+    /// A bounded peer transport operation did not finish before its deadline.
+    TransportTimeout,
+    /// A peer transport handshake failed outside configuration or pin authentication.
+    TransportProtocolFailed,
     BindPreflightFailed,
     ClientDaemonVersionIncompatible,
     DaemonAdvisorySessionAlreadyRegistered,
@@ -196,6 +200,8 @@ impl AtmErrorCode {
             Self::PeerConfigValidationFailed => "ATM_PEER_CONFIG_VALIDATION_FAILED",
             Self::CertificateOperationFailed => "ATM_CERTIFICATE_OPERATION_FAILED",
             Self::PeerAuthenticationFailed => "ATM_PEER_AUTHENTICATION_FAILED",
+            Self::TransportTimeout => "ATM_TRANSPORT_TIMEOUT",
+            Self::TransportProtocolFailed => "ATM_TRANSPORT_PROTOCOL_FAILED",
             Self::BindPreflightFailed => "ATM_BIND_PREFLIGHT_FAILED",
             Self::ClientDaemonVersionIncompatible => "ATM_CLIENT_DAEMON_VERSION_INCOMPATIBLE",
             Self::DaemonAdvisorySessionAlreadyRegistered => {
@@ -360,6 +366,8 @@ fn parse_daemon_or_address_code(value: &str) -> Option<AtmErrorCode> {
         "ATM_PEER_CONFIG_VALIDATION_FAILED" => AtmErrorCode::PeerConfigValidationFailed,
         "ATM_CERTIFICATE_OPERATION_FAILED" => AtmErrorCode::CertificateOperationFailed,
         "ATM_PEER_AUTHENTICATION_FAILED" => AtmErrorCode::PeerAuthenticationFailed,
+        "ATM_TRANSPORT_TIMEOUT" => AtmErrorCode::TransportTimeout,
+        "ATM_TRANSPORT_PROTOCOL_FAILED" => AtmErrorCode::TransportProtocolFailed,
         "ATM_BIND_PREFLIGHT_FAILED" => AtmErrorCode::BindPreflightFailed,
         "ATM_CLIENT_DAEMON_VERSION_INCOMPATIBLE" => AtmErrorCode::ClientDaemonVersionIncompatible,
         "ATM_DAEMON_ADVISORY_SESSION_ALREADY_REGISTERED" => {

--- a/crates/atm-error/src/lib.rs
+++ b/crates/atm-error/src/lib.rs
@@ -45,7 +45,7 @@ mod tests {
     }
 
     #[test]
-    fn peer_transport_error_codes_keep_their_stable_wire_spellings() {
+    fn timeout_and_protocol_error_codes_keep_their_stable_wire_spellings() {
         for (code, wire) in [
             (AtmErrorCode::TransportTimeout, "ATM_TRANSPORT_TIMEOUT"),
             (

--- a/crates/atm-error/src/lib.rs
+++ b/crates/atm-error/src/lib.rs
@@ -45,6 +45,20 @@ mod tests {
     }
 
     #[test]
+    fn peer_transport_error_codes_keep_their_stable_wire_spellings() {
+        for (code, wire) in [
+            (AtmErrorCode::TransportTimeout, "ATM_TRANSPORT_TIMEOUT"),
+            (
+                AtmErrorCode::TransportProtocolFailed,
+                "ATM_TRANSPORT_PROTOCOL_FAILED",
+            ),
+        ] {
+            assert_eq!(code.as_str(), wire);
+            assert_eq!(wire.parse::<AtmErrorCode>(), Ok(code));
+        }
+    }
+
+    #[test]
     fn error_codes_round_trip_through_json() {
         let code = AtmErrorCode::MessageValidationFailed;
         let encoded = serde_json::to_string(&code).expect("serialize error code");

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -14,6 +14,7 @@ atm-error = { path = "../atm-error", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true
+x509-parser.workspace = true
 sha2.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true
 x509-parser.workspace = true
+zeroize.workspace = true
 sha2.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -194,6 +194,12 @@ impl AtmError {
         Self::new(AtmErrorCode::CertificateOperationFailed, message)
     }
 
+    /// Reports a fail-closed mismatch between a configured peer authority and
+    /// the certificate presented during mutual TLS.
+    pub fn peer_authentication(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::PeerAuthenticationFailed, message)
+    }
+
     pub fn bind_preflight(message: impl Into<String>) -> Self {
         Self::new(AtmErrorCode::BindPreflightFailed, message)
     }

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -200,6 +200,16 @@ impl AtmError {
         Self::new(AtmErrorCode::PeerAuthenticationFailed, message)
     }
 
+    /// Reports a bounded peer transport operation that exceeded its deadline.
+    pub fn transport_timeout(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::TransportTimeout, message)
+    }
+
+    /// Reports a non-authentication peer transport handshake failure.
+    pub fn transport_protocol(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::TransportProtocolFailed, message)
+    }
+
     pub fn bind_preflight(message: impl Into<String>) -> Self {
         Self::new(AtmErrorCode::BindPreflightFailed, message)
     }

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -128,6 +128,12 @@ const fn daemon_guidance(code: AtmErrorCode) -> Option<&'static str> {
         AtmErrorCode::PeerAuthenticationFailed => Some(
             "Correct the registered peer hostname and certificate pin; do not use plaintext-test as a recovery.",
         ),
+        AtmErrorCode::TransportTimeout => Some(
+            "Check peer reachability and retry the bounded transport operation when the peer is available.",
+        ),
+        AtmErrorCode::TransportProtocolFailed => {
+            Some("Inspect the peer TLS protocol configuration and correct it before retrying.")
+        }
         _ => None,
     }
 }

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -125,6 +125,9 @@ const fn daemon_guidance(code: AtmErrorCode) -> Option<&'static str> {
         AtmErrorCode::PeerWirePlaintextAuthenticationRequired => Some(
             "Restart in mutual-TLS mode and verify the enabled peer identity, certificate, and exact trust record.",
         ),
+        AtmErrorCode::PeerAuthenticationFailed => Some(
+            "Correct the registered peer hostname and certificate pin; do not use plaintext-test as a recovery.",
+        ),
         _ => None,
     }
 }

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -60,8 +60,8 @@ pub use template_workflow::{
     WorkflowState, WorkflowTransition,
 };
 pub use tls::{
-    PinnedClientVerifier, TlsIdentity, certificate_fingerprint, install_tls_provider,
-    normalize_fingerprint,
+    PinnedClientVerifier, TlsIdentity, certificate_fingerprint, certificate_valid_now,
+    install_tls_provider, normalize_fingerprint,
 };
 pub use types::{
     AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, ModelName, PaneId, TaskId,

--- a/crates/atm-storage/src/tls.rs
+++ b/crates/atm-storage/src/tls.rs
@@ -9,8 +9,9 @@ use std::sync::RwLock;
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, UnixTime, pem::PemObject};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
-use rustls::{DigitallySignedStruct, Error, ServerConnection, SignatureScheme};
+use rustls::{CertificateError, DigitallySignedStruct, Error, ServerConnection, SignatureScheme};
 use sha2::{Digest, Sha256};
+use x509_parser::prelude::parse_x509_certificate;
 
 use crate::contract::{LocalCertificate, TrustedPeer};
 use crate::error::AtmError;
@@ -65,6 +66,9 @@ impl TlsIdentity {
         }
         let private_key = PrivateKeyDer::from_pem_slice(&pem).map_err(|source| {
             AtmError::validation("configured TLS private key PEM is invalid").with_cause(source)
+        })?;
+        certificate_valid_now(first).map_err(|_| {
+            AtmError::validation("configured TLS certificate is expired or not yet valid")
         })?;
         Ok(Self {
             certificates,
@@ -151,7 +155,9 @@ impl ClientCertVerifier for PinnedClientVerifier {
         _intermediates: &[CertificateDer<'_>],
         _now: UnixTime,
     ) -> Result<ClientCertVerified, Error> {
-        if self.host_for_certificate(end_entity).is_some() {
+        if certificate_valid_now(end_entity).is_err() {
+            Err(CertificateError::Expired.into())
+        } else if self.host_for_certificate(end_entity).is_some() {
             Ok(ClientCertVerified::assertion())
         } else {
             Err(rustls::CertificateError::UnknownIssuer.into())
@@ -178,6 +184,18 @@ impl ClientCertVerifier for PinnedClientVerifier {
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
         self.algorithms.supported_schemes()
+    }
+}
+
+/// Reject a malformed, expired, or not-yet-valid certificate before a stream
+/// wrapper can expose application bytes.
+pub fn certificate_valid_now(certificate: &CertificateDer<'_>) -> Result<(), Error> {
+    let (_, parsed) = parse_x509_certificate(certificate.as_ref())
+        .map_err(|_| Error::InvalidCertificate(CertificateError::BadEncoding))?;
+    if parsed.validity().is_valid() {
+        Ok(())
+    } else {
+        Err(CertificateError::Expired.into())
     }
 }
 

--- a/crates/atm-storage/src/tls.rs
+++ b/crates/atm-storage/src/tls.rs
@@ -12,6 +12,7 @@ use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{CertificateError, DigitallySignedStruct, Error, ServerConnection, SignatureScheme};
 use sha2::{Digest, Sha256};
 use x509_parser::prelude::parse_x509_certificate;
+use zeroize::Zeroizing;
 
 use crate::contract::{LocalCertificate, TrustedPeer};
 use crate::error::AtmError;
@@ -44,12 +45,15 @@ impl TlsIdentity {
     /// Parse and validate a durable certificate/key bundle.
     pub fn load(certificate: &LocalCertificate) -> Result<Self, AtmError> {
         let path = Path::new(certificate.private_key_ref.as_str());
-        let pem = std::fs::read(path).map_err(|source| {
+        // The certificate chain is copied into rustls-owned DER values and the
+        // private key into `PrivateKeyDer`; the source PEM must not remain in
+        // process memory after this parser scope exits.
+        let pem = Zeroizing::new(std::fs::read(path).map_err(|source| {
             AtmError::daemon_unavailable_with_cause(
                 "failed to open the configured TLS certificate/key PEM bundle",
                 source,
             )
-        })?;
+        })?);
         let certificates = CertificateDer::pem_slice_iter(&pem)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|source| {

--- a/crates/peer-tls/Cargo.toml
+++ b/crates/peer-tls/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "peer-tls"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Concrete, bounded mTLS byte-stream adapter for ATM peers."
+
+[dependencies]
+atm-storage = { path = "../atm-storage", version = "1.4.4" }
+rustls.workspace = true
+tokio.workspace = true
+tokio-rustls.workspace = true
+
+[dev-dependencies]
+rcgen = "0.13"
+tempfile = "3"

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -423,7 +423,7 @@ mod tests {
     }
 
     #[test]
-    fn disabled_or_hostname_mismatched_peer_fails_before_tcp_or_http_work() {
+    fn disabled_peer_fails_before_tcp_or_http_work() {
         let directory = tempfile::tempdir().expect("directory");
         let identity = identity(&directory, "local");
         let target = peer(&identity, false);
@@ -435,6 +435,23 @@ mod tests {
         .expect("adapter");
         let host: HostName = "localhost".parse().expect("host");
         let error = adapter.trusted_peer(&host).expect_err("disabled peer");
+        assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
+    }
+
+    #[test]
+    fn hostname_mismatch_fails_before_tcp_or_http_work() {
+        let directory = tempfile::tempdir().expect("directory");
+        let identity = identity(&directory, "local");
+        let adapter = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(identity.clone()),
+            peers: vec![peer(&identity, true)],
+        })
+        .expect("adapter");
+        let mismatched_host: HostName = "other-peer.example".parse().expect("host");
+        let error = adapter
+            .trusted_peer(&mismatched_host)
+            .expect_err("mismatched hostname");
         assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
     }
 

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -88,14 +88,9 @@ impl MtlsPeerStreamAdapter {
         let connector = TlsConnector::from(Arc::new(self.client_config(configured)?));
         timeout(self.handshake_timeout, connector.connect(server_name, tcp))
             .await
-            .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
+            .map_err(|_| AtmError::transport_timeout("mTLS peer handshake deadline expired"))?
             .map(TlsStream::Client)
-            .map_err(|source| {
-                AtmError::peer_authentication(
-                    "mTLS peer handshake failed before application processing",
-                )
-                .with_cause(source)
-            })
+            .map_err(outbound_handshake_error)
     }
 
     /// Authenticate an inbound TCP byte stream against the configured client pins.
@@ -106,14 +101,9 @@ impl MtlsPeerStreamAdapter {
         let acceptor = TlsAcceptor::from(Arc::new(self.server_config()?));
         timeout(self.handshake_timeout, acceptor.accept(tcp))
             .await
-            .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
+            .map_err(|_| AtmError::transport_timeout("mTLS peer handshake deadline expired"))?
             .map(TlsStream::Server)
-            .map_err(|source| {
-                AtmError::peer_authentication(
-                    "mTLS client certificate was rejected before application processing",
-                )
-                .with_cause(source)
-            })
+            .map_err(inbound_handshake_error)
     }
 
     fn trusted_peer(&self, peer: &HostName) -> Result<&TrustedPeer, AtmError> {
@@ -161,6 +151,35 @@ impl MtlsPeerStreamAdapter {
                 .with_cause(source)
             })
     }
+}
+
+fn outbound_handshake_error(source: std::io::Error) -> AtmError {
+    if is_certificate_authentication_error(&source) {
+        AtmError::peer_authentication(
+            "mTLS peer certificate did not satisfy the configured hostname or pin",
+        )
+    } else {
+        AtmError::transport_protocol("mTLS peer handshake failed before application processing")
+            .with_cause(source)
+    }
+}
+
+fn inbound_handshake_error(source: std::io::Error) -> AtmError {
+    if is_certificate_authentication_error(&source) {
+        AtmError::peer_authentication(
+            "mTLS client certificate did not satisfy the configured trust record",
+        )
+    } else {
+        AtmError::transport_protocol("mTLS client handshake failed before application processing")
+            .with_cause(source)
+    }
+}
+
+fn is_certificate_authentication_error(source: &std::io::Error) -> bool {
+    source
+        .get_ref()
+        .and_then(|cause| cause.downcast_ref::<Error>())
+        .is_some_and(|cause| matches!(cause, Error::InvalidCertificate(_)))
 }
 
 /// Exact fingerprint verifier for the selected outbound peer. The registered
@@ -559,7 +578,37 @@ mod tests {
             Err(error) => error,
             Ok(_) => panic!("handshake deadline must fail"),
         };
-        assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
+        assert_eq!(error.code().as_str(), "ATM_TRANSPORT_TIMEOUT");
+        raw_client.await.expect("raw client");
+    }
+
+    #[tokio::test]
+    async fn malformed_handshake_fails_with_a_transport_protocol_code() {
+        let directory = tempfile::tempdir().expect("directory");
+        let server_identity = identity(&directory, "server");
+        let client_identity = identity(&directory, "client");
+        let server = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(server_identity),
+            peers: vec![peer(&client_identity, true)],
+        })
+        .expect("server adapter");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let raw_client = tokio::spawn(async move {
+            let mut tcp = TcpStream::connect(address).await.expect("connect tcp");
+            tcp.write_all(b"not a TLS client hello")
+                .await
+                .expect("write junk");
+        });
+        let (tcp, _) = listener.accept().await.expect("accept tcp");
+        let error = match server.accept(tcp).await {
+            Err(error) => error,
+            Ok(_) => panic!("malformed handshake must fail"),
+        };
+        assert_eq!(error.code().as_str(), "ATM_TRANSPORT_PROTOCOL_FAILED");
         raw_client.await.expect("raw client");
     }
 }

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -8,7 +8,7 @@ use std::{fmt, sync::Arc, time::Duration};
 
 use atm_storage::{
     AtmError, HostName, PeerConfigStore, PinnedClientVerifier, TlsIdentity, TrustedPeer,
-    certificate_fingerprint, certificate_valid_now, install_tls_provider,
+    certificate_fingerprint, certificate_valid_now, install_tls_provider, normalize_fingerprint,
 };
 use rustls::{
     CertificateError, ClientConfig, DigitallySignedStruct, Error, ServerConfig, SignatureScheme,
@@ -201,7 +201,7 @@ impl PinnedServerVerifier {
         }
         Ok(Self {
             hostname: peer.host.as_str().to_owned(),
-            fingerprint: peer.fingerprint.as_str().to_ascii_lowercase(),
+            fingerprint: normalize_fingerprint(peer.fingerprint.as_str()),
             algorithms: rustls::crypto::ring::default_provider().signature_verification_algorithms,
         })
     }
@@ -480,6 +480,30 @@ mod tests {
         })
         .expect_err("expired certificate");
         assert_eq!(error.code().as_str(), "ATM_CERTIFICATE_OPERATION_FAILED");
+    }
+
+    #[test]
+    fn server_verifier_uses_canonical_fingerprint_normalization() {
+        let directory = tempfile::tempdir().expect("directory");
+        let identity = identity(&directory, "peer");
+        let mut configured = peer(&identity, true);
+        configured.fingerprint = CertificateFingerprint::try_from(
+            identity
+                .fingerprint
+                .as_str()
+                .as_bytes()
+                .chunks(2)
+                .map(|chunk| {
+                    std::str::from_utf8(chunk)
+                        .expect("hex")
+                        .to_ascii_uppercase()
+                })
+                .collect::<Vec<_>>()
+                .join(":"),
+        )
+        .expect("fingerprint");
+        let verifier = PinnedServerVerifier::new(&configured).expect("verifier");
+        assert_eq!(verifier.fingerprint, identity.fingerprint.as_str());
     }
 
     #[tokio::test]

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -29,9 +29,14 @@ const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// The adapter snapshots durable interface, local identity, and trust data at
 /// composition time. It cannot infer or select a peer-wire mode itself.
 pub struct MtlsPeerStreamAdapter {
-    identity: TlsIdentity,
-    trusted_peers: Vec<TrustedPeer>,
+    client_configs: Vec<PeerClientConfig>,
+    server_config: Arc<ServerConfig>,
     handshake_timeout: Duration,
+}
+
+struct PeerClientConfig {
+    authority: HostName,
+    config: Arc<ClientConfig>,
 }
 
 impl fmt::Debug for MtlsPeerStreamAdapter {
@@ -61,9 +66,22 @@ impl MtlsPeerStreamAdapter {
             AtmError::certificate_operation("configured mTLS identity is invalid")
                 .with_cause(error.detail())
         })?;
+        let trusted_peers = store.list_trusted_peers()?;
+        install_tls_provider();
+        let client_configs = trusted_peers
+            .iter()
+            .filter(|peer| peer.enabled)
+            .map(|peer| {
+                Ok(PeerClientConfig {
+                    authority: peer.host.clone(),
+                    config: Arc::new(Self::build_client_config(&identity, peer)?),
+                })
+            })
+            .collect::<Result<Vec<_>, AtmError>>()?;
+        let server_config = Arc::new(Self::build_server_config(&identity, trusted_peers)?);
         Ok(Self {
-            identity,
-            trusted_peers: store.list_trusted_peers()?,
+            client_configs,
+            server_config,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
         })
     }
@@ -81,11 +99,11 @@ impl MtlsPeerStreamAdapter {
         tcp: TcpStream,
         peer: &HostName,
     ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + use<>, AtmError> {
-        let configured = self.trusted_peer(peer)?;
+        let config = self.client_config_for(peer)?;
         let server_name = ServerName::try_from(peer.as_str().to_owned()).map_err(|_| {
             AtmError::peer_authentication("configured peer hostname is not valid for mTLS")
         })?;
-        let connector = TlsConnector::from(Arc::new(self.client_config(configured)?));
+        let connector = TlsConnector::from(Arc::clone(config));
         timeout(self.handshake_timeout, connector.connect(server_name, tcp))
             .await
             .map_err(|_| AtmError::transport_timeout("mTLS peer handshake deadline expired"))?
@@ -98,7 +116,7 @@ impl MtlsPeerStreamAdapter {
         &self,
         tcp: TcpStream,
     ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + use<>, AtmError> {
-        let acceptor = TlsAcceptor::from(Arc::new(self.server_config()?));
+        let acceptor = TlsAcceptor::from(Arc::clone(&self.server_config));
         timeout(self.handshake_timeout, acceptor.accept(tcp))
             .await
             .map_err(|_| AtmError::transport_timeout("mTLS peer handshake deadline expired"))?
@@ -106,10 +124,11 @@ impl MtlsPeerStreamAdapter {
             .map_err(inbound_handshake_error)
     }
 
-    fn trusted_peer(&self, peer: &HostName) -> Result<&TrustedPeer, AtmError> {
-        self.trusted_peers
+    fn client_config_for(&self, peer: &HostName) -> Result<&Arc<ClientConfig>, AtmError> {
+        self.client_configs
             .iter()
-            .find(|candidate| candidate.enabled && candidate.host == *peer)
+            .find(|candidate| candidate.authority == *peer)
+            .map(|candidate| &candidate.config)
             .ok_or_else(|| {
                 AtmError::peer_authentication(
                     "peer is not an enabled exact mTLS authority; plaintext fallback is forbidden",
@@ -117,14 +136,16 @@ impl MtlsPeerStreamAdapter {
             })
     }
 
-    fn client_config(&self, peer: &TrustedPeer) -> Result<ClientConfig, AtmError> {
-        install_tls_provider();
+    fn build_client_config(
+        identity: &TlsIdentity,
+        peer: &TrustedPeer,
+    ) -> Result<ClientConfig, AtmError> {
         ClientConfig::builder()
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(PinnedServerVerifier::new(peer)?))
             .with_client_auth_cert(
-                self.identity.certificates().to_vec(),
-                self.identity.private_key().clone_key(),
+                identity.certificates().to_vec(),
+                identity.private_key().clone_key(),
             )
             .map_err(|source| {
                 AtmError::certificate_operation(
@@ -134,15 +155,15 @@ impl MtlsPeerStreamAdapter {
             })
     }
 
-    fn server_config(&self) -> Result<ServerConfig, AtmError> {
-        install_tls_provider();
+    fn build_server_config(
+        identity: &TlsIdentity,
+        trusted_peers: Vec<TrustedPeer>,
+    ) -> Result<ServerConfig, AtmError> {
         ServerConfig::builder()
-            .with_client_cert_verifier(Arc::new(PinnedClientVerifier::new(
-                self.trusted_peers.clone(),
-            )))
+            .with_client_cert_verifier(Arc::new(PinnedClientVerifier::new(trusted_peers)))
             .with_single_cert(
-                self.identity.certificates().to_vec(),
-                self.identity.private_key().clone_key(),
+                identity.certificates().to_vec(),
+                identity.private_key().clone_key(),
             )
             .map_err(|source| {
                 AtmError::certificate_operation(
@@ -434,7 +455,7 @@ mod tests {
         })
         .expect("adapter");
         let host: HostName = "localhost".parse().expect("host");
-        let error = adapter.trusted_peer(&host).expect_err("disabled peer");
+        let error = adapter.client_config_for(&host).expect_err("disabled peer");
         assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
     }
 
@@ -450,9 +471,27 @@ mod tests {
         .expect("adapter");
         let mismatched_host: HostName = "other-peer.example".parse().expect("host");
         let error = adapter
-            .trusted_peer(&mismatched_host)
+            .client_config_for(&mismatched_host)
             .expect_err("mismatched hostname");
         assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
+    }
+
+    #[test]
+    fn configured_tls_configs_are_cached_at_adapter_composition() {
+        let directory = tempfile::tempdir().expect("directory");
+        let local = identity(&directory, "local");
+        let peer_identity = identity(&directory, "peer");
+        let adapter = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(local),
+            peers: vec![peer(&peer_identity, true)],
+        })
+        .expect("adapter");
+        let host: HostName = "localhost".parse().expect("host");
+        let first = adapter.client_config_for(&host).expect("cached config");
+        let second = adapter.client_config_for(&host).expect("cached config");
+        assert!(Arc::ptr_eq(first, second));
+        assert_eq!(adapter.client_configs.len(), 1);
     }
 
     #[test]

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -15,7 +15,11 @@ use rustls::{
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     pki_types::{CertificateDer, ServerName, UnixTime},
 };
-use tokio::{net::TcpStream, time::timeout};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+    time::timeout,
+};
 use tokio_rustls::{TlsAcceptor, TlsConnector, TlsStream};
 
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -76,7 +80,7 @@ impl MtlsPeerStreamAdapter {
         &self,
         tcp: TcpStream,
         peer: &HostName,
-    ) -> Result<TlsStream<TcpStream>, AtmError> {
+    ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + use<>, AtmError> {
         let configured = self.trusted_peer(peer)?;
         let server_name = ServerName::try_from(peer.as_str().to_owned()).map_err(|_| {
             AtmError::peer_authentication("configured peer hostname is not valid for mTLS")
@@ -85,7 +89,7 @@ impl MtlsPeerStreamAdapter {
         timeout(self.handshake_timeout, connector.connect(server_name, tcp))
             .await
             .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
-            .map(|stream| stream.into())
+            .map(TlsStream::Client)
             .map_err(|source| {
                 AtmError::peer_authentication(
                     "mTLS peer handshake failed before application processing",
@@ -95,12 +99,15 @@ impl MtlsPeerStreamAdapter {
     }
 
     /// Authenticate an inbound TCP byte stream against the configured client pins.
-    pub async fn accept(&self, tcp: TcpStream) -> Result<TlsStream<TcpStream>, AtmError> {
+    pub async fn accept(
+        &self,
+        tcp: TcpStream,
+    ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + use<>, AtmError> {
         let acceptor = TlsAcceptor::from(Arc::new(self.server_config()?));
         timeout(self.handshake_timeout, acceptor.accept(tcp))
             .await
             .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
-            .map(|stream| stream.into())
+            .map(TlsStream::Server)
             .map_err(|source| {
                 AtmError::peer_authentication(
                     "mTLS client certificate was rejected before application processing",
@@ -513,10 +520,10 @@ mod tests {
                 &host,
             )
             .await;
-        let server_error = server_task
-            .await
-            .expect("server task")
-            .expect_err("untrusted client must not complete mTLS");
+        let server_error = match server_task.await.expect("server task") {
+            Err(error) => error,
+            Ok(_) => panic!("untrusted client must not complete mTLS"),
+        };
         assert_eq!(
             server_error.code().as_str(),
             "ATM_PEER_AUTHENTICATION_FAILED"
@@ -548,7 +555,10 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
         });
         let (tcp, _) = listener.accept().await.expect("accept tcp");
-        let error = server.accept(tcp).await.expect_err("deadline");
+        let error = match server.accept(tcp).await {
+            Err(error) => error,
+            Ok(_) => panic!("handshake deadline must fail"),
+        };
         assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
         raw_client.await.expect("raw client");
     }

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -481,6 +481,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn untrusted_client_certificate_fails_before_opaque_bytes_can_flow() {
+        let directory = tempfile::tempdir().expect("directory");
+        let server_identity = identity(&directory, "server");
+        let client_identity = identity(&directory, "client");
+        let untrusted_identity = identity(&directory, "untrusted");
+        let server = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(server_identity.clone()),
+            peers: vec![peer(&untrusted_identity, true)],
+        })
+        .expect("server adapter");
+        let client = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(client_identity),
+            peers: vec![peer(&server_identity, true)],
+        })
+        .expect("client adapter");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("accept tcp");
+            server.accept(tcp).await
+        });
+        let host: HostName = "localhost".parse().expect("host");
+        let _client_result = client
+            .connect(
+                TcpStream::connect(address).await.expect("connect tcp"),
+                &host,
+            )
+            .await;
+        let server_error = server_task
+            .await
+            .expect("server task")
+            .expect_err("untrusted client must not complete mTLS");
+        assert_eq!(
+            server_error.code().as_str(),
+            "ATM_PEER_AUTHENTICATION_FAILED"
+        );
+        // TLS 1.3 can let the client receive the server Finished before the
+        // server observes and rejects its certificate. The authoritative
+        // inbound decision above nevertheless fails before any stream is
+        // handed to application protocol code, so no opaque bytes can flow.
+    }
+
+    #[tokio::test]
     async fn handshake_deadline_fails_before_any_application_protocol_can_start() {
         let directory = tempfile::tempdir().expect("directory");
         let server_identity = identity(&directory, "server");

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -1,0 +1,508 @@
+//! The sole concrete mutual-TLS byte-stream adapter for ATM peer transport.
+//!
+//! This crate intentionally knows only configured peer identity and byte
+//! streams. It owns neither HTTP nor any ATM request, route, persistence,
+//! acknowledgement, retry, hook, daemon lifecycle, or plaintext fallback.
+
+use std::{fmt, sync::Arc, time::Duration};
+
+use atm_storage::{
+    AtmError, HostName, PeerConfigStore, PinnedClientVerifier, TlsIdentity, TrustedPeer,
+    certificate_fingerprint, certificate_valid_now, install_tls_provider,
+};
+use rustls::{
+    CertificateError, ClientConfig, DigitallySignedStruct, Error, ServerConfig, SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+};
+use tokio::{net::TcpStream, time::timeout};
+use tokio_rustls::{TlsAcceptor, TlsConnector, TlsStream};
+
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Concrete mTLS facade assembled only after the daemon has selected mTLS.
+///
+/// The adapter snapshots durable interface, local identity, and trust data at
+/// composition time. It cannot infer or select a peer-wire mode itself.
+pub struct MtlsPeerStreamAdapter {
+    identity: TlsIdentity,
+    trusted_peers: Vec<TrustedPeer>,
+    handshake_timeout: Duration,
+}
+
+impl fmt::Debug for MtlsPeerStreamAdapter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MtlsPeerStreamAdapter")
+            .finish_non_exhaustive()
+    }
+}
+
+impl MtlsPeerStreamAdapter {
+    /// Snapshot valid mTLS configuration from the storage-neutral control plane.
+    pub fn from_peer_config(store: &(dyn PeerConfigStore + Send + Sync)) -> Result<Self, AtmError> {
+        let has_enabled_interface = store
+            .list_interfaces()?
+            .into_iter()
+            .any(|interface| interface.enabled);
+        if !has_enabled_interface {
+            return Err(AtmError::peer_config_validation(
+                "mTLS requires one enabled peer interface",
+            ));
+        }
+        let certificate = store.local_certificate()?.ok_or_else(|| {
+            AtmError::peer_config_validation("mTLS requires a configured local identity")
+        })?;
+        let identity = TlsIdentity::load(&certificate).map_err(|error| {
+            AtmError::certificate_operation("configured mTLS identity is invalid")
+                .with_cause(error.detail())
+        })?;
+        Ok(Self {
+            identity,
+            trusted_peers: store.list_trusted_peers()?,
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+        })
+    }
+
+    /// Narrow test/operations hook for a bounded handshake deadline.
+    #[must_use]
+    pub fn with_handshake_timeout(mut self, handshake_timeout: Duration) -> Self {
+        self.handshake_timeout = handshake_timeout;
+        self
+    }
+
+    /// Authenticate an outbound TCP byte stream against the exact configured authority and pin.
+    pub async fn connect(
+        &self,
+        tcp: TcpStream,
+        peer: &HostName,
+    ) -> Result<TlsStream<TcpStream>, AtmError> {
+        let configured = self.trusted_peer(peer)?;
+        let server_name = ServerName::try_from(peer.as_str().to_owned()).map_err(|_| {
+            AtmError::peer_authentication("configured peer hostname is not valid for mTLS")
+        })?;
+        let connector = TlsConnector::from(Arc::new(self.client_config(configured)?));
+        timeout(self.handshake_timeout, connector.connect(server_name, tcp))
+            .await
+            .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
+            .map(|stream| stream.into())
+            .map_err(|source| {
+                AtmError::peer_authentication(
+                    "mTLS peer handshake failed before application processing",
+                )
+                .with_cause(source)
+            })
+    }
+
+    /// Authenticate an inbound TCP byte stream against the configured client pins.
+    pub async fn accept(&self, tcp: TcpStream) -> Result<TlsStream<TcpStream>, AtmError> {
+        let acceptor = TlsAcceptor::from(Arc::new(self.server_config()?));
+        timeout(self.handshake_timeout, acceptor.accept(tcp))
+            .await
+            .map_err(|_| AtmError::peer_authentication("mTLS peer handshake deadline expired"))?
+            .map(|stream| stream.into())
+            .map_err(|source| {
+                AtmError::peer_authentication(
+                    "mTLS client certificate was rejected before application processing",
+                )
+                .with_cause(source)
+            })
+    }
+
+    fn trusted_peer(&self, peer: &HostName) -> Result<&TrustedPeer, AtmError> {
+        self.trusted_peers
+            .iter()
+            .find(|candidate| candidate.enabled && candidate.host == *peer)
+            .ok_or_else(|| {
+                AtmError::peer_authentication(
+                    "peer is not an enabled exact mTLS authority; plaintext fallback is forbidden",
+                )
+            })
+    }
+
+    fn client_config(&self, peer: &TrustedPeer) -> Result<ClientConfig, AtmError> {
+        install_tls_provider();
+        ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(PinnedServerVerifier::new(peer)?))
+            .with_client_auth_cert(
+                self.identity.certificates().to_vec(),
+                self.identity.private_key().clone_key(),
+            )
+            .map_err(|source| {
+                AtmError::certificate_operation(
+                    "configured mTLS identity cannot authenticate clients",
+                )
+                .with_cause(source)
+            })
+    }
+
+    fn server_config(&self) -> Result<ServerConfig, AtmError> {
+        install_tls_provider();
+        ServerConfig::builder()
+            .with_client_cert_verifier(Arc::new(PinnedClientVerifier::new(
+                self.trusted_peers.clone(),
+            )))
+            .with_single_cert(
+                self.identity.certificates().to_vec(),
+                self.identity.private_key().clone_key(),
+            )
+            .map_err(|source| {
+                AtmError::certificate_operation(
+                    "configured mTLS identity cannot authenticate peers",
+                )
+                .with_cause(source)
+            })
+    }
+}
+
+/// Exact fingerprint verifier for the selected outbound peer. The registered
+/// hostname is checked before connection construction; the custom verifier
+/// binds the subsequently presented certificate to that authority's pin.
+#[derive(Debug)]
+struct PinnedServerVerifier {
+    hostname: String,
+    fingerprint: String,
+    algorithms: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl PinnedServerVerifier {
+    fn new(peer: &TrustedPeer) -> Result<Self, AtmError> {
+        if !peer.host.is_durable_hostname() {
+            return Err(AtmError::peer_authentication(
+                "mTLS peer authority must use a durable hostname rather than a literal IP",
+            ));
+        }
+        Ok(Self {
+            hostname: peer.host.as_str().to_owned(),
+            fingerprint: peer.fingerprint.as_str().to_ascii_lowercase(),
+            algorithms: rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        })
+    }
+}
+
+impl ServerCertVerifier for PinnedServerVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        let presented_name = server_name.to_str();
+        if certificate_valid_now(end_entity).is_err()
+            || presented_name != self.hostname
+            || certificate_fingerprint(end_entity) != self.fingerprint
+        {
+            return Err(CertificateError::UnknownIssuer.into());
+        }
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.algorithms.supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atm_storage::{CertificateFingerprint, HttpsInterface, LocalCertificate, PrivateKeyRef};
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroU16,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[derive(Default)]
+    struct TestStore {
+        interfaces: Vec<HttpsInterface>,
+        certificate: Option<LocalCertificate>,
+        peers: Vec<TrustedPeer>,
+    }
+    impl atm_storage::contract::sealed::Sealed for TestStore {}
+    impl PeerConfigStore for TestStore {
+        fn list_interfaces(&self) -> Result<Vec<HttpsInterface>, AtmError> {
+            Ok(self.interfaces.clone())
+        }
+        fn save_interface(&self, _: &HttpsInterface) -> Result<(), AtmError> {
+            unreachable!()
+        }
+        fn remove_interface(&self, _: SocketAddr) -> Result<bool, AtmError> {
+            unreachable!()
+        }
+        fn local_certificate(&self) -> Result<Option<LocalCertificate>, AtmError> {
+            Ok(self.certificate.clone())
+        }
+        fn save_local_certificate(&self, _: &LocalCertificate) -> Result<(), AtmError> {
+            unreachable!()
+        }
+        fn list_trusted_peers(&self) -> Result<Vec<TrustedPeer>, AtmError> {
+            Ok(self.peers.clone())
+        }
+        fn trusted_peer(&self, _: &HostName) -> Result<Option<TrustedPeer>, AtmError> {
+            unreachable!()
+        }
+        fn save_trusted_peer(&self, _: &TrustedPeer) -> Result<(), AtmError> {
+            unreachable!()
+        }
+        fn remove_trusted_peer(&self, _: &HostName) -> Result<bool, AtmError> {
+            unreachable!()
+        }
+    }
+
+    fn identity(directory: &tempfile::TempDir, name: &str) -> LocalCertificate {
+        let generated =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).expect("certificate");
+        let path = directory.path().join(format!("{name}.pem"));
+        std::fs::write(
+            &path,
+            format!(
+                "{}{}",
+                generated.cert.pem(),
+                generated.key_pair.serialize_pem()
+            ),
+        )
+        .expect("PEM");
+        LocalCertificate {
+            fingerprint: CertificateFingerprint::try_from(certificate_fingerprint(
+                generated.cert.der(),
+            ))
+            .expect("fingerprint"),
+            private_key_ref: PrivateKeyRef::try_from(path.display().to_string())
+                .expect("key reference"),
+        }
+    }
+
+    fn expired_identity(directory: &tempfile::TempDir) -> LocalCertificate {
+        let mut parameters =
+            rcgen::CertificateParams::new(vec!["localhost".to_owned()]).expect("parameters");
+        parameters.not_before = rcgen::date_time_ymd(2020, 1, 1);
+        parameters.not_after = rcgen::date_time_ymd(2020, 1, 2);
+        let key = rcgen::KeyPair::generate().expect("key");
+        let certificate = parameters.self_signed(&key).expect("certificate");
+        let path = directory.path().join("expired.pem");
+        std::fs::write(
+            &path,
+            format!("{}{}", certificate.pem(), key.serialize_pem()),
+        )
+        .expect("PEM");
+        LocalCertificate {
+            fingerprint: CertificateFingerprint::try_from(certificate_fingerprint(
+                certificate.der(),
+            ))
+            .expect("fingerprint"),
+            private_key_ref: PrivateKeyRef::try_from(path.display().to_string())
+                .expect("key reference"),
+        }
+    }
+
+    fn interface() -> HttpsInterface {
+        HttpsInterface {
+            bind_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            advertise_host: "localhost".parse().expect("host"),
+            enabled: true,
+        }
+    }
+
+    fn peer(certificate: &LocalCertificate, enabled: bool) -> TrustedPeer {
+        TrustedPeer {
+            host: "localhost".parse().expect("host"),
+            fingerprint: certificate.fingerprint.clone(),
+            enabled,
+            https_port: NonZeroU16::new(443).expect("port"),
+        }
+    }
+
+    #[tokio::test]
+    async fn configured_pair_exchanges_opaque_bytes_over_mutual_tls() {
+        let directory = tempfile::tempdir().expect("directory");
+        let server_identity = identity(&directory, "server");
+        let client_identity = identity(&directory, "client");
+        let server = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(server_identity.clone()),
+            peers: vec![peer(&client_identity, true)],
+        })
+        .expect("server adapter");
+        let client = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(client_identity),
+            peers: vec![peer(&server_identity, true)],
+        })
+        .expect("client adapter");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("accept tcp");
+            let mut tls = server.accept(tcp).await.expect("accept tls");
+            let mut received = [0_u8; 5];
+            tls.read_exact(&mut received).await.expect("read bytes");
+            assert_eq!(&received, b"bytes");
+            tls.write_all(b"reply").await.expect("write bytes");
+        });
+        let tcp = TcpStream::connect(address).await.expect("connect tcp");
+        let host: HostName = "localhost".parse().expect("host");
+        let mut tls = client.connect(tcp, &host).await.expect("connect tls");
+        tls.write_all(b"bytes").await.expect("write bytes");
+        let mut reply = [0_u8; 5];
+        tls.read_exact(&mut reply).await.expect("read bytes");
+        assert_eq!(&reply, b"reply");
+        server_task.await.expect("server task");
+    }
+
+    #[test]
+    fn missing_or_disabled_interface_fails_before_any_tcp_or_http_work() {
+        let directory = tempfile::tempdir().expect("directory");
+        let identity = identity(&directory, "local");
+        let error = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![],
+            certificate: Some(identity),
+            peers: vec![],
+        })
+        .expect_err("missing interface");
+        assert_eq!(error.code().as_str(), "ATM_PEER_CONFIG_VALIDATION_FAILED");
+    }
+
+    #[test]
+    fn missing_local_identity_fails_before_any_tcp_or_http_work() {
+        let error = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: None,
+            peers: vec![],
+        })
+        .expect_err("missing identity");
+        assert_eq!(error.code().as_str(), "ATM_PEER_CONFIG_VALIDATION_FAILED");
+    }
+
+    #[test]
+    fn disabled_or_hostname_mismatched_peer_fails_before_tcp_or_http_work() {
+        let directory = tempfile::tempdir().expect("directory");
+        let identity = identity(&directory, "local");
+        let target = peer(&identity, false);
+        let adapter = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(identity),
+            peers: vec![target],
+        })
+        .expect("adapter");
+        let host: HostName = "localhost".parse().expect("host");
+        let error = adapter.trusted_peer(&host).expect_err("disabled peer");
+        assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
+    }
+
+    #[test]
+    fn bad_key_is_rejected_as_a_non_secret_certificate_error() {
+        let directory = tempfile::tempdir().expect("directory");
+        let identity = identity(&directory, "local");
+        std::fs::write(identity.private_key_ref.as_str(), "not a PEM bundle").expect("bad PEM");
+        let error = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(identity),
+            peers: vec![],
+        })
+        .expect_err("bad key");
+        assert_eq!(error.code().as_str(), "ATM_CERTIFICATE_OPERATION_FAILED");
+        assert!(!error.message().contains("not a PEM bundle"));
+    }
+
+    #[test]
+    fn expired_local_certificate_is_rejected_before_any_tcp_or_http_work() {
+        let directory = tempfile::tempdir().expect("directory");
+        let error = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(expired_identity(&directory)),
+            peers: vec![],
+        })
+        .expect_err("expired certificate");
+        assert_eq!(error.code().as_str(), "ATM_CERTIFICATE_OPERATION_FAILED");
+    }
+
+    #[tokio::test]
+    async fn pin_mismatch_fails_during_tls_before_opaque_bytes_can_flow() {
+        let directory = tempfile::tempdir().expect("directory");
+        let server_identity = identity(&directory, "server");
+        let client_identity = identity(&directory, "client");
+        let server = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(server_identity.clone()),
+            peers: vec![peer(&client_identity, true)],
+        })
+        .expect("server adapter");
+        let mut wrong_pin = peer(&server_identity, true);
+        wrong_pin.fingerprint = CertificateFingerprint::try_from("00".repeat(32)).expect("pin");
+        let client = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(client_identity),
+            peers: vec![wrong_pin],
+        })
+        .expect("client adapter");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("accept tcp");
+            server.accept(tcp).await
+        });
+        let host: HostName = "localhost".parse().expect("host");
+        let client_result = client
+            .connect(
+                TcpStream::connect(address).await.expect("connect tcp"),
+                &host,
+            )
+            .await;
+        assert!(
+            client_result.is_err(),
+            "pin mismatch must fail the TLS handshake"
+        );
+        let _ = server_task.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn handshake_deadline_fails_before_any_application_protocol_can_start() {
+        let directory = tempfile::tempdir().expect("directory");
+        let server_identity = identity(&directory, "server");
+        let client_identity = identity(&directory, "client");
+        let server = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(server_identity),
+            peers: vec![peer(&client_identity, true)],
+        })
+        .expect("server adapter")
+        .with_handshake_timeout(Duration::from_millis(10));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let raw_client = tokio::spawn(async move {
+            let _tcp = TcpStream::connect(address).await.expect("connect tcp");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+        let (tcp, _) = listener.accept().await.expect("accept tcp");
+        let error = server.accept(tcp).await.expect_err("deadline");
+        assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
+        raw_client.await.expect("raw client");
+    }
+}

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -25,6 +25,13 @@ listener or HTTP pipeline. Plaintext mode uses the preserved `DirectPeerTcpConfi
 `DirectPeerTcpConnector`, direct-peer listener, and ordinary router pipeline.
 The mTLS adapter wraps that same pipeline at the stream boundary only.
 
+AO2.2 implements that outer adapter in `peer-tls`: the crate consumes the
+storage-neutral `PeerConfigStore` and yields authenticated TCP byte streams.
+It owns certificate validity, durable-hostname, and exact-pin checks, but it
+does not compose a daemon, HTTP route, or message pipeline. Runtime wiring is
+explicitly deferred to AO2.3, so compiling the adapter cannot alter either
+the normal daemon default or the preserved plaintext benchmark path.
+
 No environment variable, durable setting, TLS adapter availability check, or
 TLS/certificate/allowlist failure may choose or change the selected mode. A
 normal restart selects mTLS; mTLS never falls back to plaintext. In particular,

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -79,6 +79,9 @@ Error codes should describe the failure class, not a specific prose message.
 - `ATM_PEER_WIRE_PLAINTEXT_AUTHENTICATION_REQUIRED` — untrusted
   `plaintext-test` was asked to satisfy authenticated peer work; restart in
   normal mutual-TLS mode and verify peer configuration.
+- `ATM_PEER_AUTHENTICATION_FAILED` — the selected mTLS peer did not satisfy
+  its exact configured hostname or certificate pin. Correct the durable peer
+  record; never use `plaintext-test` as recovery.
 
 ### 5.3 Mailbox And Message Validation
 
@@ -569,6 +572,7 @@ Classification rules:
 | `REMOTE_DELIVERY_UNCONFIRMED` | `retryable` |
 | `ATM_PEER_CONFIG_VALIDATION_FAILED` | `operator_actionable` |
 | `ATM_CERTIFICATE_OPERATION_FAILED` | `operator_actionable` |
+| `ATM_PEER_AUTHENTICATION_FAILED` | `fail_closed` |
 | `ATM_BIND_PREFLIGHT_FAILED` | `operator_actionable` |
 | `ATM_CLIENT_DAEMON_VERSION_INCOMPATIBLE` | `operator_actionable` |
 | `ATM_TEAM_INVALID` | `operator_actionable` |

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -86,12 +86,11 @@ route, retry, or daemon lifecycle. The inactive
 proof; its dependency is explicitly allowed by the helper boundary and it has
 no production delivery capability.
 
-Phase AO records the sole proposed second consumer: `peer-tls` may consume
-these helpers only after its AO.1 boundary-TOML, manifest, and architecture-
-guard transition is reviewed and merged. That explicit exception promotes
-neither the interop fixture nor any legacy daemon code, and it does not
-authorize a second certificate parser, pinning verifier, or transport
-implementation.
+AO2.2 landed `peer-tls` as the sole production stream consumer of these
+helpers, with its boundary-TOML, manifest, and architecture guard reviewed
+and merged. That explicit exception promotes neither the interop fixture nor
+any legacy daemon code, and it does not authorize a second certificate
+parser, pinning verifier, or transport implementation.
 
 ## PeerConfigStore
 

--- a/docs/plans/phase-ao/sprint-AO2-isolated-mtls-stream-adapter.md
+++ b/docs/plans/phase-ao/sprint-AO2-isolated-mtls-stream-adapter.md
@@ -71,7 +71,7 @@ AO.1 development pushed; AO.1 PR merged before AO.2 PR completion.
        pub async fn connect(
            &self,
            tcp: TcpStream,
-           peer: &PeerAuthority,
+           peer: &HostName,
        ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin, AtmError>;
 
        pub async fn accept(
@@ -80,6 +80,10 @@ AO.1 development pushed; AO.1 PR merged before AO.2 PR completion.
        ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin, AtmError>;
    }
    ```
+
+   `HostName` is the repository's concrete typed peer authority. AO.2 does
+   not introduce a second `PeerAuthority` alias or newtype solely for this
+   facade.
 
    `atm-http-runtime` receives the result only through private generic
    HTTP-over-stream helpers (`S: AsyncRead + AsyncWrite + Send + Unpin`), so it


### PR DESCRIPTION
## Summary
- Isolated peer-tls mTLS byte-stream adapter: pinned mTLS stream setup (hostname/exact pin/expiry/handshake deadline), opaque-byte success path.
- Negative coverage: missing config, bad key, expired cert, disabled/mismatched host, server-pin mismatch, untrusted client, deadline negatives.
- Daemon/HTTP/persistence/plaintext paths untouched (out of scope for this sprint).
- Merge-forward to AO2.3 (`feature/pao-s3-runtime-peer-wire-mode`) completed and pushed at the same SHA.

## Test plan
- [x] `cargo test -p peer-tls -p agent-team-mail-core -p atm-storage`
- [x] `cargo test -p atm-architecture --test boundary_enforcement`
- [x] `just lint`
- [x] `just test`

Reported by arch-ctm, ATM message 01M0G0H6XF1S7BV6F5ZZ5PSW1V.