### PR TITLE
docs(ao2): AO2.5 benchmark-db-safety and daemon-switch launch-overlay plans

### DIFF
--- a/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
+++ b/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
@@ -1,0 +1,95 @@
+# ADR-052 — Benchmark Account Isolation and Snapshot Policy
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Scope | Physical benchmark execution and benchmark-account recovery |
+| Relates to | ADR-026, REQ-P-BENCHMARK-001, REQ-CORE-TRANSPORT-005B |
+
+## Context
+
+ADR-026 gives each OS user exactly one non-configurable
+`HostRuntimeScope`, including one daemon endpoint, locks, and durable SQLite
+root. `ATM_HOME` is configuration discovery only and cannot choose another
+runtime or durable-state root.
+
+The former physical admission benchmark nevertheless supported a
+managed-host path that renamed the interactive user's canonical
+`~/.atm/db` directory, substituted an empty database, then attempted to put
+the directory back. That directory swap caused the 2026-08-21 M4 data-loss
+incident. PR #977 retired the path and refuses it before daemon-switch or
+state mutation.
+
+The retained `atm teams backup` command captures selected-team recovery
+material. It is not a verified whole-host SQLite backup and does not make the
+interactive database safe to replace for benchmarking.
+
+## Decision
+
+Physical benchmarks run only under a dedicated, disposable benchmark OS
+account. That account is a separate ADR-026 `HostRuntimeScope` by virtue of
+being a separate OS user; it is not an alternate scope for the interactive
+user. The account name is supplied by an operator/bootstrap workflow and is
+never a hardcoded identity or hostname.
+
+The benchmark runner must validate an account-local manifest against the
+executing process before it can touch state or start a daemon. The manifest
+binds the benchmark workflow to the account's UID, home, canonical durable
+state path, and an account-local bootstrap token. Absence, malformed content,
+symlink traversal, ownership mismatch, or a mismatched executing account is a
+fail-closed preflight error.
+
+Only the benchmark account's canonical durable state may be reset or restored.
+Before destructive work, the runner creates a SQLite-consistent snapshot with
+the SQLite backup API, verifies integrity and manifest metadata, and publishes
+the manifest only after successful verification. A restore re-verifies the
+published snapshot, stages changes only in the benchmark account's durable
+state parent, and records machine-readable recovery evidence. Incomplete
+staging material is diagnostic evidence, never a restore candidate.
+
+The interactive account's canonical durable root is never a physical
+benchmark fixture. A benchmark must refuse before SQLite open, daemon-switch,
+rename, replacement, deletion, or daemon launch when it is not operating as
+the validated benchmark account. It must not solve isolation with `ATM_HOME`,
+an endpoint override, a symlink, a workspace path, or an additional daemon.
+
+Snapshot, reset, daemon startup, post-run restore, and verification run
+outside timed samples. Their evidence is retained separately; a result is
+invalid if any such work is included in the measured profile.
+
+This decision does not define a general backup/recovery command for the
+interactive account. That capability, if needed, requires its own operator
+requirements and ADR; team backup remains a selected-team recovery surface.
+
+## Consequences
+
+- A physical benchmark cannot clobber a live interactive ATM database.
+- The ordinary released CLI and Tokio/Axum `atm-http-runtime` daemon continue
+  to use the normal account-scoped endpoint and state path.
+- Benchmark restoration is recoverable and inspectable without pretending
+  that a directory rename is a backup.
+- Benchmark setup cannot be confused with application throughput, preserving
+  comparability of plaintext and mTLS evidence.
+
+## Rejected alternatives
+
+1. **Temporary `ATM_HOME` or an alternate database argument.** Rejected:
+   ADR-026 intentionally prohibits alternate runtime roots for one OS user.
+2. **Directory rename/copy as a primary-state backup.** Rejected: it is not a
+   verified SQLite snapshot and can leave state absent or stale after failure.
+3. **Use `atm teams backup` before replacing the database.** Rejected: it
+   backs up selected-team recovery data, not the whole host database.
+4. **Benchmark the interactive account but restore afterward.** Rejected:
+   recovery material is not authorization to disrupt a live account.
+
+## Required evidence
+
+- The interactive-account preflight refuses before any daemon or SQLite
+  operation.
+- A valid benchmark account can snapshot, verify, reset, restore, and prove
+  paired daemon health plus loopback delivery without touching another
+  account's state.
+- An interrupted snapshot cannot be restored and leaves the last verified
+  snapshot available.
+- Benchmark reports separately identify setup/restore durations and the timed
+  admission profile.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -56,6 +56,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-046 — Template-Declared Workflow Metadata And Admission Snapshots](./ADR-046-template-declared-workflow-metadata.md)
 - [ADR-049 — hermes-atm/atm-graft First Public PyPI Release Versioning](./ADR-049-hermes-atm-first-public-pypi-release-versioning.md)
 - [ADR-051 — Permissive Declared Sender Identity and Roster Advisory](./ADR-051-permissive-declared-sender-identity.md)
+- [ADR-052 — Benchmark Account Isolation and Snapshot Policy](./ADR-052-benchmark-account-isolation-and-snapshot-policy.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/plans/phase-ao2/sprint-AO2-5-3b-daemon-switch-launch-overlay.md
+++ b/docs/plans/phase-ao2/sprint-AO2-5-3b-daemon-switch-launch-overlay.md
@@ -1,0 +1,382 @@
+---
+phase: AO2
+sprint: AO2.5.3b
+title: Daemon-switch typed temporary launch overlay
+branch: pending-worktree-provisioning
+integration_branch: integrate/phase-ao2
+status: draft_for_review
+depends_on:
+  - ADR-047-layered-peer-wire-security
+  - ADR-052-benchmark-account-isolation-and-snapshot-policy
+  - PR-976-Apple-signing-migration
+blocks:
+  - AO2.5.4-harness-integration-and-evidence-schema
+  - AO2.5.5-physical-proof-and-rollback-drill
+---
+
+# AO2.5.3b — Daemon-switch typed temporary launch overlay
+
+## Decision summary
+
+`daemon-switch` needs one narrowly typed, crash-recoverable operational
+transaction for launching the already selected ATM CLI/daemon pair temporarily
+in `mutual-tls` or `plaintext-test` peer-wire mode.  It is a control-plane
+feature: it changes the managed service launch specification before a restart,
+then restores the exact prior specification.  It does not add a benchmark
+daemon, a child-process fallback, an environment selector, an alternate
+`HostRuntimeScope`, a second HTTP route, or any work to the admission hot path.
+
+AO2.5.4 must consume this capability rather than reimplementing per-platform
+service control in `run_admission_capacity.py`.  The harness will receive only
+typed evidence from `daemon-switch`; it may neither write a service file nor
+pass arbitrary daemon arguments.
+
+## Problem statement and root cause
+
+ADR-047 deliberately makes peer-wire security a process-local launch decision:
+normal startup defaults to mTLS and a bounded diagnostic/benchmark invocation
+may use only `--peer-wire-security plaintext-test`.  AO2.5 also requires a
+physical benchmark to use a managed, selected release pair and a dedicated
+benchmark OS account.  The current `daemon-switch` can switch/restart the pair,
+but it cannot temporarily alter the managed service's launch arguments.
+
+The retired harness attempted to bridge that gap with a direct daemon child and
+`ATM_HOME`-based setup.  That violates ADR-026's one canonical runtime scope,
+creates two lifecycle owners, and previously exposed the interactive database
+to replacement.  A macOS-only plist helper is not an adequate replacement:
+Windows service `binPath`, macOS LaunchAgent plists, and Linux systemd-user
+units have different configuration and rollback mechanics.
+
+The required capability is therefore an explicit cross-platform service
+configuration transaction.  If any platform's current service specification
+is unsupported or ambiguous, the tool must refuse before stopping the daemon;
+there is no direct-process or environment-based fallback.
+
+## Goals, scope, and non-goals
+
+### Goals
+
+1. Keep CLI and daemon selection paired and preserve the existing macOS signing
+   gate before every lifecycle-changing operation.
+2. Select exactly one typed wire mode: `mutual-tls` or `plaintext-test`.
+3. Capture enough durable state to recover the original service configuration
+   after interruption, process crash, reboot, or a failed restart.
+4. Give macOS, Windows, and Linux the same operator contract and structured
+   evidence even though their service mechanisms differ.
+5. Make a normal daemon restart mTLS again after successful restoration.
+
+### In scope
+
+- a `daemon-switch` temporary-launch session API and persisted recovery journal;
+- platform adapter implementations for a current-user macOS LaunchAgent, the
+  configured Windows SCM service, and systemd `--user` service;
+- atomic capture/restore, fail-closed validation, bounded stop/start/doctor
+  proofs, and a deliberate recovery command;
+- unit, adapter-contract, failure-injection, and platform smoke evidence;
+- requirements/ADR records and an architecture guard that keeps this feature
+  outside the ATM runtime/harness hot path.
+
+### Out of scope
+
+- changing `atm-http-runtime`, its router, `WriteRequest`, storage, TLS stream
+  adapter, post-write scheduling, or benchmark workload;
+- modifying the frozen synchronous daemon; all managed service launches target
+  the Tokio/Axum `atm-http-runtime` daemon binary;
+- arbitrary daemon arguments, arbitrary service edits, an operator-selected
+  endpoint/database root, an environment peer-wire selector, or a generic
+  service-management API;
+- automatic repair that guesses a missing original configuration;
+- execution of a physical benchmark.  AO2.5.4/5 own harness integration and
+  evidence after this capability is reviewed and implemented.
+
+## Governing contracts
+
+| Contract | Constraint carried into this sprint |
+| --- | --- |
+| ADR-026 | One OS user has one non-configurable durable root, lock ownership, endpoint, and daemon. A launch overlay cannot select an alternate one. |
+| ADR-047 / `REQ-CORE-TRANSPORT-002B1` | mTLS is default. `plaintext-test` is process-local, typed, non-durable, never environment-driven, and uses the identical HTTP/router/persistence path. |
+| ADR-052 / `REQ-P-BENCHMARK-001` | Only the dedicated benchmark account can run a physical benchmark; setup and lifecycle remain outside the timed interval. |
+| `REQ-P-PLATFORM-001/002` | macOS, Linux, and Windows have product-level parity; unsupported local service shapes fail clearly rather than silently omitting a platform. |
+| PR-976 signing migration | `daemon-switch` continues to require the available Apple Development signature for both selected binaries before macOS lifecycle mutation. |
+
+Before implementation, create and review **ADR-053 — Typed Temporary
+Daemon-Service Launch Overlay** and **`REQ-P-DAEMON-SWITCH-001`**.  They must
+state the transaction/recovery guarantees below and cross-link ADR-047,
+ADR-052, and `REQ-P-BENCHMARK-001`.  The requirement must not imply that
+plaintext is normal production configuration or that a benchmark has authority
+to modify an interactive account.
+
+## Operator contract
+
+The implementation exposes a purpose-built session rather than a generic
+argument-passthrough flag.  Exact subcommand spelling remains subject to
+ADR-053 review, but the command model is fixed:
+
+```text
+daemon-switch temporary-launch begin \
+  --peer-wire-security {mutual-tls,plaintext-test} --yes <normal selectors>
+daemon-switch temporary-launch quiesce --session <id> --yes <normal selectors>
+daemon-switch temporary-launch restart --session <id> --yes <normal selectors>
+daemon-switch temporary-launch restore --session <id> --yes <normal selectors>
+daemon-switch temporary-launch recover --session <id> --yes <normal selectors>
+```
+
+`<normal selectors>` means the existing explicit selected CLI link, selected
+daemon link, service name, and (on macOS) LaunchAgent plist selector.  The
+session API cannot infer a different endpoint, service, account, or binary.
+
+`begin` validates the selected matching pair, captures the original service
+configuration, durably records the session, stops the singleton, applies the
+typed overlay, starts the same selected pair, and waits for `atm doctor --json`
+to prove pair/version and selected wire mode.  `quiesce` stops only that
+session's daemon.  `restart` requires the matching active session and starts
+the overlay service after the normal stop proof.  `restore` stops the overlay,
+restores the exact captured original service configuration, removes only the
+owned overlay after durable verification, starts the selected pair normally,
+and proves doctor reports mTLS/default state.
+
+`recover` is intentionally not implicit.  A later invocation that sees an
+unfinished session refuses normal `switch`, `restart`, or a second `begin` and
+prints the one exact recovery command.  This prevents a later agent from
+overwriting the only restoration evidence.  It also makes an interrupted
+session visible before a benchmark can run.
+
+The session returns one JSON evidence object: session ID, selected pair
+versions/hashes, platform adapter, service identifier, original/overlay
+configuration digests (never secrets), requested/doctor-observed wire mode,
+each lifecycle phase's monotonic duration, and recovery disposition.
+
+## Transaction and recovery state machine
+
+The recovery journal is an owned file below the existing per-user
+`daemon-switch` state directory, separate from the saved default binary pair.
+It is written through a private atomic-write helper: private parent directory,
+temporary same-directory file, file fsync, atomic replace, then parent-directory
+fsync where supported.  Journal files are owner-only.  They retain only the
+minimum original service material required for exact restoration (a source
+path/digest on macOS/Linux and the exact `binPath` scalar on Windows); exported
+evidence contains digests and redacted metadata only.  They never record
+private keys, certificate contents, or raw trust records.
+
+| Phase | Durable journal before mutation | Required proof to advance | Failure disposition |
+| --- | --- | --- | --- |
+| `captured` | session ID, account/service identity, selected pair digest, typed mode, original configuration bytes/path or raw `binPath`, original digest | source configuration is owned, unambiguous, and matches selected service | no daemon stop; leave journal and report refusal/recovery |
+| `stopped` | `captured` plus stop intent | service unloaded/stopped and singleton owner absent | leave service stopped; `recover` uses original capture |
+| `overlay_applied` | overlay location/raw config and digest, while original remains intact | overlay digest and service-manager reload/check succeed | do not start; `recover` restores original |
+| `overlay_started` | start attempt and selected pair identity | doctor proves matched pair and requested mode | bounded stop then `recover`; never repoint to a different pair |
+| `quiesced` | session remains active, service state stopped | singleton absent | session can `restart` or `restore` |
+| `restoring` | original digest and overlay removal intent | original config restored exactly and manager reload/check succeeds | retain journal and diagnostic artifacts; service remains stopped |
+| `completed` | completion evidence only after normal start/doctor proof | matched pair and default mTLS observed | atomically delete active-session journal; retain non-secret evidence |
+
+The original specification is immutable recovery material.  Every operation
+checks the expected digest before replacing or deleting an owned overlay.
+Digest mismatch, missing journal, conflicting active session, a different
+service identifier, a changed selected pair, a running unexpected daemon, or
+ambiguous command shape is a typed fail-closed error.  It must not "best
+effort" append an argument, start a child process, or clean up unknown files.
+
+## Platform adapter design
+
+All adapters implement one private control-plane boundary, conceptually
+`CapturedLaunchSpec`, `apply_overlay(mode)`, `restore_exact()`, and
+`inspect()`.  The boundary accepts the typed `PeerWireSecurity` value, never
+raw argument text.  It owns external command/file I/O and produces structured
+redacted evidence; `daemon-switch` owns state-machine ordering and pair/doctor
+validation.
+
+### macOS — controlled LaunchAgent overlay
+
+1. Require the existing `--launch-agent-plist` and verify it is a regular,
+   readable, current-user-owned file with a recognized launchd label and an
+   unambiguous `ProgramArguments` array for the selected Tokio/Axum daemon.
+2. Read and hash the original bytes without modifying them.  Reject duplicate,
+   malformed, or pre-existing `--peer-wire-security` values rather than trying
+   to normalize an unknown plist.
+3. Render an owned overlay plist in the daemon-switch state directory by
+   copying the accepted plist structure and adding precisely one rendered
+   typed argument.  Preserve every unrelated key/value exactly at the plist
+   data-model level; no shell command string is involved.
+4. Persist `captured`, `bootout` the original LaunchAgent, prove it unloaded,
+   then `bootstrap` the overlay plist and prove launchd loaded that exact
+   overlay path.  The normal source plist is never rewritten.
+5. Restore by booting out the overlay, verifying the original byte hash has
+   not changed, bootstrapping the original plist path, doctor-proving normal
+   mTLS, and only then deleting the owned overlay/journal.
+
+If an operator changed the original plist during the session, restore stops
+and retains the overlay/journal for inspection; it must never overwrite that
+operator change.
+
+### Windows — SCM `binPath` transaction
+
+1. Query the named configured ATM service with `sc.exe qc`; capture the raw
+   `BINARY_PATH_NAME` result and a digest before stopping it.  Prove that the
+   service exists and is an unambiguous invocation of the selected daemon.
+2. Parse/render the command line with a dedicated Windows argv codec whose
+   round-trip behavior is tested against Windows quoting cases.  It rejects
+   duplicate/pre-existing peer-wire arguments and unsupported service wrappers
+   rather than using a shell append.
+3. Build the overlay `binPath` from the validated argv plus exactly one typed
+   peer-wire option.  Store both raw original and generated raw overlay values
+   in the journal; run `sc.exe config` only after `stopped` is durable.
+4. Start through SCM and prove doctor observes the selected pair/mode.  On
+   restore, stop first, confirm the currently installed raw `binPath` equals
+   the owned overlay digest, then set the exact original raw string and start
+   normally.
+
+No service description, account, start type, failure action, or unrelated SCM
+field is changed.  If service administration privileges are unavailable or
+the current installed value does not match expected state, the command fails
+without a direct-process alternative.
+
+### Linux — systemd user-unit drop-in
+
+1. Require a named `systemd --user` service and inspect its resolved unit plus
+   current `ExecStart`.  Support only one explicit ATM daemon command shape
+   that the adapter can parse and render losslessly; reject multiple commands,
+   shell indirection, environment-file selection, template ambiguity, or a
+   pre-existing peer-wire argument.
+2. Preserve the source unit identity and `ExecStart` digest.  Generate only an
+   owned drop-in beneath the user's systemd configuration directory, with an
+   `ExecStart=` reset followed by the validated base invocation and exactly one
+   typed security option.  Record the drop-in path/digest before
+   `daemon-reload`.
+3. Stop, reload, start, and doctor-prove the selected pair/mode.  Restore
+   stops the service, verifies the owned drop-in digest, removes only that
+   drop-in, reloads, starts normal service state, and doctor-proves mTLS.
+
+The adapter cannot rewrite the base unit or consume an arbitrary systemd
+override graph.  Ambiguity is a supported refusal with remediation guidance,
+not a reason to weaken the control-plane boundary.
+
+## Work breakdown and dependency DAG
+
+```text
+AO2.5.3b.1 requirements + ADR-053
+       │
+       ├── AO2.5.3b.2 shared journal/state machine + typed CLI
+       │       ├── AO2.5.3b.3 macOS adapter
+       │       ├── AO2.5.3b.4 Windows adapter
+       │       └── AO2.5.3b.5 Linux adapter
+       │                    │
+       └────────── AO2.5.3b.6 cross-platform contract/failure tests
+                              │
+                       AO2.5.3b.7 physical adapter proofs + review
+                              │
+                      unblocks AO2.5.4 harness integration
+```
+
+1. **Requirements and ADR decision.** Add ADR-053, `REQ-P-DAEMON-SWITCH-001`,
+   traceability links, error/recovery vocabulary, and this plan's reviewed
+   command/session contract.  No implementation before this closes.
+2. **Shared control-plane session.** Refactor only
+   `.claude/skills/daemon-switch/scripts/daemon-switch.py` and its direct
+   tests.  Add typed parsing, strict selector/pair/signature preflight,
+   durable state journaling, evidence schema, and recovery gate.  Do not alter
+   the daemon binary or benchmark runner.
+3. **macOS adapter.** Implement plist capture/owned overlay/restore and unit
+   tests using temporary plists plus a fake launchctl boundary.  Then perform a
+   fresh signed release-pair loopback proof with no primary-database access.
+4. **Windows adapter.** Implement SCM capture/quoted argv/restore using a fake
+   `sc.exe` boundary and Windows-native tests.  A real fastpc4 proof is
+   required before it is called supported.
+5. **Linux adapter.** Implement narrow systemd-user unit/drop-in support using
+   a fake `systemctl` boundary and Linux-native tests.  A real user-service
+   proof is required before it is called supported.
+6. **Failure/recovery matrix.** For every transition point, inject failure and
+   verify either no mutation occurred or the exact original configuration is
+   recoverable from retained journal material.  Verify a second session and
+   normal switch/restart are blocked while an active journal exists.
+7. **Review and handoff.** Run `just lint`, `just test`, all adapter contract
+   tests, platform-specific real service proof, and a final architecture sweep.
+   QA must inspect the raw session evidence and source/destination configuration
+   digests.  Only then may AO2.5.4 receive a worktree/task assignment.
+
+## Acceptance criteria and test matrix
+
+| Case | macOS | Windows | Linux | Required result |
+| --- | --- | --- | --- | --- |
+| Normal mTLS begin/restore | LaunchAgent overlay | SCM binPath | systemd-user drop-in | paired doctor proves mTLS; exact source configuration restored |
+| Plaintext-test begin/restore | same | same | same | doctor/log/evidence prove plaintext only during active session |
+| Invalid mode / raw option | parser | parser | parser | rejected before service/configuration mutation |
+| Existing/duplicate mode argument | plist validation | argv validation | ExecStart validation | rejected before stop |
+| Capture failure | source read | `sc qc` | unit inspection | no stop and no overlay |
+| Overlay write/config failure | staged plist | `sc config` | drop-in/reload | journal preserves original and daemon remains/recoverably stops |
+| Start/doctor failure | bootstrap | SCM start | systemd start | bounded stop; journal supports exact recovery |
+| Crash after each journal phase | fake boundary | fake boundary | fake boundary | next command refuses normal lifecycle and `recover` restores exactly |
+| Operator source change | source hash change | raw binPath mismatch | drop-in/base mismatch | no overwrite; retained actionable recovery evidence |
+| Pair/signature mismatch | selected-pair gate | selected-pair gate | selected-pair gate | no service mutation |
+| Runtime/performance guard | static boundary test | static boundary test | static boundary test | no `atm-http-runtime` admission/persistence/router change; no timing work in profile |
+
+The shared test suite treats `ResourceWarning` as an error, tests atomic journal
+failure paths, and validates that the evidence is redacted.  CI runs the
+platform-neutral suite on every OS; macOS/Windows/Linux use their native
+adapter tests.  Physical proofs use only the disposable benchmark OS account
+and must prove a curl receiver check, CLI loopback send/read, and same-host
+send/read after both mTLS and plaintext-test sessions.  Cross-host proofs are
+AO2.5.5 work, not a prerequisite for this control-plane implementation.
+
+## Performance-regression prevention
+
+This feature must be mechanically absent from the admission pipeline.  It runs
+only before/after a physical profile and only in `daemon-switch`, so it must
+not add a per-request branch, logging call, TLS construction, filesystem read,
+or environment lookup to plaintext admission.  A static architecture test
+shall reject imports/calls from `atm-http-runtime`, direct-peer connector,
+router, persistence, and benchmark `run_profile` into the temporary-launch
+module.
+
+AO2.5.4 records lifecycle setup/teardown with monotonic timestamps outside its
+timed samples.  Its result is invalid if a session start, stop, snapshot,
+restore, doctor, or evidence write overlaps `run_profile`.  AO2.5.3b itself
+does not claim any throughput result.
+
+## Rollback and operational recovery
+
+Code rollback reverts the `daemon-switch` feature; it does not revert
+ADR-047's mTLS default or weaken PR-977's primary-database refusal.  An active
+session is operationally recovered with the persisted `recover` command:
+
+1. validate journal version, account/service identity, selected pair, and
+   original/overlay digests;
+2. stop the known managed service and prove singleton absence;
+3. restore only the exact captured service configuration;
+4. reload the OS service manager where required;
+5. start the existing selected pair normally and doctor-prove mTLS; and
+6. retain redacted evidence before deleting the active journal.
+
+If any step cannot prove its precondition, it leaves the service stopped and
+the journal/artifacts retained.  The tool reports the failed phase and precise
+manual inspection path.  It never changes an unknown service configuration,
+starts another daemon, or touches SQLite.
+
+## Boundary review and rejection criteria
+
+- **Daemon runtime boundary:** only the Tokio/Axum `atm-http-runtime` daemon is
+  selected/launched.  Any proposal to revive or patch the synchronous legacy
+  daemon is rejected and routed to the AL.5–AL.7 cutover work.
+- **CLI/daemon pair boundary:** `daemon-switch` retains exclusive lifecycle
+  ownership; the harness calls it but never owns child processes or platform
+  service files.
+- **Security boundary:** only typed command parsing constructs `PeerWireMode`.
+  Environment variables, durable config, certificate availability, and TLS
+  errors cannot choose plaintext or fall back to it.
+- **State boundary:** the feature journals service configuration only.  It has
+  no SQLite, roster, message, trust-store, or credential mutation authority.
+- **Platform boundary:** every OS adapter is narrow and lossless for its
+  accepted managed-service shape.  The tool rejects unknown shapes rather than
+  exposing a generic edit facility.
+
+Any implementation that weakens one of these boundaries, embeds a hostname or
+account name, changes a public ATM HTTP request/response path, or introduces a
+benchmark-only daemon is out of scope and requires a new ADR/plan review.
+
+## Review checkpoints
+
+Before implementation, reviewers must confirm that the plan is self-contained,
+that its DAG has no cycle, that each platform adapter restores a captured
+original rather than a synthesized default, and that no requirement permits an
+interactive-account service mutation.  After the requirements/ADR pass,
+perform architecture, platform, security, and failure-recovery reviews before
+the first code task.  AO2.5.4 remains blocked until all of those review gates
+pass.

--- a/docs/plans/phase-ao2/sprint-AO2-5-benchmark-primary-db-safety.md
+++ b/docs/plans/phase-ao2/sprint-AO2-5-benchmark-primary-db-safety.md
@@ -1,0 +1,204 @@
+---
+phase: AO2
+sprint: AO2.5
+title: Physical benchmark primary-database safety
+branch: fix/benchmark-primary-db-safety
+integration_branch: integrate/phase-ao2
+status: draft_for_review
+depends_on:
+  - PR-977-scoped-live-database-guard
+blocks:
+  - AO2.6-admission-writer-batching-regression-live-evidence
+---
+
+# AO2.5 — Physical benchmark primary-database safety
+
+## Decision summary
+
+The physical admission benchmark must never rename, replace, delete, restore,
+or otherwise mutate the current interactive OS user's `~/.atm/db` tree. It
+must run only as a dedicated benchmark OS user whose canonical
+`HostRuntimeScope` is intentionally disposable. A durable, verified snapshot
+of that benchmark user's state is required before any destructive reset or
+restore in that account. A snapshot is evidence and recovery material; it is
+not authorization to touch the primary database.
+
+## Problem statement and root cause
+
+`scripts/smoke/run_admission_capacity.py` formerly implemented the
+`ATM_CAPACITY_BACKUP_RESTORE_HOST_STATE=1` path by renaming the current OS
+user's `~/.atm/db` to a transient sibling and creating an empty replacement.
+The recovery path then removed that replacement and renamed the transient
+directory back. This is a directory swap, not a durable backup: interruption,
+operator error, or a later move can leave the primary state absent or stale.
+It caused the 2026-08-21 M4 data-loss incident.
+
+PR #977 is the immediate containment change: it removes the public
+managed-host flags and makes the runner refuse both the environment escape
+hatch and every managed-daemon lifecycle before it can call `daemon-switch`.
+It does not implement the durable benchmark-account workflow described here.
+
+ADR-026 requires a single non-configurable `HostRuntimeScope` for each OS
+user. An `ATM_HOME` override is not, and must never become, a way to select a
+different SQLite root. The design must therefore isolate by OS account, not by
+workspace path, symlink, environment variable, or an extra daemon endpoint.
+
+## Scope and non-goals
+
+In scope:
+
+- an explicit, cross-platform operator workflow for a disposable benchmark OS
+  account;
+- durable snapshot, verification, and restore of that account's canonical
+  SQLite state;
+- benchmark harness preflight and evidence proving which OS account and state
+  policy were used;
+- failure-safe cleanup and operator recovery instructions.
+
+Out of scope:
+
+- any move, replacement, or restart of the interactive user's ATM database or
+  daemon;
+- alternate `HostRuntimeScope` roots, endpoint overrides, or a second daemon
+  for one OS user;
+- TLS, HTTP, writer batching, or benchmark throughput changes;
+- automatic recovery of the already-lost M4 data.
+
+## Required design
+
+### 1. Dedicated benchmark account contract
+
+Introduce a checked benchmark-account manifest owned by the account bootstrap
+workflow. It records only portable facts: account home, numeric account ID,
+canonical durable-state path, creation time, and a random account-local token.
+The runner validates all of them against the executing process before it can
+open a database or start a daemon. The account name is an operator parameter,
+never a hardcoded hostname or username.
+
+The runner fails closed when:
+
+- the manifest is absent, malformed, symlinked, not owned by the executing
+  account, or does not match its home/UID;
+- an ambient ATM daemon belongs to that account before a clean-run preflight;
+- its canonical durable-state root contains data without a completed verified
+  snapshot; or
+- the process is the interactive account, as established by the bootstrap
+  manifest rather than an environment assertion.
+
+The physical invocation launches the released CLI and Tokio/Axum
+`atm-http-runtime` daemon as that benchmark account. It uses the ordinary
+ADR-026 root for that user. No benchmark argument changes the durable root,
+lock path, HTTP endpoint, or daemon ownership semantics.
+
+### 2. Durable benchmark-account snapshot protocol
+
+Before resetting or restoring the disposable account, the tool must:
+
+1. Stop only the benchmark account's daemon through the normal paired
+   `daemon-switch` workflow and verify it is stopped.
+2. Create a SQLite-consistent snapshot in a sibling staging directory using
+   the SQLite backup API (never directory rename), then fsync the snapshot and
+   its manifest.
+3. Verify `PRAGMA quick_check`, schema version, page count, byte count, and
+   SHA-256 recorded in the manifest.
+4. Atomically publish the completed snapshot manifest only after verification.
+   Incomplete staging material is never a restore candidate.
+5. On restore, verify the snapshot again, stage a replacement only within the
+   benchmark account's durable-state parent, atomically activate it, restart
+   that same account's selected CLI/daemon pair via `daemon-switch`, and prove
+   `atm doctor --json` plus a loopback send/read.
+
+Every step reports machine-readable evidence with snapshot ID, account UID,
+hash, verification result, daemon pair, and rollback status. The cleanup path
+must preserve failed staging material for diagnosis; it must not silently
+delete the last verified snapshot.
+
+### 3. Primary-data backup policy
+
+The benchmark command never backs up or restores the interactive primary
+database. AO2.5 will separately document the supported operator-owned whole
+host backup/recovery command and its verification contract, because the
+existing team backup is a selected-team recovery surface rather than a
+benchmark safety mechanism. That work requires an ADR/requirements decision
+before implementation. No physical benchmark is unblocked by an unverified
+primary snapshot.
+
+## Performance-regression prevention
+
+The risk is accidental benchmark distortion: synchronous copying, hashing,
+fsync, database checkpoints, lock contention, or daemon startup inside the
+timed admission profile can lower measured throughput and be mistaken for an
+application regression.
+
+Mitigation:
+
+- perform snapshot/verification, reset, daemon startup, and post-run restore
+  outside the timed profile;
+- timestamp each phase in raw evidence and exclude it from `run_profile`;
+- run the released daemon with the existing public HTTP admission boundary;
+- add no storage, TLS, or HTTP work to a timed write; and
+- fail a run rather than reuse a dirty account or silently skip verification.
+
+Measurement is required on the same fixed harness and hardware for
+`just benchmark --target tcp` (plaintext-test) and
+`just benchmark --target tcp-tls` (mutual TLS). Retain raw and compact
+artifacts, report p50/p95/p99/throughput and snapshot phase durations, and
+compare plaintext f64 throughput to the approved approximately 17k msg/s
+same-host baseline. Snapshot work must not appear within the measured interval;
+if it does, the result is invalid rather than a performance result.
+
+## Work breakdown and dependencies
+
+1. **AO2.5.1 — Requirements/ADR decision** (no code): reconcile ADR-026 and
+   the retained backup requirements with the benchmark-account model; explicitly
+   forbid live-root benchmark mutation. Blocks all implementation.
+2. **AO2.5.2 — Account bootstrap and manifest validation:** implement the
+   portable account-local manifest and fail-closed preflight. Depends on 1.
+3. **AO2.5.3 — Snapshot/restore transaction:** implement the verified SQLite
+   snapshot/staging/atomic-activation protocol for the benchmark account only.
+   Depends on 1 and 2.
+4. **AO2.5.4 — Harness integration and evidence schema:** make `just benchmark`
+   use the account workflow and retain phase evidence outside timed samples.
+   Depends on 2 and 3.
+5. **AO2.5.5 — Physical proof and rollback drill:** run plaintext and mTLS on
+   M4, M5, and Windows when available; restore the benchmark account after an
+   injected failure. Depends on 4.
+
+## Acceptance criteria and test matrix
+
+| Case | Required proof |
+| --- | --- |
+| Interactive account | Preflight refuses before `daemon-switch`, SQLite open, rename, remove, or daemon start. |
+| Missing/tampered manifest | Preflight fails with recovery guidance and no state mutation. |
+| Snapshot success | Hash, SQLite integrity, manifest fsync/publication, and retained evidence pass. |
+| Interrupted snapshot | No completed manifest; restore refuses it; last completed snapshot remains intact. |
+| Restore success | Only benchmark-account files change; doctor and loopback send/read pass after paired restart. |
+| Restore failure | Daemon remains stopped or returns to last verified snapshot; evidence names the recovery action. |
+| Timed benchmark | Plaintext and mTLS artifacts show setup/restore outside the timed interval. |
+| Physical platforms | M4, M5, and fastpc4/Windows evidence records the benchmark account and result. |
+
+Required gates: focused unit tests, `just lint`, `just test`, static search
+guard against primary-root move/delete operations in the harness, then a live
+benchmark-account smoke before QA. QA receives raw evidence and exact commit,
+not only a textual claim.
+
+## Rollback and recovery
+
+Implementation rollback is a normal code revert: PR #977's hard refusal stays
+in place. Operational rollback stops the benchmark account daemon, restores
+only its last completed verified snapshot, verifies integrity, then runs paired
+`daemon-switch` plus doctor and loopback proof. A failure never triggers a
+primary-user restore attempt. Operators receive the preserved snapshot/staging
+paths and the exact failed phase.
+
+## Boundary and ADR impact review
+
+- **`atm-http-runtime`:** used only as the ordinary released daemon target;
+  this sprint must not modify its HTTP or TLS admission path.
+- **`atm-storage-rusqlite`:** snapshot implementation may use SQLite backup
+  facilities, but must not alter the writer hot path.
+- **daemon/CLI boundary:** paired start/stop remains `daemon-switch` for the
+  benchmark account only; no new controller or second daemon design.
+- **ADR-026:** requires an ADR/requirements clarification before code because
+  the account manifest and durable snapshot policy are operational policy,
+  while the single-root invariant remains unchanged.

--- a/docs/plans/phase-ao2/sprint-AO2-5-benchmark-primary-db-safety.md
+++ b/docs/plans/phase-ao2/sprint-AO2-5-benchmark-primary-db-safety.md
@@ -159,10 +159,23 @@ if it does, the result is invalid rather than a performance result.
    Depends on 1 and 2.
 4. **AO2.5.4 — Harness integration and evidence schema:** make `just benchmark`
    use the account workflow and retain phase evidence outside timed samples.
-   Depends on 2 and 3.
+   Depends on 2, 3, and AO2.5.3b's reviewed `daemon-switch` typed temporary
+   launch-overlay capability.
 5. **AO2.5.5 — Physical proof and rollback drill:** run plaintext and mTLS on
    M4, M5, and Windows when available; restore the benchmark account after an
    injected failure. Depends on 4.
+
+### AO2.5.4 daemon-switch dependency
+
+The cross-platform managed-service launch overlay is intentionally owned by
+[AO2.5.3b](./sprint-AO2-5-3b-daemon-switch-launch-overlay.md), not by the
+benchmark harness.  AO2.5.4 may consume only its reviewed typed session API
+and returned evidence.  It must not start a child daemon, alter a platform
+service file, set an environment selector, choose an alternate endpoint/root,
+or pass arbitrary daemon arguments.  Snapshot, roster setup, daemon
+transitions, and restore remain timed phases with monotonic start/end
+timestamps; `run_profile` starts only after the post-snapshot doctor proof and
+ends before quiesce/restore.
 
 ## Acceptance criteria and test matrix
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2857,6 +2857,35 @@ Required testing architecture:
   - ordinary runtime logging must remain quiet enough that routine send/read/
     ack success does not clutter normal operator logs
 
+- `REQ-P-BENCHMARK-001` Physical performance benchmarks must preserve the
+  interactive OS user's canonical ATM state.
+
+  Required behavior:
+  - a physical benchmark runs only as a dedicated, disposable benchmark OS
+    account whose `HostRuntimeScope` is independently derived for that account;
+    it must not select an alternate root, endpoint, lock, or daemon through
+    `ATM_HOME`, environment variables, symlinks, a workspace path, or a
+    second daemon for the interactive account
+  - the benchmark runner must refuse before daemon-switch, SQLite open,
+    destructive filesystem work, or daemon start unless the executing account
+    proves its benchmark-account contract and canonical state policy
+  - the current interactive OS user's `~/.atm/db` tree must never be renamed,
+    replaced, deleted, restored, or used as a physical benchmark fixture
+  - destructive benchmark-account reset or restore requires a completed,
+    verified SQLite-consistent snapshot made with the SQLite backup API; the
+    snapshot manifest records integrity evidence and incomplete snapshots are
+    never restore candidates
+  - setup, snapshot verification, reset, daemon lifecycle, and post-run
+    restoration occur outside the timed benchmark interval; evidence records
+    their durations separately and invalidates a result if they contaminate a
+    timed sample
+  - `atm teams backup` is selected-team recovery material, not a whole-host
+    database backup and not authorization for a benchmark to mutate the
+    interactive user's durable SQLite state
+
+  This requirement is governed by ADR-052 and composes with ADR-026's one
+  `HostRuntimeScope` per OS user.
+
 - `REQ-P-COVERAGE-001` Coverage reporting must remain separate from ordinary
   test execution.
 
@@ -4164,9 +4193,11 @@ mail correctness.
     immutable SQLite records and enabled peer policy
   - the throughput requirement applies while the destination peer is
     unavailable as well as healthy. Release evidence runs ten consecutive
-    one-second admission intervals against one release-built daemon using a
-    disposable isolated `ATM_HOME` and SQLite database; it must never run
-    against a shared or production ATM store. Each interval has at least 1,000
+    one-second admission intervals against one release-built daemon under the
+    dedicated disposable benchmark OS account required by
+    `REQ-P-BENCHMARK-001`; `ATM_HOME` and any other path/config setting must
+    not select its SQLite root. It must never run against a shared or
+    interactive-production ATM store. Each interval has at least 1,000
     accepted requests and responses. Mock routers, direct dispatcher calls,
     and disabled peer delivery do not satisfy this evidence
   - Unix release evidence records HTTP/UDS and loopback-TCP results separately;


### PR DESCRIPTION
## Summary
Retroactive plan-doc PR for AO2.5, cherry-picked off fix/benchmark-primary-db-safety where they were authored alongside dev work. Per standing convention, plan docs target develop directly.

- ADR-052: benchmark account isolation and snapshot policy (root-causes the M4 data-loss incident; PR #977 already retired the offending directory-rename path).
- AO2.5 sprint plan: benchmark primary-db safety.
- AO2.5.3b sprint plan: daemon-switch typed temporary-launch overlay (split out mid-sprint after a user-directed architecture decision).

Both reviewed and approved by team-lead; AO2.5.3b plan also independently reviewed and approved by quality-mgr before dev work began.

## Test plan
Docs only, no code change. N/A.