### PR TITLE
AO2.3: runtime peer-wire mode seam

### DIFF
--- a/.ao.3-checklist.md
+++ b/.ao.3-checklist.md
@@ -1,4 +1,4 @@
-# AO2.3 closure checklist
+# AO.3 closure checklist
 
 - [x] Parse `--peer-wire-security` once in the Tokio/Axum bootstrap; default to mTLS and reject invalid or forbidden sources.
 - [x] Preserve the plaintext direct TCP listener/client path without touching its stream setup or TLS configuration.

--- a/.ao2.3-checklist.md
+++ b/.ao2.3-checklist.md
@@ -1,0 +1,9 @@
+# AO2.3 closure checklist
+
+- [x] Parse `--peer-wire-security` once in the Tokio/Axum bootstrap; default to mTLS and reject invalid or forbidden sources.
+- [x] Preserve the plaintext direct TCP listener/client path without touching its stream setup or TLS configuration.
+- [x] Add one opaque mTLS stream seam for the existing HTTP runtime, including authenticated inbound provenance and outbound delivery.
+- [x] Route host-qualified CLI/graft writes through the launched daemon so its selected mode governs outbound delivery.
+- [x] Project active mode/readiness through doctor and safe observability; update operations and boundary records.
+- [x] Add structural guards and release-interface tests for plaintext invalid-TLS independence, mTLS success, and pre-router failure/no downgrade.
+- [x] Re-read the plan and run validation: targeted runtime/TLS/architecture suites, `just lint`, `just test`, and `just smoke normal` all pass. Merge-forward and publish next.

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -131,7 +131,7 @@ allowed_dependencies = ["serde", "serde_json"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
-allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "serde_json", "tempfile", "tokio", "ulid"]
+allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "peer-tls", "serde_json", "tempfile", "tokio", "tracing", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-client/Cargo.toml"
@@ -151,7 +151,7 @@ allowed_dependencies = ["atm-storage", "atm-storage-rusqlite", "pyo3", "tempfile
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-http-runtime/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-core", "atm-runtime-test-support", "atm-storage", "axum", "base64", "fs4", "hyper", "hyper-util", "reqwest", "serde", "serde_json", "serde_yaml", "tempfile", "tokio", "tower", "tracing", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-core", "atm-runtime-test-support", "atm-storage", "axum", "base64", "fs4", "http-body-util", "hyper", "hyper-util", "reqwest", "serde", "serde_json", "serde_yaml", "tempfile", "tokio", "tower", "tracing", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-runtime/Cargo.toml"

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -131,6 +131,7 @@ allowed_dependencies = ["serde", "serde_json"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
+boundary_record_path = "boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml"
 allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "peer-tls", "serde_json", "tempfile", "tokio", "tracing", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -132,7 +132,7 @@ allowed_dependencies = ["serde", "serde_json"]
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-bootstrap/Cargo.toml"
 boundary_record_path = "boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml"
-allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "peer-tls", "serde_json", "tempfile", "tokio", "tracing", "ulid"]
+allowed_dependencies = ["atm-core", "atm-http-runtime", "atm-runtime", "atm-runtime-test-support", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "fs4", "peer-tls", "serde_json", "tempfile", "tokio", "tracing", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-daemon-client/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,11 @@ dependencies = [
  "atm-storage-rusqlite",
  "atm-template-sc-compose",
  "fs4",
+ "peer-tls",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "ulid",
 ]
 
@@ -280,6 +282,7 @@ dependencies = [
  "axum",
  "base64",
  "fs4",
+ "http-body-util",
  "hyper",
  "hyper-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
  "atm-runtime",
+ "atm-runtime-test-support",
  "atm-storage",
  "atm-storage-rusqlite",
  "atm-template-sc-compose",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { version = "1.48", default-features = false, features = ["io-util", "ma
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "server", "http1"] }
 hyper-util = { version = "0.1", default-features = false, features = ["server", "service", "tokio"] }
+http-body-util = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tower = { version = "0.5", default-features = false, features = ["limit", "load-shed", "util"] }
 sha2 = "0.10"

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "gra
 
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon"]
-allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "tokio", "fs4", "ulid"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "tracing", "ulid"]
 forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
 
 [references]
@@ -33,7 +33,7 @@ forbidden = []
 request_types = ["core RuntimeAssembly inputs", "core sealed MessageReceivedHookSelector"]
 response_types = ["typed runtime lifecycle outcome"]
 error_types = ["AtmError"]
-notes = ["The concrete storage factory is legal only at this composition boundary; atm-daemon and atm-http-runtime remain backend-neutral.", "AO2.3 parses the one explicit daemon launch argument into the core PeerWireMode; environment, durable settings, and TLS availability never select it."]
+notes = ["The concrete storage factory is legal only at this composition boundary; atm-daemon and atm-http-runtime remain backend-neutral.", "AO2.3 parses the one explicit daemon launch argument into the core PeerWireMode; environment, durable settings, and TLS availability never select it.", "The bootstrap may compose peer-tls only in the explicit mTLS arm and passes only its opaque stream seam to atm-http-runtime."]
 
 [testing]
 allowed_test_double_paths = []

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "gra
 
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon"]
-allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "tracing", "ulid"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "serde_json", "tempfile", "tracing", "ulid"]
 forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
 
 [references]

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "gra
 
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon"]
-allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "tracing", "ulid"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "tracing", "ulid"]
 forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
 
 [references]

--- a/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
+++ b/boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_server", "raw_http_framing", "direct_rusqlite_calls", "gra
 
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon"]
-allowed_dependencies = ["atm-core", "atm-runtime", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "serde_json", "tempfile", "tracing", "ulid"]
+allowed_dependencies = ["atm-core", "atm-runtime", "atm-runtime-test-support", "atm-storage", "atm-storage-rusqlite", "atm-template-sc-compose", "atm-http-runtime", "peer-tls", "tokio", "fs4", "serde_json", "tempfile", "tracing", "ulid"]
 forbidden_edges = ["atm-daemon -> atm-storage-rusqlite", "atm-daemon -> atm-runtime", "atm-http-runtime -> atm-daemon-bootstrap", "atm-daemon-bootstrap -> atm-graft"]
 
 [references]

--- a/boundaries/atm-http-runtime/http-runtime.toml
+++ b/boundaries/atm-http-runtime/http-runtime.toml
@@ -27,7 +27,7 @@ io_forbidden = ["direct_sqlite_io", "daemon_request_dispatch", "raw_http_framing
 
 [dependencies]
 allowed_dependents = ["atm-daemon-bootstrap", "atm", "atm-daemon-client", "atm-graft"]
-allowed_dependencies = ["atm-core", "tokio", "axum", "hyper", "hyper-util", "reqwest", "tower", "ulid", "windows-sys"]
+allowed_dependencies = ["atm-core", "tokio", "axum", "http-body-util", "hyper", "hyper-util", "reqwest", "tower", "ulid", "windows-sys"]
 forbidden_edges = ["atm-http-runtime -> atm-storage-rusqlite", "atm-http-runtime -> atm-graft", "atm-http-runtime -> atm", "atm-http-runtime -> atm-daemon-bootstrap"]
 
 [references]
@@ -41,7 +41,7 @@ error_types = ["AtmError"]
 notes = ["No runtime-private request, response, error, or persistence type is authorized.", "Received-message hooks cross only the sealed core selector/emitter boundary after a newly durable write; their failure is a response warning, never a write failure."]
 
 [testing]
-allowed_test_double_paths = ["crate::tests::TestRouter"]
+allowed_test_double_paths = ["crate::tests::TestRouter", "crate::tests::PassthroughPeerAdapter"]
 forbidden_test_bypasses = ["listener_bind", "endpoint_publication"]
 
 [enforcement]

--- a/boundaries/peer-tls/mtls-peer-stream-adapter.toml
+++ b/boundaries/peer-tls/mtls-peer-stream-adapter.toml
@@ -5,7 +5,7 @@ name = "MtlsPeerStreamAdapter"
 
 [public]
 facade = "MtlsPeerStreamAdapter"
-notes = "Concrete finite mTLS byte-stream wrapper; no public transport trait or HTTP contract."
+notes = "Concrete finite mTLS byte-stream wrapper; bootstrap adapts it to the runtime's opaque stream seam, with no HTTP contract."
 
 [implementation]
 type = "MtlsPeerStreamAdapter"
@@ -21,7 +21,7 @@ io_owns = ["tokio_rustls_stream_wrapping", "peer_certificate_pin_verification", 
 io_forbidden = ["http_runtime", "message_delivery", "message_persistence", "receipt", "nudge_emission", "retry_queue", "daemon_lifecycle"]
 
 [dependencies]
-allowed_dependents = []
+allowed_dependents = ["atm-daemon-bootstrap"]
 allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls"]
 forbidden_edges = ["atm-http-runtime -> peer-tls", "atm -> peer-tls", "atm-graft -> peer-tls", "atm-daemon -> peer-tls"]
 
@@ -44,4 +44,4 @@ review_gates = ["one_concrete_tls_owner", "no_http_or_durable_message_types", "n
 
 [status]
 state = "concrete_landed"
-notes = ["AO2.2 owns the only production Rustls/Tokio-Rustls byte-stream adapter."]
+notes = ["AO2.2 owns the only production Rustls/Tokio-Rustls byte-stream adapter; AO2.3 permits only daemon bootstrap to compose it into the opaque runtime seam."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -173,6 +173,11 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         .nth(1)
         .and_then(|source| source.split("impl LoopbackTcpConnector").next())
         .expect("direct-peer connector implementation");
+    let plaintext_mode_arm = bootstrap
+        .split("PeerWireSecurity::PlaintextTest => None")
+        .nth(1)
+        .and_then(|source| source.split("};").next())
+        .expect("explicit plaintext mode arm");
 
     assert!(
         bootstrap_direct_setup.contains("DirectPeerTcpConfig::standard()"),
@@ -191,7 +196,7 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         "AO2 plaintext listener must enter the ordinary canonical router"
     );
     for (scope, source) in [
-        ("bootstrap direct-peer setup", bootstrap_direct_setup),
+        ("plaintext mode arm", plaintext_mode_arm),
         ("direct-peer listener", direct_listener),
         ("direct-peer connector", direct_connector),
     ] {
@@ -410,10 +415,10 @@ fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
     let root = workspace_root();
     let router = read_source(&root.join("crates/atm-http-runtime/src/storage_and_nudge_router.rs"));
     assert!(
-        router.contains("dispatch_resolved_peer_ack")
+        router.contains("dispatch_resolved_peer_write")
             && !router.contains("PeerDelivery")
             && !router.contains("signal_after_persist"),
-        "the typed router may deliver only resolved acknowledgements and has no peer worker signal"
+        "the typed router may deliver one admitted remote write and has no peer worker signal"
     );
     for forbidden in ["is_loopback", "is_loopback()"] {
         assert!(
@@ -1360,7 +1365,11 @@ fn ao2_mtls_stream_adapter_is_the_only_authorized_production_tls_consumer() {
     let boundary_path = root.join("boundaries/peer-tls/mtls-peer-stream-adapter.toml");
     let boundary: BoundaryToml = toml::from_str(&read_source(&boundary_path))
         .expect("mTLS stream adapter boundary must be valid TOML");
-    assert!(boundary.dependencies.allowed_dependents.is_empty());
+    assert_eq!(
+        boundary.dependencies.allowed_dependents,
+        vec!["atm-daemon-bootstrap".to_owned()],
+        "only bootstrap may compose the concrete mTLS byte-stream adapter"
+    );
     let source = read_source(&root.join("crates/peer-tls/src/lib.rs"));
     let syntax = syn::parse_file(&source).expect("peer-tls source must parse");
     let mut visitor = PeerTlsSurfaceVisitor::default();

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -147,6 +147,8 @@ fn daemon_must_not_read_caller_workspace_config() {
 }
 
 #[test]
+/// AO.3 extends this AO.2 baseline guard with the bootstrap-selected
+/// `PlaintextTest` arm and its invalid-TLS-state independence.
 fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
     let root = workspace_root();
     let bootstrap = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
@@ -234,6 +236,8 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
 }
 
 #[test]
+/// AO.3 extends this AO.2 policy guard over the daemon launch seam while
+/// preserving the single canonical HTTP application pipeline.
 fn ao2_peer_wire_policy_keeps_one_error_registry_and_one_http_pipeline() {
     let root = workspace_root();
     let error_registry = read_source(&root.join("crates/atm-error/src/error_codes.rs"));
@@ -278,6 +282,8 @@ fn ao2_peer_wire_policy_keeps_one_error_registry_and_one_http_pipeline() {
 }
 
 #[test]
+/// AO.3 extends this AO.2 guard to require the benchmark entrypoint to reuse
+/// the launch-selected replacement runtime rather than add a pipeline.
 fn ao2_benchmark_harness_cannot_introduce_a_second_daemon_pipeline() {
     let root = workspace_root();
     let bootstrap = read_source(&root.join("crates/atm-daemon-bootstrap/src/lib.rs"));
@@ -1352,6 +1358,8 @@ fn is_zeroizing_constructor(call: &syn::ExprCall) -> bool {
 }
 
 #[test]
+/// AO.3 extends this AO.2 ownership guard: bootstrap consumes the opaque mTLS
+/// stream seam, while every other production crate stays adapter-neutral.
 fn ao2_mtls_stream_adapter_is_the_only_authorized_production_tls_consumer() {
     let root = workspace_root();
     for (source, target) in [

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -157,13 +157,9 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
     let policy = read_source(&root.join("crates/atm-core/src/peer_wire.rs"));
 
     let bootstrap_direct_setup = bootstrap
-        .split("async fn run_replacement_daemon_with_selector")
+        .split("fn replacement_runtime_config")
         .nth(1)
-        .and_then(|source| {
-            source
-                .split("/// Emit the benchmark/supervisor marker")
-                .next()
-        })
+        .and_then(|source| source.split("fn record_peer_wire_mode_selection").next())
         .expect("replacement bootstrap direct-peer setup");
     let direct_listener = runtime
         .split("async fn bind_configured_direct_peer_listener")
@@ -175,15 +171,13 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         .nth(1)
         .and_then(|source| source.split("impl LoopbackTcpConnector").next())
         .expect("direct-peer connector implementation");
-    let plaintext_mode_arm = bootstrap
-        .split("PeerWireSecurity::PlaintextTest => None")
-        .nth(1)
-        .and_then(|source| source.split("};").next())
-        .expect("explicit plaintext mode arm");
-
     assert!(
         bootstrap_direct_setup.contains("DirectPeerTcpConfig::standard()"),
         "AO2 plaintext characterization must retain the existing standard direct-peer configuration"
+    );
+    assert!(
+        bootstrap.contains("PeerWireSecurity::PlaintextTest => Ok(None),"),
+        "AO2 plaintext mode must bypass all TLS configuration and return no stream wrapper"
     );
     assert!(
         client.contains("struct DirectPeerTcpConnector")
@@ -198,7 +192,6 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         "AO2 plaintext listener must enter the ordinary canonical router"
     );
     for (scope, source) in [
-        ("plaintext mode arm", plaintext_mode_arm),
         ("direct-peer listener", direct_listener),
         ("direct-peer connector", direct_connector),
     ] {

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -175,10 +175,30 @@ fn ao2_plaintext_baseline_stays_on_the_existing_direct_peer_pipeline() {
         bootstrap_direct_setup.contains("DirectPeerTcpConfig::standard()"),
         "AO2 plaintext characterization must retain the existing standard direct-peer configuration"
     );
+    let plaintext_adapter_arm = bootstrap
+        .split("fn peer_stream_adapter_for_mode")
+        .nth(1)
+        .and_then(|source| source.split("fn replacement_runtime_config").next())
+        .and_then(|source| source.split("PeerWireSecurity::PlaintextTest =>").nth(1))
+        .and_then(|source| source.split("\n    }").next())
+        .expect("bootstrap plaintext adapter-selection arm");
     assert!(
-        bootstrap.contains("PeerWireSecurity::PlaintextTest => Ok(None),"),
+        plaintext_adapter_arm.contains("Ok(None),"),
         "AO2 plaintext mode must bypass all TLS configuration and return no stream wrapper"
     );
+    for forbidden in [
+        "build_mtls_adapter",
+        "PeerConfigStore",
+        "MtlsPeerStreamAdapter",
+        "peer_tls",
+        "rustls",
+        "certificate",
+    ] {
+        assert!(
+            !plaintext_adapter_arm.contains(forbidden),
+            "AO2 plaintext bootstrap arm must not inspect TLS/configuration/adapter state `{forbidden}`"
+        );
+    }
     assert!(
         client.contains("struct DirectPeerTcpConnector")
             && client.contains("pub fn direct_peer_tcp_client")

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -307,6 +307,7 @@ fn doctor_client_context(environment: &DoctorEnvironmentVisibility) -> DoctorExe
         version: Some(crate::protocol::ReleaseVersion::current()),
         cli_schema_version: Some(crate::protocol::CLI_SCHEMA_VERSION),
         http_api_version: Some(crate::protocol::HttpApiVersion::current()),
+        peer_wire_security: None,
     }
 }
 

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -24,8 +24,8 @@ pub use report::{
     BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
     BootstrapTraceReport, DaemonRuntimeDoctorReport, DoctorEnvironmentVisibility,
     DoctorExecutionContext, DoctorFinding, DoctorReport, DoctorSeverity, DoctorStatus,
-    DoctorSummary, PeerAuthorityDoctorReport, PeerConfigDoctorReport, PostSendDoctorReport,
-    PostSendHookRuleIndex, PostSendHookRuleReport, RecipientDeliveryPath,
+    DoctorSummary, PeerAuthorityDoctorReport, PeerConfigDoctorReport, PeerWireSecurityStatus,
+    PostSendDoctorReport, PostSendHookRuleIndex, PostSendHookRuleReport, RecipientDeliveryPath,
     RecipientDeliveryPathReport,
 };
 

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -62,6 +62,10 @@ pub struct DoctorExecutionContext {
     pub cli_schema_version: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_api_version: Option<crate::protocol::HttpApiVersion>,
+    /// The immutable peer-wire launch policy selected by this daemon process.
+    /// It is diagnostic-only and never includes a certificate, pin, or key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_wire_security: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::boundary::{ConfigDoctorReport, MailStoreDoctorReport, RosterStoreDoctorReport};
 use crate::error_codes::AtmErrorCode;
 use crate::observability::AtmObservabilityHealth;
+use crate::peer_wire::PeerWireSecurity;
 use crate::protocol::{ReleaseVersion, RuntimeStatusSnapshot};
 use crate::team_admin::MembersList;
 use crate::types::{AgentName, TeamName};
@@ -65,7 +66,27 @@ pub struct DoctorExecutionContext {
     /// The immutable peer-wire launch policy selected by this daemon process.
     /// It is diagnostic-only and never includes a certificate, pin, or key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub peer_wire_security: Option<String>,
+    pub peer_wire_security: Option<PeerWireSecurityStatus>,
+}
+
+/// Typed, public diagnostic projection of the daemon's peer-wire policy.
+///
+/// This preserves the established JSON launch spellings while preventing a
+/// doctor caller from treating an arbitrary string as a valid security mode.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PeerWireSecurityStatus {
+    MutualTls,
+    PlaintextTest,
+}
+
+impl From<PeerWireSecurity> for PeerWireSecurityStatus {
+    fn from(value: PeerWireSecurity) -> Self {
+        match value {
+            PeerWireSecurity::Mtls => Self::MutualTls,
+            PeerWireSecurity::PlaintextTest => Self::PlaintextTest,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -204,5 +225,24 @@ pub struct DoctorReport {
 impl DoctorReport {
     pub fn has_errors(&self) -> bool {
         self.summary.status == DoctorStatus::Error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PeerWireSecurityStatus;
+    use crate::peer_wire::PeerWireSecurity;
+
+    #[test]
+    fn peer_wire_security_status_is_typed_and_preserves_public_json_values() {
+        assert_eq!(
+            PeerWireSecurityStatus::from(PeerWireSecurity::Mtls),
+            PeerWireSecurityStatus::MutualTls
+        );
+        assert_eq!(
+            serde_json::to_string(&PeerWireSecurityStatus::PlaintextTest)
+                .expect("diagnostic status serializes"),
+            "\"plaintext-test\""
+        );
     }
 }

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -24,7 +24,9 @@ atm-runtime = { path = "../atm-runtime", version = "1.4.4" }
 atm-storage = { path = "../atm-storage", version = "1.4.4" }
 atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.4" }
 atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.4" }
+peer-tls = { path = "../peer-tls", version = "1.4.4" }
 tokio.workspace = true
+tracing.workspace = true
 fs4 = "0.13"
 serde_json.workspace = true
 ulid.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-benchmark-harness = []
+benchmark-harness = ["dep:serde_json"]
 
 [[bin]]
 name = "atm-daemon-benchmark"
@@ -28,8 +28,9 @@ peer-tls = { path = "../peer-tls", version = "1.4.4" }
 tokio.workspace = true
 tracing.workspace = true
 fs4 = "0.13"
-serde_json.workspace = true
+serde_json = { workspace = true, optional = true }
 ulid.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -32,5 +32,7 @@ serde_json = { workspace = true, optional = true }
 ulid.workspace = true
 
 [dev-dependencies]
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4", features = ["test-support"] }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.4" }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -69,8 +69,28 @@ fn benchmark_invocation_from_args() -> Result<BenchmarkInvocation, AtmError> {
 fn parse_benchmark_invocation(
     args: impl IntoIterator<Item = String>,
 ) -> Result<BenchmarkInvocation, AtmError> {
+    let mut peer_wire_arguments = vec![std::ffi::OsString::from("atm-daemon-benchmark")];
+    let mut primary_arguments = Vec::new();
     let mut args = args.into_iter();
-    match args.next().as_deref() {
+    let mut peer_wire_argument_seen = false;
+    while let Some(argument) = args.next() {
+        if argument == "--peer-wire-security" {
+            peer_wire_argument_seen = true;
+            peer_wire_arguments.push(argument.into());
+            peer_wire_arguments.push(args.next().map(Into::into).unwrap_or_default());
+        } else if argument.starts_with("--peer-wire-security=") {
+            peer_wire_argument_seen = true;
+            peer_wire_arguments.push(argument.into());
+        } else {
+            primary_arguments.push(argument);
+        }
+    }
+    // Reuse bootstrap's grammar. `run_benchmark_daemon` parses the original
+    // argv again immediately before composition, so this wrapper adds no
+    // second durable or environment-derived mode source.
+    atm_daemon_bootstrap::parse_peer_wire_mode(peer_wire_arguments)?;
+    let mut args = primary_arguments.into_iter();
+    let invocation = match args.next().as_deref() {
         Some("--hook-mode") => {
             let mode = args.next().ok_or_else(|| {
                 AtmError::config("usage: atm-daemon-benchmark --hook-mode <active|disabled>")
@@ -101,7 +121,13 @@ fn parse_benchmark_invocation(
         _ => Err(AtmError::config(
             "usage: atm-daemon-benchmark --hook-mode <active|disabled> | --direct-storage-admission <count> --workers <count> | --direct-core-write <count> --workers <count>",
         )),
+    }?;
+    if peer_wire_argument_seen && !matches!(invocation, BenchmarkInvocation::Daemon(_)) {
+        return Err(AtmError::config(
+            "--peer-wire-security is valid only with atm-daemon-benchmark --hook-mode",
+        ));
     }
+    Ok(invocation)
 }
 
 fn parse_concurrent_arguments(
@@ -382,6 +408,18 @@ mod tests {
             BenchmarkInvocation::Daemon(BenchmarkHookMode::Disabled)
         ));
 
+        let daemon_with_peer_wire_mode = parse_benchmark_invocation([
+            "--peer-wire-security".to_owned(),
+            "plaintext-test".to_owned(),
+            "--hook-mode".to_owned(),
+            "disabled".to_owned(),
+        ])
+        .expect("benchmark daemon accepts the bootstrap-owned mode argument");
+        assert!(matches!(
+            daemon_with_peer_wire_mode,
+            BenchmarkInvocation::Daemon(BenchmarkHookMode::Disabled)
+        ));
+
         let direct = parse_benchmark_invocation([
             "--direct-storage-admission".to_owned(),
             "10000".to_owned(),
@@ -428,5 +466,18 @@ mod tests {
                 error.message().contains("usage") || error.message().contains("positive integer")
             );
         }
+    }
+
+    #[test]
+    fn parser_rejects_peer_wire_mode_for_non_daemon_benchmarks() {
+        let error = parse_benchmark_invocation([
+            "--peer-wire-security=plaintext-test".to_owned(),
+            "--direct-storage-admission".to_owned(),
+            "100".to_owned(),
+            "--workers".to_owned(),
+            "2".to_owned(),
+        ])
+        .expect_err("direct storage does not launch a daemon wire mode");
+        assert!(error.message().contains("only with"));
     }
 }

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -294,7 +294,7 @@ fn build_replacement_handler(
         version: Some(atm_core::protocol::ReleaseVersion::current()),
         cli_schema_version: Some(atm_core::protocol::CLI_SCHEMA_VERSION),
         http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),
-        peer_wire_security: Some(peer_wire_mode.security().as_launch_value().to_owned()),
+        peer_wire_security: Some(peer_wire_mode.security().into()),
     });
     let handler = match peer_stream_adapter {
         Some(adapter) => handler.with_peer_stream_adapter(adapter),

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -303,6 +303,20 @@ fn build_replacement_handler(
     Ok(Arc::new(handler))
 }
 
+/// Selects the optional mTLS stream adapter from the immutable daemon launch
+/// mode.  Plaintext-test mode must not inspect, validate, or depend on the
+/// TLS control-plane state: it keeps the existing direct-peer HTTP pipeline
+/// intact without a stream wrapper.
+fn peer_stream_adapter_for_mode(
+    peer_wire_mode: PeerWireMode,
+    build_mtls_adapter: impl FnOnce() -> Result<Arc<dyn PeerStreamAdapter>, AtmError>,
+) -> Result<Option<Arc<dyn PeerStreamAdapter>>, AtmError> {
+    match peer_wire_mode.security() {
+        PeerWireSecurity::Mtls => build_mtls_adapter().map(Some),
+        PeerWireSecurity::PlaintextTest => Ok(None),
+    }
+}
+
 async fn run_replacement_daemon_with_selector(
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
     selector_factory: impl FnOnce(
@@ -317,14 +331,13 @@ async fn run_replacement_daemon_with_selector(
     let runtime_health = RuntimeHealth::with_owner(std::process::id());
     let assembly = assemble_daemon_runtime()?;
     let workflow_telemetry = assembly.workflow_telemetry.clone();
-    let peer_stream_adapter = match peer_wire_mode.security() {
-        PeerWireSecurity::Mtls => Some(Arc::new(BootstrapMtlsStreamAdapter {
+    let peer_stream_adapter = peer_stream_adapter_for_mode(peer_wire_mode, || {
+        Ok(Arc::new(BootstrapMtlsStreamAdapter {
             adapter: Arc::new(MtlsPeerStreamAdapter::from_peer_config(
                 assembly.peer_config_store.as_ref(),
             )?),
-        }) as Arc<dyn PeerStreamAdapter>),
-        PeerWireSecurity::PlaintextTest => None,
-    };
+        }) as Arc<dyn PeerStreamAdapter>)
+    })?;
     // The shipped daemon always keeps the injected receiver hook active.
     // Benchmark-only selection is available only from the separate binary.
     let handler = build_replacement_handler(
@@ -602,7 +615,7 @@ mod replacement_runtime_tests {
 
     use super::{
         REPLACEMENT_DRAIN_DEADLINE, ShutdownSignal, assemble_host_runtime_with_template_composer,
-        parse_peer_wire_mode, write_ready_signal_if_requested,
+        parse_peer_wire_mode, peer_stream_adapter_for_mode, write_ready_signal_if_requested,
     };
 
     #[test]
@@ -656,6 +669,19 @@ mod replacement_runtime_tests {
         ])
         .expect_err("one launch mode must select the whole runtime");
         assert!(error.message().contains("only once"));
+    }
+
+    #[test]
+    fn plaintext_test_release_mode_never_reads_invalid_tls_configuration() {
+        let adapter = peer_stream_adapter_for_mode(
+            atm_core::peer_wire::PeerWireMode::plaintext_test(),
+            || -> Result<_, atm_core::error::AtmError> {
+                panic!("plaintext-test must not inspect TLS peer configuration")
+            },
+        )
+        .expect("plaintext-test directly preserves the peer HTTP pipeline");
+
+        assert!(adapter.is_none());
     }
 
     #[test]

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -317,6 +317,71 @@ fn peer_stream_adapter_for_mode(
     }
 }
 
+fn replacement_runtime_config(
+    scope: &atm_core::home::HostRuntimeScope,
+    owner: &DaemonOwnerGuard,
+    peer_stream_adapter: &Option<Arc<dyn PeerStreamAdapter>>,
+) -> Result<HttpRuntimeConfig, AtmError> {
+    let loopback = LoopbackTcpConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        scope.runtime_root.as_ref().join(LOCAL_HTTP_RECORD_FILENAME),
+        owner.instance_id(),
+    );
+    let config = HttpRuntimeConfig::new(
+        loopback,
+        unix_socket_config(scope)?,
+        RuntimeLimits::new(
+            NonZeroUsize::new(DEFAULT_MESSAGE_MAX_BYTES + CANONICAL_WRITE_ENVELOPE_OVERHEAD_BYTES)
+                .expect("non-zero body limit"),
+            NonZeroUsize::new(128).expect("non-zero connection limit"),
+        ),
+        RuntimeTimeouts::new(
+            NonZeroDuration::new(Duration::from_secs(3)).expect("non-zero request timeout"),
+            NonZeroDuration::new(REPLACEMENT_DRAIN_DEADLINE).expect("non-zero shutdown timeout"),
+        ),
+    )
+    .with_direct_peer_tcp(DirectPeerTcpConfig::standard());
+    Ok(match peer_stream_adapter {
+        Some(adapter) => config.with_peer_stream_adapter(Arc::clone(adapter)),
+        None => config,
+    })
+}
+
+fn record_peer_wire_mode_selection(
+    observability: &dyn ObservabilityPort,
+    daemon_launch_identity: &DaemonLaunchIdentity,
+    peer_wire_mode: PeerWireMode,
+    peer_stream_adapter: &Option<Arc<dyn PeerStreamAdapter>>,
+) {
+    tracing::info!(
+        peer_wire_security = peer_wire_mode.security().as_launch_value(),
+        mtls_ready = peer_stream_adapter.is_some(),
+        "replacement daemon selected peer-wire mode"
+    );
+    // A retained startup record carries only the selected public mode. The
+    // concrete adapter remains opaque; never emit certificates, pins, keys,
+    // or trust records from this composition boundary.
+    if let (Some(team), Some(identity)) = (
+        daemon_launch_identity.team.clone(),
+        daemon_launch_identity.identity.clone(),
+    ) && let Err(error) = observability.emit(CommandEvent {
+        command: "atm-daemon",
+        action: action_name("peer_wire_mode_selected"),
+        outcome: outcome_label(peer_wire_mode.security().as_launch_value()),
+        team,
+        agent: identity.clone(),
+        sender: identity,
+        message_id: None,
+        requires_ack: false,
+        dry_run: false,
+        task_id: None,
+        error_code: None,
+        error_message: None,
+    }) {
+        tracing::warn!(%error, "failed to retain peer-wire mode startup observability event");
+    }
+}
+
 async fn run_replacement_daemon_with_selector(
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
     selector_factory: impl FnOnce(
@@ -349,56 +414,13 @@ async fn run_replacement_daemon_with_selector(
         peer_stream_adapter.clone(),
         runtime_health.clone(),
     )?;
-    let loopback = LoopbackTcpConfig::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-        scope.runtime_root.as_ref().join(LOCAL_HTTP_RECORD_FILENAME),
-        _owner.instance_id(),
+    let config = replacement_runtime_config(&scope, &_owner, &peer_stream_adapter)?;
+    record_peer_wire_mode_selection(
+        observability.as_ref(),
+        &daemon_launch_identity,
+        peer_wire_mode,
+        &peer_stream_adapter,
     );
-    let config = HttpRuntimeConfig::new(
-        loopback,
-        unix_socket_config(&scope)?,
-        RuntimeLimits::new(
-            NonZeroUsize::new(DEFAULT_MESSAGE_MAX_BYTES + CANONICAL_WRITE_ENVELOPE_OVERHEAD_BYTES)
-                .expect("non-zero body limit"),
-            NonZeroUsize::new(128).expect("non-zero connection limit"),
-        ),
-        RuntimeTimeouts::new(
-            NonZeroDuration::new(Duration::from_secs(3)).expect("non-zero request timeout"),
-            NonZeroDuration::new(REPLACEMENT_DRAIN_DEADLINE).expect("non-zero shutdown timeout"),
-        ),
-    );
-    let config = config.with_direct_peer_tcp(DirectPeerTcpConfig::standard());
-    let config = match peer_stream_adapter.as_ref() {
-        Some(adapter) => config.with_peer_stream_adapter(Arc::clone(adapter)),
-        None => config,
-    };
-    tracing::info!(
-        peer_wire_security = peer_wire_mode.security().as_launch_value(),
-        mtls_ready = peer_stream_adapter.is_some(),
-        "replacement daemon selected peer-wire mode"
-    );
-    // A retained startup record carries only the selected public mode. The
-    // concrete adapter remains opaque; never emit certificates, pins, keys,
-    // or trust records from this composition boundary.
-    if let (Some(team), Some(identity)) = (
-        daemon_launch_identity.team.clone(),
-        daemon_launch_identity.identity.clone(),
-    ) && let Err(error) = observability.emit(CommandEvent {
-        command: "atm-daemon",
-        action: action_name("peer_wire_mode_selected"),
-        outcome: outcome_label(peer_wire_mode.security().as_launch_value()),
-        team,
-        agent: identity.clone(),
-        sender: identity,
-        message_id: None,
-        requires_ack: false,
-        dry_run: false,
-        task_id: None,
-        error_code: None,
-        error_message: None,
-    }) {
-        tracing::warn!(%error, "failed to retain peer-wire mode startup observability event");
-    }
     let mut running = HttpRuntimeBuilder::new(config, handler)
         .with_runtime_health(runtime_health)
         .build()?

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -327,9 +327,27 @@ fn replacement_runtime_config(
         scope.runtime_root.as_ref().join(LOCAL_HTTP_RECORD_FILENAME),
         owner.instance_id(),
     );
-    let config = HttpRuntimeConfig::new(
+    Ok(replacement_runtime_config_with_direct_peer(
         loopback,
         unix_socket_config(scope)?,
+        DirectPeerTcpConfig::standard(),
+        peer_stream_adapter,
+    ))
+}
+
+/// Builds the maintained runtime configuration after bootstrap has selected
+/// its one wire mode. Production supplies the fixed direct-peer port; tests
+/// may supply an isolated ephemeral listener while exercising this exact
+/// composition path.
+fn replacement_runtime_config_with_direct_peer(
+    loopback: LoopbackTcpConfig,
+    unix_socket: Option<atm_http_runtime::UnixSocketConfig>,
+    direct_peer_tcp: DirectPeerTcpConfig,
+    peer_stream_adapter: &Option<Arc<dyn PeerStreamAdapter>>,
+) -> HttpRuntimeConfig {
+    let config = HttpRuntimeConfig::new(
+        loopback,
+        unix_socket,
         RuntimeLimits::new(
             NonZeroUsize::new(DEFAULT_MESSAGE_MAX_BYTES + CANONICAL_WRITE_ENVELOPE_OVERHEAD_BYTES)
                 .expect("non-zero body limit"),
@@ -340,11 +358,11 @@ fn replacement_runtime_config(
             NonZeroDuration::new(REPLACEMENT_DRAIN_DEADLINE).expect("non-zero shutdown timeout"),
         ),
     )
-    .with_direct_peer_tcp(DirectPeerTcpConfig::standard());
-    Ok(match peer_stream_adapter {
+    .with_direct_peer_tcp(direct_peer_tcp);
+    match peer_stream_adapter {
         Some(adapter) => config.with_peer_stream_adapter(Arc::clone(adapter)),
         None => config,
-    })
+    }
 }
 
 fn record_peer_wire_mode_selection(
@@ -629,16 +647,50 @@ pub fn with_default_peer_address_stores<T>(
 #[cfg(test)]
 mod replacement_runtime_tests {
     use std::ffi::OsString;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::num::NonZeroU16;
+    use std::sync::Arc;
     use std::time::Duration;
 
-    use atm_core::boundary::TemplateSource;
+    use atm_core::api::ApiRequest;
+    use atm_core::boundary::{
+        BuiltInPostSendDispatch, MessageReceivedHookSelector, RosterEntry, TemplateSource,
+    };
+    use atm_core::observability::NullObservability;
+    use atm_core::peer_wire::PeerWireMode;
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::send::{SendMessageSource, WriteRequest};
+    use atm_core::types::{AgentName, ModelName, TeamName};
+    use atm_http_runtime::{
+        DirectPeerTcpConfig, HttpRuntimeBuilder, LoopbackTcpConfig, RuntimeHealth,
+        direct_peer_tcp_client,
+    };
+    use atm_runtime_test_support::open_isolated_sqlite_boundary;
+    use atm_storage::{MessageKey, RosterHarness, RosterMemberKind, RosterSnapshot};
     use atm_template_sc_compose::ScComposeTemplateComposer;
     use serde_json::Map;
 
     use super::{
-        REPLACEMENT_DRAIN_DEADLINE, ShutdownSignal, assemble_host_runtime_with_template_composer,
-        parse_peer_wire_mode, peer_stream_adapter_for_mode, write_ready_signal_if_requested,
+        DaemonLaunchIdentity, REPLACEMENT_DRAIN_DEADLINE, ShutdownSignal,
+        assemble_host_runtime_with_template_composer, build_replacement_handler,
+        parse_peer_wire_mode, peer_stream_adapter_for_mode,
+        replacement_runtime_config_with_direct_peer, write_ready_signal_if_requested,
     };
+
+    /// Test-owned receiver selection prevents an external tmux/graft action
+    /// from obscuring the bootstrap's direct-peer persistence proof.
+    struct NoReceivedHookSelector;
+
+    impl atm_core::boundary::sealed::Sealed for NoReceivedHookSelector {}
+
+    impl MessageReceivedHookSelector for NoReceivedHookSelector {
+        fn select_emitter(
+            &self,
+            _dispatch: &BuiltInPostSendDispatch,
+        ) -> Option<&dyn atm_core::boundary::AsyncMessageReceivedHookEmitter> {
+            None
+        }
+    }
 
     #[test]
     fn ready_signal_is_absent_unless_requested() {
@@ -704,6 +756,112 @@ mod replacement_runtime_tests {
         .expect("plaintext-test directly preserves the peer HTTP pipeline");
 
         assert!(adapter.is_none());
+    }
+
+    #[tokio::test]
+    async fn plaintext_test_bootstrap_runs_direct_peer_write_without_tls_configuration() {
+        let temporary_root = tempfile::tempdir().expect("temporary bootstrap runtime root");
+        let assembly = open_isolated_sqlite_boundary(temporary_root.path())
+            .expect("assemble isolated daemon runtime")
+            .for_daemon();
+        let team: TeamName = "test-team".parse().expect("team");
+        assembly
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: ["recipient", "sender"]
+                    .into_iter()
+                    .map(|agent_name| RosterEntry {
+                        team_name: team.clone(),
+                        agent_name: agent_name.parse().expect("agent"),
+                        member_kind: RosterMemberKind::Permanent,
+                        harness: RosterHarness::PythonGraft,
+                        agent_type: atm_core::schema::AgentType::default(),
+                        model: ModelName::default(),
+                        recipient_pane_id: None,
+                        metadata_json: Map::new(),
+                    })
+                    .collect(),
+                refreshed_at: None,
+            })
+            .expect("seed direct-peer recipient roster");
+        let message_store = assembly.message_store_arc();
+        let peer_stream_adapter =
+            peer_stream_adapter_for_mode(PeerWireMode::plaintext_test(), || {
+                panic!("plaintext bootstrap must not inspect invalid TLS peer configuration")
+            })
+            .expect("plaintext bootstrap selects no TLS stream adapter");
+        let runtime_health = RuntimeHealth::with_owner(std::process::id());
+        let handler = build_replacement_handler(
+            assembly,
+            Arc::new(NullObservability),
+            |_| Arc::new(NoReceivedHookSelector),
+            &DaemonLaunchIdentity::default(),
+            PeerWireMode::plaintext_test(),
+            peer_stream_adapter.clone(),
+            runtime_health.clone(),
+        )
+        .expect("compose the replacement daemon handler");
+        let config = replacement_runtime_config_with_direct_peer(
+            LoopbackTcpConfig::new(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                temporary_root.path().join("local-http.json"),
+                ulid::Ulid::new(),
+            ),
+            None,
+            DirectPeerTcpConfig::ephemeral_for_test(),
+            &peer_stream_adapter,
+        );
+        let running = HttpRuntimeBuilder::new(config, handler)
+            .with_runtime_health(runtime_health)
+            .build()
+            .expect("validate plaintext bootstrap runtime")
+            .start()
+            .await
+            .expect("start plaintext direct-peer listener");
+        let peer_port = running
+            .direct_peer_address()
+            .expect("ephemeral direct peer listener bound")
+            .port();
+        let client = direct_peer_tcp_client(
+            "127.0.0.1".parse().expect("direct peer host"),
+            NonZeroU16::new(peer_port).expect("non-zero direct peer port"),
+            Duration::from_secs(3),
+        )
+        .expect("direct peer client");
+        let request = WriteRequest::new(
+            temporary_root.path().join("home"),
+            temporary_root.path().join("workspace"),
+            "sender".parse::<AgentName>().expect("sender"),
+            "recipient@test-team",
+            team,
+            SendMessageSource::Inline("bootstrap plaintext direct-peer proof".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("direct peer write request");
+        let response = client
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
+            .await
+            .expect("plaintext direct peer write response")
+            .into_inner();
+        let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
+            panic!("plaintext direct peer write must return the canonical send response");
+        };
+        assert!(
+            message_store
+                .load_message(&MessageKey::from(outcome.message_id))
+                .expect("inspect durable direct peer message")
+                .is_some(),
+            "plaintext mode reaches the same durable storage pipeline without TLS configuration"
+        );
+        running
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("plaintext bootstrap runtime drains");
     }
 
     #[test]

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -19,15 +19,22 @@ use atm_core::error::AtmError;
 use atm_core::home::HOST_RUNTIME_SOCKET_FILE;
 use atm_core::home::current_host_runtime_scope;
 use atm_core::local_http::LOCAL_HTTP_RECORD_FILENAME;
-use atm_core::observability::{NullObservability, ObservabilityPort};
+use atm_core::observability::{
+    CommandEvent, NullObservability, ObservabilityPort, action_name, outcome_label,
+};
+use atm_core::peer_wire::{PeerWireMode, PeerWireSecurity};
 use atm_core::send::input::DEFAULT_MESSAGE_MAX_BYTES;
+use atm_core::types::HostName;
 use atm_core::types::{AgentName, TeamName};
 use atm_http_runtime::{
-    DirectPeerTcpConfig, HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig, NonZeroDuration,
+    AcceptedPeerStream, DirectPeerTcpConfig, EstablishedPeerStream, HttpRuntimeBuilder,
+    HttpRuntimeConfig, LoopbackTcpConfig, NonZeroDuration, PeerStreamAdapter, PeerStreamFuture,
     RuntimeHealth, RuntimeLimits, RuntimeTimeouts, StorageAndNudgeRouter,
 };
 use atm_runtime::{RuntimeAssembly, RuntimeAssemblyInputs, assemble_runtime};
 use atm_storage_rusqlite::SqliteStorageFactory;
+use peer_tls::MtlsPeerStreamAdapter;
+use tokio::net::TcpStream;
 
 mod owner_gate;
 mod received_hook_selector;
@@ -69,6 +76,88 @@ pub fn resolve_daemon_launch_identity() -> DaemonLaunchIdentity {
         identity: atm_core::caller_context::read_cli_identity_from_env_or_warn(
             "atm_daemon_bootstrap::resolve_daemon_launch_identity",
         ),
+    }
+}
+
+/// Parse the sole non-durable peer-wire launch policy before composition.
+///
+/// The process mode deliberately has no environment, database, or adapter
+/// availability source: those inputs can cause a startup error but cannot
+/// select plaintext.
+pub fn parse_peer_wire_mode(
+    arguments: impl IntoIterator<Item = std::ffi::OsString>,
+) -> Result<PeerWireMode, AtmError> {
+    if std::env::var_os("ATM_PEER_WIRE_SECURITY").is_some() {
+        return Err(AtmError::peer_wire_mode_source_forbidden(
+            "ATM_PEER_WIRE_SECURITY is forbidden; use --peer-wire-security at daemon launch",
+        ));
+    }
+    let mut arguments = arguments.into_iter();
+    let _program = arguments.next();
+    let mut mode = None;
+    while let Some(argument) = arguments.next() {
+        let argument = argument.into_string().map_err(|_| {
+            AtmError::peer_wire_mode_invalid("daemon launch arguments must be valid UTF-8")
+        })?;
+        let value = if argument == "--peer-wire-security" {
+            Some(arguments.next().ok_or_else(|| {
+                AtmError::peer_wire_mode_invalid(
+                    "--peer-wire-security requires `mutual-tls` or `plaintext-test`",
+                )
+            })?)
+        } else {
+            argument
+                .strip_prefix("--peer-wire-security=")
+                .map(std::ffi::OsString::from)
+        };
+        let Some(value) = value else {
+            continue;
+        };
+        let value = value.into_string().map_err(|_| {
+            AtmError::peer_wire_mode_invalid("peer-wire launch mode must be valid UTF-8")
+        })?;
+        let parsed = match value.as_str() {
+            "mutual-tls" => PeerWireMode::mtls(),
+            "plaintext-test" => PeerWireMode::plaintext_test(),
+            _ => {
+                return Err(AtmError::peer_wire_mode_invalid(
+                    "--peer-wire-security accepts only `mutual-tls` or `plaintext-test`",
+                ));
+            }
+        };
+        if mode.replace(parsed).is_some() {
+            return Err(AtmError::peer_wire_mode_invalid(
+                "--peer-wire-security may be supplied only once",
+            ));
+        }
+    }
+    Ok(mode.unwrap_or_default())
+}
+
+struct BootstrapMtlsStreamAdapter {
+    adapter: Arc<MtlsPeerStreamAdapter>,
+}
+
+impl PeerStreamAdapter for BootstrapMtlsStreamAdapter {
+    fn connect<'a>(
+        &'a self,
+        stream: TcpStream,
+        peer: &'a HostName,
+    ) -> PeerStreamFuture<'a, EstablishedPeerStream> {
+        Box::pin(async move {
+            let stream: EstablishedPeerStream = Box::new(self.adapter.connect(stream, peer).await?);
+            Ok(stream)
+        })
+    }
+
+    fn accept<'a>(&'a self, stream: TcpStream) -> PeerStreamFuture<'a, AcceptedPeerStream> {
+        Box::pin(async move {
+            let (stream, source_host) = self.adapter.accept_with_peer(stream).await?;
+            Ok(AcceptedPeerStream {
+                source_host,
+                stream: Box::new(stream),
+            })
+        })
     }
 }
 
@@ -154,10 +243,12 @@ pub async fn run_replacement_daemon() -> Result<(), AtmError> {
 pub async fn run_replacement_daemon_with_observability(
     observability: Arc<dyn ObservabilityPort + Send + Sync>,
 ) -> Result<(), AtmError> {
+    let peer_wire_mode = parse_peer_wire_mode(std::env::args_os())?;
     run_replacement_daemon_with_selector(
         observability,
         active_received_hook_selector,
         resolve_daemon_launch_identity(),
+        peer_wire_mode,
     )
     .await
 }
@@ -168,10 +259,12 @@ pub async fn run_replacement_daemon_with_observability(
 /// exists only behind the `benchmark-harness` feature.
 #[cfg(feature = "benchmark-harness")]
 pub async fn run_benchmark_daemon(hook_mode: BenchmarkHookMode) -> Result<(), AtmError> {
+    let peer_wire_mode = parse_peer_wire_mode(std::env::args_os())?;
     run_replacement_daemon_with_selector(
         Arc::new(NullObservability),
         move |service_runtime| benchmark_received_hook_selector(service_runtime, hook_mode),
         resolve_daemon_launch_identity(),
+        peer_wire_mode,
     )
     .await
 }
@@ -183,25 +276,31 @@ fn build_replacement_handler(
         atm_core::LocalServiceRuntime,
     ) -> Arc<dyn atm_core::boundary::MessageReceivedHookSelector>,
     daemon_launch_identity: &DaemonLaunchIdentity,
+    peer_wire_mode: PeerWireMode,
+    peer_stream_adapter: Option<Arc<dyn PeerStreamAdapter>>,
     runtime_health: RuntimeHealth,
 ) -> Result<Arc<StorageAndNudgeRouter>, AtmError> {
     let selector = selector_factory(assembly.service_runtime.clone());
-    Ok(Arc::new(
-        StorageAndNudgeRouter::new(
-            assembly.service_runtime,
-            observability,
-            selector,
-            atm_core::home::atm_home()?,
-        )
-        .with_runtime_health(runtime_health, assembly.doctor_ports)
-        .with_daemon_context(atm_core::doctor::DoctorExecutionContext {
-            team: daemon_launch_identity.team.clone(),
-            identity: daemon_launch_identity.identity.clone(),
-            version: Some(atm_core::protocol::ReleaseVersion::current()),
-            cli_schema_version: Some(atm_core::protocol::CLI_SCHEMA_VERSION),
-            http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),
-        }),
-    ))
+    let handler = StorageAndNudgeRouter::new(
+        assembly.service_runtime,
+        observability,
+        selector,
+        atm_core::home::atm_home()?,
+    )
+    .with_runtime_health(runtime_health, assembly.doctor_ports)
+    .with_daemon_context(atm_core::doctor::DoctorExecutionContext {
+        team: daemon_launch_identity.team.clone(),
+        identity: daemon_launch_identity.identity.clone(),
+        version: Some(atm_core::protocol::ReleaseVersion::current()),
+        cli_schema_version: Some(atm_core::protocol::CLI_SCHEMA_VERSION),
+        http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),
+        peer_wire_security: Some(peer_wire_mode.security().as_launch_value().to_owned()),
+    });
+    let handler = match peer_stream_adapter {
+        Some(adapter) => handler.with_peer_stream_adapter(adapter),
+        None => handler,
+    };
+    Ok(Arc::new(handler))
 }
 
 async fn run_replacement_daemon_with_selector(
@@ -210,6 +309,7 @@ async fn run_replacement_daemon_with_selector(
         atm_core::LocalServiceRuntime,
     ) -> Arc<dyn atm_core::boundary::MessageReceivedHookSelector>,
     daemon_launch_identity: DaemonLaunchIdentity,
+    peer_wire_mode: PeerWireMode,
 ) -> Result<(), AtmError> {
     install_sqlite_retained_runtime_factory();
     let scope = current_host_runtime_scope()?;
@@ -217,13 +317,23 @@ async fn run_replacement_daemon_with_selector(
     let runtime_health = RuntimeHealth::with_owner(std::process::id());
     let assembly = assemble_daemon_runtime()?;
     let workflow_telemetry = assembly.workflow_telemetry.clone();
+    let peer_stream_adapter = match peer_wire_mode.security() {
+        PeerWireSecurity::Mtls => Some(Arc::new(BootstrapMtlsStreamAdapter {
+            adapter: Arc::new(MtlsPeerStreamAdapter::from_peer_config(
+                assembly.peer_config_store.as_ref(),
+            )?),
+        }) as Arc<dyn PeerStreamAdapter>),
+        PeerWireSecurity::PlaintextTest => None,
+    };
     // The shipped daemon always keeps the injected receiver hook active.
     // Benchmark-only selection is available only from the separate binary.
     let handler = build_replacement_handler(
         assembly,
-        observability,
+        Arc::clone(&observability),
         selector_factory,
         &daemon_launch_identity,
+        peer_wire_mode,
+        peer_stream_adapter.clone(),
         runtime_health.clone(),
     )?;
     let loopback = LoopbackTcpConfig::new(
@@ -245,6 +355,37 @@ async fn run_replacement_daemon_with_selector(
         ),
     );
     let config = config.with_direct_peer_tcp(DirectPeerTcpConfig::standard());
+    let config = match peer_stream_adapter.as_ref() {
+        Some(adapter) => config.with_peer_stream_adapter(Arc::clone(adapter)),
+        None => config,
+    };
+    tracing::info!(
+        peer_wire_security = peer_wire_mode.security().as_launch_value(),
+        mtls_ready = peer_stream_adapter.is_some(),
+        "replacement daemon selected peer-wire mode"
+    );
+    // A retained startup record carries only the selected public mode. The
+    // concrete adapter remains opaque; never emit certificates, pins, keys,
+    // or trust records from this composition boundary.
+    if let (Some(team), Some(identity)) = (
+        daemon_launch_identity.team.clone(),
+        daemon_launch_identity.identity.clone(),
+    ) && let Err(error) = observability.emit(CommandEvent {
+        command: "atm-daemon",
+        action: action_name("peer_wire_mode_selected"),
+        outcome: outcome_label(peer_wire_mode.security().as_launch_value()),
+        team,
+        agent: identity.clone(),
+        sender: identity,
+        message_id: None,
+        requires_ack: false,
+        dry_run: false,
+        task_id: None,
+        error_code: None,
+        error_message: None,
+    }) {
+        tracing::warn!(%error, "failed to retain peer-wire mode startup observability event");
+    }
     let mut running = HttpRuntimeBuilder::new(config, handler)
         .with_runtime_health(runtime_health)
         .build()?
@@ -452,6 +593,7 @@ pub fn with_default_peer_address_stores<T>(
 
 #[cfg(test)]
 mod replacement_runtime_tests {
+    use std::ffi::OsString;
     use std::time::Duration;
 
     use atm_core::boundary::TemplateSource;
@@ -460,7 +602,7 @@ mod replacement_runtime_tests {
 
     use super::{
         REPLACEMENT_DRAIN_DEADLINE, ShutdownSignal, assemble_host_runtime_with_template_composer,
-        write_ready_signal_if_requested,
+        parse_peer_wire_mode, write_ready_signal_if_requested,
     };
 
     #[test]
@@ -480,6 +622,40 @@ mod replacement_runtime_tests {
     #[test]
     fn replacement_runtime_uses_the_architecture_drain_deadline() {
         assert_eq!(REPLACEMENT_DRAIN_DEADLINE, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn peer_wire_mode_defaults_to_mutual_tls_and_accepts_only_launch_values() {
+        let mutual_tls = parse_peer_wire_mode([OsString::from("atm-daemon")])
+            .expect("mTLS is the secure default");
+        assert_eq!(mutual_tls.security().as_launch_value(), "mutual-tls");
+
+        let plaintext = parse_peer_wire_mode([
+            OsString::from("atm-daemon"),
+            OsString::from("--peer-wire-security=plaintext-test"),
+        ])
+        .expect("explicit plaintext test mode");
+        assert_eq!(plaintext.security().as_launch_value(), "plaintext-test");
+
+        let invalid = parse_peer_wire_mode([
+            OsString::from("atm-daemon"),
+            OsString::from("--peer-wire-security"),
+            OsString::from("opportunistic"),
+        ])
+        .expect_err("no opportunistic or fallback mode exists");
+        assert!(invalid.message().contains("mutual-tls"));
+    }
+
+    #[test]
+    fn peer_wire_mode_rejects_duplicate_launch_values() {
+        let error = parse_peer_wire_mode([
+            OsString::from("atm-daemon"),
+            OsString::from("--peer-wire-security"),
+            OsString::from("mutual-tls"),
+            OsString::from("--peer-wire-security=plaintext-test"),
+        ])
+        .expect_err("one launch mode must select the whole runtime");
+        assert!(error.message().contains("only once"));
     }
 
     #[test]

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -9,6 +9,11 @@ description = "Tokio HTTP runtime contract for ATM daemon composition."
 repository.workspace = true
 homepage.workspace = true
 
+[features]
+# Exposes isolated listener construction only to workspace integration tests.
+# It is never enabled by the shipped daemon dependency.
+test-support = []
+
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.4" }
 base64.workspace = true

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -15,6 +15,7 @@ base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
+http-body-util.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -24,8 +24,15 @@ use atm_core::protocol::{RequestEnvelope, RequestId, next_request_id};
 use atm_core::schema::AtmMessageId;
 use atm_core::send::SendRequest;
 use atm_core::types::{HostName, IsoTimestamp};
+use axum::body::Body;
+use http_body_util::BodyExt;
+use hyper::client::conn::http1;
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
 
 use reqwest::header::{HeaderName, HeaderValue};
+
+use crate::PeerStreamAdapter;
 
 /// Fixed plain-TCP port for direct peer writes.
 ///
@@ -38,9 +45,8 @@ const REQUEST_ID_HEADER: &str = "X-ATM-Request-Id";
 
 /// One bounded budget for the selected write connector.
 ///
-/// CLI and graft deliberately share this value and
-/// [`selected_write_transport`], so a host-qualified write cannot acquire a
-/// different deadline or silently select a different connector by caller.
+/// The daemon owns this direct-plaintext budget after the CLI or graft
+/// submits the canonical request through its ordinary local transport.
 pub const SAME_HOST_REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 
 /// Returns the fixed direct-peer protocol port.
@@ -140,6 +146,26 @@ pub fn direct_peer_tcp_client(
     )?))
 }
 
+/// Builds the same typed peer-write client over a bootstrap-selected opaque
+/// stream adapter.  The caller provides no TLS value: this runtime owns only
+/// the established stream, normal request encoding, deadline, and response
+/// decoding.
+pub fn peer_stream_write_client(
+    host: HostName,
+    port: NonZeroU16,
+    request_timeout: Duration,
+    adapter: Arc<dyn PeerStreamAdapter>,
+) -> Result<Arc<dyn DaemonApiClient + Send + Sync>, AtmError> {
+    if request_timeout.is_zero() {
+        return Err(AtmError::config(
+            "direct peer HTTP client request timeout must be greater than zero",
+        ));
+    }
+    let connector = PeerStreamConnector::new(host, port, adapter);
+    let client = Arc::new(HttpRuntimeClient::new(Arc::new(connector), request_timeout));
+    Ok(Arc::new(PeerStreamWriteClient { client }))
+}
+
 pub(crate) fn direct_peer_write_client(
     host: HostName,
     port: NonZeroU16,
@@ -155,20 +181,18 @@ pub(crate) fn direct_peer_write_client(
     Ok(DirectPeerWriteClient { client })
 }
 
-/// Selects the one physical connector for a canonical write before encoding.
+/// Selects the owner-authorized local daemon for every canonical write.
 ///
-/// An unqualified recipient stays on the caller-supplied, owner-authorized
-/// same-host client. A host-qualified recipient is an explicit direct-peer
-/// request and selects the shared direct-peer HTTP client; configuration or
-/// connection failures never downgrade it to same-host IPC.
+/// Host-qualified addressing remains part of the canonical request, but the
+/// CLI and graft never select a peer socket themselves. The selected daemon
+/// owns the one peer-wire mode and forwards the admitted write through either
+/// the unchanged plaintext connector or its bootstrap-composed opaque stream
+/// adapter.
 pub fn selected_write_transport<'client>(
-    request: &SendRequest,
+    _request: &SendRequest,
     same_host_transport: &Arc<dyn DaemonApiClient + Send + Sync + 'client>,
 ) -> Result<Arc<dyn DaemonApiClient + Send + Sync + 'client>, AtmError> {
-    let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
-        return Ok(Arc::clone(same_host_transport));
-    };
-    direct_peer_tcp_client(host.clone(), direct_peer_port(), SAME_HOST_REQUEST_DEADLINE)
+    Ok(Arc::clone(same_host_transport))
 }
 
 /// Builds the one selected same-host client for retained write call chains.
@@ -232,6 +256,14 @@ struct DirectPeerTcpConnector {
     authority: String,
 }
 
+/// Transport-neutral outbound connector over an authenticated opaque stream.
+struct PeerStreamConnector {
+    authority: String,
+    host: HostName,
+    port: NonZeroU16,
+    adapter: Arc<dyn PeerStreamAdapter>,
+}
+
 /// Send-only peer adapter over the shared typed HTTP client.
 ///
 /// The client owns only sender-side provenance completion.  It never changes
@@ -244,6 +276,48 @@ pub(crate) struct DirectPeerWriteClient {
     client: Arc<HttpRuntimeClient<DirectPeerTcpConnector>>,
 }
 
+/// Mirrors the direct peer's one-write provenance completion while replacing
+/// only connection establishment with the selected opaque stream adapter.
+struct PeerStreamWriteClient {
+    client: Arc<HttpRuntimeClient<PeerStreamConnector>>,
+}
+
+impl boundary::sealed::Sealed for PeerStreamWriteClient {}
+
+#[async_trait]
+impl DaemonApiClient for PeerStreamWriteClient {
+    async fn execute(&self, request: ApiRequest) -> Result<ApiResponse, AtmError> {
+        let RequestEnvelope::Write(write) = request.into_inner() else {
+            return Err(AtmError::validation(
+                "direct peer HTTP transport accepts canonical write requests only",
+            ));
+        };
+        let write = *write;
+        let has_id = write.origin_message_id.is_some();
+        let has_timestamp = write.origin_timestamp.is_some();
+        if has_id != has_timestamp {
+            return Err(AtmError::validation(
+                "direct peer write origin metadata must contain both message ID and timestamp",
+            ));
+        }
+        let write = if has_id {
+            write
+        } else {
+            write.with_origin_metadata(AtmMessageId::new(), IsoTimestamp::now())
+        };
+        let mut peer_response_shape = write.clone();
+        peer_response_shape.acknowledges_message_id = None;
+        self.client
+            .execute_envelope_with_deadline(
+                RequestEnvelope::Write(Box::new(write)),
+                RequestEnvelope::Write(Box::new(peer_response_shape)),
+                RequestDeadline::after(self.client.request_timeout),
+                None,
+            )
+            .await
+    }
+}
+
 impl boundary::sealed::Sealed for DirectPeerWriteClient {}
 
 #[async_trait]
@@ -254,15 +328,6 @@ impl DaemonApiClient for DirectPeerWriteClient {
 }
 
 impl DirectPeerWriteClient {
-    pub(crate) async fn execute_with_request_id(
-        &self,
-        request: ApiRequest,
-        request_id: RequestId,
-    ) -> Result<ApiResponse, AtmError> {
-        self.execute_with_optional_request_id(request, Some(request_id))
-            .await
-    }
-
     async fn execute_with_optional_request_id(
         &self,
         request: ApiRequest,
@@ -322,6 +387,22 @@ impl DirectPeerTcpConnector {
     }
 }
 
+impl PeerStreamConnector {
+    fn new(host: HostName, port: NonZeroU16, adapter: Arc<dyn PeerStreamAdapter>) -> Self {
+        let authority = if host.as_str().contains(':') {
+            format!("[{}]:{}", host.as_str(), port)
+        } else {
+            format!("{}:{}", host.as_str(), port)
+        };
+        Self {
+            authority,
+            host,
+            port,
+            adapter,
+        }
+    }
+}
+
 #[async_trait]
 impl HttpRuntimeConnector for DirectPeerTcpConnector {
     fn connection_target(&self) -> String {
@@ -354,6 +435,113 @@ impl HttpRuntimeConnector for DirectPeerTcpConnector {
             .await
             .map_err(|failure| direct_peer_connection_failure(&self.authority, failure))
     }
+}
+
+#[async_trait]
+impl HttpRuntimeConnector for PeerStreamConnector {
+    fn connection_target(&self) -> String {
+        format!("direct peer `{}`", self.authority)
+    }
+
+    fn deadline_elapsed(&self) -> HttpRuntimeClientFailure {
+        HttpRuntimeClientFailure::PeerConnectTimeout {
+            target: self.authority.clone(),
+            cause: format!(
+                "{} did not resolve or establish a connection before the configured request deadline",
+                self.connection_target()
+            ),
+        }
+    }
+
+    async fn exchange(
+        &self,
+        request: HttpRequest,
+        deadline: RequestDeadline,
+    ) -> Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure> {
+        let stream = TcpStream::connect((self.host.as_str(), self.port.get()))
+            .await
+            .map_err(|source| HttpRuntimeClientFailure::PeerConnect {
+                target: self.authority.clone(),
+                cause: source.to_string(),
+            })?;
+        let stream = self
+            .adapter
+            .connect(stream, &self.host)
+            .await
+            .map_err(|error| HttpRuntimeClientFailure::PeerConnect {
+                target: self.authority.clone(),
+                cause: error.to_string(),
+            })?;
+        execute_opaque_peer_request(stream, request, deadline)
+            .await
+            .map_err(|failure| direct_peer_connection_failure(&self.authority, failure))
+    }
+}
+
+async fn execute_opaque_peer_request(
+    stream: Box<dyn crate::AuthenticatedPeerStream>,
+    request: HttpRequest,
+    deadline: RequestDeadline,
+) -> Result<axum::http::Response<Vec<u8>>, HttpRuntimeClientFailure> {
+    let (mut sender, connection) = http1::handshake(TokioIo::new(stream))
+        .await
+        .map_err(|source| HttpRuntimeClientFailure::Connect(source.to_string()))?;
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            tracing::debug!(%error, "opaque peer HTTP client connection ended");
+        }
+    });
+    let method: axum::http::Method = request.method.parse().map_err(|source| {
+        HttpRuntimeClientFailure::RequestWrite(format!(
+            "shared HTTP request has an invalid method `{}`: {source}",
+            request.method
+        ))
+    })?;
+    let mut builder = axum::http::Request::builder()
+        .method(method)
+        .uri(&request.path);
+    for header in request.headers {
+        let (name, value) = header.split_once(':').ok_or_else(|| {
+            HttpRuntimeClientFailure::RequestWrite(format!(
+                "shared HTTP request has a malformed header `{header}`"
+            ))
+        })?;
+        let name = HeaderName::from_bytes(name.as_bytes()).map_err(|source| {
+            HttpRuntimeClientFailure::RequestWrite(format!(
+                "shared HTTP request has an invalid header name `{name}`: {source}"
+            ))
+        })?;
+        let value = HeaderValue::from_str(value.trim_start()).map_err(|source| {
+            HttpRuntimeClientFailure::RequestWrite(format!(
+                "shared HTTP request has an invalid value for `{name}`: {source}"
+            ))
+        })?;
+        builder = builder.header(name, value);
+    }
+    let request = builder.body(Body::from(request.body)).map_err(|source| {
+        HttpRuntimeClientFailure::RequestWrite(format!(
+            "shared HTTP request could not be built for opaque peer stream: {source}"
+        ))
+    })?;
+    let remaining = deadline
+        .remaining()
+        .ok_or(HttpRuntimeClientFailure::Cancelled)?;
+    let response = tokio::time::timeout(remaining, sender.send_request(request))
+        .await
+        .map_err(|_| HttpRuntimeClientFailure::Timeout)?
+        .map_err(|source| HttpRuntimeClientFailure::Connect(source.to_string()))?;
+    let (parts, body) = response.into_parts();
+    let body = body
+        .collect()
+        .await
+        .map_err(|source| {
+            HttpRuntimeClientFailure::ResponseDecode(
+                AtmError::daemon_unavailable("failed to read opaque peer HTTP response body")
+                    .with_cause(source),
+            )
+        })?
+        .to_bytes();
+    Ok(axum::http::Response::from_parts(parts, body.to_vec()))
 }
 
 /// Preserve the direct-peer authority when the shared HTTP exchange fails
@@ -764,8 +952,24 @@ mod tests {
 
     use super::{
         DirectPeerTcpConnector, HttpRuntimeClient, HttpRuntimeClientFailure, HttpRuntimeConnector,
-        direct_peer_connection_failure, direct_peer_tcp_client,
+        direct_peer_connection_failure, direct_peer_tcp_client, selected_write_transport,
     };
+
+    struct LocalOnlyClient;
+
+    impl atm_core::boundary::sealed::Sealed for LocalOnlyClient {}
+
+    #[async_trait]
+    impl DaemonApiClient for LocalOnlyClient {
+        async fn execute(
+            &self,
+            _request: ApiRequest,
+        ) -> Result<atm_core::api::ApiResponse, AtmError> {
+            Err(AtmError::daemon_unavailable(
+                "test local transport is not invoked",
+            ))
+        }
+    }
 
     #[derive(Default)]
     struct RecordingConnector {
@@ -821,6 +1025,27 @@ mod tests {
         .err()
         .expect("zero budget must fail before a peer request is attempted");
         assert!(error.message().contains("timeout"));
+    }
+
+    #[test]
+    fn host_qualified_write_stays_on_the_same_host_daemon_transport() {
+        let mut request = match write_request() {
+            RequestEnvelope::Write(request) => *request,
+            _ => unreachable!("fixture is a write"),
+        };
+        request.to = Some(
+            "recipient@test-team.rand-m5"
+                .parse()
+                .expect("host-qualified fixture"),
+        );
+        let same_host: Arc<dyn DaemonApiClient + Send + Sync> = Arc::new(LocalOnlyClient);
+
+        let selected = selected_write_transport(&request, &same_host)
+            .expect("host qualification must not make the CLI or graft open a socket");
+        assert!(
+            Arc::ptr_eq(&selected, &same_host),
+            "daemon composition, not the caller, selects the peer-wire transport"
+        );
     }
 
     fn sent_response() -> axum::http::Response<Vec<u8>> {

--- a/crates/atm-http-runtime/src/http1_server.rs
+++ b/crates/atm-http-runtime/src/http1_server.rs
@@ -23,6 +23,11 @@ use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinSet;
 use tower::ServiceExt;
 
+use crate::message_handler::AuthenticatedConnector;
+use crate::{
+    CanonicalWriteHandler, PeerStreamAdapter, RuntimeLimits, RuntimeTimeouts, canonical_api_router,
+};
+
 /// Serves the capability-authenticated loopback adapter with bounded
 /// header-read time and cooperative graceful shutdown.
 pub(crate) async fn serve_loopback_http1(
@@ -64,6 +69,69 @@ pub(crate) async fn serve_loopback_http1(
                         // not a listener failure. Hyper has already closed it;
                         // keep accepting healthy clients.
                         tracing::debug!(%error, peer = %peer, "HTTP/1 loopback connection ended");
+                    }
+                });
+            }
+        }
+    }
+
+    drain_connections(connections).await
+}
+
+/// Serves authenticated opaque peer streams through the exact canonical Axum
+/// route used by every other runtime adapter. Authentication completes before
+/// the router is constructed or HTTP bytes are decoded.
+pub(crate) async fn serve_authenticated_peer_http1(
+    listener: TcpListener,
+    adapter: Arc<dyn PeerStreamAdapter>,
+    handler: Arc<dyn CanonicalWriteHandler>,
+    limits: RuntimeLimits,
+    timeouts: RuntimeTimeouts,
+    mut shutdown_rx: watch::Receiver<()>,
+) -> io::Result<()> {
+    let mut connections = JoinSet::new();
+    let permits = Arc::new(Semaphore::new(limits.max_connections));
+
+    loop {
+        let permit = tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            permit = Arc::clone(&permits).acquire_owned() => permit.expect("connection semaphore remains owned by the server"),
+        };
+        tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            accepted = listener.accept() => {
+                let (stream, peer) = accepted?;
+                let adapter = Arc::clone(&adapter);
+                let handler = Arc::clone(&handler);
+                let connection_shutdown = shutdown_rx.clone();
+                connections.spawn(async move {
+                    let _permit = permit;
+                    let accepted = match adapter.accept(stream).await {
+                        Ok(accepted) => accepted,
+                        Err(error) => {
+                            tracing::debug!(%error, peer = %peer, "peer stream authentication failed before HTTP decode");
+                            return;
+                        }
+                    };
+                    let router = canonical_api_router(
+                        handler,
+                        AuthenticatedConnector::peer(accepted.source_host),
+                        limits,
+                        timeouts,
+                    );
+                    let service = router
+                        .into_make_service_with_connect_info::<SocketAddr>()
+                        .oneshot(peer)
+                        .await
+                        .expect("Axum's peer make-service is infallible");
+                    if let Err(error) = serve_connection(
+                        TokioIo::new(accepted.stream),
+                        service,
+                        timeouts.request,
+                        connection_shutdown,
+                    )
+                    .await {
+                        tracing::debug!(%error, peer = %peer, "authenticated peer HTTP/1 connection ended");
                     }
                 });
             }

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -806,27 +806,13 @@ async fn drain_server_group(inputs: ServerGroupInputs) -> std::io::Result<()> {
         shutdown_rx.clone(),
     ));
     if let Some(direct_peer) = direct_peer {
-        match direct_peer {
-            DirectPeerServer::Plaintext(listener, router) => {
-                servers.spawn(serve_loopback_http1(
-                    listener,
-                    router,
-                    max_connections,
-                    header_read_timeout,
-                    shutdown_rx.clone(),
-                ));
-            }
-            DirectPeerServer::Authenticated(listener, adapter, handler, limits, timeouts) => {
-                servers.spawn(serve_authenticated_peer_http1(
-                    listener,
-                    adapter,
-                    handler,
-                    limits,
-                    timeouts,
-                    shutdown_rx.clone(),
-                ));
-            }
-        }
+        spawn_direct_peer_server(
+            &mut servers,
+            direct_peer,
+            max_connections,
+            header_read_timeout,
+            shutdown_rx.clone(),
+        );
     }
     #[cfg(unix)]
     if let Some((listener, cleanup, router)) = unix_socket {
@@ -867,6 +853,36 @@ async fn drain_server_group(inputs: ServerGroupInputs) -> std::io::Result<()> {
         }
     }
     first
+}
+
+fn spawn_direct_peer_server(
+    servers: &mut tokio::task::JoinSet<std::io::Result<()>>,
+    direct_peer: DirectPeerServer,
+    max_connections: usize,
+    header_read_timeout: Duration,
+    shutdown_rx: watch::Receiver<()>,
+) {
+    match direct_peer {
+        DirectPeerServer::Plaintext(listener, router) => {
+            servers.spawn(serve_loopback_http1(
+                listener,
+                router,
+                max_connections,
+                header_read_timeout,
+                shutdown_rx,
+            ));
+        }
+        DirectPeerServer::Authenticated(listener, adapter, handler, limits, timeouts) => {
+            servers.spawn(serve_authenticated_peer_http1(
+                listener,
+                adapter,
+                handler,
+                limits,
+                timeouts,
+                shutdown_rx,
+            ));
+        }
+    }
 }
 
 impl HttpRuntime<Running> {

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -195,10 +195,13 @@ impl DirectPeerTcpConfig {
         }
     }
 
-    /// Test-only isolated listener selection without a probe/rebind race.
-    #[cfg(test)]
+    /// Test-support-only isolated listener selection without a probe/rebind race.
+    ///
+    /// This is available to workspace composition tests through the explicit
+    /// `test-support` feature, never to the production bootstrap dependency.
+    #[cfg(any(test, feature = "test-support"))]
     #[must_use]
-    pub(crate) fn ephemeral_for_test() -> Self {
+    pub fn ephemeral_for_test() -> Self {
         Self {
             port: 0,
             allow_ephemeral_test_port: true,

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -53,15 +53,16 @@ mod client;
 mod http1_server;
 mod loopback_tcp;
 mod message_handler;
+mod peer_stream;
 mod private_staging;
 mod runtime_health;
 mod storage_and_nudge_router;
 #[cfg(unix)]
 mod unix_socket;
 
-use http1_server::serve_loopback_http1;
 #[cfg(unix)]
 use http1_server::serve_unix_http1;
+use http1_server::{serve_authenticated_peer_http1, serve_loopback_http1};
 use loopback_tcp::{
     LoopbackEndpointRecordGuard, authenticated_loopback_router, cleanup_loopback_endpoint_record,
     publish_loopback_endpoint_record, validate_loopback_config,
@@ -86,6 +87,10 @@ pub use loopback_tcp::LoopbackTcpConfig;
 pub use message_handler::{
     AuthenticatedConnector, CanonicalWriteHandler, canonical_api_router, canonical_message_router,
 };
+pub use peer_stream::{
+    AcceptedPeerStream, AuthenticatedPeerStream, EstablishedPeerStream, PeerStreamAdapter,
+    PeerStreamFuture,
+};
 pub use runtime_health::RuntimeHealth;
 pub use storage_and_nudge_router::StorageAndNudgeRouter;
 
@@ -93,13 +98,31 @@ pub use storage_and_nudge_router::StorageAndNudgeRouter;
 ///
 /// The fields remain private so composition cannot bypass validation before a
 /// listener is introduced in a later AL sprint.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HttpRuntimeConfig {
     loopback_tcp: LoopbackTcpConfig,
     unix_socket: Option<UnixSocketConfig>,
     direct_peer_tcp: Option<DirectPeerTcpConfig>,
+    peer_stream_adapter: Option<Arc<dyn PeerStreamAdapter>>,
     limits: RuntimeLimits,
     timeouts: RuntimeTimeouts,
+}
+
+impl std::fmt::Debug for HttpRuntimeConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HttpRuntimeConfig")
+            .field("loopback_tcp", &self.loopback_tcp)
+            .field("unix_socket", &self.unix_socket)
+            .field("direct_peer_tcp", &self.direct_peer_tcp)
+            .field(
+                "peer_stream_adapter",
+                &self.peer_stream_adapter.as_ref().map(|_| "configured"),
+            )
+            .field("limits", &self.limits)
+            .field("timeouts", &self.timeouts)
+            .finish()
+    }
 }
 
 impl HttpRuntimeConfig {
@@ -116,6 +139,7 @@ impl HttpRuntimeConfig {
             loopback_tcp,
             unix_socket,
             direct_peer_tcp: None,
+            peer_stream_adapter: None,
             limits,
             timeouts,
         }
@@ -130,6 +154,15 @@ impl HttpRuntimeConfig {
     #[must_use]
     pub fn with_direct_peer_tcp(mut self, direct_peer_tcp: DirectPeerTcpConfig) -> Self {
         self.direct_peer_tcp = Some(direct_peer_tcp);
+        self
+    }
+
+    /// Composes an already-selected authenticated stream adapter around the
+    /// direct peer listener. The runtime receives only opaque streams; TLS
+    /// construction and peer configuration remain bootstrap-owned.
+    #[must_use]
+    pub fn with_peer_stream_adapter(mut self, adapter: Arc<dyn PeerStreamAdapter>) -> Self {
+        self.peer_stream_adapter = Some(adapter);
         self
     }
 }
@@ -434,19 +467,31 @@ impl HttpRuntime<Configured> {
             self.config.timeouts,
         );
         let loopback_router = authenticated_loopback_router(canonical_router.clone(), capability);
-        let direct_peer_router = direct_peer_listener.as_ref().map(|_| {
-            canonical_api_router(
-                Arc::clone(&self.handler),
-                AuthenticatedConnector::peer_socket(),
-                self.config.limits,
-                self.config.timeouts,
-            )
-        });
+        let direct_peer = match direct_peer_listener {
+            Some(listener) => match self.config.peer_stream_adapter.as_ref() {
+                Some(adapter) => Some(DirectPeerServer::Authenticated(
+                    listener,
+                    Arc::clone(adapter),
+                    Arc::clone(&self.handler),
+                    self.config.limits,
+                    self.config.timeouts,
+                )),
+                None => Some(DirectPeerServer::Plaintext(
+                    listener,
+                    canonical_api_router(
+                        Arc::clone(&self.handler),
+                        AuthenticatedConnector::peer_socket(),
+                        self.config.limits,
+                        self.config.timeouts,
+                    ),
+                )),
+            },
+            None => None,
+        };
         let server_task = match start_server_task(ServerTaskInputs {
             listener,
             loopback_router,
-            direct_peer_listener,
-            direct_peer_router,
+            direct_peer,
             #[cfg(unix)]
             canonical_router,
             #[cfg(unix)]
@@ -619,8 +664,7 @@ async fn publish_loopback_endpoint(
 struct ServerTaskInputs {
     listener: TcpListener,
     loopback_router: axum::Router,
-    direct_peer_listener: Option<TcpListener>,
-    direct_peer_router: Option<axum::Router>,
+    direct_peer: Option<DirectPeerServer>,
     #[cfg(unix)]
     canonical_router: axum::Router,
     #[cfg(unix)]
@@ -631,6 +675,17 @@ struct ServerTaskInputs {
     shutdown_rx: watch::Receiver<()>,
     server_stopped_tx: watch::Sender<bool>,
     health: RuntimeHealth,
+}
+
+enum DirectPeerServer {
+    Plaintext(TcpListener, axum::Router),
+    Authenticated(
+        TcpListener,
+        Arc<dyn PeerStreamAdapter>,
+        Arc<dyn CanonicalWriteHandler>,
+        RuntimeLimits,
+        RuntimeTimeouts,
+    ),
 }
 
 /// Marks the process-owned status projection when the one managed server task
@@ -675,8 +730,7 @@ async fn start_server_task(
     let ServerTaskInputs {
         listener,
         loopback_router,
-        direct_peer_listener,
-        direct_peer_router,
+        direct_peer,
         #[cfg(unix)]
         canonical_router,
         #[cfg(unix)]
@@ -694,7 +748,7 @@ async fn start_server_task(
         async move {
             drain_server_group(ServerGroupInputs {
                 loopback: (listener, loopback_router),
-                direct_peer: direct_peer_listener.zip(direct_peer_router),
+                direct_peer,
                 #[cfg(unix)]
                 unix_socket: unix_listener
                     .map(|(listener, cleanup)| (listener, cleanup, canonical_router)),
@@ -710,7 +764,7 @@ async fn start_server_task(
 
 struct ServerGroupInputs {
     loopback: (TcpListener, axum::Router),
-    direct_peer: Option<(TcpListener, axum::Router)>,
+    direct_peer: Option<DirectPeerServer>,
     #[cfg(unix)]
     unix_socket: Option<(UnixListener, UnixSocketPathGuard, axum::Router)>,
     max_connections: usize,
@@ -741,14 +795,28 @@ async fn drain_server_group(inputs: ServerGroupInputs) -> std::io::Result<()> {
         header_read_timeout,
         shutdown_rx.clone(),
     ));
-    if let Some((listener, router)) = direct_peer {
-        servers.spawn(serve_loopback_http1(
-            listener,
-            router,
-            max_connections,
-            header_read_timeout,
-            shutdown_rx.clone(),
-        ));
+    if let Some(direct_peer) = direct_peer {
+        match direct_peer {
+            DirectPeerServer::Plaintext(listener, router) => {
+                servers.spawn(serve_loopback_http1(
+                    listener,
+                    router,
+                    max_connections,
+                    header_read_timeout,
+                    shutdown_rx.clone(),
+                ));
+            }
+            DirectPeerServer::Authenticated(listener, adapter, handler, limits, timeouts) => {
+                servers.spawn(serve_authenticated_peer_http1(
+                    listener,
+                    adapter,
+                    handler,
+                    limits,
+                    timeouts,
+                    shutdown_rx.clone(),
+                ));
+            }
+        }
     }
     #[cfg(unix)]
     if let Some((listener, cleanup, router)) = unix_socket {
@@ -905,6 +973,12 @@ fn validate_config(config: &HttpRuntimeConfig) -> Result<(), AtmError> {
             "must use a non-zero port",
         ));
     }
+    if config.peer_stream_adapter.is_some() && config.direct_peer_tcp.is_none() {
+        return Err(preflight(
+            "peer_stream_adapter",
+            "requires an enabled direct peer listener",
+        ));
+    }
     #[cfg(not(unix))]
     if config.unix_socket.is_some() {
         return Err(preflight(
@@ -951,8 +1025,10 @@ fn preflight(field: &str, cause: impl std::fmt::Display) -> AtmError {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::num::{NonZeroU32, NonZeroUsize};
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -966,16 +1042,52 @@ mod tests {
     use atm_core::send::{SendMessageSource, SendRequest};
     use atm_core::test_support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
     use atm_core::types::{AgentName, TeamName};
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
 
     use super::{
-        CanonicalWriteHandler, DirectPeerTcpConfig, HttpRuntimeBuilder, HttpRuntimeConfig,
-        LoopbackTcpConfig, NonZeroDuration, RuntimeHealth, RuntimeLimits, RuntimeTimeouts,
-        UnixSocketConfig, UnixSocketMode, UnixSocketOwnerUid, direct_peer_tcp_client,
+        AcceptedPeerStream, AuthenticatedPeerStream, CanonicalWriteHandler, DirectPeerTcpConfig,
+        HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig, NonZeroDuration,
+        PeerStreamAdapter, RuntimeHealth, RuntimeLimits, RuntimeTimeouts, UnixSocketConfig,
+        UnixSocketMode, UnixSocketOwnerUid, direct_peer_tcp_client,
     };
     use ulid::Ulid;
 
     struct TestRouter;
+
+    /// Test-only adapter proving the runtime treats an already-authenticated
+    /// stream as opaque. Real certificate and pin verification remains tested
+    /// in `peer-tls`; this double deliberately contains no security policy.
+    struct PassthroughPeerAdapter;
+
+    impl PeerStreamAdapter for PassthroughPeerAdapter {
+        fn connect<'a>(
+            &'a self,
+            stream: TcpStream,
+            _peer: &'a atm_core::types::HostName,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<Box<dyn AuthenticatedPeerStream>, AtmError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                let stream: Box<dyn AuthenticatedPeerStream> = Box::new(stream);
+                Ok(stream)
+            })
+        }
+
+        fn accept<'a>(
+            &'a self,
+            stream: TcpStream,
+        ) -> Pin<Box<dyn Future<Output = Result<AcceptedPeerStream, AtmError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                Ok(AcceptedPeerStream {
+                    source_host: "trusted.example.test".parse().expect("test host"),
+                    stream: Box::new(stream),
+                })
+            })
+        }
+    }
 
     #[derive(Default)]
     struct RecordingPeerRouter {
@@ -1389,7 +1501,10 @@ mod tests {
             let calls = handler.calls.lock().expect("recorded peer calls");
             assert_eq!(calls.len(), 1, "one request reaches one canonical write");
             let (request, ingress) = &calls[0];
-            assert_eq!(*ingress, AuthenticatedIngress::Peer);
+            assert!(
+                matches!(ingress, AuthenticatedIngress::UntrustedSmoke(provenance)
+                if provenance.declared_source_host().as_str() == "127.0.0.1")
+            );
             assert_eq!(
                 request
                     .authenticated_source_host
@@ -1409,6 +1524,74 @@ mod tests {
             .finish()
             .await
             .expect("runtime shuts down cleanly");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn authenticated_peer_stream_uses_the_same_canonical_router_after_the_adapter() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let config = config_with_record(0, temporary_directory.path().join("local-http.json"))
+            .with_direct_peer_tcp(DirectPeerTcpConfig::ephemeral_for_test())
+            .with_peer_stream_adapter(Arc::new(PassthroughPeerAdapter));
+        let handler = Arc::new(RecordingPeerRouter::default());
+        let runtime_handler: Arc<dyn CanonicalWriteHandler> = handler.clone();
+        let running = HttpRuntimeBuilder::new(config, runtime_handler)
+            .build()
+            .expect("valid opaque stream configuration")
+            .start()
+            .await
+            .expect("runtime starts the authenticated stream listener");
+        let peer_port = running
+            .direct_peer_address()
+            .expect("ephemeral direct peer listener is bound")
+            .port();
+        let client = direct_peer_tcp_client(
+            "localhost".parse().expect("direct host"),
+            std::num::NonZeroU16::new(peer_port).expect("non-zero port"),
+            Duration::from_secs(1),
+        )
+        .expect("typed test client");
+
+        let _ = client
+            .execute(ApiRequest::new(write_request()))
+            .await
+            .expect("the opaque stream reaches the shared HTTP route");
+        let (call_count, ingress, authenticated_source_host) = {
+            let calls = handler.calls.lock().expect("recorded peer calls");
+            (
+                calls.len(),
+                calls[0].1.clone(),
+                calls[0]
+                    .0
+                    .authenticated_source_host
+                    .as_ref()
+                    .map(atm_core::types::HostName::as_str)
+                    .map(str::to_owned),
+            )
+        };
+        assert_eq!(call_count, 1, "one opaque peer stream has one dispatch");
+        assert_eq!(ingress, AuthenticatedIngress::Peer);
+        assert_eq!(
+            authenticated_source_host.as_deref(),
+            Some("trusted.example.test"),
+            "only the adapter supplies peer authentication provenance"
+        );
+        running
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("runtime shuts down cleanly");
+    }
+
+    #[test]
+    fn authenticated_peer_stream_adapter_requires_the_single_peer_listener() {
+        let temporary_directory = tempfile::tempdir().expect("temporary directory");
+        let config = config_with_record(0, temporary_directory.path().join("local-http.json"))
+            .with_peer_stream_adapter(Arc::new(PassthroughPeerAdapter));
+        let error = match HttpRuntimeBuilder::new(config, Arc::new(TestRouter)).build() {
+            Ok(_) => panic!("an opaque peer stream has no standalone listener"),
+            Err(error) => error,
+        };
+        assert!(error.message().contains("peer_stream_adapter"));
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -467,27 +467,11 @@ impl HttpRuntime<Configured> {
             self.config.timeouts,
         );
         let loopback_router = authenticated_loopback_router(canonical_router.clone(), capability);
-        let direct_peer = match direct_peer_listener {
-            Some(listener) => match self.config.peer_stream_adapter.as_ref() {
-                Some(adapter) => Some(DirectPeerServer::Authenticated(
-                    listener,
-                    Arc::clone(adapter),
-                    Arc::clone(&self.handler),
-                    self.config.limits,
-                    self.config.timeouts,
-                )),
-                None => Some(DirectPeerServer::Plaintext(
-                    listener,
-                    canonical_api_router(
-                        Arc::clone(&self.handler),
-                        AuthenticatedConnector::peer_socket(),
-                        self.config.limits,
-                        self.config.timeouts,
-                    ),
-                )),
-            },
-            None => None,
-        };
+        let direct_peer = build_direct_peer_server(
+            direct_peer_listener,
+            &self.config,
+            Arc::clone(&self.handler),
+        );
         let server_task = match start_server_task(ServerTaskInputs {
             listener,
             loopback_router,
@@ -527,6 +511,32 @@ impl HttpRuntime<Configured> {
             },
         })
     }
+}
+
+fn build_direct_peer_server(
+    listener: Option<TcpListener>,
+    config: &HttpRuntimeConfig,
+    handler: Arc<dyn CanonicalWriteHandler>,
+) -> Option<DirectPeerServer> {
+    let listener = listener?;
+    Some(match config.peer_stream_adapter.as_ref() {
+        Some(adapter) => DirectPeerServer::Authenticated(
+            listener,
+            Arc::clone(adapter),
+            handler,
+            config.limits,
+            config.timeouts,
+        ),
+        None => DirectPeerServer::Plaintext(
+            listener,
+            canonical_api_router(
+                handler,
+                AuthenticatedConnector::peer_socket(),
+                config.limits,
+                config.timeouts,
+            ),
+        ),
+    })
 }
 
 async fn bind_configured_direct_peer_listener(

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 
 use atm_core::api::{
     ApiRequest, ApiResponse, AuthenticatedIngress, CLEAR_OUTCOME_HEADER, HttpRequest,
-    HttpRouteKind, MessageCollectionRequest, RequestDeadline, http_route_kind, http_route_surface,
+    HttpRouteKind, MessageCollectionRequest, RequestDeadline, UntrustedSmokeProvenance,
+    http_route_kind, http_route_surface,
 };
 use atm_core::clear::ClearQuery;
 use atm_core::doctor::DoctorQuery;
@@ -182,17 +183,25 @@ impl AuthenticatedConnector {
                         "direct peer HTTP request did not carry an accepted socket address",
                     )
                 })?;
-                let source_host = peer_address.ip().to_string().parse().map_err(|source| {
-                    AtmError::validation(
-                        "accepted direct peer address cannot be represented as a host identity",
-                    )
-                    .with_cause(source)
-                })?;
-                request.authenticated_source_host = Some(source_host);
+                let source_host: HostName =
+                    peer_address.ip().to_string().parse().map_err(|source| {
+                        AtmError::validation(
+                            "accepted direct peer address cannot be represented as a host identity",
+                        )
+                        .with_cause(source)
+                    })?;
+                // A TCP source address is adapter-derived diagnostic
+                // provenance, never peer authentication. The ingress below
+                // remains `UntrustedSmoke`; retaining the address lets an
+                // explicit plaintext test reply to the actual socket peer
+                // without accepting a JSON-forged value.
+                request.authenticated_source_host = Some(source_host.clone());
                 if let Some(destination) = request.to.take() {
                     request.to = Some(destination.without_host());
                 }
-                Ok(AuthenticatedIngress::Peer)
+                Ok(AuthenticatedIngress::UntrustedSmoke(
+                    UntrustedSmokeProvenance::new(source_host),
+                ))
             }
         }
     }
@@ -206,7 +215,8 @@ impl AuthenticatedConnector {
             ApiRequest::Write(write) => self.normalize_write(write, peer_address),
             _ => match self {
                 Self::Local => Ok(AuthenticatedIngress::Local),
-                Self::Peer { .. } | Self::PeerSocket => Ok(AuthenticatedIngress::Peer),
+                Self::Peer { .. } => Ok(AuthenticatedIngress::Peer),
+                Self::PeerSocket => Ok(AuthenticatedIngress::AnonymousSmoke),
             },
         }
     }

--- a/crates/atm-http-runtime/src/peer_stream.rs
+++ b/crates/atm-http-runtime/src/peer_stream.rs
@@ -1,0 +1,52 @@
+//! Opaque authenticated peer-stream seam.
+//!
+//! The HTTP runtime deliberately owns only the established byte stream.  The
+//! daemon bootstrap composes the concrete security adapter; this module never
+//! imports TLS, certificates, or peer configuration.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use atm_core::error::AtmError;
+use atm_core::types::HostName;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+
+/// Opaque bidirectional byte stream admitted by the selected peer-wire
+/// adapter.  It intentionally exposes no security implementation detail to
+/// the HTTP route or application pipeline.
+pub trait AuthenticatedPeerStream: AsyncRead + AsyncWrite + Send + Unpin {}
+
+impl<Stream> AuthenticatedPeerStream for Stream where Stream: AsyncRead + AsyncWrite + Send + Unpin {}
+
+/// Result stream returned after outbound peer authentication completes.
+pub type EstablishedPeerStream = Box<dyn AuthenticatedPeerStream>;
+
+/// Boxed asynchronous peer-stream establishment operation.
+pub type PeerStreamFuture<'a, Output> =
+    Pin<Box<dyn Future<Output = Result<Output, AtmError>> + Send + 'a>>;
+
+/// One established authenticated inbound connection.
+pub struct AcceptedPeerStream {
+    /// Adapter-authenticated source identity, never derived from JSON or IP.
+    pub source_host: HostName,
+    /// The opaque stream that carries the ordinary canonical HTTP protocol.
+    pub stream: EstablishedPeerStream,
+}
+
+/// Bootstrap-composed peer-stream establishment.
+///
+/// This narrow seam carries only TCP streams and the already-authenticated
+/// inbound identity.  It cannot select a mode, inspect an HTTP DTO, or
+/// introduce a second application route.
+pub trait PeerStreamAdapter: Send + Sync {
+    /// Authenticate an outbound TCP stream for the exact configured peer.
+    fn connect<'a>(
+        &'a self,
+        stream: TcpStream,
+        peer: &'a HostName,
+    ) -> PeerStreamFuture<'a, EstablishedPeerStream>;
+
+    /// Authenticate an inbound TCP stream before HTTP decoding begins.
+    fn accept<'a>(&'a self, stream: TcpStream) -> PeerStreamFuture<'a, AcceptedPeerStream>;
+}

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -27,6 +27,7 @@ use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::send::{WarningEntry, WriteOutcome, prepare_write_with_async_runtime};
 
 use crate::CanonicalWriteHandler;
+use crate::PeerStreamAdapter;
 use crate::RuntimeHealth;
 
 /// Bounded bridge for a synchronous core operation that is not a storage-writer
@@ -99,6 +100,7 @@ pub struct StorageAndNudgeRouter {
     doctor_ports: Option<atm_core::doctor::RuntimeDoctorPorts>,
     daemon_context: Option<atm_core::doctor::DoctorExecutionContext>,
     direct_peer_port: NonZeroU16,
+    peer_stream_adapter: Option<Arc<dyn PeerStreamAdapter>>,
 }
 
 impl StorageAndNudgeRouter {
@@ -121,6 +123,7 @@ impl StorageAndNudgeRouter {
             doctor_ports: None,
             daemon_context: None,
             direct_peer_port: crate::direct_peer_port(),
+            peer_stream_adapter: None,
         }
     }
 
@@ -156,6 +159,15 @@ impl StorageAndNudgeRouter {
         self
     }
 
+    /// Installs the bootstrap-selected opaque peer-stream adapter for remote
+    /// writes. Absence is explicit plaintext-test mode and preserves the
+    /// existing direct TCP connector unchanged.
+    #[must_use]
+    pub fn with_peer_stream_adapter(mut self, adapter: Arc<dyn PeerStreamAdapter>) -> Self {
+        self.peer_stream_adapter = Some(adapter);
+        self
+    }
+
     async fn commit_write(
         &self,
         request: atm_core::send::WriteRequest,
@@ -186,19 +198,17 @@ impl StorageAndNudgeRouter {
         })
     }
 
-    /// Delivers a locally admitted acknowledgement to the exact authenticated
-    /// source host retained on its received message.  This is deliberately
-    /// absent for ordinary sends: their CLI/graft caller selects the peer
-    /// client before admission.  ACK target discovery is storage-owned, so it
-    /// happens only after the sealed storage transaction materializes the
-    /// canonical host-qualified reply.
-    async fn dispatch_resolved_peer_ack(
+    /// Delivers one locally admitted host-qualified write using the daemon's
+    /// selected peer-wire mode. The record is already durable at this point;
+    /// this method creates neither a second application route nor delivery
+    /// recovery state.
+    async fn dispatch_resolved_peer_write(
         &self,
         request: &atm_core::send::WriteRequest,
         message_id: atm_core::schema::AtmMessageId,
         timestamp: atm_core::types::IsoTimestamp,
         deadline: RequestDeadline,
-        request_id: RequestId,
+        _request_id: RequestId,
     ) -> Result<(), AtmError> {
         let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
             return Ok(());
@@ -208,24 +218,29 @@ impl StorageAndNudgeRouter {
                 "request deadline expired before cross-host acknowledgement delivery",
             )
         })?;
-        let client = crate::client::direct_peer_write_client(
-            host.clone(),
-            self.direct_peer_port,
-            remaining,
-        )?;
+        let client = match self.peer_stream_adapter.as_ref() {
+            Some(adapter) => crate::client::peer_stream_write_client(
+                host.clone(),
+                self.direct_peer_port,
+                remaining,
+                Arc::clone(adapter),
+            )?,
+            None => crate::client::direct_peer_tcp_client(
+                host.clone(),
+                self.direct_peer_port,
+                remaining,
+            )?,
+        };
         let request = request.clone().with_origin_metadata(message_id, timestamp);
         match client
-            .execute_with_request_id(
-                ApiRequest::new(RequestEnvelope::Write(Box::new(request))),
-                request_id,
-            )
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
             .await?
             .into_inner()
         {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => Ok(()),
             response => Err(AtmError::new(
                 atm_core::error_codes::AtmErrorCode::InternalError,
-                "cross-host acknowledgement delivery returned a non-write response",
+                "cross-host daemon-owned delivery returned a non-write response",
             )
             .with_cause(format!("received response: {response:?}"))),
         }
@@ -521,9 +536,15 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             request.current_dir = self.daemon_home.clone();
             let mut committed = self.commit_write(request).await?;
             if ingress == AuthenticatedIngress::Local
-                && matches!(committed.outcome, WriteOutcome::Acknowledged(_))
+                && committed.newly_persisted
+                && committed
+                    .canonical_request
+                    .to
+                    .as_ref()
+                    .and_then(|recipient| recipient.host())
+                    .is_some()
             {
-                self.dispatch_resolved_peer_ack(
+                self.dispatch_resolved_peer_write(
                     &committed.canonical_request,
                     committed.message_id,
                     committed.persisted_timestamp,
@@ -647,7 +668,7 @@ fn hook_warning(error: AtmError) -> WarningEntry {
 mod tests {
     use std::fs;
     use std::future::Future;
-    use std::num::NonZeroUsize;
+    use std::num::{NonZeroU16, NonZeroUsize};
     use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -1317,6 +1338,7 @@ mod tests {
             version: Some(atm_core::protocol::ReleaseVersion::current()),
             cli_schema_version: Some(atm_core::protocol::CLI_SCHEMA_VERSION),
             http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),
+            peer_wire_security: None,
         };
         let response = fixture
             .router
@@ -1561,17 +1583,20 @@ mod tests {
         );
 
         let mut message_keys = Vec::new();
-        for request in [
-            same_local,
-            same_team_cross_host,
-            foreign_team_local,
-            foreign_team_cross_host,
+        for (request, ingress) in [
+            (same_local, AuthenticatedIngress::Local),
+            // This matrix concerns persisted template routing, not outbound
+            // delivery. Model cross-host rows as an already-admitted peer so
+            // the daemon does not try to deliver to the fixture hostname.
+            (same_team_cross_host, AuthenticatedIngress::Peer),
+            (foreign_team_local, AuthenticatedIngress::Local),
+            (foreign_team_cross_host, AuthenticatedIngress::Peer),
         ] {
             let response = fixture
                 .router
                 .dispatch(
                     ApiRequest::new(RequestEnvelope::Write(Box::new(request))),
-                    AuthenticatedIngress::Local,
+                    ingress,
                     RequestDeadline::after(Duration::from_secs(1)),
                 )
                 .await
@@ -2086,6 +2111,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn locally_admitted_host_qualified_write_is_forwarded_by_the_selected_daemon() {
+        let remote = fixture(true, None, None);
+        let remote_runtime = HttpRuntimeBuilder::new(
+            direct_peer_runtime_config(&remote, crate::DirectPeerTcpConfig::ephemeral_for_test()),
+            Arc::new(remote.router.clone()),
+        )
+        .build()
+        .expect("valid remote direct peer configuration")
+        .start()
+        .await
+        .expect("remote direct peer runtime starts");
+        let remote_port = remote_runtime
+            .direct_peer_address()
+            .expect("ephemeral remote direct peer listener is bound")
+            .port();
+
+        let mut local = fixture(true, None, None);
+        local.router = local
+            .router
+            .clone()
+            .with_direct_peer_port(NonZeroU16::new(remote_port).expect("non-zero port"));
+        let mut outbound = write_request(local.home_dir.clone(), local.current_dir.clone());
+        outbound.to = Some(
+            "recipient@test-team.127.0.0.1"
+                .parse()
+                .expect("host-qualified remote recipient"),
+        );
+        let response = local
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(outbound))),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("local daemon owns host-qualified delivery");
+        assert!(matches!(
+            response.into_inner(),
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+        ));
+        assert_eq!(
+            remote
+                .message_store
+                .list_messages(&MessageQuery {
+                    team: "test-team".parse().expect("team"),
+                    agent: "recipient".parse().expect("agent"),
+                    sender: None,
+                    task_id: None,
+                    limit: None,
+                })
+                .expect("read remote recipient mailbox")
+                .len(),
+            1,
+            "the peer listener receives exactly the locally admitted canonical write"
+        );
+        remote_runtime
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("remote runtime drains");
+    }
+
+    #[tokio::test]
     async fn local_ack_routes_to_the_received_peer_and_peer_receipt_does_not_reacknowledge() {
         let remote = fixture(true, None, None);
         let remote_runtime = HttpRuntimeBuilder::new(
@@ -2381,13 +2469,10 @@ mod tests {
     async fn axum_route_idempotent_duplicate_skips_the_second_received_hook() {
         let fixture = fixture(true, None, None);
         let message_id = AtmMessageId::new();
-        let mut write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone())
+        let write = write_request(fixture.home_dir.clone(), fixture.current_dir.clone())
             .with_origin_metadata(message_id, atm_core::types::IsoTimestamp::now());
-        write.to = Some(
-            "recipient@test-team.localhost"
-                .parse()
-                .expect("same-host target"),
-        );
+        // This test isolates idempotency. An unqualified mailbox target
+        // avoids exercising AO2.3's separate daemon-owned remote delivery.
 
         let origin = post_write(router(&fixture, AuthenticatedConnector::local()), &write).await;
         assert_eq!(origin.status(), StatusCode::CREATED);

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -30,6 +30,7 @@ const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// composition time. It cannot infer or select a peer-wire mode itself.
 pub struct MtlsPeerStreamAdapter {
     client_configs: Vec<PeerClientConfig>,
+    client_verifier: Arc<PinnedClientVerifier>,
     server_config: Arc<ServerConfig>,
     handshake_timeout: Duration,
 }
@@ -78,9 +79,14 @@ impl MtlsPeerStreamAdapter {
                 })
             })
             .collect::<Result<Vec<_>, AtmError>>()?;
-        let server_config = Arc::new(Self::build_server_config(&identity, trusted_peers)?);
+        let client_verifier = Arc::new(PinnedClientVerifier::new(trusted_peers));
+        let server_config = Arc::new(Self::build_server_config(
+            &identity,
+            Arc::clone(&client_verifier),
+        )?);
         Ok(Self {
             client_configs,
+            client_verifier,
             server_config,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
         })
@@ -116,12 +122,32 @@ impl MtlsPeerStreamAdapter {
         &self,
         tcp: TcpStream,
     ) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + use<>, AtmError> {
+        self.accept_server(tcp).await.map(TlsStream::Server)
+    }
+
+    async fn accept_server(
+        &self,
+        tcp: TcpStream,
+    ) -> Result<tokio_rustls::server::TlsStream<TcpStream>, AtmError> {
         let acceptor = TlsAcceptor::from(Arc::clone(&self.server_config));
         timeout(self.handshake_timeout, acceptor.accept(tcp))
             .await
             .map_err(|_| AtmError::transport_timeout("mTLS peer handshake deadline expired"))?
-            .map(TlsStream::Server)
             .map_err(inbound_handshake_error)
+    }
+
+    /// Authenticate an inbound TCP stream and return the configured identity
+    /// proven by its client certificate.  The caller receives no certificate
+    /// bytes, trust record, or Rustls connection state.
+    pub async fn accept_with_peer(
+        &self,
+        tcp: TcpStream,
+    ) -> Result<(impl AsyncRead + AsyncWrite + Send + Unpin + use<>, HostName), AtmError> {
+        let stream = self.accept_server(tcp).await?;
+        let source_host = self
+            .client_verifier
+            .authenticated_host(stream.get_ref().1)?;
+        Ok((TlsStream::Server(stream), source_host))
     }
 
     fn client_config_for(&self, peer: &HostName) -> Result<&Arc<ClientConfig>, AtmError> {
@@ -157,10 +183,10 @@ impl MtlsPeerStreamAdapter {
 
     fn build_server_config(
         identity: &TlsIdentity,
-        trusted_peers: Vec<TrustedPeer>,
+        client_verifier: Arc<PinnedClientVerifier>,
     ) -> Result<ServerConfig, AtmError> {
         ServerConfig::builder()
-            .with_client_cert_verifier(Arc::new(PinnedClientVerifier::new(trusted_peers)))
+            .with_client_cert_verifier(client_verifier)
             .with_single_cert(
                 identity.certificates().to_vec(),
                 identity.private_key().clone_key(),
@@ -381,7 +407,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configured_pair_exchanges_opaque_bytes_over_mutual_tls() {
+    async fn configured_pair_exchanges_opaque_bytes_over_mutual_tls_and_returns_pinned_identity() {
         let directory = tempfile::tempdir().expect("directory");
         let server_identity = identity(&directory, "server");
         let client_identity = identity(&directory, "client");
@@ -403,7 +429,12 @@ mod tests {
         let address = listener.local_addr().expect("address");
         let server_task = tokio::spawn(async move {
             let (tcp, _) = listener.accept().await.expect("accept tcp");
-            let mut tls = server.accept(tcp).await.expect("accept tls");
+            let (mut tls, peer) = server.accept_with_peer(tcp).await.expect("accept tls");
+            assert_eq!(
+                peer.as_str(),
+                "localhost",
+                "server reports the configured pinned peer"
+            );
             let mut received = [0_u8; 5];
             tls.read_exact(&mut received).await.expect("read bytes");
             assert_eq!(&received, b"bytes");

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -25,11 +25,11 @@ listener or HTTP pipeline. Plaintext mode uses the preserved `DirectPeerTcpConfi
 `DirectPeerTcpConnector`, direct-peer listener, and ordinary router pipeline.
 The mTLS adapter wraps that same pipeline at the stream boundary only.
 
-AO2.2 implements that outer adapter in `peer-tls`: the crate consumes the
+AO.2 implements that outer adapter in `peer-tls`: the crate consumes the
 storage-neutral `PeerConfigStore` and yields authenticated TCP byte streams.
 It owns certificate validity, durable-hostname, and exact-pin checks, but it
 does not compose a daemon, HTTP route, or message pipeline. Runtime wiring is
-explicitly deferred to AO2.3, so compiling the adapter cannot alter either
+explicitly deferred to AO.3, so compiling the adapter cannot alter either
 the normal daemon default or the preserved plaintext benchmark path.
 
 No environment variable, durable setting, TLS adapter availability check, or
@@ -58,9 +58,9 @@ Doctor, retained diagnostics, smoke JSON/XHTML, and benchmark evidence must
 record the active peer-wire mode. Plaintext-test evidence cannot satisfy any
 mTLS or peer-allowlist acceptance criterion.
 
-## AO2.3 implementation evidence
+## AO.3 implementation evidence
 
-AO2.3 implements the launch seam in `atm-daemon-bootstrap`. It parses
+AO.3 implements the launch seam in `atm-daemon-bootstrap`. It parses
 `--peer-wire-security` once, defaults to `mutual-tls`, rejects duplicate or
 unknown values, and rejects `ATM_PEER_WIRE_SECURITY` rather than treating the
 environment as an alternate selector. Bootstrap constructs `peer-tls` only in

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -57,3 +57,24 @@ wording. ADR-033's one-router contract remains unchanged.
 Doctor, retained diagnostics, smoke JSON/XHTML, and benchmark evidence must
 record the active peer-wire mode. Plaintext-test evidence cannot satisfy any
 mTLS or peer-allowlist acceptance criterion.
+
+## AO2.3 implementation evidence
+
+AO2.3 implements the launch seam in `atm-daemon-bootstrap`. It parses
+`--peer-wire-security` once, defaults to `mutual-tls`, rejects duplicate or
+unknown values, and rejects `ATM_PEER_WIRE_SECURITY` rather than treating the
+environment as an alternate selector. Bootstrap constructs `peer-tls` only in
+the mTLS arm and passes its opaque established-stream seam to
+`atm-http-runtime`; the runtime has no Rustls, certificate, pin, or
+`PeerConfigStore` dependency.
+
+The CLI and graft submit every `WriteRequest` to their selected local daemon.
+For a host-qualified request the daemon performs the durable admission and
+then uses the selected stream establishment mode for the one outbound HTTP
+request. Plaintext therefore retains the existing direct TCP connector and
+listener; mTLS changes only the outer byte stream. Inbound plaintext is
+explicit `UntrustedSmoke` provenance, while mTLS supplies the exact configured
+host only after the client certificate/pin verification completes before HTTP
+decode. Startup writes the selected public mode to the retained observability
+port and daemon doctor context; neither includes key material, certificate
+contents, pins, or raw trust records.

--- a/docs/atm-core/modules/doctor.md
+++ b/docs/atm-core/modules/doctor.md
@@ -3,10 +3,10 @@
 Owns local diagnostics, config/path/inbox checks, observability readiness
 checks, and the finding model used by the CLI renderer.
 
-For the Tokio/Axum daemon, `DoctorExecutionContext.peer_wire_security` is the
-bootstrap-injected public launch value (`mutual-tls` or `plaintext-test`). It
-is absent for client-only doctor execution and must never expose certificate,
-pin, key, or peer-record data.
+For the Tokio/Axum daemon, `DoctorExecutionContext.peer_wire_security` is a
+typed bootstrap-injected diagnostic status that serializes as the public launch
+value (`mutual-tls` or `plaintext-test`). It is absent for client-only doctor
+execution and must never expose certificate, pin, key, or peer-record data.
 
 It must not own:
 

--- a/docs/atm-core/modules/doctor.md
+++ b/docs/atm-core/modules/doctor.md
@@ -3,6 +3,11 @@
 Owns local diagnostics, config/path/inbox checks, observability readiness
 checks, and the finding model used by the CLI renderer.
 
+For the Tokio/Axum daemon, `DoctorExecutionContext.peer_wire_security` is the
+bootstrap-injected public launch value (`mutual-tls` or `plaintext-test`). It
+is absent for client-only doctor execution and must never expose certificate,
+pin, key, or peer-record data.
+
 It must not own:
 
 - clap parsing

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -31,6 +31,13 @@ Peer-wire evidence must record the active ADR-047 security mode. Normal
 benchmark and release evidence is mutual TLS; `plaintext-test` is explicit
 diagnostic evidence only and cannot satisfy mTLS or peer-allowlist criteria.
 
+The daemon selects this mode only at process launch. Verify the selected value
+with `atm doctor --json` before a peer-wire smoke. A disposable
+`--peer-wire-security plaintext-test` daemon uses the preserved direct TCP
+pipeline for connectivity diagnostics; a normal restart without that argument
+returns to the mTLS default. A failed mTLS configuration or handshake is a
+failure to repair, never a reason to retry the same run in plaintext.
+
 The routed smoke implementations are deliberately not independent public
 commands:
 

--- a/scripts/smoke/run.py
+++ b/scripts/smoke/run.py
@@ -559,21 +559,21 @@ NORMAL_ROWS = FAST_ROWS + [
     ),
     SuiteRowSpec(
         id="AD17-CI-001",
-        flow="windows CI retains the explicit atm-daemon lane on the accepted line",
+        flow="CI exercises the replacement runtime without restoring the frozen daemon lane",
         commands=[
             [
                 "rg",
                 "-n",
-                "Run atm-daemon tests",
+                "Run replacement-workspace tests excluding legacy atm-daemon",
                 ".github/workflows/ci.yml",
             ],
             [
                 "python3",
                 "-c",
-                "from pathlib import Path; data = Path('.github/workflows/ci.yml').read_text(encoding='utf-8'); raise SystemExit(1 if \"if: runner.os != 'Windows'\" in data else 0)",
+                "from pathlib import Path; data = Path('.github/workflows/ci.yml').read_text(encoding='utf-8'); required = 'cargo test --workspace --exclude atm-daemon --verbose'; forbidden = 'Run atm-daemon tests'; raise SystemExit(0 if required in data and forbidden not in data else 1)",
             ],
         ],
-        pass_note="the explicit atm-daemon CI lane remains present and the Windows skip guard is absent",
+        pass_note="the replacement-runtime CI lane remains present and no frozen atm-daemon test lane is restored",
     ),
     SuiteRowSpec(
         id="AD18-RUNTIME-ROOT-001",


### PR DESCRIPTION
## Summary
- daemon-only `--peer-wire-security` selection (mTLS default / plaintext-test)
- opaque mTLS stream adapter
- daemon-owned cross-host forwarding
- provenance/doctor/observability/boundary guards
- benchmark mode parsing

Validation: targeted runtime/TLS/architecture suites, `just lint` (28/28), `just test`, `just smoke normal` — all PASS.

Merge-forwarded into AO2.4 (`feature/pao-s4-peer-wire-proof`) at the same commit.