### PR TITLE
fix(signing): migrate ATM binaries to Apple Development identity

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -20,12 +20,13 @@ worktree binary directly.
    is healthy again.
 6. When peer-interface or trust configuration changes, use `restart` to reload
    the one selected daemon; never launch an extra process.
-7. On macOS, when the local keychain contains `atm-daemon-dev`, `switch` and
-   `restart` fail closed unless both selected `atm` and `atm-daemon` strictly
-   verify and carry that exact signing authority. Build with `just build` (or
+7. On macOS, `switch` and `restart` fail closed unless both selected `atm` and
+   `atm-daemon` strictly verify with the stable Apple Development identifiers
+   and the configured Apple team identifier. Build with `just build` (or
    explicitly run `python3 .just/sign_daemon_dev.py`) before switching. This
    enforces a matched, signed local build; it is separate from macOS Local
-   Network Privacy authorization.
+   Network Privacy authorization. Windows currently warns and skips signing;
+   other platforms are no-ops.
 
 ## Commands
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -24,8 +24,11 @@ if str(SCRIPTS_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIRECTORY))
 
 from macos_development_signing import (  # noqa: E402
-    DEVELOPMENT_SIGNING_IDENTITY,
-    find_identity_output_has_development_identity,
+    CLI_IDENTIFIER,
+    DAEMON_IDENTIFIER,
+    SigningIdentityError,
+    resolve_apple_development_identity,
+    verify_apple_signature,
 )
 
 
@@ -87,52 +90,46 @@ def require_executable(path: Path, label: str) -> Path:
 
 
 def macos_development_signing_identity_available() -> bool:
-    """Return whether the exact local development signing identity is usable.
-
-    The switcher only adds this precondition when the host is configured to
-    sign development daemons.  Hosts without that identity retain the normal
-    cross-platform switching path.
-    """
+    """Return whether the required Apple Development identity is usable."""
     if platform.system() != "Darwin":
         return False
-    security = shutil.which("security")
-    if security is None:
-        return False
     try:
-        result = run([security, "find-identity", "-v", "-p", "codesigning"], timeout=10.0)
-    except (OSError, subprocess.TimeoutExpired):
+        resolve_apple_development_identity()
+    except (OSError, subprocess.SubprocessError, SigningIdentityError):
         return False
-    return result.returncode == 0 and find_identity_output_has_development_identity(result.stdout)
+    return True
 
 
-def macos_binary_has_development_signature(binary: Path) -> bool:
-    """Prove one managed binary strictly verifies with the configured authority."""
-    codesign = shutil.which("codesign")
-    if codesign is None:
-        return False
+def macos_binary_has_development_signature(
+    binary: Path, identifier: str, team_identifier: str
+) -> bool:
+    """Prove one managed binary carries its stable Apple Development signature."""
     try:
-        verification = run([codesign, "--verify", "--strict", str(binary)], timeout=10.0)
-        if verification.returncode != 0:
-            return False
-        result = run([codesign, "-dv", "--verbose=4", str(binary)], timeout=10.0)
-    except (OSError, subprocess.TimeoutExpired):
+        return verify_apple_signature(str(binary), identifier, team_identifier)
+    except (OSError, subprocess.SubprocessError):
         return False
-    if result.returncode != 0:
-        return False
-    authority = f"Authority={DEVELOPMENT_SIGNING_IDENTITY}"
-    output = f"{result.stdout}\n{result.stderr}"
-    return any(line.strip() == authority for line in output.splitlines())
 
 
 def require_macos_development_signatures(cli: Path, daemon: Path) -> None:
     """Fail closed before any managed-pair lifecycle mutation on macOS."""
-    if not macos_development_signing_identity_available():
+    system = platform.system()
+    if system == "Windows":
+        print("warning: Windows signing not yet implemented; skipping ATM signature gate.", file=sys.stderr)
         return
-    for label, binary in (("CLI", cli), ("daemon", daemon)):
-        if not macos_binary_has_development_signature(binary):
+    if system != "Darwin":
+        return
+    try:
+        identity = resolve_apple_development_identity()
+    except (OSError, subprocess.SubprocessError, SigningIdentityError) as error:
+        raise SwitchError(f"Apple Development signing preflight failed: {error}") from error
+    for label, binary, identifier in (
+        ("CLI", cli, CLI_IDENTIFIER),
+        ("daemon", daemon, DAEMON_IDENTIFIER),
+    ):
+        if not macos_binary_has_development_signature(binary, identifier, identity.team_identifier):
             raise SwitchError(
-                f"macOS development signing identity `{DEVELOPMENT_SIGNING_IDENTITY}` is installed, "
-                f"but {label} target is not strictly signed by it: {binary}. "
+                f"{label} target is not strictly signed by the required Apple Development identity: "
+                f"{binary}. "
                 "Build with `just build` or run `python3 .just/sign_daemon_dev.py` before daemon-switch."
             )
 

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 from pathlib import Path
 import socket
 import subprocess
@@ -98,22 +99,14 @@ class QuiesceTests(unittest.TestCase):
 
 
 class MacosDevelopmentSigningTests(unittest.TestCase):
-    def test_identity_discovery_requires_the_exact_quoted_identity(self) -> None:
-        partial = subprocess.CompletedProcess(
-            ["security"], 0, stdout='1) HASH "not-atm-daemon-dev"\n', stderr=""
-        )
-        exact = subprocess.CompletedProcess(
-            ["security"], 0, stdout='1) HASH "atm-daemon-dev"\n', stderr=""
-        )
+    def test_identity_discovery_uses_the_shared_apple_resolver(self) -> None:
         with (
             mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
-            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/security"),
-            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[partial, exact]),
+            mock.patch.object(DAEMON_SWITCH, "resolve_apple_development_identity"),
         ):
-            self.assertFalse(DAEMON_SWITCH.macos_development_signing_identity_available())
             self.assertTrue(DAEMON_SWITCH.macos_development_signing_identity_available())
 
-    def test_signer_and_switcher_share_the_identity_detection_helper(self) -> None:
+    def test_signer_and_switcher_share_the_apple_identity_resolver(self) -> None:
         signing_module = SCRIPT.parents[4] / ".just" / "sign_daemon_dev.py"
         spec = importlib.util.spec_from_file_location("sign_daemon_dev_for_gate_test", signing_module)
         assert spec is not None and spec.loader is not None
@@ -121,28 +114,30 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         spec.loader.exec_module(signer)
 
         self.assertIs(
-            DAEMON_SWITCH.find_identity_output_has_development_identity,
-            signer.find_identity_output_has_development_identity,
+            DAEMON_SWITCH.resolve_apple_development_identity,
+            signer.resolve_apple_development_identity,
         )
         self.assertEqual(
-            DAEMON_SWITCH.DEVELOPMENT_SIGNING_IDENTITY,
-            signer.DEVELOPMENT_SIGNING_IDENTITY,
+            DAEMON_SWITCH.CLI_IDENTIFIER,
+            signer.CLI_IDENTIFIER,
         )
 
-    def test_no_signing_gate_when_identity_is_not_installed(self) -> None:
+    def test_non_macos_has_no_signing_gate(self) -> None:
         daemon = Path("/candidate/atm-daemon")
         with (
-            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=False),
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Linux"),
             mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature") as signed,
         ):
             DAEMON_SWITCH.require_macos_development_signatures(Path("/candidate/atm"), daemon)
         signed.assert_not_called()
 
-    def test_rejects_unsigned_cli_before_daemon_when_development_identity_is_installed(self) -> None:
+    def test_rejects_unsigned_cli_before_daemon_when_apple_identity_is_available(self) -> None:
         cli = Path("/candidate/atm")
         daemon = Path("/candidate/atm-daemon")
+        identity = mock.Mock(team_identifier="4869P2ZYC6")
         with (
-            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "resolve_apple_development_identity", return_value=identity),
             mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature", return_value=False),
         ):
             with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "just build"):
@@ -151,8 +146,10 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
     def test_rejects_unsigned_daemon_after_accepting_signed_cli(self) -> None:
         cli = Path("/candidate/atm")
         daemon = Path("/candidate/atm-daemon")
+        identity = mock.Mock(team_identifier="4869P2ZYC6")
         with (
-            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "resolve_apple_development_identity", return_value=identity),
             mock.patch.object(
                 DAEMON_SWITCH,
                 "macos_binary_has_development_signature",
@@ -161,51 +158,54 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "daemon target"):
                 DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
-        self.assertEqual(signed.call_args_list, [mock.call(cli), mock.call(daemon)])
+        self.assertEqual(
+            signed.call_args_list,
+            [
+                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity.team_identifier),
+                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity.team_identifier),
+            ],
+        )
 
     def test_accepts_cli_and_daemon_with_exact_development_authority(self) -> None:
         cli = Path("/candidate/atm")
         daemon = Path("/candidate/atm-daemon")
+        identity = mock.Mock(team_identifier="4869P2ZYC6")
         with (
-            mock.patch.object(DAEMON_SWITCH, "macos_development_signing_identity_available", return_value=True),
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "resolve_apple_development_identity", return_value=identity),
             mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature", return_value=True) as signed,
         ):
             DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
-        self.assertEqual(signed.call_args_list, [mock.call(cli), mock.call(daemon)])
-
-    def test_signature_check_requires_exact_authority_line(self) -> None:
-        daemon = Path("/candidate/atm-daemon")
-        result = subprocess.CompletedProcess(
-            ["codesign"],
-            0,
-            stdout="Authority=another-atm-daemon-dev\n",
-            stderr="Authority=atm-daemon-dev-extra\n",
+        self.assertEqual(
+            signed.call_args_list,
+            [
+                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity.team_identifier),
+                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity.team_identifier),
+            ],
         )
-        with (
-            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
-            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr=""), result]),
-        ):
-            self.assertFalse(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
 
-    def test_signature_check_accepts_exact_authority_line_from_codesign_stderr(self) -> None:
+    def test_signature_check_uses_shared_stable_identifier_verifier(self) -> None:
         daemon = Path("/candidate/atm-daemon")
-        result = subprocess.CompletedProcess(
-            ["codesign"], 0, stdout="", stderr="Authority=atm-daemon-dev\n"
-        )
         with (
-            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
-            mock.patch.object(DAEMON_SWITCH, "run", side_effect=[subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr=""), result]),
+            mock.patch.object(DAEMON_SWITCH, "verify_apple_signature", return_value=True) as verify,
         ):
-            self.assertTrue(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
+            self.assertTrue(
+                DAEMON_SWITCH.macos_binary_has_development_signature(
+                    daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, "4869P2ZYC6"
+                )
+            )
+        verify.assert_called_once_with(str(daemon), DAEMON_SWITCH.DAEMON_IDENTIFIER, "4869P2ZYC6")
 
-    def test_strict_verification_failure_rejects_matching_authority(self) -> None:
-        daemon = Path("/candidate/atm-daemon")
-        failed_verification = subprocess.CompletedProcess(["codesign"], 1, stdout="", stderr="invalid")
+    def test_windows_warns_and_skips_the_unimplemented_signature_gate(self) -> None:
+        stderr = io.StringIO()
         with (
-            mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/usr/bin/codesign"),
-            mock.patch.object(DAEMON_SWITCH, "run", return_value=failed_verification),
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            mock.patch.object(DAEMON_SWITCH, "macos_binary_has_development_signature") as signed,
+            mock.patch.object(DAEMON_SWITCH.sys, "stderr", stderr),
         ):
-            self.assertFalse(DAEMON_SWITCH.macos_binary_has_development_signature(daemon))
+            DAEMON_SWITCH.require_macos_development_signatures(Path("/candidate/atm"), Path("/candidate/atm-daemon"))
+        signed.assert_not_called()
+        self.assertIn("Windows signing not yet implemented", stderr.getvalue())
 
 
 class HttpRuntimeOwnerLockTests(unittest.TestCase):

--- a/.just/sign_daemon_dev.py
+++ b/.just/sign_daemon_dev.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Strictly sign managed local ATM binaries when the development key is available."""
+"""Strictly sign managed local ATM binaries with Apple Development on macOS."""
 
 from __future__ import annotations
 
@@ -14,64 +14,71 @@ if str(SCRIPTS_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIRECTORY))
 
 from macos_development_signing import (  # noqa: E402
-    DEVELOPMENT_SIGNING_IDENTITY,
-    find_identity_output_has_development_identity,
+    CLI_IDENTIFIER,
+    DAEMON_IDENTIFIER,
+    SigningIdentity,
+    SigningIdentityError,
+    resolve_apple_development_identity,
+    verify_apple_signature,
 )
 
 
-IDENTITY = DEVELOPMENT_SIGNING_IDENTITY
 MANAGED_TARGETS = (
-    REPO_ROOT / "target" / "debug" / "atm",
-    REPO_ROOT / "target" / "debug" / "atm-daemon",
-    REPO_ROOT / "target" / "release" / "atm",
-    REPO_ROOT / "target" / "release" / "atm-daemon",
+    (REPO_ROOT / "target" / "debug" / "atm", CLI_IDENTIFIER),
+    (REPO_ROOT / "target" / "debug" / "atm-daemon", DAEMON_IDENTIFIER),
+    (REPO_ROOT / "target" / "release" / "atm", CLI_IDENTIFIER),
+    (REPO_ROOT / "target" / "release" / "atm-daemon", DAEMON_IDENTIFIER),
 )
-def has_development_identity() -> bool:
-    """Return whether the local keychain exposes the exact development identity."""
-    try:
-        result = subprocess.run(
-            ["security", "find-identity", "-v", "-p", "codesigning"],
-            cwd=REPO_ROOT,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return result.returncode == 0 and find_identity_output_has_development_identity(result.stdout)
+ENTITLEMENTS = REPO_ROOT / "scripts" / "macos_debug.entitlements"
 
 
-def sign_and_verify_binary(binary: Path) -> None:
+def sign_and_verify_binary(binary: Path, identifier: str, identity: SigningIdentity) -> None:
     """Sign and strictly verify one managed binary or raise on any failure."""
     subprocess.run(
-        ["codesign", "--force", "--sign", IDENTITY, str(binary)],
+        [
+            "codesign",
+            "--force",
+            "--sign",
+            identity.fingerprint,
+            "--identifier",
+            identifier,
+            "--entitlements",
+            str(ENTITLEMENTS),
+            str(binary),
+        ],
         cwd=REPO_ROOT,
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    subprocess.run(
-        ["codesign", "--verify", "--strict", str(binary)],
-        cwd=REPO_ROOT,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    if not verify_apple_signature(str(binary), identifier, identity.team_identifier):
+        raise SigningIdentityError(
+            f"post-sign verification failed for {binary}; expected {identifier} "
+            "and the configured Apple Development team."
+        )
 
 
 def main() -> int:
     """Sign and verify existing managed binaries on macOS; otherwise do nothing."""
-    if sys.platform != "darwin" or not has_development_identity():
+    if sys.platform == "win32":
+        print("warning: Windows signing not yet implemented; skipping ATM binary signing.", file=sys.stderr)
         return 0
-    for binary in MANAGED_TARGETS:
+    if sys.platform != "darwin":
+        return 0
+    try:
+        identity = resolve_apple_development_identity()
+    except (OSError, subprocess.SubprocessError, SigningIdentityError) as error:
+        print(f"error: unable to resolve Apple Development signing identity: {error}", file=sys.stderr)
+        return 1
+    for binary, identifier in MANAGED_TARGETS:
         try:
             exists = binary.is_file()
         except OSError:
             exists = False
         if exists:
             try:
-                sign_and_verify_binary(binary)
-            except (OSError, subprocess.SubprocessError) as error:
+                sign_and_verify_binary(binary, identifier, identity)
+            except (OSError, subprocess.SubprocessError, SigningIdentityError) as error:
                 print(f"error: unable to sign and verify {binary}: {error}", file=sys.stderr)
                 return 1
     return 0

--- a/.just/tests/test_macos_development_signing.py
+++ b/.just/tests/test_macos_development_signing.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+from unittest import mock
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "macos_development_signing.py"
+SPEC = importlib.util.spec_from_file_location("macos_development_signing", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+signing = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = signing
+SPEC.loader.exec_module(signing)
+
+
+class AppleDevelopmentSigningTests(unittest.TestCase):
+    def test_parses_only_complete_identity_rows(self) -> None:
+        parsed = signing.parse_identities(
+            '  1) 0123456789ABCDEF0123456789ABCDEF01234567 "Apple Development: test"\n'
+            '  2) invalid identity\n'
+        )
+        self.assertEqual(
+            parsed,
+            (signing.SigningIdentity("0123456789ABCDEF0123456789ABCDEF01234567", "Apple Development: test"),),
+        )
+
+    def test_default_resolution_uses_apple_prefix_and_team_identifier_not_hostname(self) -> None:
+        selected = signing.SigningIdentity(
+            "A" * 40,
+            "Apple Development: apple@example.test (N285DY5G36)",
+            signing.DEFAULT_TEAM_IDENTIFIER,
+        )
+        wrong_team = signing.SigningIdentity("B" * 40, "Apple Development: other@example.test")
+        with (
+            mock.patch.object(signing, "_valid_identities", return_value=(selected, wrong_team)),
+            mock.patch.object(
+                signing,
+                "_certificate_team_identifier",
+                side_effect=[signing.DEFAULT_TEAM_IDENTIFIER, "OTHERTEAM"],
+            ),
+            mock.patch.dict(signing.os.environ, {}, clear=True),
+        ):
+            self.assertEqual(signing.resolve_apple_development_identity(), selected)
+
+    def test_default_resolution_rejects_ambiguous_team_candidates(self) -> None:
+        identities = (
+            signing.SigningIdentity("A" * 40, "Apple Development: one"),
+            signing.SigningIdentity("B" * 40, "Apple Development: two"),
+        )
+        with (
+            mock.patch.object(signing, "_valid_identities", return_value=identities),
+            mock.patch.object(signing, "_certificate_team_identifier", return_value=signing.DEFAULT_TEAM_IDENTIFIER),
+            mock.patch.dict(signing.os.environ, {}, clear=True),
+        ):
+            with self.assertRaisesRegex(signing.SigningIdentityError, "exactly one"):
+                signing.resolve_apple_development_identity()
+
+    def test_override_selects_the_matching_valid_identity(self) -> None:
+        selected = signing.SigningIdentity("A" * 40, "Apple Development: alternate", "OTHERTEAM")
+        with (
+            mock.patch.object(
+                signing,
+                "_valid_identities",
+                return_value=(signing.SigningIdentity(selected.fingerprint, selected.common_name),),
+            ),
+            mock.patch.object(signing, "_certificate_team_identifier", return_value=selected.team_identifier),
+            mock.patch.dict(signing.os.environ, {signing.SIGNING_IDENTITY_ENVIRONMENT_VARIABLE: selected.fingerprint}),
+        ):
+            self.assertEqual(signing.resolve_apple_development_identity(), selected)
+
+    def test_invalid_identity_reports_wwdr_recovery(self) -> None:
+        with (
+            mock.patch.object(signing, "_valid_identities", return_value=()),
+            mock.patch.object(signing, "_identity_exists_but_is_not_valid", return_value=True),
+            mock.patch.dict(signing.os.environ, {}, clear=True),
+        ):
+            with self.assertRaisesRegex(signing.SigningIdentityError, "WWDR G3"):
+                signing.resolve_apple_development_identity()
+
+    def test_verification_requires_strict_signature_stable_identifier_and_team(self) -> None:
+        verified = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        details = subprocess.CompletedProcess(
+            ["codesign"],
+            0,
+            stdout="",
+            stderr=(
+                f"Identifier={signing.CLI_IDENTIFIER}\n"
+                f"TeamIdentifier={signing.DEFAULT_TEAM_IDENTIFIER}\n"
+            ),
+        )
+        with mock.patch.object(signing, "_run", side_effect=[verified, details]):
+            self.assertTrue(signing.verify_apple_signature("/candidate/atm", signing.CLI_IDENTIFIER))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -20,79 +20,72 @@ SPEC.loader.exec_module(sign_daemon_dev)
 class SignDaemonDevTests(unittest.TestCase):
     def test_non_macos_is_a_silent_noop(self) -> None:
         with mock.patch.object(sign_daemon_dev.sys, "platform", "linux"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run"
-        ) as run:
+            sign_daemon_dev, "resolve_apple_development_identity"
+        ) as resolve:
             self.assertEqual(sign_daemon_dev.main(), 0)
-        run.assert_not_called()
+        resolve.assert_not_called()
 
-    def test_missing_identity_is_a_silent_noop(self) -> None:
-        security = subprocess.CompletedProcess(
-            ["security"], 0, stdout="     0 valid identities found\n", stderr=""
-        )
-        with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run", return_value=security
-        ) as run:
+    def test_windows_warns_and_skips_signing(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(sign_daemon_dev.sys, "platform", "win32"),
+            mock.patch.object(sign_daemon_dev.sys, "stderr", stderr),
+            mock.patch.object(sign_daemon_dev, "resolve_apple_development_identity") as resolve,
+        ):
             self.assertEqual(sign_daemon_dev.main(), 0)
-        self.assertEqual(run.call_count, 1)
-        self.assertEqual(run.call_args.args[0], ["security", "find-identity", "-v", "-p", "codesigning"])
+        self.assertIn("Windows signing not yet implemented", stderr.getvalue())
+        resolve.assert_not_called()
 
-    def test_exact_identity_signs_and_strictly_verifies_each_existing_managed_binary(self) -> None:
-        security = subprocess.CompletedProcess(
-            ["security"], 0, stdout='  1) ABCD "atm-daemon-dev"\n', stderr=""
-        )
-        codesign = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
-        with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess,
-            "run",
-            side_effect=[security, *([codesign] * (len(sign_daemon_dev.MANAGED_TARGETS) * 2))],
-        ) as run, mock.patch.object(
-            sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)
+    def test_apple_identity_signs_and_strictly_verifies_each_existing_managed_binary(self) -> None:
+        identity = sign_daemon_dev.SigningIdentity("FINGERPRINT", "Apple Development: test")
+        completed = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        with (
+            mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"),
+            mock.patch.object(sign_daemon_dev, "resolve_apple_development_identity", return_value=identity),
+            mock.patch.object(sign_daemon_dev.subprocess, "run", return_value=completed) as run,
+            mock.patch.object(sign_daemon_dev, "verify_apple_signature", return_value=True),
+            mock.patch.object(sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)),
         ):
             self.assertEqual(sign_daemon_dev.main(), 0)
 
         commands = [call.args[0] for call in run.call_args_list]
-        self.assertEqual(commands[0], ["security", "find-identity", "-v", "-p", "codesigning"])
         self.assertEqual(
-            commands[1:],
+            commands,
             [
-                command
-                for binary in sign_daemon_dev.MANAGED_TARGETS
-                for command in (
-                    ["codesign", "--force", "--sign", "atm-daemon-dev", str(binary)],
-                    ["codesign", "--verify", "--strict", str(binary)],
-                )
+                [
+                    "codesign", "--force", "--sign", "FINGERPRINT", "--identifier", identifier,
+                    "--entitlements", str(sign_daemon_dev.ENTITLEMENTS), str(binary),
+                ]
+                for binary, identifier in sign_daemon_dev.MANAGED_TARGETS
             ],
         )
 
-    def test_similar_identity_name_does_not_match(self) -> None:
-        security = subprocess.CompletedProcess(
-            ["security"], 0, stdout='  1) ABCD "atm-daemon-dev-old"\n', stderr=""
-        )
-        with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run", return_value=security
-        ) as run:
-            self.assertEqual(sign_daemon_dev.main(), 0)
-        self.assertEqual(run.call_count, 1)
-
-    def test_security_failure_is_treated_as_an_unavailable_identity(self) -> None:
-        with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run", side_effect=OSError("security unavailable")
+    def test_identity_resolution_failure_fails_the_macos_build(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"),
+            mock.patch.object(
+                sign_daemon_dev,
+                "resolve_apple_development_identity",
+                side_effect=sign_daemon_dev.SigningIdentityError("missing Apple identity"),
+            ),
+            mock.patch.object(sign_daemon_dev.sys, "stderr", stderr),
         ):
-            self.assertEqual(sign_daemon_dev.main(), 0)
-
-    def test_signing_failure_fails_closed_when_identity_is_available(self) -> None:
-        security = subprocess.CompletedProcess(
-            ["security"], 0, stdout='  1) ABCD "atm-daemon-dev"\n', stderr=""
-        )
-        with mock.patch.object(sign_daemon_dev.sys, "platform", "darwin"), mock.patch.object(
-            sign_daemon_dev.subprocess, "run", side_effect=[security, subprocess.CalledProcessError(1, "codesign")]
-        ), mock.patch.object(sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)):
-            with mock.patch.object(sign_daemon_dev.sys, "stderr", new=io.StringIO()):
-                self.assertEqual(sign_daemon_dev.main(), 1)
+            self.assertEqual(sign_daemon_dev.main(), 1)
+        self.assertIn("missing Apple identity", stderr.getvalue())
 
     def test_build_recipe_runs_signing_hook_after_cargo(self) -> None:
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
         self.assertIn("build:\n    cargo build --workspace\n    {{python_cmd}} .just/sign_daemon_dev.py", justfile)
+
+    def test_test_recipe_re_signs_debug_artifacts_after_tests(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn(
+            "test mode='default':\n"
+            "    {{python_cmd}} .just/run_tests.py {{mode}}\n"
+            "    {{python_cmd}} .just/sign_daemon_dev.py",
+            justfile,
+        )
 
     def test_benchmark_recipe_builds_its_feature_gated_daemon(self) -> None:
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")

--- a/Justfile
+++ b/Justfile
@@ -137,6 +137,7 @@ build:
 # Run the full workspace test suite or explicit coverage reporting.
 test mode='default':
     {{python_cmd}} .just/run_tests.py {{mode}}
+    {{python_cmd}} .just/sign_daemon_dev.py
 
 # Validate and plan a bounded adversarial-fuzz campaign (no real execution).
 fuzz *args:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ cd atm-core
 cargo install --path crates/atm --bin atm
 ```
 
+### macOS development signing
+
+On a Mac that builds or switches the local daemon, configure the Apple Development
+certificate once: in Xcode open **Settings → Accounts**, add `apple@randlee.com`,
+choose **Manage Certificates**, then create **Apple Development**. Install the
+[Apple WWDR G3 intermediate](https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer)
+and verify the identity is valid:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+`just build` signs both `atm` and `atm-daemon` using that identity. The signer
+selects the Apple Development certificate by its certificate team identifier,
+not by any Mac hostname.
+
 ## Quick Start
 
 ATM runs against the accepted ATM home/runtime layout and persists retained

--- a/docs/plans/phase-ai/sprint-ai3152-tooling-daemon-devcert-signing.md
+++ b/docs/plans/phase-ai/sprint-ai3152-tooling-daemon-devcert-signing.md
@@ -11,13 +11,13 @@ target: integrate/phase-ai-31-33
 ## Goal
 
 Make local macOS daemon builds usable by the development harness when the
-`atm-daemon-dev` signing identity is installed, while keeping normal builds
+the retired self-signed signing identity is installed, while keeping normal builds
 portable and silent on hosts without that identity.
 
 ## Scope
 
-- `.just/sign_daemon_dev.py` checks the macOS keychain for the exact
-  `atm-daemon-dev` identity and force-signs existing debug and release daemon
+- `.just/sign_daemon_dev.py` checked the macOS keychain for the retired
+  self-signed identity and force-signed existing debug and release daemon
   binaries.
 - The helper is invoked after `cargo build --workspace` in `Justfile`.
 - Non-macOS hosts, missing `security`/`codesign`, absent identities, and

--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -72,7 +72,7 @@ final retained run must be noninteractive and free of that interference.
 
    ```sh
    cargo build --release -p agent-team-mail -p atm-daemon
-   python3 .just/sign_daemon_dev.py
+   python3 .just/sign_daemon_dev.py  # Apple Development signing hook
    ```
 
 4. Each host records the selected CLI and daemon versions. They must be equal

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1025,7 +1025,7 @@ Implementation Branches:
 | `AI.50` | `complete` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |
 | `AI.51` | `complete` | `feature/pAI-s51-local-http-framing-adversarial-campaign` | bounded local HTTP framing campaign |
 | `AI.52` | `complete` | `feature/pAI-s52-windows-transport-benchmark` | cwin Windows TCP confirmation after accepted M5 performance evidence |
-| `AI3152-TOOLING` | `complete` | `feature/daemon-devcert-signing` | silent macOS `atm-daemon-dev` signing hook for local daemon builds |
+| `AI3152-TOOLING` | `complete` | `feature/daemon-devcert-signing` | retired self-signed macOS development-signing hook for local daemon builds |
 
 Authoritative plan: [Phase AI plan](./plans/phase-ai/plan-phase-ai.md).
 

--- a/scripts/macos_debug.entitlements
+++ b/scripts/macos_debug.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/macos_development_signing.py
+++ b/scripts/macos_development_signing.py
@@ -1,16 +1,147 @@
-"""Shared macOS development-signing identity rules for build and deployment tools."""
+"""Shared Apple Development signing rules for local ATM binaries."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import os
 import re
+import subprocess
+from typing import Sequence
 
 
-DEVELOPMENT_SIGNING_IDENTITY = "atm-daemon-dev"
-_EXACT_IDENTITY_LINE = re.compile(
-    rf'^\s*\d+\)\s+\S+\s+"{re.escape(DEVELOPMENT_SIGNING_IDENTITY)}"\s*$'
+APPLE_DEVELOPMENT_PREFIX = "Apple Development"
+DEFAULT_TEAM_IDENTIFIER = "4869P2ZYC6"
+SIGNING_IDENTITY_ENVIRONMENT_VARIABLE = "ATM_SIGNING_IDENTITY"
+CLI_IDENTIFIER = "com.synapticcanvas.atm.cli"
+DAEMON_IDENTIFIER = "com.synapticcanvas.atm.daemon"
+WWDR_G3_INSTRUCTION = (
+    "Install Apple WWDR G3 from "
+    "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer, then retry."
 )
 
+_IDENTITY_LINE = re.compile(r'^\s*\d+\)\s+([0-9A-F]{40})\s+"(.+)"\s*$')
+_TEAM_IDENTIFIER = re.compile(r"(?:^|[,/])OU=([^,/]+)")
 
-def find_identity_output_has_development_identity(output: str) -> bool:
-    """Return whether ``security find-identity`` lists the exact development key."""
-    return any(_EXACT_IDENTITY_LINE.match(line) for line in output.splitlines())
+
+class SigningIdentityError(RuntimeError):
+    """The local Apple Development identity cannot safely sign ATM binaries."""
+
+
+@dataclass(frozen=True)
+class SigningIdentity:
+    """A keychain signing identity selected without machine-name metadata."""
+
+    fingerprint: str
+    common_name: str
+    team_identifier: str = ""
+
+
+def _run(command: Sequence[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        input=input_text,
+        text=True,
+        timeout=10.0,
+    )
+
+
+def parse_identities(output: str) -> tuple[SigningIdentity, ...]:
+    """Parse the valid identity rows emitted by ``security find-identity``."""
+    matches = (_IDENTITY_LINE.match(line) for line in output.splitlines())
+    return tuple(
+        SigningIdentity(match.group(1), match.group(2))
+        for match in matches
+        if match is not None
+    )
+
+
+def _certificate_team_identifier(common_name: str) -> str | None:
+    certificate = _run(["security", "find-certificate", "-c", common_name, "-p"])
+    if certificate.returncode != 0 or not certificate.stdout:
+        return None
+    subject = _run(
+        ["openssl", "x509", "-noout", "-subject", "-nameopt", "RFC2253"],
+        input_text=certificate.stdout,
+    )
+    if subject.returncode != 0:
+        return None
+    match = _TEAM_IDENTIFIER.search(subject.stdout)
+    return match.group(1) if match is not None else None
+
+
+def _valid_identities() -> tuple[SigningIdentity, ...]:
+    result = _run(["security", "find-identity", "-v", "-p", "codesigning"])
+    if result.returncode != 0:
+        return ()
+    return parse_identities(result.stdout)
+
+
+def _identity_with_team_identifier(identity: SigningIdentity) -> SigningIdentity | None:
+    team_identifier = _certificate_team_identifier(identity.common_name)
+    if team_identifier is None:
+        return None
+    return SigningIdentity(identity.fingerprint, identity.common_name, team_identifier)
+
+
+def _identity_exists_but_is_not_valid() -> bool:
+    result = _run(["security", "find-identity", "-p", "codesigning"])
+    return result.returncode == 0 and any(
+        identity.common_name.startswith(APPLE_DEVELOPMENT_PREFIX)
+        for identity in parse_identities(result.stdout)
+    )
+
+
+def resolve_apple_development_identity() -> SigningIdentity:
+    """Resolve one valid Apple Development identity, or fail with recovery."""
+    override = os.environ.get(SIGNING_IDENTITY_ENVIRONMENT_VARIABLE, "").strip()
+    valid_identities = _valid_identities()
+    if override:
+        candidates = tuple(
+            resolved
+            for identity in valid_identities
+            if override in {identity.fingerprint, identity.common_name}
+            if (resolved := _identity_with_team_identifier(identity)) is not None
+        )
+        if len(candidates) == 1:
+            return candidates[0]
+        raise SigningIdentityError(
+            f"{SIGNING_IDENTITY_ENVIRONMENT_VARIABLE} must identify exactly one valid signing identity."
+        )
+
+    candidates = tuple(
+        resolved
+        for identity in valid_identities
+        if identity.common_name.startswith(APPLE_DEVELOPMENT_PREFIX)
+        if (resolved := _identity_with_team_identifier(identity)) is not None
+        if resolved.team_identifier == DEFAULT_TEAM_IDENTIFIER
+    )
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates and _identity_exists_but_is_not_valid():
+        raise SigningIdentityError(
+            "Apple Development identity is installed but invalid. " + WWDR_G3_INSTRUCTION
+        )
+    raise SigningIdentityError(
+        "Expected exactly one valid Apple Development identity for team "
+        f"{DEFAULT_TEAM_IDENTIFIER}; found {len(candidates)}."
+    )
+
+
+def verify_apple_signature(
+    binary: str, expected_identifier: str, expected_team_identifier: str = DEFAULT_TEAM_IDENTIFIER
+) -> bool:
+    """Return whether one binary has the stable Apple Development signature."""
+    verification = _run(["codesign", "--verify", "--strict", binary])
+    if verification.returncode != 0:
+        return False
+    details = _run(["codesign", "-dvv", binary])
+    output = f"{details.stdout}\n{details.stderr}"
+    return details.returncode == 0 and all(
+        line in output.splitlines()
+        for line in (
+            f"Identifier={expected_identifier}",
+            f"TeamIdentifier={expected_team_identifier}",
+        )
+    )


### PR DESCRIPTION
Stacked on PR #975; do not merge directly to develop.

This replaces the self-signed macOS identity with Apple Development signing, stable CLI/daemon identifiers, strict team verification, WWDR recovery guidance, and a post-`just test` signing hook.

Validation completed locally: focused signing/switch tests; `just lint && just test` (exit 0); live M4 fresh-build daemon-switch and localhost/cross-host sends. M5 signing/DR evidence is pending its newly installed identity.