### PR TITLE
fix(daemon-switch): gate signed cli and daemon pairs (cherry-pick to develop)

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -21,11 +21,11 @@ worktree binary directly.
 6. When peer-interface or trust configuration changes, use `restart` to reload
    the one selected daemon; never launch an extra process.
 7. On macOS, when the local keychain contains `atm-daemon-dev`, `switch` and
-   `restart` fail closed unless the selected `atm-daemon` carries that exact
-   signing authority. Build with `just build` (or explicitly run
-   `python3 .just/sign_daemon_dev.py`) before switching. This is enforced by
-   the switcher so an unsigned development binary cannot create repeated
-   privacy-approval dialogs.
+   `restart` fail closed unless both selected `atm` and `atm-daemon` strictly
+   verify and carry that exact signing authority. Build with `just build` (or
+   explicitly run `python3 .just/sign_daemon_dev.py`) before switching. This
+   enforces a matched, signed local build; it is separate from macOS Local
+   Network Privacy authorization.
 
 ## Commands
 

--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -20,6 +20,12 @@ worktree binary directly.
    is healthy again.
 6. When peer-interface or trust configuration changes, use `restart` to reload
    the one selected daemon; never launch an extra process.
+7. On macOS, when the local keychain contains `atm-daemon-dev`, `switch` and
+   `restart` fail closed unless the selected `atm-daemon` carries that exact
+   signing authority. Build with `just build` (or explicitly run
+   `python3 .just/sign_daemon_dev.py`) before switching. This is enforced by
+   the switcher so an unsigned development binary cannot create repeated
+   privacy-approval dialogs.
 
 ## Commands
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -20,6 +20,7 @@ from typing import Sequence
 
 WINDOWS_SERVICE_NOT_FOUND = 1060
 LIVE_PAIR_READINESS_ATTEMPTS = 200
+MACOS_DEVELOPMENT_SIGNING_IDENTITY = "atm-daemon-dev"
 # [cass: helpful starter-rust-logging] - retains the bounded readiness state
 # as one named operational contract rather than an unexplained retry literal.
 """Bounded 20-second readiness window for a managed replacement daemon.
@@ -73,6 +74,57 @@ def require_executable(path: Path, label: str) -> Path:
     if not os.access(resolved, os.X_OK):
         raise SwitchError(f"{label} is not executable: {resolved}")
     return resolved
+
+
+def macos_development_signing_identity_available() -> bool:
+    """Return whether the exact local development signing identity is usable.
+
+    The switcher only adds this precondition when the host is configured to
+    sign development daemons.  Hosts without that identity retain the normal
+    cross-platform switching path.
+    """
+    if platform.system() != "Darwin":
+        return False
+    security = shutil.which("security")
+    if security is None:
+        return False
+    try:
+        result = run([security, "find-identity", "-v", "-p", "codesigning"], timeout=10.0)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    quoted_identity = f'"{MACOS_DEVELOPMENT_SIGNING_IDENTITY}"'
+    return result.returncode == 0 and any(
+        quoted_identity in line for line in result.stdout.splitlines()
+    )
+
+
+def macos_daemon_has_development_signature(daemon: Path) -> bool:
+    """Prove one daemon binary carries the exact configured development authority."""
+    codesign = shutil.which("codesign")
+    if codesign is None:
+        return False
+    try:
+        result = run([codesign, "-dv", "--verbose=4", str(daemon)], timeout=10.0)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    authority = f"Authority={MACOS_DEVELOPMENT_SIGNING_IDENTITY}"
+    output = f"{result.stdout}\n{result.stderr}"
+    return any(line.strip() == authority for line in output.splitlines())
+
+
+def require_macos_development_signature(daemon: Path) -> None:
+    """Fail closed before a macOS daemon selection or restart can prompt again."""
+    if not macos_development_signing_identity_available():
+        return
+    if macos_daemon_has_development_signature(daemon):
+        return
+    raise SwitchError(
+        f"macOS development signing identity `{MACOS_DEVELOPMENT_SIGNING_IDENTITY}` is installed, "
+        f"but daemon target is not signed by it: {daemon}. "
+        "Build with `just build` or run `python3 .just/sign_daemon_dev.py` before daemon-switch."
+    )
 
 
 def homebrew_pair() -> tuple[Path, Path] | None:
@@ -365,6 +417,7 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         raise SwitchError(
             "refusing targets from different release directories; build or install the matched pair together"
         )
+    require_macos_development_signature(daemon_target)
     if cli_link.resolve() == cli_target and daemon_link.resolve() == daemon_target:
         print("already selected; service left running")
         return
@@ -426,6 +479,7 @@ def restart(args: argparse.Namespace) -> None:
     if not args.yes:
         raise SwitchError("restart changes the singleton daemon; re-run with --yes")
     cli, daemon = selected_links(args)
+    require_macos_development_signature(require_executable(daemon, "selected atm daemon"))
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
     run_service(args, "start")

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -18,9 +18,19 @@ import time
 from typing import Sequence
 
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPTS_DIRECTORY = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIRECTORY))
+
+from macos_development_signing import (  # noqa: E402
+    DEVELOPMENT_SIGNING_IDENTITY,
+    find_identity_output_has_development_identity,
+)
+
+
 WINDOWS_SERVICE_NOT_FOUND = 1060
 LIVE_PAIR_READINESS_ATTEMPTS = 200
-MACOS_DEVELOPMENT_SIGNING_IDENTITY = "atm-daemon-dev"
 # [cass: helpful starter-rust-logging] - retains the bounded readiness state
 # as one named operational contract rather than an unexplained retry literal.
 """Bounded 20-second readiness window for a managed replacement daemon.
@@ -92,39 +102,39 @@ def macos_development_signing_identity_available() -> bool:
         result = run([security, "find-identity", "-v", "-p", "codesigning"], timeout=10.0)
     except (OSError, subprocess.TimeoutExpired):
         return False
-    quoted_identity = f'"{MACOS_DEVELOPMENT_SIGNING_IDENTITY}"'
-    return result.returncode == 0 and any(
-        quoted_identity in line for line in result.stdout.splitlines()
-    )
+    return result.returncode == 0 and find_identity_output_has_development_identity(result.stdout)
 
 
-def macos_daemon_has_development_signature(daemon: Path) -> bool:
-    """Prove one daemon binary carries the exact configured development authority."""
+def macos_binary_has_development_signature(binary: Path) -> bool:
+    """Prove one managed binary strictly verifies with the configured authority."""
     codesign = shutil.which("codesign")
     if codesign is None:
         return False
     try:
-        result = run([codesign, "-dv", "--verbose=4", str(daemon)], timeout=10.0)
+        verification = run([codesign, "--verify", "--strict", str(binary)], timeout=10.0)
+        if verification.returncode != 0:
+            return False
+        result = run([codesign, "-dv", "--verbose=4", str(binary)], timeout=10.0)
     except (OSError, subprocess.TimeoutExpired):
         return False
     if result.returncode != 0:
         return False
-    authority = f"Authority={MACOS_DEVELOPMENT_SIGNING_IDENTITY}"
+    authority = f"Authority={DEVELOPMENT_SIGNING_IDENTITY}"
     output = f"{result.stdout}\n{result.stderr}"
     return any(line.strip() == authority for line in output.splitlines())
 
 
-def require_macos_development_signature(daemon: Path) -> None:
-    """Fail closed before a macOS daemon selection or restart can prompt again."""
+def require_macos_development_signatures(cli: Path, daemon: Path) -> None:
+    """Fail closed before any managed-pair lifecycle mutation on macOS."""
     if not macos_development_signing_identity_available():
         return
-    if macos_daemon_has_development_signature(daemon):
-        return
-    raise SwitchError(
-        f"macOS development signing identity `{MACOS_DEVELOPMENT_SIGNING_IDENTITY}` is installed, "
-        f"but daemon target is not signed by it: {daemon}. "
-        "Build with `just build` or run `python3 .just/sign_daemon_dev.py` before daemon-switch."
-    )
+    for label, binary in (("CLI", cli), ("daemon", daemon)):
+        if not macos_binary_has_development_signature(binary):
+            raise SwitchError(
+                f"macOS development signing identity `{DEVELOPMENT_SIGNING_IDENTITY}` is installed, "
+                f"but {label} target is not strictly signed by it: {binary}. "
+                "Build with `just build` or run `python3 .just/sign_daemon_dev.py` before daemon-switch."
+            )
 
 
 def homebrew_pair() -> tuple[Path, Path] | None:
@@ -417,7 +427,7 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         raise SwitchError(
             "refusing targets from different release directories; build or install the matched pair together"
         )
-    require_macos_development_signature(daemon_target)
+    require_macos_development_signatures(cli_target, daemon_target)
     if cli_link.resolve() == cli_target and daemon_link.resolve() == daemon_target:
         print("already selected; service left running")
         return
@@ -479,7 +489,9 @@ def restart(args: argparse.Namespace) -> None:
     if not args.yes:
         raise SwitchError("restart changes the singleton daemon; re-run with --yes")
     cli, daemon = selected_links(args)
-    require_macos_development_signature(require_executable(daemon, "selected atm daemon"))
+    cli = require_executable(cli, "selected atm CLI")
+    daemon = require_executable(daemon, "selected atm daemon")
+    require_macos_development_signatures(cli, daemon)
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
     run_service(args, "start")

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -97,6 +97,74 @@ class QuiesceTests(unittest.TestCase):
             DAEMON_SWITCH.run_service(args, "stop", allow_absent=True)
 
 
+class MacosDevelopmentSigningTests(unittest.TestCase):
+    def test_identity_discovery_requires_the_exact_quoted_identity(self) -> None:
+        partial = subprocess.CompletedProcess(
+            ["security"], 0, stdout='1) HASH "not-atm-daemon-dev"\n', stderr=""
+        )
+        exact = subprocess.CompletedProcess(
+            ["security"], 0, stdout='1) HASH "atm-daemon-dev"\n', stderr=""
+        )
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/security"),
+            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[partial, exact]),
+        ):
+            self.assertFalse(DAEMON_SWITCH.macos_development_signing_identity_available())
+            self.assertTrue(DAEMON_SWITCH.macos_development_signing_identity_available())
+
+    def test_no_signing_gate_when_identity_is_not_installed(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=False),
+            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature") as signed,
+        ):
+            DAEMON_SWITCH.require_macos_development_signature(daemon)
+        signed.assert_not_called()
+
+    def test_rejects_unsigned_daemon_when_development_identity_is_installed(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature", return_value=False),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "just build"):
+                DAEMON_SWITCH.require_macos_development_signature(daemon)
+
+    def test_accepts_daemon_with_exact_development_authority(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature", return_value=True),
+        ):
+            DAEMON_SWITCH.require_macos_development_signature(daemon)
+
+    def test_signature_check_requires_exact_authority_line(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        result = subprocess.CompletedProcess(
+            ["codesign"],
+            0,
+            stdout="Authority=another-atm-daemon-dev\n",
+            stderr="Authority=atm-daemon-dev-extra\n",
+        )
+        with (
+            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=result),
+        ):
+            self.assertFalse(DAEMON_SWITCH.macos_daemon_has_development_signature(daemon))
+
+    def test_signature_check_accepts_exact_authority_line_from_codesign_stderr(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        result = subprocess.CompletedProcess(
+            ["codesign"], 0, stdout="", stderr="Authority=atm-daemon-dev\n"
+        )
+        with (
+            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=result),
+        ):
+            self.assertTrue(DAEMON_SWITCH.macos_daemon_has_development_signature(daemon))
+
+
 class HttpRuntimeOwnerLockTests(unittest.TestCase):
     def test_owner_lock_identifies_http_runtime_without_legacy_socket(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -201,6 +269,7 @@ class ReadinessAndRollbackTests(unittest.TestCase):
             ),
             mock.patch.object(DAEMON_SWITCH, "validate_selectors"),
             mock.patch.object(DAEMON_SWITCH, "save_default_pair"),
+            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signature"),
             mock.patch.object(DAEMON_SWITCH, "run_service") as service,
             mock.patch.object(DAEMON_SWITCH, "require_stopped_daemon") as stopped,
             mock.patch.object(DAEMON_SWITCH, "replace_link") as replace,

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -113,31 +113,65 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
             self.assertFalse(DAEMON_SWITCH.macos_development_signing_identity_available())
             self.assertTrue(DAEMON_SWITCH.macos_development_signing_identity_available())
 
+    def test_signer_and_switcher_share_the_identity_detection_helper(self) -> None:
+        signing_module = SCRIPT.parents[4] / ".just" / "sign_daemon_dev.py"
+        spec = importlib.util.spec_from_file_location("sign_daemon_dev_for_gate_test", signing_module)
+        assert spec is not None and spec.loader is not None
+        signer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(signer)
+
+        self.assertIs(
+            DAEMON_SWITCH.find_identity_output_has_development_identity,
+            signer.find_identity_output_has_development_identity,
+        )
+        self.assertEqual(
+            DAEMON_SWITCH.DEVELOPMENT_SIGNING_IDENTITY,
+            signer.DEVELOPMENT_SIGNING_IDENTITY,
+        )
+
     def test_no_signing_gate_when_identity_is_not_installed(self) -> None:
         daemon = Path("/candidate/atm-daemon")
         with (
             mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=False),
-            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature") as signed,
+            mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature") as signed,
         ):
-            DAEMON_SWITCH.require_macos_development_signature(daemon)
+            DAEMON_SWITCH.require_macos_development_signatures(Path("/candidate/atm"), daemon)
         signed.assert_not_called()
 
-    def test_rejects_unsigned_daemon_when_development_identity_is_installed(self) -> None:
+    def test_rejects_unsigned_cli_before_daemon_when_development_identity_is_installed(self) -> None:
+        cli = Path("/candidate/atm")
         daemon = Path("/candidate/atm-daemon")
         with (
             mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
-            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature", return_value=False),
+            mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature", return_value=False),
         ):
             with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "just build"):
-                DAEMON_SWITCH.require_macos_development_signature(daemon)
+                DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
 
-    def test_accepts_daemon_with_exact_development_authority(self) -> None:
+    def test_rejects_unsigned_daemon_after_accepting_signed_cli(self) -> None:
+        cli = Path("/candidate/atm")
         daemon = Path("/candidate/atm-daemon")
         with (
             mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
-            mock.patch.object(DAEMON_SWITCH, "macos_daemon_has_development_signature", return_value=True),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "macos_binary_has_development_signature",
+                side_effect=[True, False],
+            ) as signed,
         ):
-            DAEMON_SWITCH.require_macos_development_signature(daemon)
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "daemon target"):
+                DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
+        self.assertEqual(signed.call_args_list, [mock.call(cli), mock.call(daemon)])
+
+    def test_accepts_cli_and_daemon_with_exact_development_authority(self) -> None:
+        cli = Path("/candidate/atm")
+        daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature", return_value=True) as signed,
+        ):
+            DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
+        self.assertEqual(signed.call_args_list, [mock.call(cli), mock.call(daemon)])
 
     def test_signature_check_requires_exact_authority_line(self) -> None:
         daemon = Path("/candidate/atm-daemon")
@@ -149,9 +183,9 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         )
         with (
             mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
-            mock.patch.object(DAEMON_SWITCH, "run", return_value=result),
+            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr=""), result]),
         ):
-            self.assertFalse(DAEMON_SWITCH.macos_daemon_has_development_signature(daemon))
+            self.assertFalse(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
 
     def test_signature_check_accepts_exact_authority_line_from_codesign_stderr(self) -> None:
         daemon = Path("/candidate/atm-daemon")
@@ -160,9 +194,18 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         )
         with (
             mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
-            mock.patch.object(DAEMON_SWITCH, "run", return_value=result),
+            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr=""), result]),
         ):
-            self.assertTrue(DAEMON_SWITCH.macos_daemon_has_development_signature(daemon))
+            self.assertTrue(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
+
+    def test_strict_verification_failure_rejects_matching_authority(self) -> None:
+        daemon = Path("/candidate/atm-daemon")
+        failed_verification = subprocess.CompletedProcess(["codesign"], 1, stdout="", stderr="invalid")
+        with (
+            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=failed_verification),
+        ):
+            self.assertFalse(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
 
 
 class HttpRuntimeOwnerLockTests(unittest.TestCase):
@@ -269,7 +312,7 @@ class ReadinessAndRollbackTests(unittest.TestCase):
             ),
             mock.patch.object(DAEMON_SWITCH, "validate_selectors"),
             mock.patch.object(DAEMON_SWITCH, "save_default_pair"),
-            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signature"),
+            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signatures"),
             mock.patch.object(DAEMON_SWITCH, "run_service") as service,
             mock.patch.object(DAEMON_SWITCH, "require_stopped_daemon") as stopped,
             mock.patch.object(DAEMON_SWITCH, "replace_link") as replace,

--- a/.just/sign_daemon_dev.py
+++ b/.just/sign_daemon_dev.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
-"""Best-effort signing of local ATM daemon binaries for macOS development."""
+"""Strictly sign managed local ATM binaries when the development key is available."""
 
 from __future__ import annotations
 
 from pathlib import Path
-import re
 import subprocess
 import sys
 
 
-IDENTITY = "atm-daemon-dev"
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DAEMON_TARGETS = (
+SCRIPTS_DIRECTORY = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIRECTORY))
+
+from macos_development_signing import (  # noqa: E402
+    DEVELOPMENT_SIGNING_IDENTITY,
+    find_identity_output_has_development_identity,
+)
+
+
+IDENTITY = DEVELOPMENT_SIGNING_IDENTITY
+MANAGED_TARGETS = (
+    REPO_ROOT / "target" / "debug" / "atm",
     REPO_ROOT / "target" / "debug" / "atm-daemon",
+    REPO_ROOT / "target" / "release" / "atm",
     REPO_ROOT / "target" / "release" / "atm-daemon",
 )
-IDENTITY_PATTERN = re.compile(rf'"{re.escape(IDENTITY)}"')
-
-
 def has_development_identity() -> bool:
     """Return whether the local keychain exposes the exact development identity."""
     try:
@@ -30,36 +38,42 @@ def has_development_identity() -> bool:
         )
     except (OSError, subprocess.SubprocessError):
         return False
-    return result.returncode == 0 and any(
-        IDENTITY_PATTERN.search(line) for line in result.stdout.splitlines()
+    return result.returncode == 0 and find_identity_output_has_development_identity(result.stdout)
+
+
+def sign_and_verify_binary(binary: Path) -> None:
+    """Sign and strictly verify one managed binary or raise on any failure."""
+    subprocess.run(
+        ["codesign", "--force", "--sign", IDENTITY, str(binary)],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["codesign", "--verify", "--strict", str(binary)],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 
-def sign_binary(binary: Path) -> None:
-    """Sign one binary, swallowing unavailable-identity/tool failures."""
-    try:
-        subprocess.run(
-            ["codesign", "-s", IDENTITY, "--force", str(binary)],
-            cwd=REPO_ROOT,
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return
-
-
 def main() -> int:
-    """Sign existing debug/release binaries on macOS; otherwise do nothing."""
+    """Sign and verify existing managed binaries on macOS; otherwise do nothing."""
     if sys.platform != "darwin" or not has_development_identity():
         return 0
-    for binary in DAEMON_TARGETS:
+    for binary in MANAGED_TARGETS:
         try:
             exists = binary.is_file()
         except OSError:
             exists = False
         if exists:
-            sign_binary(binary)
+            try:
+                sign_and_verify_binary(binary)
+            except (OSError, subprocess.SubprocessError) as error:
+                print(f"error: unable to sign and verify {binary}: {error}", file=sys.stderr)
+                return 1
     return 0
 
 

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -50,7 +50,42 @@ class DaemonSwitchTests(unittest.TestCase):
             run_service=mock.DEFAULT,
             live_pair_matches=mock.DEFAULT,
             require_stopped_daemon=mock.DEFAULT,
+            require_macos_development_signature=mock.DEFAULT,
         )
+
+    def test_switch_rejects_unsigned_target_before_touching_selectors_or_service(self) -> None:
+        with self.patch_switch_inputs() as patched:
+            patched["selected_links"].return_value = (self.cli_link, self.daemon_link)
+            patched["require_executable"].side_effect = [
+                self.old_cli,
+                self.old_daemon,
+                self.new_cli,
+                self.new_daemon,
+            ]
+            patched["require_macos_development_signature"].side_effect = self.module.SwitchError(
+                "unsigned daemon"
+            )
+            with self.assertRaisesRegex(self.module.SwitchError, "unsigned daemon"):
+                self.module.switch_pair(self.args, self.new_cli, self.new_daemon)
+
+        patched["run_service"].assert_not_called()
+        patched["replace_link"].assert_not_called()
+
+    def test_restart_rejects_unsigned_selected_daemon_before_stopping_service(self) -> None:
+        args = argparse.Namespace(yes=True)
+        with (
+            mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)),
+            mock.patch.object(self.module, "require_executable", return_value=self.old_daemon),
+            mock.patch.object(
+                self.module,
+                "require_macos_development_signature",
+                side_effect=self.module.SwitchError("unsigned daemon"),
+            ),
+            mock.patch.object(self.module, "run_service") as service,
+        ):
+            with self.assertRaisesRegex(self.module.SwitchError, "unsigned daemon"):
+                self.module.restart(args)
+        service.assert_not_called()
 
     def test_switch_pair_stops_then_replaces_both_selectors_then_starts(self) -> None:
         with self.patch_switch_inputs() as patched:
@@ -186,6 +221,8 @@ class DaemonSwitchTests(unittest.TestCase):
         args = argparse.Namespace(yes=True)
         with (
             mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)),
+            mock.patch.object(self.module, "require_executable", return_value=self.old_daemon),
+            mock.patch.object(self.module, "require_macos_development_signature"),
             mock.patch.object(self.module, "run_service") as run_service,
             mock.patch.object(self.module, "require_stopped_daemon") as stopped,
             mock.patch.object(self.module, "live_pair_matches", return_value=(True, "matched")),

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -50,7 +50,7 @@ class DaemonSwitchTests(unittest.TestCase):
             run_service=mock.DEFAULT,
             live_pair_matches=mock.DEFAULT,
             require_stopped_daemon=mock.DEFAULT,
-            require_macos_development_signature=mock.DEFAULT,
+            require_macos_development_signatures=mock.DEFAULT,
         )
 
     def test_switch_rejects_unsigned_target_before_touching_selectors_or_service(self) -> None:
@@ -62,30 +62,34 @@ class DaemonSwitchTests(unittest.TestCase):
                 self.new_cli,
                 self.new_daemon,
             ]
-            patched["require_macos_development_signature"].side_effect = self.module.SwitchError(
-                "unsigned daemon"
+            patched["require_macos_development_signatures"].side_effect = self.module.SwitchError(
+                "unsigned CLI"
             )
-            with self.assertRaisesRegex(self.module.SwitchError, "unsigned daemon"):
+            with self.assertRaisesRegex(self.module.SwitchError, "unsigned CLI"):
                 self.module.switch_pair(self.args, self.new_cli, self.new_daemon)
 
         patched["run_service"].assert_not_called()
         patched["replace_link"].assert_not_called()
+        patched["require_macos_development_signatures"].assert_called_once_with(
+            self.new_cli, self.new_daemon
+        )
 
-    def test_restart_rejects_unsigned_selected_daemon_before_stopping_service(self) -> None:
+    def test_restart_rejects_unsigned_selected_pair_before_stopping_service(self) -> None:
         args = argparse.Namespace(yes=True)
         with (
             mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)),
-            mock.patch.object(self.module, "require_executable", return_value=self.old_daemon),
+            mock.patch.object(self.module, "require_executable", side_effect=[self.old_cli, self.old_daemon]),
             mock.patch.object(
                 self.module,
-                "require_macos_development_signature",
-                side_effect=self.module.SwitchError("unsigned daemon"),
-            ),
+                "require_macos_development_signatures",
+                side_effect=self.module.SwitchError("unsigned CLI"),
+            ) as signatures,
             mock.patch.object(self.module, "run_service") as service,
         ):
-            with self.assertRaisesRegex(self.module.SwitchError, "unsigned daemon"):
+            with self.assertRaisesRegex(self.module.SwitchError, "unsigned CLI"):
                 self.module.restart(args)
         service.assert_not_called()
+        signatures.assert_called_once_with(self.old_cli, self.old_daemon)
 
     def test_switch_pair_stops_then_replaces_both_selectors_then_starts(self) -> None:
         with self.patch_switch_inputs() as patched:
@@ -101,6 +105,9 @@ class DaemonSwitchTests(unittest.TestCase):
             self.module.switch_pair(self.args, self.new_cli, self.new_daemon)
 
         patched["validate_selectors"].assert_called_once_with(self.cli_link, self.daemon_link)
+        patched["require_macos_development_signatures"].assert_called_once_with(
+            self.new_cli, self.new_daemon
+        )
         patched["save_default_pair"].assert_called_once_with(self.old_cli, self.old_daemon)
         self.assertEqual(
             patched["run_service"].call_args_list,
@@ -221,8 +228,8 @@ class DaemonSwitchTests(unittest.TestCase):
         args = argparse.Namespace(yes=True)
         with (
             mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)),
-            mock.patch.object(self.module, "require_executable", return_value=self.old_daemon),
-            mock.patch.object(self.module, "require_macos_development_signature"),
+            mock.patch.object(self.module, "require_executable", side_effect=[self.old_cli, self.old_daemon]),
+            mock.patch.object(self.module, "require_macos_development_signatures"),
             mock.patch.object(self.module, "run_service") as run_service,
             mock.patch.object(self.module, "require_stopped_daemon") as stopped,
             mock.patch.object(self.module, "live_pair_matches", return_value=(True, "matched")),

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 import importlib.util
 from unittest import mock
@@ -35,15 +36,17 @@ class SignDaemonDevTests(unittest.TestCase):
         self.assertEqual(run.call_count, 1)
         self.assertEqual(run.call_args.args[0], ["security", "find-identity", "-v", "-p", "codesigning"])
 
-    def test_exact_identity_signs_each_existing_daemon_binary(self) -> None:
+    def test_exact_identity_signs_and_strictly_verifies_each_existing_managed_binary(self) -> None:
         security = subprocess.CompletedProcess(
             ["security"], 0, stdout='  1) ABCD "atm-daemon-dev"\n', stderr=""
         )
         codesign = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
         with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run", side_effect=[security, codesign, codesign]
+            sign_daemon_dev.subprocess,
+            "run",
+            side_effect=[security, *([codesign] * (len(sign_daemon_dev.MANAGED_TARGETS) * 2))],
         ) as run, mock.patch.object(
-            sign_daemon_dev.Path, "is_file", side_effect=[True, True]
+            sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)
         ):
             self.assertEqual(sign_daemon_dev.main(), 0)
 
@@ -52,8 +55,12 @@ class SignDaemonDevTests(unittest.TestCase):
         self.assertEqual(
             commands[1:],
             [
-                ["codesign", "-s", "atm-daemon-dev", "--force", str(sign_daemon_dev.DAEMON_TARGETS[0])],
-                ["codesign", "-s", "atm-daemon-dev", "--force", str(sign_daemon_dev.DAEMON_TARGETS[1])],
+                command
+                for binary in sign_daemon_dev.MANAGED_TARGETS
+                for command in (
+                    ["codesign", "--force", "--sign", "atm-daemon-dev", str(binary)],
+                    ["codesign", "--verify", "--strict", str(binary)],
+                )
             ],
         )
 
@@ -67,19 +74,21 @@ class SignDaemonDevTests(unittest.TestCase):
             self.assertEqual(sign_daemon_dev.main(), 0)
         self.assertEqual(run.call_count, 1)
 
-    def test_security_and_codesign_failures_are_swallowed(self) -> None:
+    def test_security_failure_is_treated_as_an_unavailable_identity(self) -> None:
         with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
             sign_daemon_dev.subprocess, "run", side_effect=OSError("security unavailable")
         ):
             self.assertEqual(sign_daemon_dev.main(), 0)
 
+    def test_signing_failure_fails_closed_when_identity_is_available(self) -> None:
         security = subprocess.CompletedProcess(
             ["security"], 0, stdout='  1) ABCD "atm-daemon-dev"\n', stderr=""
         )
         with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
             sign_daemon_dev.subprocess, "run", side_effect=[security, subprocess.CalledProcessError(1, "codesign")]
-        ), mock.patch.object(sign_daemon_dev.Path, "is_file", side_effect=[True, False]):
-            self.assertEqual(sign_daemon_dev.main(), 0)
+        ), mock.patch.object(sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)):
+            with mock.patch.object(sign_daemon_dev.sys, "stderr", new=io.StringIO()):
+                self.assertEqual(sign_daemon_dev.main(), 1)
 
     def test_build_recipe_runs_signing_hook_after_cargo(self) -> None:
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")

--- a/scripts/macos_development_signing.py
+++ b/scripts/macos_development_signing.py
@@ -1,0 +1,16 @@
+"""Shared macOS development-signing identity rules for build and deployment tools."""
+
+from __future__ import annotations
+
+import re
+
+
+DEVELOPMENT_SIGNING_IDENTITY = "atm-daemon-dev"
+_EXACT_IDENTITY_LINE = re.compile(
+    rf'^\s*\d+\)\s+\S+\s+"{re.escape(DEVELOPMENT_SIGNING_IDENTITY)}"\s*$'
+)
+
+
+def find_identity_output_has_development_identity(output: str) -> bool:
+    """Return whether ``security find-identity`` lists the exact development key."""
+    return any(_EXACT_IDENTITY_LINE.match(line) for line in output.splitlines())


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #974's two commits (`dc679621e`, `c51b2bbff`) directly onto `develop`, bypassing the phase-ao2 integration chain since this change is script/doc-only with no dependency on phase-ao2's Rust crate changes.
- Adds `require_macos_development_signatures` gate to `.claude/skills/daemon-switch/scripts/daemon-switch.py`: blocks `switch_pair`/`restart` when an atm-dev cert exists on the machine and either the `atm` or `atm-daemon` binary is not signed with it (`codesign --verify --strict`, exact `Authority=atm-daemon-dev` match).
- Strengthens `.just/sign_daemon_dev.py` to sign+verify both `atm` and `atm-daemon` (previously daemon-only, previously silently swallowed failures — now fails closed).
- New shared `scripts/macos_development_signing.py` module (single `DEVELOPMENT_SIGNING_IDENTITY` constant + exact-line-anchored regex matcher) used by both consumers, eliminating duplicated identity-detection logic (fixes RBQA-F001 from PR #974's QA).
- New asymmetric test `test_rejects_unsigned_daemon_after_accepting_signed_cli` (fixes RBQA-F002 from PR #974's QA).

## Provenance
- Original work: PR #974 (`fix/daemon-switch-signing-gate` → `integrate/phase-ao2`), fully QA-cleared by quality-mgr (MERGE GATE CLEAR) and live-verified twice (arch-ctm's real non-dry-run unsigned-binary switch attempt on M4, independently re-checked by quality-mgr).
- This PR is a clean, conflict-free cherry-pick of the same two commits onto a fresh worktree off `develop`. Diff content is identical to PR #974's; only the base differs.
- All 45 associated tests re-run and pass locally on this branch: `.just/tests/test_daemon_switch.py`, `.just/tests/test_sign_daemon_dev.py` (25 passed), `.claude/skills/daemon-switch/tests/test_daemon_switch.py` (20 passed).

## Test plan
- [x] Clean cherry-pick, no conflicts
- [x] All associated unit tests pass
- [ ] quality-mgr independent verification of the cherry-pick (requested)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)