### PR TITLE
fix(graft): receiver reconnect + nudge body propagation (GH-985)

### DIFF
--- a/crates/atm-architecture/tests/graft_receiver_ownership_boundary.rs
+++ b/crates/atm-architecture/tests/graft_receiver_ownership_boundary.rs
@@ -23,11 +23,23 @@ fn receiver_record_publication_and_unlink_stay_in_the_listener_owner() {
         !production.contains("pub fn write_receiver_record"),
         "endpoint record publication must remain private to GraftReceiverListener"
     );
+    let authorized_record_publication_sites = [
+        "fn write_receiver_record(",
+        "write_receiver_record(record_path, &record)?;",
+        "write_receiver_record(&self.record_path, &self.record)?;",
+    ];
     assert_eq!(
         production.matches("write_receiver_record(").count(),
-        2,
-        "only the private helper and GraftReceiverListener::bind may publish a receiver record"
+        authorized_record_publication_sites.len(),
+        "only the private helper, GraftReceiverListener::bind, and same-owner republish may publish a receiver record"
     );
+    for site in authorized_record_publication_sites {
+        assert_eq!(
+            production.matches(site).count(),
+            1,
+            "receiver record publication site must remain the reviewed exact call site: {site}"
+        );
+    }
     assert_eq!(
         production
             .matches("fs::remove_file(&self.record_path)")

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -138,6 +138,12 @@ pub struct GraftNudgeTarget {
     pub recipient_team: TeamName,
     /// Canonical database-resolved `<atm …>` nudge text for the receiver.
     pub rendered_nudge: String,
+    /// Immutable body of the message that triggered this nudge.
+    ///
+    /// Unlike `description`, this preserves the complete admitted content so
+    /// an embedded host never needs to perform a follow-up mailbox read just
+    /// to inject the message it was notified about.
+    pub message_body: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -46,6 +46,8 @@ pub struct GraftPostSendRequest {
     /// Canonical database-resolved `<atm …>` nudge text. The receiver must
     /// inject this text, never substitute the stored message description.
     pub rendered_nudge: String,
+    /// Immutable message content associated with `rendered_nudge`.
+    pub message_body: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -88,6 +90,7 @@ where
         recipient,
         recipient_team,
         rendered_nudge,
+        message_body,
     }) = &dispatch.target
     else {
         return Err(AtmError::validation(
@@ -113,6 +116,7 @@ where
         &GraftPostSendRequest {
             event: dispatch.event.clone(),
             rendered_nudge: rendered_nudge.clone(),
+            message_body: message_body.clone(),
         },
         deadline,
     )? {
@@ -298,6 +302,7 @@ pub struct GraftReceiverListener {
     record_path: PathBuf,
     owner_generation: String,
     capability: LocalCapability,
+    record: GraftReceiverEndpointRecord,
     _ownership: ReceiverOwnershipGuard,
 }
 
@@ -402,8 +407,45 @@ impl GraftReceiverListener {
             record_path: record_path.to_path_buf(),
             owner_generation,
             capability,
+            record,
             _ownership: ownership,
         })
+    }
+
+    /// Restore this listener's endpoint record when an external lifecycle
+    /// event removed it. A successor record is never overwritten: ownership
+    /// remains fail-closed and process-lifetime exclusive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when record publication fails or a different owner has
+    /// published a record at this path.
+    pub fn republish_if_missing(&self) -> Result<bool, AtmError> {
+        match fs::exists(&self.record_path).map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to inspect graft receiver record at {}",
+                self.record_path.display()
+            ))
+            .with_cause(source)
+        })? {
+            false => {
+                prepare_receiver_record_parent(&self.record_path)?;
+                write_receiver_record(&self.record_path, &self.record)?;
+                tracing::info!(record_path = %self.record_path.display(), action = "receiver_record_republish", outcome = "restored", "graft receiver restored its missing endpoint record");
+                Ok(true)
+            }
+            true => {
+                let current = read_receiver_record(&self.record_path)?;
+                if current.owner_generation == self.owner_generation {
+                    Ok(false)
+                } else {
+                    Err(AtmError::new(
+                        AtmErrorCode::GraftReceiverAlreadyActive,
+                        graft_receiver_identity(&self.record_path),
+                    ))
+                }
+            }
+        }
     }
 
     /// Poll for one pending loopback connection without blocking.
@@ -797,6 +839,7 @@ mod tests {
         let request = GraftPostSendRequest {
             event: test_event(),
             rendered_nudge: "<atm>test nudge</atm>".to_string(),
+            message_body: "full immutable body".to_string(),
         };
         let sender = std::thread::spawn({
             let record_path = record_path.clone();
@@ -820,6 +863,7 @@ mod tests {
             .read_request(&mut stream, Duration::from_secs(3))
             .expect("read request");
         assert_eq!(received.rendered_nudge, "<atm>test nudge</atm>");
+        assert_eq!(received.message_body, "full immutable body");
         assert_eq!(received.event.description, "loopback graft transport");
         listener
             .write_response(&mut stream, &GraftPostSendResponse::Delivered)
@@ -827,6 +871,34 @@ mod tests {
 
         let response = sender.join().expect("join sender").expect("deliver");
         assert_eq!(response, GraftPostSendResponse::Delivered);
+    }
+
+    #[test]
+    fn receiver_republishes_its_record_after_external_removal() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let record_path = graft_receiver_record_path_from_home(
+            tempdir.path(),
+            &TeamName::from_validated(TEST_TEAM),
+            &AgentName::from_validated(TEST_QA),
+        );
+        let listener = GraftReceiverListener::bind(&record_path, None).expect("bind listener");
+        let expected = read_receiver_record(&record_path).expect("read published record");
+
+        fs::remove_file(&record_path).expect("remove endpoint record");
+        assert!(
+            listener
+                .republish_if_missing()
+                .expect("restore missing endpoint record")
+        );
+        assert_eq!(
+            read_receiver_record(&record_path).expect("read restored record"),
+            expected
+        );
+        assert!(
+            !listener
+                .republish_if_missing()
+                .expect("existing owner record is unchanged")
+        );
     }
 
     #[test]
@@ -847,6 +919,7 @@ mod tests {
                 request: GraftPostSendRequest {
                     event: test_event(),
                     rendered_nudge: "<atm>test nudge</atm>".to_string(),
+                    message_body: "full immutable body".to_string(),
                 },
             };
             super::write_graft_post_send_message(&mut stream, &wire, "write", "oversized")

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -18,6 +18,7 @@ pub(crate) fn build_built_in_dispatch<R>(
     runtime: &R,
     delivery_snapshot: &DeliveryRecipientSnapshot,
     event: &PostSendHookEvent,
+    message_body: &str,
 ) -> Option<BuiltInPostSendDispatch>
 where
     R: RetainedServiceRuntime + ?Sized,
@@ -44,6 +45,7 @@ where
                 recipient: event.recipient.clone(),
                 recipient_team: event.recipient_team.clone(),
                 rendered_nudge,
+                message_body: message_body.to_owned(),
             }),
         });
     }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -404,9 +404,12 @@ impl PreparedWrite {
                 message,
                 post_write.delivery_snapshot.recipient_pane_id.as_ref(),
             )?;
-            if let Some(dispatch) =
-                hook::build_built_in_dispatch(runtime, &post_write.delivery_snapshot, &event)
-            {
+            if let Some(dispatch) = hook::build_built_in_dispatch(
+                runtime,
+                &post_write.delivery_snapshot,
+                &event,
+                &message.envelope.text,
+            ) {
                 dispatches.push(dispatch);
             }
         }

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -1121,6 +1121,9 @@ mod tests {
 
     #[test]
     fn closed_python_session_rejects_reconnect() {
+        // reconnect_client converts the closed-session error into PyErr, so
+        // this test must not rely on another parallel test initializing PyO3.
+        Python::initialize();
         let caller = PyAgentAddress::new(TEST_SENDER.to_string(), TEST_TEAM.to_string(), None)
             .expect("caller");
         let session = PyGraftSession {

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -68,6 +68,7 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
             recipient,
             recipient_team,
             rendered_nudge,
+            message_body,
         }) = &dispatch.target
         else {
             return Err(AtmError::validation(
@@ -80,9 +81,10 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
                 "graft receive hook received an event for a different recipient",
             ));
         }
-        // The agent loop receives the canonical `<atm …>` payload.  Telegram's
-        // visible notice is intentionally a separate plain-text rendering so
-        // it shows sender and subject without masquerading as a dispatch.
+        // The agent loop receives the canonical `<atm …>` payload followed by
+        // the exact immutable message body admitted with that event. Telegram's
+        // visible notice remains a separate plain-text rendering so it shows
+        // sender and subject without masquerading as a dispatch.
         let notice_text = format!(
             "📬 from {}\n{}",
             dispatch.event.source_address(),
@@ -90,7 +92,7 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
         );
         self.deliver(HostNudge {
             event: dispatch.event.clone(),
-            body: rendered_nudge.clone(),
+            body: format!("{rendered_nudge}\n\n{message_body}"),
             notice_text,
         })?;
         Ok(PostSendEmissionPath::GraftPort)
@@ -187,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn graft_nudge_sink_injects_the_rendered_xml_not_the_stored_description() {
+    fn graft_nudge_sink_injects_rendered_xml_and_full_message_body() {
         let injector = RecordingInjector::default();
         let sink = GraftReceiveHook {
             injector: &injector,
@@ -201,6 +203,7 @@ mod tests {
                 recipient: TEST_ARCH_CTM.parse().expect("recipient"),
                 recipient_team: TEST_TEAM.parse().expect("team"),
                 rendered_nudge: "<atm><action>read atm</action></atm>".to_string(),
+                message_body: "full immutable body".to_string(),
             }),
         };
 
@@ -212,7 +215,10 @@ mod tests {
 
         let nudges = injector.nudges.lock().expect("nudges");
         assert_eq!(nudges.len(), 1);
-        assert_eq!(nudges[0].body, "<atm><action>read atm</action></atm>");
+        assert_eq!(
+            nudges[0].body,
+            "<atm><action>read atm</action></atm>\n\nfull immutable body"
+        );
         assert_eq!(
             nudges[0].notice_text,
             "📬 from test-lead@test-team\nreview failing smoke lane"

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -49,6 +49,12 @@ const GRAFT_RECEIVER_RECOVERY_MAX_DURATION: Duration = Duration::from_secs(30);
 /// Give a persistently unavailable endpoint time to recover before a new
 /// bounded recovery burst begins after the circuit opens.
 const GRAFT_RECEIVER_RECOVERY_CIRCUIT_DELAY: Duration = Duration::from_secs(5);
+/// Repeated receiver failures are initially reported after this delay, then
+/// exponentially backed off to retain useful diagnostics without log storms.
+const GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY: Duration = Duration::from_secs(1);
+/// Cap the warning backoff so a long-lived outage still leaves a periodic,
+/// actionable diagnostic trail.
+const GRAFT_RECEIVER_RECOVERY_WARN_MAX_DELAY: Duration = Duration::from_secs(30);
 const MAX_HOST_NUDGE_HELPERS: usize = 8;
 
 type ReceiveLoopJoinHelper = (
@@ -60,11 +66,29 @@ type ReceiveLoopJoinHelper = (
 #[derive(Debug)]
 struct ReceiverRecoveryCircuit {
     began_at: Instant,
+    next_warning_at: Instant,
+    warning_delay: Duration,
 }
 
 impl ReceiverRecoveryCircuit {
     fn new(now: Instant) -> Self {
-        Self { began_at: now }
+        Self {
+            began_at: now,
+            next_warning_at: now + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY,
+            warning_delay: GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY,
+        }
+    }
+
+    fn warning_due(&mut self, now: Instant) -> bool {
+        if now < self.next_warning_at {
+            return false;
+        }
+        self.next_warning_at = now + self.warning_delay;
+        self.warning_delay = self
+            .warning_delay
+            .saturating_mul(2)
+            .min(GRAFT_RECEIVER_RECOVERY_WARN_MAX_DELAY);
+        true
     }
 
     fn is_exhausted(&self, now: Instant) -> bool {
@@ -620,6 +644,9 @@ fn recover_graft_receiver(
             Err(error) => {
                 let now = Instant::now();
                 let snapshot = read_snapshot(&ctx.snapshot)?;
+                if recovery_circuit.warning_due(now) {
+                    warn_runtime_error("rearm_graft_receiver", Some(&ctx.endpoint_path), &error);
+                }
                 if recovery_circuit.is_exhausted(now) {
                     ctx.observability.receiver_ownership(
                         &snapshot,
@@ -641,7 +668,6 @@ fn recover_graft_receiver(
                     }
                     recovery_circuit.reset(Instant::now());
                 } else {
-                    warn_runtime_error("rearm_graft_receiver", Some(&ctx.endpoint_path), &error);
                     ctx.observability.receiver_ownership(
                         &snapshot,
                         "rebind_receiver_owner",
@@ -669,7 +695,6 @@ fn rebind_graft_receiver(
                 return Ok(Some(listener));
             }
             Err(error) => {
-                warn_runtime_error("rebind_graft_receiver", Some(&ctx.endpoint_path), &error);
                 last_error = Some(error);
                 if attempt < GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS {
                     let delay = GRAFT_RECEIVER_REBIND_INITIAL_DELAY.saturating_mul(attempt as u32);
@@ -756,7 +781,8 @@ mod tests {
     use crate::{GraftObservability, HostNudge, HostNudgeInjector};
 
     use super::{
-        BoundedHostNudgeInjector, GRAFT_RECEIVER_RECOVERY_MAX_DURATION, GraftReceiverLoopContext,
+        BoundedHostNudgeInjector, GRAFT_RECEIVER_RECOVERY_MAX_DURATION,
+        GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY, GraftReceiverLoopContext,
         MAX_HOST_NUDGE_HELPERS, RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch,
         ReceiverRecoveryCircuit, handle_graft_receiver_connection, join_receive_loop_with_deadline,
         load_graft_config, read_snapshot, recover_after_poll_accept_error, recover_graft_receiver,
@@ -1231,10 +1257,24 @@ mod tests {
         let mut circuit = ReceiverRecoveryCircuit::new(started);
 
         assert!(!circuit.is_exhausted(started));
+        assert!(!circuit.warning_due(started));
+        assert!(circuit.warning_due(started + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY));
+        assert!(!circuit.warning_due(
+            started
+                + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY
+                + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY
+                - Duration::from_millis(1)
+        ));
+        assert!(circuit.warning_due(
+            started
+                + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY
+                + GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY
+        ));
         assert!(circuit.is_exhausted(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION));
 
         circuit.reset(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION);
         assert!(!circuit.is_exhausted(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION));
+        assert!(!circuit.warning_due(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION));
     }
 
     #[test]

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -945,7 +945,7 @@ mod tests {
         let snapshot = Arc::new(RwLock::new(SessionSnapshot {
             team: TeamName::from_validated(TEST_TEAM),
             agent: AgentName::from_validated(TEST_QA),
-            state: GraftSessionState::Degraded,
+            state: GraftSessionState::Listening,
         }));
         let ctx = GraftReceiverLoopContext {
             endpoint_path,
@@ -1146,7 +1146,7 @@ mod tests {
         let snapshot = Arc::new(RwLock::new(SessionSnapshot {
             team: TeamName::from_validated(TEST_TEAM),
             agent: AgentName::from_validated(TEST_QA),
-            state: GraftSessionState::Listening,
+            state: GraftSessionState::Degraded,
         }));
         let ctx = GraftReceiverLoopContext {
             endpoint_path: endpoint_path.clone(),

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -670,7 +670,8 @@ mod tests {
     use atm_core::boundary::PostSendHookEvent;
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::graft::{
-        GraftPostSendRequest, GraftPostSendResponse, GraftReceiverListener, deliver_graft_post_send,
+        GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL, GraftPostSendRequest, GraftPostSendResponse,
+        GraftReceiverListener, deliver_graft_post_send,
     };
     use atm_core::schema::AtmMessageId;
     use atm_core::test_support::{TEST_LEAD, TEST_QA, TEST_TEAM};
@@ -1010,8 +1011,12 @@ mod tests {
 
         fs::remove_file(&endpoint_path).expect("remove published endpoint record");
         let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        let (_poll_wait_tx, poll_wait_rx) = mpsc::channel();
         while !endpoint_path.exists() && std::time::Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(25));
+            assert!(
+                !wait_for_stop_or_delay(&poll_wait_rx, GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL),
+                "test-only wait channel must remain open until the endpoint record is restored"
+            );
         }
         assert!(
             endpoint_path.exists(),

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -27,9 +27,21 @@ use crate::{
 pub(crate) const RECEIVE_LOOP_READY_DEADLINE: Duration = Duration::from_secs(3);
 const HOST_NUDGE_INJECTION_DEADLINE: Duration = Duration::from_millis(250);
 const GRAFT_RECEIVER_IO_DEADLINE: Duration = Duration::from_secs(3);
+/// A live listener checks its published record at this cadence so an external
+/// record deletion is repaired without adding filesystem work to every poll.
 const GRAFT_RECEIVER_RECORD_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
+/// Each recovery cycle makes a small, bounded number of bind attempts before
+/// yielding to the slower re-arm cadence below.
 const GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS: usize = 3;
-const GRAFT_RECEIVER_REBIND_DELAY: Duration = Duration::from_millis(100);
+/// The first rebind delay is short enough for interactive recovery; later
+/// attempts increase linearly so a persistently bad socket does not spin.
+const GRAFT_RECEIVER_REBIND_INITIAL_DELAY: Duration = Duration::from_millis(100);
+/// Cool down after a successful rebind before polling again, preventing a
+/// repeated hard accept failure from becoming a tight rebind loop.
+const GRAFT_RECEIVER_REBIND_CYCLE_DELAY: Duration = Duration::from_millis(100);
+/// Wait between exhausted rebind cycles. The receiver remains armed and never
+/// starts a daemon; it only retries its own loopback listener publication.
+const GRAFT_RECEIVER_REARM_DELAY: Duration = Duration::from_secs(1);
 const MAX_HOST_NUDGE_HELPERS: usize = 8;
 
 type ReceiveLoopJoinHelper = (
@@ -513,7 +525,10 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
                     thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL);
                 }
                 Err(error) => {
-                    listener = recover_after_poll_accept_error(&ctx, listener, &error)?;
+                    match recover_after_poll_accept_error(&ctx, listener, &error)? {
+                        Some(rebound_listener) => listener = rebound_listener,
+                        None => return Ok(()),
+                    }
                     last_record_recheck = Instant::now();
                 }
             }
@@ -539,15 +554,37 @@ fn recover_after_poll_accept_error(
     ctx: &GraftReceiverLoopContext,
     listener: GraftReceiverListener,
     error: &AtmError,
-) -> Result<GraftReceiverListener, AtmError> {
+) -> Result<Option<GraftReceiverListener>, AtmError> {
     warn_runtime_error("poll_graft_receiver", Some(&ctx.endpoint_path), error);
     drop(listener);
-    rebind_graft_receiver(ctx)
+    loop {
+        if stop_requested(&ctx.stop_rx) {
+            return Ok(None);
+        }
+        match rebind_graft_receiver(ctx) {
+            Ok(Some(listener)) => {
+                if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_REBIND_CYCLE_DELAY) {
+                    return Ok(None);
+                }
+                return Ok(Some(listener));
+            }
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                warn_runtime_error("rearm_graft_receiver", Some(&ctx.endpoint_path), &error);
+                let snapshot = read_snapshot(&ctx.snapshot)?;
+                ctx.observability
+                    .receiver_ownership(&snapshot, "rebind_receiver_owner", "retry");
+                if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_REARM_DELAY) {
+                    return Ok(None);
+                }
+            }
+        }
+    }
 }
 
 fn rebind_graft_receiver(
     ctx: &GraftReceiverLoopContext,
-) -> Result<GraftReceiverListener, AtmError> {
+) -> Result<Option<GraftReceiverListener>, AtmError> {
     let mut last_error = None;
     for attempt in 1..=GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS {
         match GraftReceiverListener::bind(&ctx.endpoint_path, ctx.owner_chat_id.clone()) {
@@ -555,13 +592,16 @@ fn rebind_graft_receiver(
                 let snapshot = read_snapshot(&ctx.snapshot)?;
                 ctx.observability
                     .receiver_ownership(&snapshot, "rebind_receiver_owner", "ok");
-                return Ok(listener);
+                return Ok(Some(listener));
             }
             Err(error) => {
                 warn_runtime_error("rebind_graft_receiver", Some(&ctx.endpoint_path), &error);
                 last_error = Some(error);
                 if attempt < GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS {
-                    thread::sleep(GRAFT_RECEIVER_REBIND_DELAY);
+                    let delay = GRAFT_RECEIVER_REBIND_INITIAL_DELAY.saturating_mul(attempt as u32);
+                    if wait_for_stop_or_delay(&ctx.stop_rx, delay) {
+                        return Ok(None);
+                    }
                 }
             }
         }
@@ -570,6 +610,13 @@ fn rebind_graft_receiver(
     ctx.observability
         .receiver_ownership(&snapshot, "rebind_receiver_owner", "error");
     Err(last_error.expect("at least one graft receiver rebind attempt"))
+}
+
+fn wait_for_stop_or_delay(stop_rx: &Receiver<()>, delay: Duration) -> bool {
+    matches!(
+        stop_rx.recv_timeout(delay),
+        Ok(()) | Err(RecvTimeoutError::Disconnected)
+    )
 }
 
 fn stop_requested(stop_rx: &Receiver<()>) -> bool {
@@ -637,7 +684,7 @@ mod tests {
         BoundedHostNudgeInjector, GraftReceiverLoopContext, MAX_HOST_NUDGE_HELPERS,
         RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch, handle_graft_receiver_connection,
         join_receive_loop_with_deadline, load_graft_config, read_snapshot,
-        recover_after_poll_accept_error, run_graft_receiver_loop,
+        recover_after_poll_accept_error, run_graft_receiver_loop, wait_for_stop_or_delay,
     };
     use crate::{GraftSessionState, SessionSnapshot};
 
@@ -840,6 +887,13 @@ mod tests {
     }
 
     #[test]
+    fn receiver_recovery_delays_observe_stop_without_waiting_for_backoff() {
+        let (stop_tx, stop_rx) = mpsc::channel();
+        stop_tx.send(()).expect("request stop");
+        assert!(wait_for_stop_or_delay(&stop_rx, Duration::from_secs(1)));
+    }
+
+    #[test]
     fn receiver_listener_binds_at_expected_endpoint() {
         let paths = test_paths();
         let endpoint_path = receiver_endpoint_path(&paths);
@@ -996,6 +1050,7 @@ mod tests {
             listener,
             &AtmError::daemon_unavailable("simulated hard accept failure"),
         )
+        .expect("recover after hard accept failure")
         .expect("rebind after hard accept failure");
         assert_ne!(
             fs::read_to_string(&endpoint_path).expect("read rebound record"),

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use std::sync::mpsc::TrySendError;
 
@@ -27,6 +27,9 @@ use crate::{
 pub(crate) const RECEIVE_LOOP_READY_DEADLINE: Duration = Duration::from_secs(3);
 const HOST_NUDGE_INJECTION_DEADLINE: Duration = Duration::from_millis(250);
 const GRAFT_RECEIVER_IO_DEADLINE: Duration = Duration::from_secs(3);
+const GRAFT_RECEIVER_RECORD_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
+const GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS: usize = 3;
+const GRAFT_RECEIVER_REBIND_DELAY: Duration = Duration::from_millis(100);
 const MAX_HOST_NUDGE_HELPERS: usize = 8;
 
 type ReceiveLoopJoinHelper = (
@@ -431,7 +434,7 @@ pub(crate) struct GraftReceiverLoopContext {
 pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(), AtmError> {
     let injector = BoundedHostNudgeInjector::spawn(Arc::clone(&ctx.injector));
     let result = (|| {
-        let listener =
+        let mut listener =
             match GraftReceiverListener::bind(&ctx.endpoint_path, ctx.owner_chat_id.clone()) {
                 Ok(listener) => {
                     let snapshot = read_snapshot(&ctx.snapshot)?;
@@ -463,12 +466,13 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
         // Non-blocking accept + poll: the loop re-checks its stop signal every
         // ACCEPT_POLL_INTERVAL instead of parking in a blocking accept, so no
         // wake-by-connect machinery is needed to unblock shutdown.
+        let mut last_record_recheck = Instant::now();
         loop {
             if stop_requested(&ctx.stop_rx) {
                 return Ok(());
             }
-            match listener.poll_accept()? {
-                Some(mut stream) => {
+            match listener.poll_accept() {
+                Ok(Some(mut stream)) => {
                     if stop_requested(&ctx.stop_rx) {
                         return Ok(());
                     }
@@ -482,7 +486,38 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
                         );
                     }
                 }
-                None => thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL),
+                Ok(None) => {
+                    if last_record_recheck.elapsed() >= GRAFT_RECEIVER_RECORD_RECHECK_INTERVAL {
+                        last_record_recheck = Instant::now();
+                        match listener.republish_if_missing() {
+                            Ok(true) => {
+                                let snapshot = read_snapshot(&ctx.snapshot)?;
+                                ctx.observability.receiver_ownership(
+                                    &snapshot,
+                                    "restore_receiver_record",
+                                    "ok",
+                                );
+                            }
+                            Ok(false) => {}
+                            Err(error) => {
+                                let snapshot = read_snapshot(&ctx.snapshot)?;
+                                ctx.observability.receiver_ownership(
+                                    &snapshot,
+                                    "restore_receiver_record",
+                                    "error",
+                                );
+                                return Err(error);
+                            }
+                        }
+                    }
+                    thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL);
+                }
+                Err(error) => {
+                    warn_runtime_error("poll_graft_receiver", Some(&ctx.endpoint_path), &error);
+                    drop(listener);
+                    listener = rebind_graft_receiver(&ctx)?;
+                    last_record_recheck = Instant::now();
+                }
             }
         }
     })();
@@ -502,6 +537,33 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
     result
 }
 
+fn rebind_graft_receiver(
+    ctx: &GraftReceiverLoopContext,
+) -> Result<GraftReceiverListener, AtmError> {
+    let mut last_error = None;
+    for attempt in 1..=GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS {
+        match GraftReceiverListener::bind(&ctx.endpoint_path, ctx.owner_chat_id.clone()) {
+            Ok(listener) => {
+                let snapshot = read_snapshot(&ctx.snapshot)?;
+                ctx.observability
+                    .receiver_ownership(&snapshot, "rebind_receiver_owner", "ok");
+                return Ok(listener);
+            }
+            Err(error) => {
+                warn_runtime_error("rebind_graft_receiver", Some(&ctx.endpoint_path), &error);
+                last_error = Some(error);
+                if attempt < GRAFT_RECEIVER_REBIND_MAX_ATTEMPTS {
+                    thread::sleep(GRAFT_RECEIVER_REBIND_DELAY);
+                }
+            }
+        }
+    }
+    let snapshot = read_snapshot(&ctx.snapshot)?;
+    ctx.observability
+        .receiver_ownership(&snapshot, "rebind_receiver_owner", "error");
+    Err(last_error.expect("at least one graft receiver rebind attempt"))
+}
+
 fn stop_requested(stop_rx: &Receiver<()>) -> bool {
     matches!(
         stop_rx.try_recv(),
@@ -518,11 +580,13 @@ fn handle_graft_receiver_connection(
     let request = listener.read_request(stream, GRAFT_RECEIVER_IO_DEADLINE)?;
     let event = request.event;
     let rendered_nudge = request.rendered_nudge;
+    let message_body = request.message_body;
     let dispatch = BuiltInPostSendDispatch {
         target: PostSendBuiltInTarget::Graft(GraftNudgeTarget {
             recipient: event.recipient.clone(),
             recipient_team: event.recipient_team.clone(),
             rendered_nudge,
+            message_body,
         }),
         event,
     };
@@ -670,6 +734,7 @@ mod tests {
             &GraftPostSendRequest {
                 event,
                 rendered_nudge: "<atm>test nudge</atm>".to_string(),
+                message_body: "full immutable body".to_string(),
             },
             DELIVER_CONNECT_DEADLINE,
             DELIVER_IO_DEADLINE,
@@ -854,10 +919,42 @@ mod tests {
         let nudges = injector.nudges.lock().expect("nudges lock");
         assert_eq!(nudges.len(), 100);
         assert_eq!(
+            nudges[0].body,
+            "<atm>test nudge</atm>\n\nfull immutable body"
+        );
+        assert_eq!(
             read_snapshot(&snapshot).expect("snapshot").state,
             GraftSessionState::Listening
         );
 
+        stop_receiver(stop_tx, join);
+    }
+
+    #[test]
+    fn receiver_loop_restores_a_missing_endpoint_record_before_the_next_delivery() {
+        let paths = test_paths();
+        let endpoint_path = receiver_endpoint_path(&paths);
+        let injector = Arc::new(RecordingInjector::default());
+        let (stop_tx, join, _snapshot) = spawn_receiver(
+            endpoint_path.clone(),
+            injector.clone() as Arc<dyn HostNudgeInjector>,
+        );
+
+        fs::remove_file(&endpoint_path).expect("remove published endpoint record");
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while !endpoint_path.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            endpoint_path.exists(),
+            "receiver must restore a record deleted by an external lifecycle event"
+        );
+
+        assert_eq!(
+            deliver_request(&endpoint_path, request_event()),
+            GraftPostSendResponse::Delivered
+        );
+        assert_eq!(injector.nudges.lock().expect("nudges lock").len(), 1);
         stop_receiver(stop_tx, join);
     }
 

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -445,95 +445,7 @@ pub(crate) struct GraftReceiverLoopContext {
 
 pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(), AtmError> {
     let injector = BoundedHostNudgeInjector::spawn(Arc::clone(&ctx.injector));
-    let result = (|| {
-        let mut listener =
-            match GraftReceiverListener::bind(&ctx.endpoint_path, ctx.owner_chat_id.clone()) {
-                Ok(listener) => {
-                    let snapshot = read_snapshot(&ctx.snapshot)?;
-                    ctx.observability.receiver_ownership(
-                        &snapshot,
-                        "activate_receiver_owner",
-                        "ok",
-                    );
-                    listener
-                }
-                Err(error) => {
-                    let snapshot = read_snapshot(&ctx.snapshot)?;
-                    let outcome = if error.code() == AtmErrorCode::GraftReceiverAlreadyActive {
-                        "conflict"
-                    } else {
-                        "error"
-                    };
-                    ctx.observability.receiver_ownership(
-                        &snapshot,
-                        "activate_receiver_owner",
-                        outcome,
-                    );
-                    return Err(error);
-                }
-            };
-        if let Some(ready_tx) = ctx.ready_tx.as_ref() {
-            signal_ready_sender(ready_tx)?;
-        }
-        // Non-blocking accept + poll: the loop re-checks its stop signal every
-        // ACCEPT_POLL_INTERVAL instead of parking in a blocking accept, so no
-        // wake-by-connect machinery is needed to unblock shutdown.
-        let mut last_record_recheck = Instant::now();
-        loop {
-            if stop_requested(&ctx.stop_rx) {
-                return Ok(());
-            }
-            match listener.poll_accept() {
-                Ok(Some(mut stream)) => {
-                    if stop_requested(&ctx.stop_rx) {
-                        return Ok(());
-                    }
-                    if let Err(error) =
-                        handle_graft_receiver_connection(&ctx, &injector, &listener, &mut stream)
-                    {
-                        warn_runtime_error(
-                            "handle_graft_receiver_connection",
-                            Some(&ctx.endpoint_path),
-                            &error,
-                        );
-                    }
-                }
-                Ok(None) => {
-                    if last_record_recheck.elapsed() >= GRAFT_RECEIVER_RECORD_RECHECK_INTERVAL {
-                        last_record_recheck = Instant::now();
-                        match listener.republish_if_missing() {
-                            Ok(true) => {
-                                let snapshot = read_snapshot(&ctx.snapshot)?;
-                                ctx.observability.receiver_ownership(
-                                    &snapshot,
-                                    "restore_receiver_record",
-                                    "ok",
-                                );
-                            }
-                            Ok(false) => {}
-                            Err(error) => {
-                                let snapshot = read_snapshot(&ctx.snapshot)?;
-                                ctx.observability.receiver_ownership(
-                                    &snapshot,
-                                    "restore_receiver_record",
-                                    "error",
-                                );
-                                return Err(error);
-                            }
-                        }
-                    }
-                    thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL);
-                }
-                Err(error) => {
-                    match recover_after_poll_accept_error(&ctx, listener, &error)? {
-                        Some(rebound_listener) => listener = rebound_listener,
-                        None => return Ok(()),
-                    }
-                    last_record_recheck = Instant::now();
-                }
-            }
-        }
-    })();
+    let result = listen_for_graft_nudges(&ctx, &injector);
     let terminal_state = if result.is_ok() {
         GraftSessionState::Closed
     } else {
@@ -548,6 +460,99 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
         warn_runtime_error("set_session_state", Some(&ctx.endpoint_path), &state_error);
     }
     result
+}
+
+fn listen_for_graft_nudges(
+    ctx: &GraftReceiverLoopContext,
+    injector: &BoundedHostNudgeInjector,
+) -> Result<(), AtmError> {
+    let mut listener = activate_graft_receiver(ctx)?;
+    if let Some(ready_tx) = ctx.ready_tx.as_ref() {
+        signal_ready_sender(ready_tx)?;
+    }
+    // Non-blocking accept + poll: the loop re-checks its stop signal every
+    // ACCEPT_POLL_INTERVAL instead of parking in a blocking accept, so no
+    // wake-by-connect machinery is needed to unblock shutdown.
+    let mut last_record_recheck = Instant::now();
+    loop {
+        if stop_requested(&ctx.stop_rx) {
+            return Ok(());
+        }
+        match listener.poll_accept() {
+            Ok(Some(mut stream)) => {
+                if stop_requested(&ctx.stop_rx) {
+                    return Ok(());
+                }
+                if let Err(error) =
+                    handle_graft_receiver_connection(ctx, injector, &listener, &mut stream)
+                {
+                    warn_runtime_error(
+                        "handle_graft_receiver_connection",
+                        Some(&ctx.endpoint_path),
+                        &error,
+                    );
+                }
+            }
+            Ok(None) => handle_idle_graft_receiver(ctx, &listener, &mut last_record_recheck)?,
+            Err(error) => {
+                match recover_after_poll_accept_error(ctx, listener, &error)? {
+                    Some(rebound_listener) => listener = rebound_listener,
+                    None => return Ok(()),
+                }
+                last_record_recheck = Instant::now();
+            }
+        }
+    }
+}
+
+fn activate_graft_receiver(
+    ctx: &GraftReceiverLoopContext,
+) -> Result<GraftReceiverListener, AtmError> {
+    match GraftReceiverListener::bind(&ctx.endpoint_path, ctx.owner_chat_id.clone()) {
+        Ok(listener) => {
+            let snapshot = read_snapshot(&ctx.snapshot)?;
+            ctx.observability
+                .receiver_ownership(&snapshot, "activate_receiver_owner", "ok");
+            Ok(listener)
+        }
+        Err(error) => {
+            let snapshot = read_snapshot(&ctx.snapshot)?;
+            let outcome = if error.code() == AtmErrorCode::GraftReceiverAlreadyActive {
+                "conflict"
+            } else {
+                "error"
+            };
+            ctx.observability
+                .receiver_ownership(&snapshot, "activate_receiver_owner", outcome);
+            Err(error)
+        }
+    }
+}
+
+fn handle_idle_graft_receiver(
+    ctx: &GraftReceiverLoopContext,
+    listener: &GraftReceiverListener,
+    last_record_recheck: &mut Instant,
+) -> Result<(), AtmError> {
+    if last_record_recheck.elapsed() >= GRAFT_RECEIVER_RECORD_RECHECK_INTERVAL {
+        *last_record_recheck = Instant::now();
+        match listener.republish_if_missing() {
+            Ok(true) => {
+                let snapshot = read_snapshot(&ctx.snapshot)?;
+                ctx.observability
+                    .receiver_ownership(&snapshot, "restore_receiver_record", "ok");
+            }
+            Ok(false) => {}
+            Err(error) => {
+                let snapshot = read_snapshot(&ctx.snapshot)?;
+                ctx.observability
+                    .receiver_ownership(&snapshot, "restore_receiver_record", "error");
+                return Err(error);
+            }
+        }
+    }
+    thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL);
+    Ok(())
 }
 
 fn recover_after_poll_accept_error(

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -562,12 +562,28 @@ fn recover_after_poll_accept_error(
 ) -> Result<Option<GraftReceiverListener>, AtmError> {
     warn_runtime_error("poll_graft_receiver", Some(&ctx.endpoint_path), error);
     drop(listener);
+    recover_graft_receiver(ctx)
+}
+
+fn recover_graft_receiver(
+    ctx: &GraftReceiverLoopContext,
+) -> Result<Option<GraftReceiverListener>, AtmError> {
+    set_session_state(
+        &ctx.snapshot,
+        GraftSessionState::Degraded,
+        ctx.observability.as_ref(),
+    )?;
     loop {
         if stop_requested(&ctx.stop_rx) {
             return Ok(None);
         }
         match rebind_graft_receiver(ctx) {
             Ok(Some(listener)) => {
+                set_session_state(
+                    &ctx.snapshot,
+                    GraftSessionState::Listening,
+                    ctx.observability.as_ref(),
+                )?;
                 if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_REBIND_CYCLE_DELAY) {
                     return Ok(None);
                 }
@@ -690,7 +706,8 @@ mod tests {
         BoundedHostNudgeInjector, GraftReceiverLoopContext, MAX_HOST_NUDGE_HELPERS,
         RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch, handle_graft_receiver_connection,
         join_receive_loop_with_deadline, load_graft_config, read_snapshot,
-        recover_after_poll_accept_error, run_graft_receiver_loop, wait_for_stop_or_delay,
+        recover_after_poll_accept_error, recover_graft_receiver, run_graft_receiver_loop,
+        wait_for_stop_or_delay,
     };
     use crate::{GraftSessionState, SessionSnapshot};
 
@@ -722,6 +739,16 @@ mod tests {
     struct NoopObservability;
 
     impl GraftObservability for NoopObservability {}
+
+    struct StateObservability {
+        states: mpsc::SyncSender<GraftSessionState>,
+    }
+
+    impl GraftObservability for StateObservability {
+        fn session_state_changed(&self, snapshot: &SessionSnapshot) {
+            let _ = self.states.try_send(snapshot.state);
+        }
+    }
 
     #[derive(Debug)]
     struct FirstCallBlocksInjector {
@@ -839,7 +866,7 @@ mod tests {
         let snapshot = Arc::new(RwLock::new(SessionSnapshot {
             team: TeamName::from_validated(TEST_TEAM),
             agent: AgentName::from_validated(TEST_QA),
-            state: GraftSessionState::Listening,
+            state: GraftSessionState::Degraded,
         }));
         let ctx = GraftReceiverLoopContext {
             endpoint_path,
@@ -1062,6 +1089,13 @@ mod tests {
         )
         .expect("recover after hard accept failure")
         .expect("rebind after hard accept failure");
+        assert_eq!(
+            read_snapshot(&snapshot)
+                .expect("read post-rebind snapshot")
+                .state,
+            GraftSessionState::Listening,
+            "only a successful rebind returns the session to Listening"
+        );
         assert_ne!(
             fs::read_to_string(&endpoint_path).expect("read rebound record"),
             initial_record,
@@ -1086,6 +1120,56 @@ mod tests {
             GraftPostSendResponse::Delivered
         );
         assert_eq!(injector.nudges.lock().expect("nudges lock").len(), 1);
+    }
+
+    #[test]
+    fn receiver_recovery_marks_session_degraded_while_rebind_is_blocked() {
+        let paths = test_paths();
+        let endpoint_path = receiver_endpoint_path(&paths);
+        let initial_listener =
+            GraftReceiverListener::bind(&endpoint_path, None).expect("bind initial listener");
+        drop(initial_listener);
+        let blocker =
+            GraftReceiverListener::bind(&endpoint_path, None).expect("bind competing listener");
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let (state_tx, state_rx) = mpsc::sync_channel(2);
+        let snapshot = Arc::new(RwLock::new(SessionSnapshot {
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_QA),
+            state: GraftSessionState::Listening,
+        }));
+        let ctx = GraftReceiverLoopContext {
+            endpoint_path,
+            owner_chat_id: None,
+            snapshot: Arc::clone(&snapshot),
+            injector: Arc::new(RecordingInjector::default()),
+            observability: Arc::new(StateObservability { states: state_tx }),
+            stop_rx,
+            ready_tx: None,
+        };
+        let recovery = std::thread::spawn(move || recover_graft_receiver(&ctx));
+
+        assert_eq!(
+            state_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("recovery must publish its degraded state"),
+            GraftSessionState::Degraded
+        );
+        assert_eq!(
+            read_snapshot(&snapshot).expect("read retry snapshot").state,
+            GraftSessionState::Degraded
+        );
+
+        stop_tx.send(()).expect("stop recovery");
+        assert!(
+            recovery
+                .join()
+                .expect("join recovery")
+                .expect("recover result")
+                .is_none(),
+            "stop must end the rebind loop without a false Listening state"
+        );
+        drop(blocker);
     }
 
     #[test]

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -513,9 +513,7 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
                     thread::sleep(GRAFT_RECEIVER_ACCEPT_POLL_INTERVAL);
                 }
                 Err(error) => {
-                    warn_runtime_error("poll_graft_receiver", Some(&ctx.endpoint_path), &error);
-                    drop(listener);
-                    listener = rebind_graft_receiver(&ctx)?;
+                    listener = recover_after_poll_accept_error(&ctx, listener, &error)?;
                     last_record_recheck = Instant::now();
                 }
             }
@@ -535,6 +533,16 @@ pub(crate) fn run_graft_receiver_loop(ctx: GraftReceiverLoopContext) -> Result<(
         warn_runtime_error("set_session_state", Some(&ctx.endpoint_path), &state_error);
     }
     result
+}
+
+fn recover_after_poll_accept_error(
+    ctx: &GraftReceiverLoopContext,
+    listener: GraftReceiverListener,
+    error: &AtmError,
+) -> Result<GraftReceiverListener, AtmError> {
+    warn_runtime_error("poll_graft_receiver", Some(&ctx.endpoint_path), error);
+    drop(listener);
+    rebind_graft_receiver(ctx)
 }
 
 fn rebind_graft_receiver(
@@ -627,8 +635,9 @@ mod tests {
 
     use super::{
         BoundedHostNudgeInjector, GraftReceiverLoopContext, MAX_HOST_NUDGE_HELPERS,
-        RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch, join_receive_loop_with_deadline,
-        load_graft_config, read_snapshot, run_graft_receiver_loop,
+        RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch, handle_graft_receiver_connection,
+        join_receive_loop_with_deadline, load_graft_config, read_snapshot,
+        recover_after_poll_accept_error, run_graft_receiver_loop,
     };
     use crate::{GraftSessionState, SessionSnapshot};
 
@@ -956,6 +965,62 @@ mod tests {
         );
         assert_eq!(injector.nudges.lock().expect("nudges lock").len(), 1);
         stop_receiver(stop_tx, join);
+    }
+
+    #[test]
+    fn hard_accept_failure_rebinds_and_resumes_authenticated_delivery() {
+        let paths = test_paths();
+        let endpoint_path = receiver_endpoint_path(&paths);
+        let injector = Arc::new(RecordingInjector::default());
+        let (_stop_tx, stop_rx) = mpsc::channel();
+        let snapshot = Arc::new(RwLock::new(SessionSnapshot {
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_QA),
+            state: GraftSessionState::Listening,
+        }));
+        let ctx = GraftReceiverLoopContext {
+            endpoint_path: endpoint_path.clone(),
+            owner_chat_id: None,
+            snapshot: Arc::clone(&snapshot),
+            injector: injector.clone() as Arc<dyn HostNudgeInjector>,
+            observability: Arc::new(NoopObservability),
+            stop_rx,
+            ready_tx: None,
+        };
+        let listener =
+            GraftReceiverListener::bind(&endpoint_path, None).expect("bind initial listener");
+        let initial_record = fs::read_to_string(&endpoint_path).expect("read initial record");
+
+        let listener = recover_after_poll_accept_error(
+            &ctx,
+            listener,
+            &AtmError::daemon_unavailable("simulated hard accept failure"),
+        )
+        .expect("rebind after hard accept failure");
+        assert_ne!(
+            fs::read_to_string(&endpoint_path).expect("read rebound record"),
+            initial_record,
+            "rebind must republish a fresh capability record"
+        );
+
+        let sender = std::thread::spawn({
+            let endpoint_path = endpoint_path.clone();
+            move || deliver_request(&endpoint_path, request_event())
+        });
+        let mut stream = loop {
+            if let Some(stream) = listener.poll_accept().expect("poll rebound listener") {
+                break stream;
+            }
+            std::thread::yield_now();
+        };
+        let bounded_injector = BoundedHostNudgeInjector::spawn(injector.clone());
+        handle_graft_receiver_connection(&ctx, &bounded_injector, &listener, &mut stream)
+            .expect("deliver through rebound listener");
+        assert_eq!(
+            sender.join().expect("join sender"),
+            GraftPostSendResponse::Delivered
+        );
+        assert_eq!(injector.nudges.lock().expect("nudges lock").len(), 1);
     }
 
     #[test]

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -42,6 +42,13 @@ const GRAFT_RECEIVER_REBIND_CYCLE_DELAY: Duration = Duration::from_millis(100);
 /// Wait between exhausted rebind cycles. The receiver remains armed and never
 /// starts a daemon; it only retries its own loopback listener publication.
 const GRAFT_RECEIVER_REARM_DELAY: Duration = Duration::from_secs(1);
+/// Stop a failed recovery burst after this interval, emit a distinct degraded
+/// signal, then enter a slower half-open retry cycle instead of retrying
+/// indefinitely without escalation.
+const GRAFT_RECEIVER_RECOVERY_MAX_DURATION: Duration = Duration::from_secs(30);
+/// Give a persistently unavailable endpoint time to recover before a new
+/// bounded recovery burst begins after the circuit opens.
+const GRAFT_RECEIVER_RECOVERY_CIRCUIT_DELAY: Duration = Duration::from_secs(5);
 const MAX_HOST_NUDGE_HELPERS: usize = 8;
 
 type ReceiveLoopJoinHelper = (
@@ -49,6 +56,25 @@ type ReceiveLoopJoinHelper = (
     JoinHandle<()>,
     std::thread::ThreadId,
 );
+
+#[derive(Debug)]
+struct ReceiverRecoveryCircuit {
+    began_at: Instant,
+}
+
+impl ReceiverRecoveryCircuit {
+    fn new(now: Instant) -> Self {
+        Self { began_at: now }
+    }
+
+    fn is_exhausted(&self, now: Instant) -> bool {
+        now.duration_since(self.began_at) >= GRAFT_RECEIVER_RECOVERY_MAX_DURATION
+    }
+
+    fn reset(&mut self, now: Instant) {
+        *self = Self::new(now);
+    }
+}
 
 #[derive(Debug)]
 struct HelperThreadBudget {
@@ -573,6 +599,7 @@ fn recover_graft_receiver(
         GraftSessionState::Degraded,
         ctx.observability.as_ref(),
     )?;
+    let mut recovery_circuit = ReceiverRecoveryCircuit::new(Instant::now());
     loop {
         if stop_requested(&ctx.stop_rx) {
             return Ok(None);
@@ -591,12 +618,38 @@ fn recover_graft_receiver(
             }
             Ok(None) => return Ok(None),
             Err(error) => {
-                warn_runtime_error("rearm_graft_receiver", Some(&ctx.endpoint_path), &error);
+                let now = Instant::now();
                 let snapshot = read_snapshot(&ctx.snapshot)?;
-                ctx.observability
-                    .receiver_ownership(&snapshot, "rebind_receiver_owner", "retry");
-                if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_REARM_DELAY) {
-                    return Ok(None);
+                if recovery_circuit.is_exhausted(now) {
+                    ctx.observability.receiver_ownership(
+                        &snapshot,
+                        "rebind_receiver_owner",
+                        "circuit_open",
+                    );
+                    ctx.observability.session_error(
+                        &snapshot,
+                        "graft_receiver_recovery_circuit_open",
+                        &error,
+                    );
+                    warn_runtime_error(
+                        "graft_receiver_recovery_circuit_open",
+                        Some(&ctx.endpoint_path),
+                        &error,
+                    );
+                    if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_RECOVERY_CIRCUIT_DELAY) {
+                        return Ok(None);
+                    }
+                    recovery_circuit.reset(Instant::now());
+                } else {
+                    warn_runtime_error("rearm_graft_receiver", Some(&ctx.endpoint_path), &error);
+                    ctx.observability.receiver_ownership(
+                        &snapshot,
+                        "rebind_receiver_owner",
+                        "retry",
+                    );
+                    if wait_for_stop_or_delay(&ctx.stop_rx, GRAFT_RECEIVER_REARM_DELAY) {
+                        return Ok(None);
+                    }
                 }
             }
         }
@@ -697,17 +750,17 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc;
     use std::sync::{Arc, Mutex, RwLock};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     use crate::{GraftObservability, HostNudge, HostNudgeInjector};
 
     use super::{
-        BoundedHostNudgeInjector, GraftReceiverLoopContext, MAX_HOST_NUDGE_HELPERS,
-        RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch, handle_graft_receiver_connection,
-        join_receive_loop_with_deadline, load_graft_config, read_snapshot,
-        recover_after_poll_accept_error, recover_graft_receiver, run_graft_receiver_loop,
-        wait_for_stop_or_delay,
+        BoundedHostNudgeInjector, GRAFT_RECEIVER_RECOVERY_MAX_DURATION, GraftReceiverLoopContext,
+        MAX_HOST_NUDGE_HELPERS, RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch,
+        ReceiverRecoveryCircuit, handle_graft_receiver_connection, join_receive_loop_with_deadline,
+        load_graft_config, read_snapshot, recover_after_poll_accept_error, recover_graft_receiver,
+        run_graft_receiver_loop, wait_for_stop_or_delay,
     };
     use crate::{GraftSessionState, SessionSnapshot};
 
@@ -1170,6 +1223,18 @@ mod tests {
             "stop must end the rebind loop without a false Listening state"
         );
         drop(blocker);
+    }
+
+    #[test]
+    fn receiver_recovery_circuit_escalates_after_a_bounded_recovery_window() {
+        let started = Instant::now();
+        let mut circuit = ReceiverRecoveryCircuit::new(started);
+
+        assert!(!circuit.is_exhausted(started));
+        assert!(circuit.is_exhausted(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION));
+
+        circuit.reset(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION);
+        assert!(!circuit.is_exhausted(started + GRAFT_RECEIVER_RECOVERY_MAX_DURATION));
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1193,6 +1193,7 @@ mod tests {
                 recipient: "recipient".parse().expect("recipient"),
                 recipient_team: "test-team".parse().expect("team"),
                 rendered_nudge: "<atm kind=\"nudge\"/>".to_owned(),
+                message_body: "message body".to_owned(),
             }),
         };
 
@@ -2595,6 +2596,7 @@ mod tests {
                 recipient: "recipient".parse().expect("recipient"),
                 recipient_team: "test-team".parse().expect("team"),
                 rendered_nudge: "<atm kind=\"nudge\"/>".to_owned(),
+                message_body: "message body".to_owned(),
             }),
         };
 

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -175,6 +175,8 @@ impl GraftNudgeSink {
         let request = GraftPostSendRequest {
             event: event.clone(),
             rendered_nudge: rendered_nudge.to_string(),
+            // This legacy diagnostic command has no admitted message body.
+            message_body: String::new(),
         };
         let response = deliver_graft_post_send(
             &record_path,

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -188,7 +188,7 @@ impl GraftNudgeSink {
             if error.code() == AtmErrorCode::PostSendGraftUnavailable {
                 error
             } else {
-                AtmError::for_code(AtmErrorCode::PostSendGraftUnavailable)
+                AtmError::for_code(AtmErrorCode::PostSendGraftUnavailable).with_cause(error)
             }
         })?;
         match response {
@@ -208,9 +208,9 @@ fn tmux_command() -> Command {
 
 fn run_tmux_command(mut command: Command, action: &'static str) -> Result<()> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let child = command
-        .spawn()
-        .map_err(|_source| AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed))?;
+    let child = command.spawn().map_err(|source| {
+        AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed).with_cause(source)
+    })?;
     let output = wait_for_tmux_output(child, action)?;
     ensure_tmux_success(output, action).map_err(Into::into)
 }
@@ -220,8 +220,10 @@ fn wait_for_tmux_output(mut child: Child, _action: &'static str) -> Result<Outpu
     loop {
         match child.try_wait() {
             Ok(Some(_)) => {
-                return child.wait_with_output().map_err(|_source| {
-                    AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed).into()
+                return child.wait_with_output().map_err(|source| {
+                    AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed)
+                        .with_cause(source)
+                        .into()
                 });
             }
             Ok(None) if started_at.elapsed() < TMUX_SEND_TIMEOUT => {
@@ -232,10 +234,12 @@ fn wait_for_tmux_output(mut child: Child, _action: &'static str) -> Result<Outpu
                 let _ = child.wait();
                 return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed).into());
             }
-            Err(_source) => {
+            Err(source) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed).into());
+                return Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed)
+                    .with_cause(source)
+                    .into());
             }
         }
     }
@@ -246,12 +250,12 @@ fn ensure_tmux_success(output: Output, action: &'static str) -> Result<(), AtmEr
         return Ok(());
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let _detail = if stderr.is_empty() {
+    let detail = if stderr.is_empty() {
         format!("tmux exited unsuccessfully while trying to {action}")
     } else {
         format!("tmux exited unsuccessfully while trying to {action}: {stderr}")
     };
-    Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed))
+    Err(AtmError::for_code(AtmErrorCode::PostSendTmuxSendFailed).with_cause(detail))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Restores a missing authenticated graft receiver record and rebinds its listener with bounded retry after a hard socket accept failure (fixes: no nudge delivered after ATM daemon restart / port change).
- Carries the immutable admitted message body alongside the canonical `<atm>` XML nudge through the authenticated loopback path (fixes: nudge body truncated to envelope-only when connected).
- No daemon runtime changes, no Hermes-specific reconnect logic.

Fixes #985

## Test plan
- [x] `cargo fmt --check`
- [x] `just lint`
- [x] `cargo test -p atm-graft -p agent-team-mail-core -p atm-http-runtime -p agent-team-mail` (all passed)
- [ ] quality-mgr review (dispatching now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)