### PR TITLE
build: centralize pinned bootstrap tooling ('just bootstrap')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,38 +57,18 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-
-      - name: Install sc-compose CLI
-        # Template JSON escaping requires the released sc-compose 1.4.0 API.
-        # Keep this pin aligned with .claude/lib/sc_compose_dependency.py.
-        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+          python-version: "3.14.7"
 
       - name: Expose Cargo binaries on PATH
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
       - name: Install just
-        uses: taiki-e/install-action@just
-
-      - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.19.9
+          tool: just@1.58.0
 
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
-
-      - name: Install cargo-shear
-        uses: taiki-e/install-action@cargo-shear
-
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@cargo-binstall
-
-      - name: Install cargo-modules
-        run: cargo binstall cargo-modules@0.26.0 --no-confirm
-
-      - name: Install Python lint dependencies
-        run: python -m pip install codespell 'pydantic>=2.12,<3'
+      - name: Bootstrap exact repository tools
+        run: just bootstrap
 
       - name: Run just lint
         run: just lint
@@ -191,18 +171,21 @@ jobs:
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.7"
 
-      - name: Install Python test dependencies
+      - name: Install just
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: python -m pip install 'pydantic>=2.12,<3'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.58.0
 
-      - name: Install sc-compose CLI for passthrough parity tests
-        # The AN.7 process-level tests compare the ATM command with the
-        # pinned upstream CLI on every platform, so the test lane needs the
-        # same source revision already used by just-lint.
+      - name: Expose Cargo binaries on PATH
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
+        run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
+
+      - name: Bootstrap exact repository tools
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        run: just bootstrap
 
       - name: Cache cargo registry
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
@@ -258,10 +241,6 @@ jobs:
       - name: Run ATM CLI surface compatibility contract
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: cargo test -p agent-team-mail --features cli-surface-dump --test cli_surface --verbose
-
-      - name: Install Maturin for Hermes graft bridge tests
-        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: python -m pip install maturin
 
       - name: Download host release-wheel candidate
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
@@ -371,7 +350,7 @@ jobs:
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
           command: build
-          maturin-version: v1.11.5
+          maturin-version: v1.14.1
           rust-toolchain: "1.94.1"
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
@@ -481,7 +460,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Maturin
-        run: python -m pip install maturin
+        run: python -m pip install maturin==1.14.1
 
       - name: Build atm-graft source distribution
         run: maturin sdist --manifest-path crates/atm-graft-python/Cargo.toml --out dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Test admission-capacity benchmark runner
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: python -m unittest scripts/smoke/test_run_admission_capacity.py
+        run: just test-admission-capacity
 
       - name: Run graft receiver crash/reclaim proof
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
@@ -381,7 +381,7 @@ jobs:
         if: ${{ matrix.smoke == 'native' }}
         shell: bash
         run: |
-          python -m pip install 'pydantic>=2,<3'
+          python -m pip install --disable-pip-version-check --no-deps --requirement tools/bootstrap-requirements.txt
           python -m pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
           python -c "import atm_graft, hermes_atm"
 
@@ -395,7 +395,7 @@ jobs:
             python:3.11-alpine \
             sh -euxc '
               python -m venv /tmp/atm-wheel-smoke
-              /tmp/atm-wheel-smoke/bin/pip install --disable-pip-version-check "pydantic>=2,<3"
+              /tmp/atm-wheel-smoke/bin/pip install --disable-pip-version-check --no-deps --requirement /workspace/tools/bootstrap-requirements.txt
               /tmp/atm-wheel-smoke/bin/pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
               /tmp/atm-wheel-smoke/bin/python -c "import atm_graft, hermes_atm"
             '
@@ -432,7 +432,7 @@ jobs:
 
       - name: Install and test abi3 wheel pair
         run: |
-          python -m pip install 'pydantic>=2,<3'
+          python -m pip install --disable-pip-version-check --no-deps --requirement tools/bootstrap-requirements.txt
           python -m pip install --no-deps dist/atm_graft*.whl dist/hermes_atm*.whl
           python -c "import atm_graft, hermes_atm"
           python -m unittest discover -s crates/hermes-atm/tests -p "test_*.py"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -47,35 +47,18 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-
-      - name: Install Python validation dependencies
-        run: python -m pip install codespell 'pydantic>=2.12,<3'
-
-      - name: Install sc-compose CLI
-        # Template JSON escaping requires the released sc-compose 1.4.0 API.
-        # Keep this pin aligned with .github/workflows/ci.yml.
-        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+          python-version: "3.14.7"
 
       - name: Install just
-        uses: taiki-e/install-action@just
-
-      - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.19.9
+          tool: just@1.58.0
 
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+      - name: Expose Cargo binaries on PATH
+        run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
-      - name: Install cargo-shear
-        uses: taiki-e/install-action@cargo-shear
-
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@cargo-binstall
-
-      - name: Install cargo-modules
-        run: cargo binstall cargo-modules@0.26.0 --no-confirm
+      - name: Bootstrap exact repository tools
+        run: just bootstrap
 
       - name: Normalize version input
         id: meta

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Cargo.toml.ci
 # Python bytecode caches
 **/__pycache__/
 scripts/__pycache__/
+.bootstrap-venv/
 
 # Local Synaptic Canvas orchestration state: retain it locally for agent
 # history/status, but never treat it as repository content.

--- a/.just/lint_cargo_deny.py
+++ b/.just/lint_cargo_deny.py
@@ -25,9 +25,9 @@ DNS_RESOLUTION_FAILURE_MARKER = "could not resolve hostname"
 def build_command(repo_root: Path, config_path: Path) -> list[str]:
     return [
         "cargo-deny",
-        "check",
         "--config",
         str(config_path),
+        "check",
         "advisories",
         "bans",
         "licenses",

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -9,6 +9,7 @@ SECTIONS = (
         "General",
         (
             ("help", "Show this help."),
+            ("bootstrap", "Install and verify the exact pinned CI tool contract."),
             ("build", "Build the full workspace."),
             ("test", "Run the full workspace test suite."),
             ("clean", "Remove workspace build artifacts."),

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -19,6 +19,13 @@ from lint_common import workspace_crate_section_lines
 from lint_common import write_log
 
 
+if sys.platform == "win32":
+    # Cross-host diagnostics may contain Unicode that the legacy Windows
+    # console code page cannot encode.
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+
 PYTHON_LINT_ORDER = (
     "version",
     "boundaries",

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -110,6 +110,18 @@ class BootstrapTests(unittest.TestCase):
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
         self.assertIn("$PWD/.bootstrap-venv/bin:$PATH", justfile)
         self.assertIn("PYO3_PYTHON", justfile)
+        self.assertIn(
+            "test-admission-capacity:\n"
+            "    {{python_cmd}} -m unittest scripts/smoke/test_run_admission_capacity.py",
+            justfile,
+        )
+
+    def test_ci_uses_bootstrap_python_and_requirements_for_all_pydantic_consumers(self) -> None:
+        workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("run: just test-admission-capacity", workflow)
+        self.assertNotIn("run: python -m unittest scripts/smoke/test_run_admission_capacity.py", workflow)
+        self.assertNotIn("pydantic>=2,<3", workflow)
+        self.assertEqual(workflow.count("tools/bootstrap-requirements.txt"), 3)
 
     def test_seed_python_preserves_ci_python_precedence(self) -> None:
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -70,8 +70,13 @@ class BootstrapTests(unittest.TestCase):
         verify.assert_not_called()
 
     def test_pip_installs_inside_the_repository_venv(self) -> None:
-        command = bootstrap.pip_install_command(Path("/repo/.bootstrap-venv/bin/python"))
-        self.assertEqual(command[0], "/repo/.bootstrap-venv/bin/python")
+        python = (
+            Path(r"C:\repo\.bootstrap-venv\Scripts\python.exe")
+            if sys.platform == "win32"
+            else Path("/repo/.bootstrap-venv/bin/python")
+        )
+        command = bootstrap.pip_install_command(python)
+        self.assertEqual(Path(command[0]), python)
         self.assertIn("--no-deps", command)
 
     def test_seed_version_mismatch_refuses_before_any_installs(self) -> None:

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "tools" / "bootstrap.py"
+SPEC = importlib.util.spec_from_file_location("bootstrap", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+bootstrap = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bootstrap
+SPEC.loader.exec_module(bootstrap)
+
+
+class BootstrapTests(unittest.TestCase):
+    def test_manifest_has_only_exact_tool_versions(self) -> None:
+        manifest = bootstrap.load_manifest()
+        versions = [manifest.rust, manifest.python, manifest.just]
+        versions.extend(version for _, version in manifest.cargo_tools)
+        versions.extend(version for _, version in manifest.python_packages)
+        self.assertTrue(all("*" not in version and ">" not in version and "<" not in version for version in versions))
+
+    def test_sc_compose_uses_the_repository_authoritative_revision(self) -> None:
+        manifest = bootstrap.load_manifest()
+        command = bootstrap.sc_compose_install_command(manifest.sc_compose_rev, force=True)
+        self.assertIn(manifest.sc_compose_rev, command)
+        self.assertIn("--locked", command)
+
+    def test_registry_tools_are_exact_and_locked(self) -> None:
+        command = bootstrap.cargo_install_command("cargo-audit", "0.22.2", force=True)
+        self.assertEqual(command, ["cargo", "install", "--locked", "--force", "--version", "0.22.2", "cargo-audit"])
+
+    def test_matching_registry_receipt_avoids_a_rebuild(self) -> None:
+        receipt = {"cargo-audit 0.22.2 (registry+https://example.test/index)": {"rustc": "release: 1.94.1"}}
+        with mock.patch.object(bootstrap, "cargo_receipts", return_value=receipt):
+            self.assertTrue(bootstrap.registry_tool_matches("cargo-audit", "0.22.2", "1.94.1"))
+
+    def test_registry_receipt_rejects_an_unpinned_release(self) -> None:
+        receipt = {"cargo-shear 1.13.2 (registry+https://example.test/index)": {"rustc": "release: 1.94.1"}}
+        with mock.patch.object(bootstrap, "cargo_receipts", return_value=receipt):
+            self.assertFalse(bootstrap.registry_tool_matches("cargo-shear", "1.12.0", "1.94.1"))
+
+    def test_manifest_uses_current_compatible_stable_releases(self) -> None:
+        manifest = bootstrap.load_manifest()
+        self.assertEqual(manifest.python, "3.14.7")
+        self.assertEqual(manifest.just, "1.58.0")
+        self.assertEqual(dict(manifest.cargo_tools), {
+            "cargo-deny": "0.20.2",
+            "cargo-audit": "0.22.2",
+            "cargo-shear": "1.12.0",
+            "cargo-modules": "0.26.0",
+        })
+        self.assertEqual(dict(manifest.python_packages)["maturin"], "1.14.1")
+
+    def test_dry_run_never_executes_installers(self) -> None:
+        manifest = bootstrap.load_manifest()
+        with (
+            mock.patch.object(bootstrap, "verify_seed_tools"),
+            mock.patch.object(bootstrap, "ensure_bootstrap_venv", return_value=Path("/tmp/bootstrap-python")),
+            mock.patch.object(bootstrap, "verify_installed_tools") as verify,
+            mock.patch.object(bootstrap, "registry_tool_matches", return_value=False),
+            mock.patch.object(bootstrap, "sc_compose_matches", return_value=False),
+            mock.patch.object(bootstrap.subprocess, "run") as run,
+        ):
+            bootstrap.bootstrap(manifest, dry_run=True)
+        run.assert_not_called()
+        verify.assert_not_called()
+
+    def test_pip_installs_inside_the_repository_venv(self) -> None:
+        command = bootstrap.pip_install_command(Path("/repo/.bootstrap-venv/bin/python"))
+        self.assertEqual(command[0], "/repo/.bootstrap-venv/bin/python")
+        self.assertIn("--no-deps", command)
+
+    def test_seed_version_mismatch_refuses_before_any_installs(self) -> None:
+        manifest = bootstrap.load_manifest()
+        with mock.patch.object(bootstrap, "platform") as platform_module:
+            platform_module.python_version.return_value = "3.11.9"
+            with self.assertRaisesRegex(bootstrap.BootstrapError, "Python must be exactly"):
+                bootstrap.verify_seed_tools(manifest)
+
+    def test_sc_compose_receipt_requires_the_exact_git_revision(self) -> None:
+        manifest = bootstrap.load_manifest()
+        expected_key = (
+            "sc-compose 1.4.0 "
+            f"(git+{bootstrap.SC_COMPOSE_REPOSITORY}?rev={manifest.sc_compose_rev}#{manifest.sc_compose_rev})"
+        )
+        with mock.patch.object(bootstrap, "cargo_receipts", return_value={expected_key: {"rustc": "release: 1.94.1"}}):
+            bootstrap.verify_sc_compose_receipt(manifest.sc_compose_rev)
+
+    def test_sc_compose_receipt_rejects_a_different_revision(self) -> None:
+        with mock.patch.object(bootstrap, "cargo_receipts", return_value={"sc-compose 1.4.0": {"rustc": "release: 1.94.1"}}):
+            with self.assertRaisesRegex(bootstrap.BootstrapError, "exact source revision"):
+                bootstrap.verify_sc_compose_receipt("expected-revision")
+
+    def test_ci_uses_the_shared_bootstrap_recipe(self) -> None:
+        workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn('python-version: "3.14.7"', workflow)
+        self.assertIn("tool: just@1.58.0", workflow)
+        self.assertGreaterEqual(workflow.count("run: just bootstrap"), 2)
+
+    def test_just_recipes_propagate_the_bootstrap_python_to_children(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn("$PWD/.bootstrap-venv/bin:$PATH", justfile)
+        self.assertIn("PYO3_PYTHON", justfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -106,6 +106,11 @@ class BootstrapTests(unittest.TestCase):
         self.assertIn("$PWD/.bootstrap-venv/bin:$PATH", justfile)
         self.assertIn("PYO3_PYTHON", justfile)
 
+    def test_seed_python_preserves_ci_python_precedence(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn('PATH=\\"$PATH:/opt/homebrew/bin\\" python3.14', justfile)
+        self.assertNotIn("PATH=/opt/homebrew/bin:$PATH python3.14", justfile)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_lint_external_tools.py
+++ b/.just/tests/test_lint_external_tools.py
@@ -32,9 +32,9 @@ class ExternalLintToolTests(unittest.TestCase):
                 build_cargo_deny_command(repo_root, config_path),
                 [
                     "cargo-deny",
-                    "check",
                     "--config",
                     str(config_path),
+                    "check",
                     "advisories",
                     "bans",
                     "licenses",

--- a/.just/tests/test_release_preflight.py
+++ b/.just/tests/test_release_preflight.py
@@ -21,15 +21,17 @@ class ReleasePreflightWorkflowTests(unittest.TestCase):
         self.assertIn("python3 scripts/validate_release.py all \\", text)
         self.assertIn("--staged-install-root \"${STAGED_INSTALL_ROOT}\"", text)
 
-    def test_release_preflight_installs_validation_python_dependencies_before_validation(self) -> None:
+    def test_release_preflight_uses_the_shared_pinned_bootstrap_before_validation(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
 
         install_python = text.index("- name: Install Python\n")
-        install_dependencies = text.index("- name: Install Python validation dependencies")
+        bootstrap = text.index("- name: Bootstrap exact repository tools")
         validate = text.index("- name: Run canonical retained release validation suite")
-        self.assertLess(install_python, install_dependencies)
-        self.assertLess(install_dependencies, validate)
-        self.assertIn("python -m pip install codespell 'pydantic>=2.12,<3'", text)
+        self.assertLess(install_python, bootstrap)
+        self.assertLess(bootstrap, validate)
+        self.assertIn('python-version: "3.14.7"', text)
+        self.assertIn("tool: just@1.58.0", text)
+        self.assertIn("run: just bootstrap", text)
 
 
 if __name__ == "__main__":

--- a/Justfile
+++ b/Justfile
@@ -1,14 +1,27 @@
 set windows-shell := ["pwsh", "-NoLogo", "-Command"]
 
-python_cmd := if os_family() == "windows" { "python" } else { "python3" }
-clippy_cmd := if os_family() == "windows" { "cargo clippy --workspace --all-targets --target x86_64-pc-windows-msvc -- -D warnings" } else { "cargo clippy --workspace --all-targets -- -D warnings" }
+# Homebrew is absent from non-interactive macOS account PATHs. Prepending its
+# standard location still leaves CI/Linux's python3.14 discoverable, while the
+# bootstrap script verifies the exact patch release before doing any work.
+seed_python_cmd := if os_family() == "windows" { "py -3.14" } else { "env PATH=/opt/homebrew/bin:$PATH python3.14" }
+# Keep the bootstrap venv first in PATH as well as executing its Python
+# directly. The path is absolute so helpers remain pinned after changing cwd;
+# PyO3 additionally receives its interpreter explicitly.
+python_cmd := if os_family() == "windows" { "$env:PATH = \"$PWD\\.bootstrap-venv\\Scripts;\" + $env:PATH; & \"$PWD\\.bootstrap-venv\\Scripts\\python.exe\"" } else { "env PATH=\"$PWD/.bootstrap-venv/bin:$PATH\" \"$PWD/.bootstrap-venv/bin/python\"" }
+clippy_cmd := if os_family() == "windows" { "$env:PATH = \"$PWD\\.bootstrap-venv\\Scripts;\" + $env:PATH; $env:PYO3_PYTHON = \"$PWD\\.bootstrap-venv\\Scripts\\python.exe\"; cargo clippy --workspace --all-targets --target x86_64-pc-windows-msvc -- -D warnings" } else { "env PATH=\"$PWD/.bootstrap-venv/bin:$PATH\" PYO3_PYTHON=\"$PWD/.bootstrap-venv/bin/python\" cargo clippy --workspace --all-targets -- -D warnings" }
 
 # Show the curated repo task help.
 default: help
 
 # Show the curated repo task help.
 help:
-    {{python_cmd}} .just/print_help.py
+    {{seed_python_cmd}} .just/print_help.py
+
+# Install and verify the exact toolchain/dependency contract shared by CI and
+# deterministic benchmark accounts. The seed Python, Rust, and Just versions
+# must already match tools/bootstrap.toml; this recipe never selects "latest".
+bootstrap *args:
+    {{seed_python_cmd}} tools/bootstrap.py {{args}}
 
 [private]
 _fmt-write:

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ set windows-shell := ["pwsh", "-NoLogo", "-Command"]
 # standard location as a developer-account fallback, never ahead of the
 # interpreter selected by CI (for example actions/setup-python's 3.14.7).
 # The bootstrap script verifies the exact patch release before doing any work.
-seed_python_cmd := if os_family() == "windows" { "py -3.14" } else { "env PATH=\"$PATH:/opt/homebrew/bin\" python3.14" }
+seed_python_cmd := if os_family() == "windows" { "python" } else { "env PATH=\"$PATH:/opt/homebrew/bin\" python3.14" }
 # Keep the bootstrap venv first in PATH as well as executing its Python
 # directly. The path is absolute so helpers remain pinned after changing cwd;
 # PyO3 additionally receives its interpreter explicitly.

--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,10 @@ reports-index *args:
 test-graft-python:
     {{python_cmd}} scripts/test_atm_graft_python.py
 
+# Run the benchmark-runner unit tests with the repository bootstrap Python.
+test-admission-capacity:
+    {{python_cmd}} -m unittest scripts/smoke/test_run_admission_capacity.py
+
 # Build the PyO3 extension and run the Hermes graft reference-adapter tests.
 test-hermes-graft-bridge:
     {{python_cmd}} .just/run_hermes_graft_bridge_tests.py

--- a/Justfile
+++ b/Justfile
@@ -1,9 +1,10 @@
 set windows-shell := ["pwsh", "-NoLogo", "-Command"]
 
-# Homebrew is absent from non-interactive macOS account PATHs. Prepending its
-# standard location still leaves CI/Linux's python3.14 discoverable, while the
-# bootstrap script verifies the exact patch release before doing any work.
-seed_python_cmd := if os_family() == "windows" { "py -3.14" } else { "env PATH=/opt/homebrew/bin:$PATH python3.14" }
+# Homebrew is absent from non-interactive macOS account PATHs. Append its
+# standard location as a developer-account fallback, never ahead of the
+# interpreter selected by CI (for example actions/setup-python's 3.14.7).
+# The bootstrap script verifies the exact patch release before doing any work.
+seed_python_cmd := if os_family() == "windows" { "py -3.14" } else { "env PATH=\"$PATH:/opt/homebrew/bin\" python3.14" }
 # Keep the bootstrap venv first in PATH as well as executing its Python
 # directly. The path is absolute so helpers remain pinned after changing cwd;
 # PyO3 additionally receives its interpreter explicitly.

--- a/docs/development/bootstrap.md
+++ b/docs/development/bootstrap.md
@@ -1,0 +1,55 @@
+# Pinned bootstrap
+
+`just bootstrap` is the sole repository-owned installation contract for the
+tools used by the normal CI lint/test lanes and by an isolated benchmark OS
+account. Its complete, exact version set is in
+[`tools/bootstrap.toml`](../../tools/bootstrap.toml); Python's exact dependency
+closure is in [`tools/bootstrap-requirements.txt`](../../tools/bootstrap-requirements.txt).
+
+The recipe deliberately does not select a latest release, a version range, or
+an M5-specific installation path. It installs the manifest's exact Cargo tools
+and source revision, creates a repository-local `.bootstrap-venv`, installs the
+exact Python packages there with `--no-deps`,
+then verifies every reported version.
+
+## Seed contract
+
+`just` cannot install itself and Python must exist before a Python recipe can
+run. A runner therefore supplies these exact seed tools before it invokes the
+shared recipe:
+
+- Rust `1.94.1`, with `clippy` and `rustfmt`;
+- Python `3.14.7`; and
+- `just` `1.58.0`.
+
+GitHub CI provisions those seeds explicitly and then runs `just bootstrap`.
+An operator provisioning a benchmark account must supply the same three exact
+versions and run the same command from a clean checkout. If any seed version is
+different, the recipe refuses before it installs or modifies any dependent
+tool. The bootstrap never writes packages into the system Python; every other
+Python-backed `just` recipe runs through `.bootstrap-venv` after setup. Its
+`bin`/`Scripts` directory is also first on child-process `PATH`, so PyO3 and
+other helpers cannot accidentally select an unrelated account-level Python.
+
+On macOS, the recipe includes `/opt/homebrew/bin` while locating `python3.14`.
+That makes the same command work from a non-interactive account whose shell
+does not source the interactive Homebrew PATH setup; the bootstrap still
+rejects any patch release other than the manifest's exact Python version.
+
+For review without changing tools, run:
+
+```sh
+just bootstrap --dry-run
+```
+
+This is a tool-environment operation only. It does not build ATM, sign a
+binary, run `daemon-switch`, start a daemon, or touch an ATM database.
+
+## Version-selection policy
+
+Every manifest entry pins the newest stable release compatible with the
+repository's pinned Rust and Python baselines. The current exceptions are
+`cargo-shear` `1.12.0` (upstream `1.13.4` requires Rust `1.95.0`) and
+`cargo-modules` `0.26.0` (upstream `0.27.0` requires Rust `1.95.0`), while this
+repository deliberately pins Rust `1.94.1`. Compatibility exceptions must be
+documented here and re-evaluated whenever the seed Rust version changes.

--- a/tools/bootstrap-requirements.txt
+++ b/tools/bootstrap-requirements.txt
@@ -1,0 +1,9 @@
+# This file is deliberately a fully exact closure for the Python packages that
+# `just lint`, the test helpers, and the physical benchmark harness import.
+annotated-types==0.8.0
+codespell==2.4.3
+maturin==1.14.1
+pydantic==2.13.4
+pydantic-core==2.46.4
+typing-extensions==4.16.0
+typing-inspection==0.4.4

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Install and verify the repository's exact CI/bootstrap tool contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import subprocess
+import sys
+import tomllib
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = ROOT / "tools" / "bootstrap.toml"
+REQUIREMENTS_PATH = ROOT / "tools" / "bootstrap-requirements.txt"
+VENV_PATH = ROOT / ".bootstrap-venv"
+SC_COMPOSE_REPOSITORY = "https://github.com/randlee/sc-compose.git"
+
+
+class BootstrapError(RuntimeError):
+    """The pinned bootstrap contract cannot be satisfied safely."""
+
+
+@dataclass(frozen=True)
+class BootstrapManifest:
+    rust: str
+    python: str
+    just: str
+    cargo_tools: tuple[tuple[str, str], ...]
+    sc_compose_rev: str
+    python_packages: tuple[tuple[str, str], ...]
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> BootstrapManifest:
+    """Load the exact tool versions from the one checked-in contract."""
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    toolchain = raw["toolchain"]
+    cargo = raw["cargo"]
+    python = raw["python"]
+    return BootstrapManifest(
+        rust=toolchain["rust"],
+        python=toolchain["python"],
+        just=toolchain["just"],
+        cargo_tools=(
+            ("cargo-deny", cargo["cargo-deny"]),
+            ("cargo-audit", cargo["cargo-audit"]),
+            ("cargo-shear", cargo["cargo-shear"]),
+            ("cargo-modules", cargo["cargo-modules"]),
+        ),
+        sc_compose_rev=cargo["sc-compose-rev"],
+        python_packages=tuple(sorted(python.items())),
+    )
+
+
+def command_output(command: Sequence[str]) -> str:
+    """Run one inspection command and return its combined output."""
+    result = subprocess.run(command, capture_output=True, check=False, text=True, cwd=ROOT)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise BootstrapError(f"{' '.join(command)} failed: {detail}")
+    return f"{result.stdout}\n{result.stderr}".strip()
+
+
+def require_version(label: str, actual: str, expected: str) -> None:
+    """Reject a prefix, range, or unrelated version rather than guessing."""
+    if re.search(rf"(?<![0-9.]){re.escape(expected)}(?![0-9.])", actual) is None:
+        raise BootstrapError(f"{label} must be exactly {expected}; found {actual or 'no version output'}.")
+
+
+def verify_seed_tools(manifest: BootstrapManifest) -> None:
+    """Verify the minimal tools that must exist before a Just recipe can run."""
+    require_version("Python", platform.python_version(), manifest.python)
+    require_version("Rust", command_output(["rustc", "--version"]), manifest.rust)
+    require_version("just", command_output(["just", "--version"]), manifest.just)
+
+
+def cargo_install_command(name: str, version: str, *, force: bool) -> list[str]:
+    """Return the deterministic cargo-install command for one registry tool."""
+    command = ["cargo", "install", "--locked"]
+    if force:
+        command.append("--force")
+    return [*command, "--version", version, name]
+
+
+def sc_compose_install_command(revision: str, *, force: bool) -> list[str]:
+    """Return the authoritative sc-compose source-revision install command."""
+    command = [
+        "cargo",
+        "install",
+        "--git",
+        SC_COMPOSE_REPOSITORY,
+        "--rev",
+        revision,
+        "--locked",
+    ]
+    if force:
+        command.append("--force")
+    return [*command, "--bin", "sc-compose"]
+
+
+def venv_python_path() -> Path:
+    """Return the repository-local Python executable for the exact bootstrap venv."""
+    return VENV_PATH / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+
+
+def ensure_bootstrap_venv(manifest: BootstrapManifest, *, dry_run: bool) -> Path:
+    """Create or repair the isolated Python environment without mutating the OS Python."""
+    python = venv_python_path()
+    if python.is_file():
+        try:
+            require_version("bootstrap venv Python", command_output([str(python), "--version"]), manifest.python)
+            return python
+        except BootstrapError:
+            pass
+    run([sys.executable, "-m", "venv", "--clear", str(VENV_PATH)], dry_run=dry_run)
+    if not dry_run:
+        require_version("bootstrap venv Python", command_output([str(python), "--version"]), manifest.python)
+    return python
+
+
+def pip_install_command(python: Path) -> list[str]:
+    """Install only the exact, checked-in Python dependency closure."""
+    return [
+        str(python),
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        "--requirement",
+        str(REQUIREMENTS_PATH),
+    ]
+
+
+def cargo_bin_path(name: str) -> Path:
+    """Locate the binary installed by Cargo without trusting PATH precedence."""
+    cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo"))
+    suffix = ".exe" if sys.platform == "win32" else ""
+    return cargo_home / "bin" / f"{name}{suffix}"
+
+
+def cargo_receipts() -> dict[str, object]:
+    """Load Cargo's installation receipt for exact Git-source verification."""
+    receipt = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")) / ".crates2.json"
+    try:
+        raw = json.loads(receipt.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        raise BootstrapError(f"Cargo installation receipt is unavailable: {receipt}") from error
+    installs = raw.get("installs")
+    if not isinstance(installs, dict):
+        raise BootstrapError(f"Cargo installation receipt has no installs map: {receipt}")
+    return installs
+
+
+def receipt_matches(key_prefix: str, *, required_fragments: Sequence[str]) -> bool:
+    """Return whether one Cargo receipt proves this exact installation contract."""
+    try:
+        receipts = cargo_receipts()
+    except BootstrapError:
+        return False
+    for key, value in receipts.items():
+        if not key.startswith(key_prefix) or not isinstance(value, dict):
+            continue
+        rustc = value.get("rustc")
+        if not isinstance(rustc, str):
+            continue
+        if all(fragment in key or fragment in rustc for fragment in required_fragments):
+            return True
+    return False
+
+
+def registry_tool_matches(name: str, version: str, rust: str) -> bool:
+    """Prove the registry tool is both the required version and Rust build."""
+    return receipt_matches(
+        f"{name} {version} (registry+",
+        required_fragments=(f"release: {rust}",),
+    )
+
+
+def verify_sc_compose_receipt(revision: str) -> None:
+    """Prove Cargo installed sc-compose from the manifest's exact Git revision."""
+    if not receipt_matches(
+        "sc-compose ",
+        required_fragments=(f"git+{SC_COMPOSE_REPOSITORY}", revision),
+    ):
+        raise BootstrapError(f"sc-compose was not installed from the exact source revision {revision}.")
+
+
+def sc_compose_matches(manifest: BootstrapManifest) -> bool:
+    """Prove the Git source and compiler match before omitting a rebuild."""
+    return receipt_matches(
+        "sc-compose ",
+        required_fragments=(
+            f"git+{SC_COMPOSE_REPOSITORY}",
+            manifest.sc_compose_rev,
+            f"release: {manifest.rust}",
+        ),
+    )
+
+
+def run(command: Sequence[str], *, dry_run: bool) -> None:
+    """Execute one deterministic installation step or render it for review."""
+    print("+", " ".join(command))
+    if dry_run:
+        return
+    result = subprocess.run(command, check=False, cwd=ROOT)
+    if result.returncode != 0:
+        raise BootstrapError(f"bootstrap install command failed with exit {result.returncode}: {' '.join(command)}")
+
+
+def python_package_version(python: Path, package: str) -> str:
+    """Read one distribution version from the isolated bootstrap environment."""
+    program = f"from importlib.metadata import version; print(version({package!r}))"
+    return command_output([str(python), "-c", program]).strip()
+
+
+def verify_installed_tools(manifest: BootstrapManifest, python: Path) -> None:
+    """Prove every installed external tool reports the exact manifest version."""
+    for name, version in manifest.cargo_tools:
+        binary = cargo_bin_path(name)
+        command_output([str(binary), "--version"])
+        if not registry_tool_matches(name, version, manifest.rust):
+            raise BootstrapError(f"{name} is not the exact pinned version built by Rust {manifest.rust}.")
+    sc_compose = cargo_bin_path("sc-compose")
+    command_output([str(sc_compose), "--version"])
+    verify_sc_compose_receipt(manifest.sc_compose_rev)
+    if not sc_compose_matches(manifest):
+        raise BootstrapError(f"sc-compose was not built by the pinned Rust {manifest.rust} toolchain.")
+    for package, version in manifest.python_packages:
+        try:
+            actual = python_package_version(python, package)
+        except BootstrapError as error:
+            raise BootstrapError(f"Python package {package} is not installed.") from error
+        if actual != version:
+            raise BootstrapError(f"Python package {package} must be exactly {version}; found {actual}.")
+
+
+def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
+    """Install the complete contract, then verify it rather than trusting installs."""
+    verify_seed_tools(manifest)
+    python = ensure_bootstrap_venv(manifest, dry_run=dry_run)
+    for name, version in manifest.cargo_tools:
+        run(cargo_install_command(name, version, force=not registry_tool_matches(name, version, manifest.rust)), dry_run=dry_run)
+    run(sc_compose_install_command(manifest.sc_compose_rev, force=not sc_compose_matches(manifest)), dry_run=dry_run)
+    run(pip_install_command(python), dry_run=dry_run)
+    if not dry_run:
+        verify_installed_tools(manifest, python)
+
+
+def main(argv: Sequence[str]) -> int:
+    """Run a real bootstrap or a reviewable command-only dry run."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print exact install commands without changing state.")
+    args = parser.parse_args(argv[1:])
+    try:
+        bootstrap(load_manifest(), dry_run=args.dry_run)
+    except (BootstrapError, KeyError, OSError, tomllib.TOMLDecodeError) as error:
+        print(f"bootstrap refused: {error}", file=sys.stderr)
+        return 1
+    print("bootstrap complete: exact pinned tool contract verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/bootstrap.toml
+++ b/tools/bootstrap.toml
@@ -1,0 +1,22 @@
+# One reproducible developer/CI/bootstrap tool contract.  Do not replace an
+# exact value with a range, a major-only selector, or "latest".
+[toolchain]
+rust = "1.94.1"
+python = "3.14.7"
+just = "1.58.0"
+
+[cargo]
+cargo-deny = "0.20.2"
+cargo-audit = "0.22.2"
+cargo-shear = "1.12.0"
+cargo-modules = "0.26.0"
+sc-compose-rev = "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661"
+
+[python]
+codespell = "2.4.3"
+maturin = "1.14.1"
+pydantic = "2.13.4"
+annotated-types = "0.8.0"
+pydantic-core = "2.46.4"
+typing-extensions = "4.16.0"
+typing-inspection = "0.4.4"


### PR DESCRIPTION
## Summary
- Introduces a single repo-owned, fully pinned toolchain/dependency contract (`just bootstrap`), invoked by both GitHub CI and deterministic benchmark-account provisioning — no more floating/latest tool installs, no M5-specific script.
- Pinned versions: Rust 1.94.1, Python 3.14.7, just 1.58.0, cargo-deny 0.20.2, cargo-modules 0.26.0, maturin 1.14.1.
- sc-lint follow-up tracked separately: randlee/sc-lint#117.

## Test plan
- [x] Operationally proven on `atmbench@M5` (isolated non-admin account, no daemon/ATM database/benchmark touched): fresh clone → `just bootstrap` → `just lint`, all PASS with the pinned versions above.
- [ ] quality-mgr review

🤖 Generated with [Claude Code](https://claude.com/claude-code)