### PR TITLE
docs(ao2): AO2.9 benchmark report template and publication procedure

### DIFF
--- a/docs/adr/ADR-054-benchmark-report-finalizer-trust-model.md
+++ b/docs/adr/ADR-054-benchmark-report-finalizer-trust-model.md
@@ -1,0 +1,65 @@
+---
+adr: ADR-054
+title: Benchmark Report Finalizer Trust Model
+status: Proposed
+date: 2026-08-22
+---
+
+# ADR-054 — Benchmark Report Finalizer Trust Model
+
+## Context
+
+AO2.9 publishes physical benchmark evidence from a dedicated local account.
+The account can observe the benchmark process and repository, but there is no
+independent measurement verifier in this sprint. Publication is nevertheless
+publicly consequential: a result becomes discoverable through the Pages branch
+only after an evidence-branch commit, push, and reviewed pull request. The
+implementation therefore needs an explicit trust boundary rather than an
+implicit assumption that a local script is authoritative.
+
+## Decision
+
+1. `scripts/smoke/benchmark_publication.py` is the sole publication seam. Its
+   `begin_run` function pushes the pre-execution intent and pending marker;
+   `finalize_run` is the only function permitted to classify the outcome, write
+   the immutable result/envelope/report/index, and push the publication.
+2. The finalizer accepts only the canonical
+   `evidence/ao2-benchmark-reports` branch with an open pull request into the
+   Pages publisher branch. A local branch or an unreviewed push is evidence,
+   not public publication.
+3. The local benchmark account and finalizer are trusted to capture and
+   classify their own measurement. The trust is bounded by the pushed intent,
+   immutable result path, source and binary hashes, raw evidence, schema/path
+   validation, generated-index checks, branch protection, and pull-request
+   review.
+4. AO2.9 does not add an independent verifier. A future verifier may compare
+   raw evidence and recompute classifications in a separate reviewed sprint;
+   its absence is recorded as residual risk rather than hidden behind a
+   stronger status claim.
+
+## Consequences
+
+- A crash, power loss, or failed push leaves a durable intent/lock that exposes
+  an `INCOMPLETE` attempt and prevents the next target from silently proceeding.
+- Reviewers can distinguish what the local account measured from what the
+  repository accepted as published, and can inspect the complete evidence
+  lineage before merging the Pages PR.
+- The local operator remains a trust anchor for measurement truth; hashes and
+  raw artifacts improve auditability but cannot prove that a compromised
+  account measured the intended workload.
+
+## Residual risk and alternatives
+
+The accepted residual risk is a compromised or mistaken local account
+falsifying metrics or raw evidence before the finalizer pushes. Requiring a
+remote measurement service or an independent verifier now would add a new
+operational dependency and delay the isolated AO2 benchmark lane. That
+alternative is explicitly deferred, not claimed to be equivalent.
+
+## Required evidence
+
+Implementation review must show the single-writer boundary, intent-before-run
+ordering, failed-push lock behavior, immutable result/schema validation, raw
+evidence retention, and the reviewed PR that makes the report reachable from
+the Pages publisher. Quality review must cite this ADR when accepting the
+local-finalizer trust model.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -57,6 +57,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-049 — hermes-atm/atm-graft First Public PyPI Release Versioning](./ADR-049-hermes-atm-first-public-pypi-release-versioning.md)
 - [ADR-051 — Permissive Declared Sender Identity and Roster Advisory](./ADR-051-permissive-declared-sender-identity.md)
 - [ADR-052 — Benchmark Account Isolation and Snapshot Policy](./ADR-052-benchmark-account-isolation-and-snapshot-policy.md)
+- [ADR-054 — Benchmark Report Finalizer Trust Model](./ADR-054-benchmark-report-finalizer-trust-model.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md
+++ b/docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md
@@ -28,6 +28,14 @@ the batching comparison: historical M5 TCP evidence recorded approximately
 setup and historically measured about 12.3k. One- and two-frame data remains
 mandatory diagnostics but is not substituted for the batching threshold.
 
+### Reporting contract
+
+Use the normative AO2.9 benchmark reporting, publication, and aggregate
+procedure (`sprint-AO2-9-benchmark-report-template-and-procedure.md`). This
+sprint owns the M5 TCP f8 threshold and safety gates; AO2.9 owns the template,
+per-run path, failure/incomplete publication rule, and index contract. Publish
+this run as the `tcp` target with its raw evidence and calculated result.
+
 ## Preconditions
 
 - AO2.5.4 is merged and `just benchmark` proves snapshot-before-roster and

--- a/docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md
+++ b/docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md
@@ -5,9 +5,12 @@ title: M5 TCP benchmark parity evidence after writer batching restoration
 branch: future-evidence-worktree
 integration_branch: integrate/phase-ao2
 status: draft_for_review
+must_follow: AO2.9-benchmark-report-template-and-procedure merged to integrate/phase-ao2
+parallel_safe: false
 depends_on:
   - AO2.5.4-mandatory-benchmark-snapshot-restore
   - AO2.6-admission-writer-batching-regression
+  - AO2.9-benchmark-report-template-and-procedure
 blocks:
   - AO2.8-windows-tcp-benchmark-parity
 ---
@@ -83,6 +86,7 @@ evidence-only.
 | Throughput | TCP f8 p50 >15,000 messages/second. |
 | Integrity | Accepted count, durable restart check, no unexpected errors, and clean baseline after restore. |
 | Diagnostics | TCP f1/f2 results retained but not confused with the f8 batching threshold. |
+| Publication | Published via the AO2.9 finalizer on `evidence/ao2-benchmark-reports`, reachable through its reviewed Pages PR, with intent/result/index commits retained. |
 
 Required gates are no code changes, successful existing test suite at the
 tested SHA, the physical raw artifact, and independent review of the exact

--- a/docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md
+++ b/docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md
@@ -26,6 +26,15 @@ For example, if AO2.7 records 15,500 msg/s, the Windows floor is 12,400 msg/s.
 The exact floor must be calculated from the committed AO2.7 artifact and
 recorded in the Windows raw/compact evidence; it must never be hardcoded.
 
+### Reporting contract
+
+Use the normative AO2.9 benchmark reporting, publication, and aggregate
+procedure (`sprint-AO2-9-benchmark-report-template-and-procedure.md`). This
+sprint owns the Windows parity calculation and safety gates; AO2.9 owns the
+template, per-run path, failure/incomplete publication rule, and index
+contract. Publish this run as the Windows `tcp` target and retain the AO2.7
+reference artifact and calculated floor in the run JSON.
+
 ## Preconditions
 
 - AO2.7 has passed on M5 with a reviewed f8 raw artifact and known p50.

--- a/docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md
+++ b/docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md
@@ -5,10 +5,13 @@ title: Windows TCP benchmark parity evidence against accepted M5 result
 branch: future-evidence-worktree
 integration_branch: integrate/phase-ao2
 status: draft_for_review
+must_follow: AO2.9 and AO2.7 merged to integrate/phase-ao2
+parallel_safe: false
 depends_on:
   - AO2.5.4-mandatory-benchmark-snapshot-restore
   - AO2.6-admission-writer-batching-regression
   - AO2.7-m5-tcp-benchmark-parity
+  - AO2.9-benchmark-report-template-and-procedure
 ---
 
 # AO2.8 — Windows TCP benchmark parity evidence against accepted M5 result
@@ -80,6 +83,7 @@ AO2.8.
 | Threshold | Windows TCP f8 p50 ≥ `0.80 × AO2.7 M5 TCP f8 p50`. |
 | Integrity | All timed samples retained; accepted/durable counts and cleanup/restore pass. |
 | Traceability | Raw evidence names both host labels, both exact SHAs, M5 p50, and computed floor. |
+| Publication | Published via the AO2.9 finalizer on `evidence/ao2-benchmark-reports`, reachable through its reviewed Pages PR, with intent/result/index commits retained. |
 
 Required gates are the existing validation suite at the tested SHA, the raw
 physical Windows evidence, independent artifact review, and an explicit

--- a/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
+++ b/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
@@ -1,0 +1,70 @@
+# Sprint AO2.9 — Benchmark Report Template and Procedure
+
+Status: DRAFT — requirements captured on-the-fly by Rand; not yet hardened,
+reviewed, or dispatched. Must be formalized before Phase AO2 closes.
+
+## Background
+
+During AO2.7/AO2.8 execution, quality-mgr identified a process gap: benchmark
+campaigns were run and discarded/never published because no standard,
+required reporting artifact or publish location existed for `just benchmark`
+runs (see `.triage`/ATM history around the six-unpublished-campaigns finding,
+2026-08-22). Rand separately requested a consistent, templated report format
+and a formalized target matrix per OS. This sprint formalizes both.
+
+## Requirements
+
+1. **Report template**: introduce a `<file>.xhtml.j2` template (rendered via
+   the repo's existing `sc-compose` templating convention) that produces a
+   consistent, human-readable benchmark report for a single run. Exact
+   filename/location TBD during hardening — mirror the existing
+   `site/reports/smoke/*`, `site/reports/fuzz/*` convention
+   (`.just/generate_report_index.py`).
+
+2. **Mandatory per-run publish**: every `just benchmark` run — pass, fail, or
+   incomplete — must render its xhtml report immediately after the attempt
+   and commit/push it into `site/reports/` under a benchmark-specific,
+   per-computer subpath (e.g. `site/reports/benchmark/<host>/<timestamp>/`).
+   A run that is not published is itself a documented process violation, not
+   merely an incomplete result. No campaign result may be discarded or
+   silently represented as valid.
+
+3. **Compiled/aggregate report**: individual per-run xhtml reports must be
+   compiled into a single final report (index/summary) — reuse or extend
+   `.just/generate_report_index.py`.
+
+4. **Target matrix, per OS** (this is the authoritative matrix for AO2.7/AO2.8
+   completion — supersedes any narrower prior framing):
+   - **macOS / Linux**: all 4 targets — `sqlite`, `uds`, `tcp`, `tcp+tls`.
+   - **Windows**: 3 targets — `sqlite`, `tcp`, `tcp+tls` (no `uds` — not a
+     meaningful/available transport on Windows).
+
+## Open items for hardening pass
+
+- Exact xhtml.j2 template location and variable contract.
+- Exact `site/reports/benchmark/...` path convention (host naming, timestamp
+  format, retention/pruning policy if any).
+- Whether AO2.7 (M5/macOS) and AO2.8 (Windows) sprint docs get amended in
+  place to reference this matrix/template, or whether this doc is the sole
+  source of truth and they defer to it.
+- CI wiring, if any, vs. manual/agent-triggered publish.
+
+## Acceptance criteria (draft — refine during hardening)
+
+- [ ] `<file>.xhtml.j2` template exists and renders a complete single-run report.
+- [ ] `just benchmark` (or equivalent wrapper) publishes the rendered report to
+      `site/reports/benchmark/...` immediately after every attempt, including
+      failed/incomplete ones.
+- [ ] An aggregate/compiled report is generated from all published per-run
+      reports.
+- [ ] AO2.7 target matrix = sqlite, uds, tcp, tcp+tls (macOS/Linux).
+- [ ] AO2.8 target matrix = sqlite, tcp, tcp+tls (Windows).
+- [ ] Plan doc reviewed by quality-mgr before dispatch to dev.
+
+## References
+
+- quality-mgr process-gap finding, ATM message 01M0NGE2MEV5QER37YXFYTHTK3
+  (2026-08-22T19:51:16Z)
+- `docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md`
+- `docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md`
+- `.just/generate_report_index.py`, `site/reports/smoke/*`, `site/reports/fuzz/*`

--- a/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
+++ b/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
@@ -1,70 +1,237 @@
-# Sprint AO2.9 — Benchmark Report Template and Procedure
+---
+phase: AO2
+sprint: AO2.9
+title: Benchmark report template, publication, and aggregate procedure
+branch: plan/ao2-9-benchmark-report-template
+integration_branch: integrate/phase-ao2
+status: ready_for_review
+depends_on:
+  - AO2.5.4-mandatory-benchmark-snapshot-restore
+  - AO2.6-admission-writer-batching-regression
+  - AO2.7-m5-tcp-benchmark-parity
+  - AO2.8-windows-tcp-benchmark-parity
+---
 
-Status: DRAFT — requirements captured on-the-fly by Rand; not yet hardened,
-reviewed, or dispatched. Must be formalized before Phase AO2 closes.
+# AO2.9 — Benchmark report template, publication, and aggregate procedure
 
-## Background
+## Decision and scope
 
-During AO2.7/AO2.8 execution, quality-mgr identified a process gap: benchmark
-campaigns were run and discarded/never published because no standard,
-required reporting artifact or publish location existed for `just benchmark`
-runs (see `.triage`/ATM history around the six-unpublished-campaigns finding,
-2026-08-22). Rand separately requested a consistent, templated report format
-and a formalized target matrix per OS. This sprint formalizes both.
+AO2.9 closes the benchmark-evidence process gap. It defines one durable
+single-run report contract, one immutable publication path, and one aggregate
+index for every physical `just benchmark` attempt. It is documentation and
+procedure work: it does not change the daemon, client, storage, transport,
+TLS, benchmark algorithm, or performance threshold.
 
-## Requirements
+The benchmark remains an explicitly isolated operation under AO2.5.4. It must
+not use the interactive account, the interactive daemon, an alternate data
+root, or a benchmark-only production behavior. A result is evidence only when
+its report and raw artifacts are published by the procedure below.
 
-1. **Report template**: introduce a `<file>.xhtml.j2` template (rendered via
-   the repo's existing `sc-compose` templating convention) that produces a
-   consistent, human-readable benchmark report for a single run. Exact
-   filename/location TBD during hardening — mirror the existing
-   `site/reports/smoke/*`, `site/reports/fuzz/*` convention
-   (`.just/generate_report_index.py`).
+The report contract is normative for AO2.7 and AO2.8. Those sprint documents
+retain their target-specific thresholds and safety gates; they defer to this
+document for template, variable schema, path, publication, and aggregation.
+They must not duplicate those details, so the contract cannot drift.
 
-2. **Mandatory per-run publish**: every `just benchmark` run — pass, fail, or
-   incomplete — must render its xhtml report immediately after the attempt
-   and commit/push it into `site/reports/` under a benchmark-specific,
-   per-computer subpath (e.g. `site/reports/benchmark/<host>/<timestamp>/`).
-   A run that is not published is itself a documented process violation, not
-   merely an incomplete result. No campaign result may be discarded or
-   silently represented as valid.
+## Existing assets and implementation boundary
 
-3. **Compiled/aggregate report**: individual per-run xhtml reports must be
-   compiled into a single final report (index/summary) — reuse or extend
-   `.just/generate_report_index.py`.
+The repository already contains the intended sc-compose assets:
 
-4. **Target matrix, per OS** (this is the authoritative matrix for AO2.7/AO2.8
-   completion — supersedes any narrower prior framing):
-   - **macOS / Linux**: all 4 targets — `sqlite`, `uds`, `tcp`, `tcp+tls`.
-   - **Windows**: 3 targets — `sqlite`, `tcp`, `tcp+tls` (no `uds` — not a
-     meaningful/available transport on Windows).
+| Asset | Contract |
+| --- | --- |
+| `templates/benchmark-report/benchmark-run.xhtml.j2` | Single-run XHTML panel; its front matter is the variable contract. |
+| `templates/benchmark-report/benchmark-report.html.j2` | Aggregate benchmark report shell. |
+| `scripts/smoke/benchmark_report.py` | Validates/persists benchmark JSON and renders the two templates. |
+| `.just/generate_report_index.py` | Builds the public `site/reports/index.html` from validated envelopes. |
+| `Justfile` recipe `benchmark` | Isolated benchmark entry point and finalizer hook. |
 
-## Open items for hardening pass
+The existing implementation is a starting point, not proof that AO2.9 is
+complete. In particular, it currently writes a flat historical directory and
+only validates `uds` and `tcp`. The implementation work derived from this
+plan must extend those seams rather than introduce a second renderer or an
+untracked reporting path.
 
-- Exact xhtml.j2 template location and variable contract.
-- Exact `site/reports/benchmark/...` path convention (host naming, timestamp
-  format, retention/pruning policy if any).
-- Whether AO2.7 (M5/macOS) and AO2.8 (Windows) sprint docs get amended in
-  place to reference this matrix/template, or whether this doc is the sole
-  source of truth and they defer to it.
-- CI wiring, if any, vs. manual/agent-triggered publish.
+## Single-run template contract
 
-## Acceptance criteria (draft — refine during hardening)
+The canonical template is
+`templates/benchmark-report/benchmark-run.xhtml.j2`. It is rendered with
+`sc-compose render --root <repo> --file <template> --var-file <vars.json>
+--output <run.xhtml>`. The producer must validate the variables before
+rendering and must never interpolate untrusted values as HTML fragments.
 
-- [ ] `<file>.xhtml.j2` template exists and renders a complete single-run report.
-- [ ] `just benchmark` (or equivalent wrapper) publishes the rendered report to
-      `site/reports/benchmark/...` immediately after every attempt, including
-      failed/incomplete ones.
-- [ ] An aggregate/compiled report is generated from all published per-run
-      reports.
-- [ ] AO2.7 target matrix = sqlite, uds, tcp, tcp+tls (macOS/Linux).
-- [ ] AO2.8 target matrix = sqlite, tcp, tcp+tls (Windows).
-- [ ] Plan doc reviewed by quality-mgr before dispatch to dev.
+The template front matter is the authoritative required-variable list. The
+values have these types and meanings:
+
+| Variable | Type and rule |
+| --- | --- |
+| `title` | Non-empty string; escaped by the template. |
+| `artifact_id` | Safe opaque run identifier; `[A-Za-z0-9][A-Za-z0-9._-]{0,127}`. |
+| `generated_at` | UTC ISO-8601 timestamp with `Z`; generated once for the attempt. |
+| `host_label` | Stable, safe per-computer label; never a raw hostname, path, username, or IP. |
+| `transport` | One of the target values in the authoritative matrix below (`sqlite`, `uds`, `tcp`, `tcp+tls`). |
+| `frames_per_connection` | Non-negative integer; `0` for a target where frames are not applicable. |
+| `run_duration_s` | Non-negative number covering the measured interval only. |
+| `passed` | Boolean. `false` for a failed or incomplete attempt. |
+| `failure` | Escaped diagnostic string; empty when no failure occurred. |
+| `cleanup_failure` | Escaped cleanup/restore diagnostic string; empty when cleanup succeeded. |
+| `sample_html` | Renderer-owned, already-escaped table fragment; never caller-supplied HTML. |
+| `direct_sqlite_html` | Renderer-owned, already-escaped SQLite evidence fragment; never caller-supplied HTML. |
+
+The JSON result beside the XHTML is the source of truth. The XHTML is a
+view of that immutable JSON and must contain the run identity, status, target,
+tested SHA, host label, measured duration, diagnostics, and links to raw
+evidence. A failed or incomplete run is a valid report with `passed: false`;
+it must not be omitted or converted into a passing empty result.
+
+## Authoritative target matrix
+
+This matrix supersedes narrower AO2.7/AO2.8 wording. `sqlite` is a direct
+storage-admission target; it is not silently substituted for a public
+transport run. `uds`, `tcp`, and `tcp+tls` are public transport targets.
+
+| Operating system | Required targets |
+| --- | --- |
+| macOS | `sqlite`, `uds`, `tcp`, `tcp+tls` |
+| Linux | `sqlite`, `uds`, `tcp`, `tcp+tls` |
+| Windows | `sqlite`, `tcp`, `tcp+tls` |
+
+The producer schema, CLI validation, aggregate table, and acceptance tests
+must all use this same matrix. Windows must reject `uds` as unsupported; it
+must not report a skipped UDS case as a pass. A target that was not attempted
+is represented as missing in the aggregate, not as a synthetic result.
+
+## Immutable publication layout
+
+Every attempt receives one `run_id` before any build or benchmark command is
+started. It is a UTC timestamp in `YYYYMMDDTHHMMSSZ` form. If two attempts on
+the same host collide in one second, append `-<8 lowercase hex nonce>`; the
+resulting ID remains safe and immutable.
+
+The required layout is:
+
+```text
+site/reports/benchmark/
+  index.html                              # generated aggregate/final report
+  <host_label>/
+    <run_id>/
+      result.json                         # immutable validated source
+      result.envelope.json                # public-index envelope
+      run.xhtml                           # sc-compose single-run report
+      raw/                                # stdout, stderr, daemon logs, traces
+```
+
+`host_label` is the same safe opaque label passed to the template. The
+envelope's `report_html` is the safe repository-relative path
+`benchmark/<host_label>/<run_id>/run.xhtml`; it must not contain `..`, an
+absolute path, a backslash, or an unvalidated host string. The envelope also
+records `schema_version`, `report_type: "benchmark"`, `generated_at`, and
+`host_label`. The aggregate links to the JSON, XHTML, and raw evidence using
+paths relative to `site/reports`.
+
+The implementation must extend `.just/generate_report_index.py` to discover
+and validate nested benchmark envelopes and to reject a missing run directory,
+missing XHTML, malformed envelope, unsafe path, or missing raw evidence. The
+root `site/reports/index.html` remains the public cross-type index and must
+link to `benchmark/index.html`; the benchmark aggregate is the authoritative
+single report for the benchmark family. Historical reports remain immutable;
+there is no pruning or overwrite policy in AO2.9.
+
+## Mandatory lifecycle for every `just benchmark` attempt
+
+The `benchmark` recipe (or its one bounded wrapper) owns a `try/finally`
+equivalent finalizer. The finalizer runs for success, build failure, runner
+failure, validation failure, timeout, cancellation, and cleanup/restore
+failure. It must:
+
+1. Allocate `run_id`, `host_label`, target, source SHA, binary hashes, and the
+   per-run directory before execution.
+2. Capture command lines, stdout, stderr, exit status, target, profile,
+   account identity, lifecycle phase, and all raw evidence under `raw/`.
+3. Emit `result.json` with `status` (`PASS`, `FAIL`, or `INCOMPLETE`) and
+   diagnostics. `INCOMPLETE` is rendered with `passed: false`; it is never
+   silently treated as `FAIL` or success.
+4. Render `run.xhtml` with the canonical template and write the envelope.
+5. Rebuild `site/reports/benchmark/index.html` and the root report index.
+6. Immediately `git add` the complete run directory and generated indexes,
+   create a commit identifying `run_id` and status, and push it to the
+   operator's evidence branch. The push must happen before the operator starts
+   another benchmark target.
+
+If rendering, indexing, commit, or push fails, the finalizer reports a
+process violation and preserves the local run directory for recovery. It
+must not claim that the run was published. A missing or uncommitted run is a
+documented process violation even when the measured benchmark passed.
+
+The benchmark command is manual/agent-triggered because it requires a
+dedicated physical account and host lifecycle. CI does not run physical
+benchmarks or manufacture evidence. CI must run the report-schema tests and
+`just reports-index --check`; if a CI job is later authorized to execute a
+physical run, it must use this same finalizer and push through a bot evidence
+branch/PR. No direct push to `develop` or an integration branch is required by
+this procedure.
+
+## Aggregate/final report
+
+`site/reports/benchmark/index.html` is regenerated after every attempt from
+all immutable `result.json` records. It must show, at minimum:
+
+- current campaign status (`PASS`, `FAIL`, or `INCOMPLETE`),
+- one row for every attempted target, including failed/incomplete attempts,
+- missing targets from the authoritative OS matrix,
+- host label, run ID, tested SHA, target/profile, and measured status,
+- links to each run's JSON, XHTML, and raw evidence, and
+- historical count and generation timestamp.
+
+The aggregate must not collapse a failed historical run when a later run
+passes. Campaign summaries may identify the latest candidate, but all immutable
+per-run records remain discoverable. A complete campaign is `PASS` only when
+all required targets for that OS are present and pass their target-specific
+acceptance gates; otherwise it is `FAIL` or `INCOMPLETE` with the missing
+reason shown.
+
+## AO2.7 and AO2.8 relationship
+
+AO2.7 remains the M5 TCP f8 throughput evidence sprint and AO2.8 remains the
+Windows parity sprint. Their existing thresholds, dedicated-account safety
+requirements, and target-specific evidence remain authoritative. They must
+reference this document for the publication path and use the `tcp` target
+record (not a generic historical HTML file). AO2.8 additionally records the
+accepted AO2.7 M5 artifact and calculated floor in its run JSON. The matrix,
+failure/incomplete publication rule, and aggregate/index behavior are owned
+only here and are not copied into either sprint document.
+
+## Acceptance criteria
+
+- [ ] The implementation uses `templates/benchmark-report/benchmark-run.xhtml.j2`
+      and its front matter as the validated single-run variable contract.
+- [ ] The schema/producer accepts exactly the authoritative per-OS target
+      matrix, including `sqlite` and `tcp+tls`, and rejects Windows UDS.
+- [ ] Every success, failure, and incomplete `just benchmark` attempt emits
+      immutable JSON, XHTML, envelope, and raw evidence under
+      `site/reports/benchmark/<host_label>/<run_id>/`.
+- [ ] The finalizer executes on build, runner, timeout, cancellation, and
+      cleanup/restore failure, and records the exit status and diagnostics.
+- [ ] The finalizer rebuilds `site/reports/benchmark/index.html` and the root
+      index, then commits and pushes before another target is started.
+- [ ] `.just/generate_report_index.py` validates nested benchmark paths and
+      rejects unsafe or incomplete envelopes; `just reports-index --check` is
+      green for the published tree.
+- [ ] The aggregate preserves all immutable historical runs, displays missing
+      targets, and links JSON/XHTML/raw evidence for each attempted run.
+- [ ] AO2.7 and AO2.8 explicitly defer to this document for reporting and
+      publication while retaining their own performance/safety gates.
+- [ ] Report schema, path-safety, failed/incomplete-finalizer, matrix, and
+      aggregate tests pass in CI; no physical M5/Windows execution is required
+      to complete this documentation sprint.
+- [ ] Quality-mgr reviews this plan before any implementation task is
+      dispatched.
 
 ## References
 
-- quality-mgr process-gap finding, ATM message 01M0NGE2MEV5QER37YXFYTHTK3
-  (2026-08-22T19:51:16Z)
+- `templates/benchmark-report/benchmark-run.xhtml.j2`
+- `templates/benchmark-report/benchmark-report.html.j2`
+- `scripts/smoke/benchmark_report.py`
+- `scripts/smoke/benchmark_schema.py`
+- `.just/generate_report_index.py`
+- `Justfile` (`benchmark`, `benchmark-report`, and `reports-index` recipes)
 - `docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md`
 - `docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md`
-- `.just/generate_report_index.py`, `site/reports/smoke/*`, `site/reports/fuzz/*`

--- a/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
+++ b/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
@@ -5,32 +5,50 @@ title: Benchmark report template, publication, and aggregate procedure
 branch: plan/ao2-9-benchmark-report-template
 integration_branch: integrate/phase-ao2
 status: ready_for_review
+must_follow: AO2.5.4 and AO2.6 merged to integrate/phase-ao2
+parallel_safe: false
 depends_on:
-  - AO2.5.4-mandatory-benchmark-snapshot-restore
-  - AO2.6-admission-writer-batching-regression
-  - AO2.7-m5-tcp-benchmark-parity
-  - AO2.8-windows-tcp-benchmark-parity
+  - sprint: AO2.5.4-mandatory-benchmark-snapshot-restore
+    relation: must_follow
+  - sprint: AO2.6-admission-writer-batching-regression
+    relation: must_follow
 ---
 
 # AO2.9 — Benchmark report template, publication, and aggregate procedure
 
 ## Decision and scope
 
-AO2.9 closes the benchmark-evidence process gap. It defines one durable
-single-run report contract, one immutable publication path, and one aggregate
-index for every physical `just benchmark` attempt. It is documentation and
-procedure work: it does not change the daemon, client, storage, transport,
-TLS, benchmark algorithm, or performance threshold.
+AO2.9 closes the benchmark-evidence process gap. It specifies one durable
+single-run report contract, one immutable publication path, one aggregate
+index, and one guarded finalizer for every physical `just benchmark` attempt.
+This is a bounded tooling/documentation sprint: it may change the benchmark
+runner, report/index scripts, Justfile, CI contract tests, host manifest, and
+ADRs, but it must not change the daemon, client, storage, transport, TLS,
+benchmark algorithm, or performance thresholds.
 
 The benchmark remains an explicitly isolated operation under AO2.5.4. It must
 not use the interactive account, the interactive daemon, an alternate data
 root, or a benchmark-only production behavior. A result is evidence only when
-its report and raw artifacts are published by the procedure below.
+its intent, report, raw artifacts, and publication commits satisfy this plan.
 
-The report contract is normative for AO2.7 and AO2.8. Those sprint documents
-retain their target-specific thresholds and safety gates; they defer to this
-document for template, variable schema, path, publication, and aggregation.
-They must not duplicate those details, so the contract cannot drift.
+AO2.9 must complete before AO2.7 or AO2.8 begins physical execution. Their
+target-specific threshold and safety documents defer to this plan for report
+generation and publication. AO2.7/AO2.8 therefore list AO2.9 as a
+`must_follow` dependency and include an explicit finalizer acceptance row.
+
+## Dependency and ordering contract
+
+| Predecessor | Relation | Gate |
+| --- | --- | --- |
+| AO2.5.4 mandatory snapshot/restore | `must_follow` | Its dedicated-account lifecycle is merged to `integrate/phase-ao2`; AO2.9 does not redefine recovery. |
+| AO2.6 writer-batching regression | `must_follow` | Its tested benchmark subject is merged to `integrate/phase-ao2`; report tooling is validated against that interface. |
+| AO2.7 M5 evidence | downstream | AO2.7 must follow AO2.9 and uses the finalizer; it is not an AO2.9 predecessor. |
+| AO2.8 Windows evidence | downstream | AO2.8 must follow AO2.9 and AO2.7; it is not an AO2.9 predecessor. |
+
+AO2.9 is `parallel_safe: false` with respect to AO2.7/AO2.8 because it owns
+the only publication seam those sprints are allowed to call. Documentation
+review may proceed in parallel with unrelated AO2 work, but no physical
+benchmark target may run until this plan and its implementation PR are merged.
 
 ## Existing assets and implementation boundary
 
@@ -40,53 +58,135 @@ The repository already contains the intended sc-compose assets:
 | --- | --- |
 | `templates/benchmark-report/benchmark-run.xhtml.j2` | Single-run XHTML panel; its front matter is the variable contract. |
 | `templates/benchmark-report/benchmark-report.html.j2` | Aggregate benchmark report shell. |
-| `scripts/smoke/benchmark_report.py` | Validates/persists benchmark JSON and renders the two templates. |
-| `.just/generate_report_index.py` | Builds the public `site/reports/index.html` from validated envelopes. |
-| `Justfile` recipe `benchmark` | Isolated benchmark entry point and finalizer hook. |
+| `scripts/smoke/benchmark_report.py` | Schema validation and rendering only after the finalizer split. |
+| `.just/generate_report_index.py` | Public report-envelope discovery and root index generation. |
+| `Justfile` recipe `benchmark` | Isolated benchmark entry point; it must invoke the finalizer in all exit paths. |
 
 The existing implementation is a starting point, not proof that AO2.9 is
-complete. In particular, it currently writes a flat historical directory and
-only validates `uds` and `tcp`. The implementation work derived from this
-plan must extend those seams rather than introduce a second renderer or an
-untracked reporting path.
+complete: it writes a flat historical directory and only validates `uds` and
+`tcp`. The implementation must extend these seams and must not create a
+second renderer, result writer, or git publisher.
 
-## Single-run template contract
+## Risk split and ownership seam
+
+The security-sensitive work is explicitly split into two independently
+reviewed packages in this sprint:
+
+1. **Report package:** schema migration/validation, sc-compose panels,
+   nested index discovery, aggregate rendering, and path/public-data tests.
+2. **Publication package:** host binding, pre-execution intent, pending-run
+   lock, outcome classification, commit/push protocol, crash recovery, and
+   branch/PR reachability checks.
+
+The second package requires ADR-054 and its own reviewer sign-off before the
+implementation PR can merge. Keeping both packages in AO2.9 is intentional:
+AO2.7/AO2.8 cannot safely run until the publication package exists. They share
+one named module and one writer; no sprint may add an alternate `result.json`
+writer or finalizer.
+
+The actual shared publication module is
+`scripts/smoke/benchmark_publication.py`. Its only public write API is:
+
+```python
+begin_run(spec: BenchmarkRunSpec, git: GitPublisher) -> PendingRun
+finalize_run(pending: PendingRun, outcome: BenchmarkOutcome,
+             git: GitPublisher) -> PublishedRun
+```
+
+`Justfile`'s `benchmark` recipe calls these functions around the existing
+`scripts/smoke/run_admission_capacity.py` runner. AO2.7 and AO2.8 both call
+the same recipe/API; neither may write `result.json`, render a panel, or run
+`git commit`/`git push` independently. A CI boundary test must fail if a
+second result writer or git-publish implementation is introduced.
+
+## Single-run template and result contract
 
 The canonical template is
 `templates/benchmark-report/benchmark-run.xhtml.j2`. It is rendered with
 `sc-compose render --root <repo> --file <template> --var-file <vars.json>
---output <run.xhtml>`. The producer must validate the variables before
-rendering and must never interpolate untrusted values as HTML fragments.
+--output <run.xhtml>`. The producer validates all variables before rendering
+and never interpolates untrusted values as HTML fragments.
 
-The template front matter is the authoritative required-variable list. The
-values have these types and meanings:
+The template front matter is the authoritative required-variable list:
 
 | Variable | Type and rule |
 | --- | --- |
 | `title` | Non-empty string; escaped by the template. |
 | `artifact_id` | Safe opaque run identifier; `[A-Za-z0-9][A-Za-z0-9._-]{0,127}`. |
 | `generated_at` | UTC ISO-8601 timestamp with `Z`; generated once for the attempt. |
-| `host_label` | Stable, safe per-computer label; never a raw hostname, path, username, or IP. |
-| `transport` | One of the target values in the authoritative matrix below (`sqlite`, `uds`, `tcp`, `tcp+tls`). |
-| `frames_per_connection` | Non-negative integer; `0` for a target where frames are not applicable. |
+| `host_label` | Stable label from the checked-in host manifest; never an operator-minted per-run value. |
+| `transport` | One of `sqlite`, `uds`, `tcp`, `tcp+tls`. |
+| `frames_per_connection` | Non-negative integer; `0` when not applicable. |
 | `run_duration_s` | Non-negative number covering the measured interval only. |
-| `passed` | Boolean. `false` for a failed or incomplete attempt. |
+| `passed` | Boolean projection of machine-classified `status`; never caller-selected. |
 | `failure` | Escaped diagnostic string; empty when no failure occurred. |
 | `cleanup_failure` | Escaped cleanup/restore diagnostic string; empty when cleanup succeeded. |
-| `sample_html` | Renderer-owned, already-escaped table fragment; never caller-supplied HTML. |
-| `direct_sqlite_html` | Renderer-owned, already-escaped SQLite evidence fragment; never caller-supplied HTML. |
+| `sample_html` | Renderer-owned, escaped table fragment; never caller HTML. |
+| `direct_sqlite_html` | Renderer-owned, escaped SQLite fragment; never caller HTML. |
 
-The JSON result beside the XHTML is the source of truth. The XHTML is a
-view of that immutable JSON and must contain the run identity, status, target,
-tested SHA, host label, measured duration, diagnostics, and links to raw
-evidence. A failed or incomplete run is a valid report with `passed: false`;
-it must not be omitted or converted into a passing empty result.
+`result.json` is the immutable source of truth. Its required schema is
+`schema_version: 4` and these fields:
+
+```json
+{
+  "schema_version": 4,
+  "run_id": "20260822T200000Z-a1b2c3d4",
+  "host_label": "mac-arm64-01",
+  "os_family": "macos",
+  "target": "tcp",
+  "status": "PASS | FAIL | INCOMPLETE",
+  "passed": false,
+  "started_at": "2026-08-22T20:00:00Z",
+  "finished_at": "2026-08-22T20:08:00Z",
+  "source_revision": "<40 lowercase hex>",
+  "binary_hashes": {"cli": "<sha256>", "daemon": "<sha256>"},
+  "benchmark_account_label": "m5-benchmark",
+  "profile": {"frames_per_connection": 8},
+  "lifecycle": {
+    "intent_pushed": true,
+    "measurement_started": true,
+    "measurement_completed": true,
+    "cleanup_completed": true,
+    "restore_completed": true,
+    "interruption_reason": null
+  },
+  "threshold": {"name": "tcp-f8-p50", "expected": ">15000"},
+  "metrics": {},
+  "failure": null,
+  "cleanup_failure": null,
+  "raw_evidence": ["raw/stdout.log", "raw/stderr.log"]
+}
+```
+
+`binary_hashes`, metrics, and threshold details are populated by the runner;
+the operator cannot override them in a finalizer argument. `host_label` and
+`benchmark_account_label` are public opaque labels only; raw host/account
+facts remain local raw evidence and are not serialized into `site/`.
+
+### Machine-classified FAIL versus INCOMPLETE
+
+The finalizer derives status from structured lifecycle facts and the target
+oracle; it does not accept a caller-provided status. The rules are:
+
+- `FAIL`: the required measured interval completed and a measured assertion
+  failed (for example, TCP f8 p50 missed its threshold), or the completed
+  runner returned a non-zero validation/error result after producing a valid
+  measurement. A threshold failure can never be relabelled `INCOMPLETE`.
+- `INCOMPLETE`: the intent was pushed but build, preflight, launch, required
+  measurement, cleanup, restore, or finalizer publication did not complete;
+  this includes timeout, cancellation, process crash, and lost connection.
+  The remaining intent marker is the evidence of registration.
+- `PASS`: every required lifecycle phase completed and the target-specific
+  oracle passed.
+
+The aggregate retains every `FAIL` and `INCOMPLETE` record. A later pass never
+collapses, overwrites, or hides either status; only the current-candidate
+summary may select the newest complete campaign.
 
 ## Authoritative target matrix
 
-This matrix supersedes narrower AO2.7/AO2.8 wording. `sqlite` is a direct
-storage-admission target; it is not silently substituted for a public
-transport run. `uds`, `tcp`, and `tcp+tls` are public transport targets.
+`sqlite` is a direct storage-admission target, not a silent substitute for a
+public transport. `uds`, `tcp`, and `tcp+tls` are public transport targets.
 
 | Operating system | Required targets |
 | --- | --- |
@@ -94,136 +194,265 @@ transport run. `uds`, `tcp`, and `tcp+tls` are public transport targets.
 | Linux | `sqlite`, `uds`, `tcp`, `tcp+tls` |
 | Windows | `sqlite`, `tcp`, `tcp+tls` |
 
-The producer schema, CLI validation, aggregate table, and acceptance tests
-must all use this same matrix. Windows must reject `uds` as unsupported; it
-must not report a skipped UDS case as a pass. A target that was not attempted
-is represented as missing in the aggregate, not as a synthetic result.
+The schema, CLI validation, aggregate, and tests use exactly this matrix.
+Windows rejects `uds`; an unsupported or unattempted target is missing, never
+a synthetic pass. A campaign is complete only when all required targets for
+that OS have machine-classified `PASS` results.
 
-## Immutable publication layout
+## Host identity and public labels
 
-Every attempt receives one `run_id` before any build or benchmark command is
-started. It is a UTC timestamp in `YYYYMMDDTHHMMSSZ` form. If two attempts on
-the same host collide in one second, append `-<8 lowercase hex nonce>`; the
-resulting ID remains safe and immutable.
+`host_label` is provisioned, not self-reported. The implementation adds
+`tools/benchmark-hosts.toml`, a reviewed allowlist of stable opaque labels,
+OS/architecture, benchmark-account label, and a non-reversible host-binding
+digest. The raw machine facts used to calculate the digest remain local.
 
-The required layout is:
+`begin_run` accepts only a label present in that manifest and verifies the
+executing OS, architecture, benchmark-account manifest, and binding digest.
+Adding or changing a host label is a separate reviewed manifest commit; a
+run cannot modify the manifest and publish in the same operation. Reusing a
+label for multiple attempts is therefore required and launder-by-new-label
+behavior is rejected before an intent marker is written.
+
+## Canonical branch, site reachability, and immutable layout
+
+The canonical operator evidence branch is
+`evidence/ao2-benchmark-reports`. The finalizer refuses any other current
+branch and refuses to start unless that branch has an open PR into
+`integrate/phase-ai-31-33`, the branch named by `docs/github-pages.md` as the
+GitHub Pages publisher. A pushed run is therefore reachable from the
+published-site branch through that PR; it is not considered published merely
+because it exists on a private local branch. The operator must merge/update
+that PR under the normal review gate before claiming public-site publication.
+
+Every attempt receives one `run_id` before any build or benchmark command. It
+is `YYYYMMDDTHHMMSSZ`; a same-second collision appends `-<8 lowercase hex
+nonce>`. The nonce is generated only by `begin_run` using the OS CSPRNG and is
+recorded in the intent marker and result; callers cannot supply it.
 
 ```text
 site/reports/benchmark/
-  index.html                              # generated aggregate/final report
-  <host_label>/
-    <run_id>/
-      result.json                         # immutable validated source
-      result.envelope.json                # public-index envelope
-      run.xhtml                           # sc-compose single-run report
-      raw/                                # stdout, stderr, daemon logs, traces
+  index.html                              # aggregate/final report
+  .pending/<run_id>.json                  # one active lock; safe public metadata
+  <host_label>/<run_id>/
+    intent.json                           # pushed before execution
+    result.json                           # immutable validated source
+    result.envelope.json                  # public-index envelope
+    run.xhtml                             # sc-compose single-run report
+    raw/                                  # stdout, stderr, daemon logs, traces
 ```
 
-`host_label` is the same safe opaque label passed to the template. The
-envelope's `report_html` is the safe repository-relative path
-`benchmark/<host_label>/<run_id>/run.xhtml`; it must not contain `..`, an
-absolute path, a backslash, or an unvalidated host string. The envelope also
-records `schema_version`, `report_type: "benchmark"`, `generated_at`, and
-`host_label`. The aggregate links to the JSON, XHTML, and raw evidence using
-paths relative to `site/reports`.
+The envelope's `report_html` is the safe repository-relative path
+`benchmark/<host_label>/<run_id>/run.xhtml`; it rejects `..`, absolute paths,
+backslashes, and unmanifested labels. The envelope records
+`schema_version`, `report_type: "benchmark"`, `generated_at`, and
+`host_label`. The aggregate links JSON, XHTML, and raw evidence relative to
+`site/reports`.
 
-The implementation must extend `.just/generate_report_index.py` to discover
-and validate nested benchmark envelopes and to reject a missing run directory,
-missing XHTML, malformed envelope, unsafe path, or missing raw evidence. The
-root `site/reports/index.html` remains the public cross-type index and must
-link to `benchmark/index.html`; the benchmark aggregate is the authoritative
-single report for the benchmark family. Historical reports remain immutable;
-there is no pruning or overwrite policy in AO2.9.
+The implementation extends `.just/generate_report_index.py` to validate
+nested benchmark envelopes, intent/result pairing, safe paths, and raw
+evidence. An intent with no result is rendered as a flagged `INCOMPLETE`
+process violation. The root `site/reports/index.html` links to
+`benchmark/index.html`; historical reports are immutable and never pruned.
 
-## Mandatory lifecycle for every `just benchmark` attempt
+The root index is a cross-report directory, not a benchmark-only page. It must
+remain browsable even when only one report family has new output and must expose
+three category sections for `benchmark`, `smoke`, and `fuzz`. Category order is
+defined by the generator's `REPORT_TYPES` constant (currently
+`benchmark`, `fuzz`, `smoke`) rather than duplicated in a second template.
+Within each section, entries are sorted newest-first by their canonical
+`generated_at` timestamp, with the report path as a deterministic tie-breaker.
+Each entry links to the rendered HTML report; benchmark entries may link to a
+nested run report while smoke/fuzz links retain their existing layout.
 
-The `benchmark` recipe (or its one bounded wrapper) owns a `try/finally`
-equivalent finalizer. The finalizer runs for success, build failure, runner
-failure, validation failure, timeout, cancellation, and cleanup/restore
-failure. It must:
+The current `.just/generate_report_index.py` already declares
+`REPORT_TYPES = ("benchmark", "fuzz", "smoke")`, groups entries by that
+category in `render_index`, and sorts each category by descending timestamp in
+`aggregate_entries`. Therefore category grouping and recency ordering for
+existing smoke/fuzz output are an existing behavior to preserve and test, not a
+new renderer to invent. AO2.9 still needs to extend discovery/validation for
+the nested benchmark envelopes and prove that the same root index renders
+benchmark, smoke, and fuzz sections together. Existing smoke/fuzz output is in
+scope for regression coverage, but their producer contracts are not rewritten.
 
-1. Allocate `run_id`, `host_label`, target, source SHA, binary hashes, and the
-   per-run directory before execution.
-2. Capture command lines, stdout, stderr, exit status, target, profile,
-   account identity, lifecycle phase, and all raw evidence under `raw/`.
-3. Emit `result.json` with `status` (`PASS`, `FAIL`, or `INCOMPLETE`) and
-   diagnostics. `INCOMPLETE` is rendered with `passed: false`; it is never
-   silently treated as `FAIL` or success.
-4. Render `run.xhtml` with the canonical template and write the envelope.
-5. Rebuild `site/reports/benchmark/index.html` and the root report index.
-6. Immediately `git add` the complete run directory and generated indexes,
-   create a commit identifying `run_id` and status, and push it to the
-   operator's evidence branch. The push must happen before the operator starts
-   another benchmark target.
+## Durable intent, lock, and finalizer protocol
 
-If rendering, indexing, commit, or push fails, the finalizer reports a
-process violation and preserves the local run directory for recovery. It
-must not claim that the run was published. A missing or uncommitted run is a
-documented process violation even when the measured benchmark passed.
+`begin_run` is an external pre-execution registration, not an in-memory
+callback:
 
-The benchmark command is manual/agent-triggered because it requires a
-dedicated physical account and host lifecycle. CI does not run physical
-benchmarks or manufacture evidence. CI must run the report-schema tests and
-`just reports-index --check`; if a CI job is later authorized to execute a
-physical run, it must use this same finalizer and push through a bot evidence
-branch/PR. No direct push to `develop` or an integration branch is required by
-this procedure.
+```text
+begin_run(spec, git):
+  verify current branch == evidence/ao2-benchmark-reports
+  verify open PR targets integrate/phase-ai-31-33
+  fetch the remote evidence branch
+  reject if any remote .pending/<run_id>.json exists
+  verify the host manifest and generate run_id/nonce
+  atomically write intent.json and .pending/<run_id>.json
+  commit "benchmark: register <run_id> (<host_label>)"
+  push and verify the remote branch contains that commit
+  return PendingRun(intent_path, run_id, expected_remote_sha)
+```
+
+The pending marker is the single-flight lock. A second target is refused
+until the prior finalizer has successfully pushed its completion and lock
+release; the check is against the fetched remote branch, not just local
+filesystem state. A test must mock a failed push and prove the next
+`begin_run` refuses while the remote marker remains.
+
+`finalize_run` is the only result writer and git publisher:
+
+```text
+finalize_run(pending, outcome, git):
+  classify PASS/FAIL/INCOMPLETE from lifecycle + target oracle
+  write immutable result.json and sc-compose run.xhtml
+  rebuild benchmark/index.html and site/reports/index.html
+  commit report + aggregate while .pending/<run_id>.json remains
+  push; verify remote SHA and open-PR reachability
+  remove .pending/<run_id>.json only after the report push succeeds
+  commit/push lock release; verify no pending marker remains remotely
+  return PublishedRun(remote_report_sha, status)
+```
+
+If the runner is killed with `SIGKILL`, crashes, loses power, or loses the
+network, `finalize_run` cannot run; the already-pushed intent remains and the
+index flags the registered run as `INCOMPLETE`/process violation. If report,
+commit, or either push fails, the marker remains remotely and the next target
+is blocked. Recovery must finish or explicitly close that run with a machine
+classified incomplete result; operators may not delete the marker to unblock
+the matrix.
 
 ## Aggregate/final report
 
-`site/reports/benchmark/index.html` is regenerated after every attempt from
-all immutable `result.json` records. It must show, at minimum:
+`site/reports/benchmark/index.html` is regenerated after every finalization
+from all immutable results and intents. It shows:
 
 - current campaign status (`PASS`, `FAIL`, or `INCOMPLETE`),
-- one row for every attempted target, including failed/incomplete attempts,
+- every attempted target, including failed/incomplete runs and intent-only runs,
 - missing targets from the authoritative OS matrix,
 - host label, run ID, tested SHA, target/profile, and measured status,
-- links to each run's JSON, XHTML, and raw evidence, and
-- historical count and generation timestamp.
+- links to JSON, XHTML, and raw evidence, and
+- historical count, pending-lock state, and generation timestamp.
 
-The aggregate must not collapse a failed historical run when a later run
-passes. Campaign summaries may identify the latest candidate, but all immutable
-per-run records remain discoverable. A complete campaign is `PASS` only when
-all required targets for that OS are present and pass their target-specific
-acceptance gates; otherwise it is `FAIL` or `INCOMPLETE` with the missing
-reason shown.
+A failed historical run is never collapsed when a later run passes; the same
+rule applies to incomplete runs. A complete campaign is `PASS` only when all
+required targets for that OS have passed target-specific gates.
+
+The finalizer also regenerates the root `site/reports/index.html`. That file
+must present browsable HTML sections for **benchmark**, **smoke**, and **fuzz**
+reports, using the generator-defined category order, with each section sorted
+most-recent-first by `generated_at`. It must link both the new nested benchmark
+reports and the existing smoke/fuzz reports; an empty category is rendered
+explicitly rather than omitted. The generator's existing
+`REPORT_TYPES`/`aggregate_entries`/`render_index` behavior is the baseline for
+smoke/fuzz and receives regression tests while benchmark discovery is added.
 
 ## AO2.7 and AO2.8 relationship
 
-AO2.7 remains the M5 TCP f8 throughput evidence sprint and AO2.8 remains the
-Windows parity sprint. Their existing thresholds, dedicated-account safety
-requirements, and target-specific evidence remain authoritative. They must
-reference this document for the publication path and use the `tcp` target
-record (not a generic historical HTML file). AO2.8 additionally records the
-accepted AO2.7 M5 artifact and calculated floor in its run JSON. The matrix,
-failure/incomplete publication rule, and aggregate/index behavior are owned
-only here and are not copied into either sprint document.
+AO2.7 remains the M5 TCP f8 throughput sprint and AO2.8 remains the Windows
+parity sprint. Their thresholds, dedicated-account safety, and target evidence
+remain authoritative. They defer to AO2.9 for schema, host identity, path,
+intent/lock, finalization, and index behavior and must call the shared
+`benchmark_publication.begin_run`/`finalize_run` path through `just benchmark`.
+
+AO2.8 additionally records the accepted AO2.7 artifact and calculated floor in
+its result JSON. Neither sprint may add a result writer, alternate finalizer,
+or direct site publisher.
+
+## ADR and trust model
+
+ADR-054 (`docs/adr/ADR-054-benchmark-report-finalizer-trust-model.md`) records
+the accepted trust model: the local benchmark account/finalizer is trusted to
+classify and publish its own evidence through the canonical branch, while
+GitHub branch protection, PR review, immutable intent/result paths, schema
+validation, and generated-index checks provide independent repository gates.
+There is no independent measurement verifier in AO2.9. The residual risk is
+that a compromised operator account can falsify a measurement before pushing;
+the plan accepts that risk for this local performance lane and makes it
+visible through the immutable intent, source/binary hashes, raw evidence,
+reviewable PR, and explicit trust statement. A future independent verifier is
+deferred, not implied by this plan.
+
+## Deliverables
+
+- [ ] Hardened `templates/benchmark-report/benchmark-run.xhtml.j2` contract
+      and schema-version migration, with the aggregate template retained.
+- [ ] `scripts/smoke/benchmark_publication.py` implementing the named
+      `begin_run`/`finalize_run` APIs and the single writer/publisher seam.
+- [ ] `tools/benchmark-hosts.toml` reviewed stable-label/host-binding manifest.
+- [ ] `Justfile` benchmark wrapper invoking the finalizer on every exit path.
+- [ ] Nested benchmark discovery and aggregate support in
+      `.just/generate_report_index.py`.
+- [ ] Root `site/reports/index.html` remains a browsable directory with
+      benchmark, smoke, and fuzz sections, each newest-first; existing
+      smoke/fuzz output is preserved and covered by regression tests.
+- [ ] ADR-054 and its entry in `docs/adr/INDEX.md`.
+- [ ] Contract tests for schema, path safety, host binding, matrix, lock,
+      crash/incomplete recovery, finalizer, aggregate, and one-writer guard.
+- [ ] AO2.7 and AO2.8 metadata/acceptance rows updated to require AO2.9
+      finalizer publication.
 
 ## Acceptance criteria
 
-- [ ] The implementation uses `templates/benchmark-report/benchmark-run.xhtml.j2`
-      and its front matter as the validated single-run variable contract.
-- [ ] The schema/producer accepts exactly the authoritative per-OS target
-      matrix, including `sqlite` and `tcp+tls`, and rejects Windows UDS.
-- [ ] Every success, failure, and incomplete `just benchmark` attempt emits
-      immutable JSON, XHTML, envelope, and raw evidence under
-      `site/reports/benchmark/<host_label>/<run_id>/`.
-- [ ] The finalizer executes on build, runner, timeout, cancellation, and
-      cleanup/restore failure, and records the exit status and diagnostics.
-- [ ] The finalizer rebuilds `site/reports/benchmark/index.html` and the root
-      index, then commits and pushes before another target is started.
-- [ ] `.just/generate_report_index.py` validates nested benchmark paths and
-      rejects unsafe or incomplete envelopes; `just reports-index --check` is
-      green for the published tree.
-- [ ] The aggregate preserves all immutable historical runs, displays missing
-      targets, and links JSON/XHTML/raw evidence for each attempted run.
-- [ ] AO2.7 and AO2.8 explicitly defer to this document for reporting and
-      publication while retaining their own performance/safety gates.
-- [ ] Report schema, path-safety, failed/incomplete-finalizer, matrix, and
-      aggregate tests pass in CI; no physical M5/Windows execution is required
-      to complete this documentation sprint.
-- [ ] Quality-mgr reviews this plan before any implementation task is
-      dispatched.
+- [ ] `begin_run` requires the canonical evidence branch and an open PR into
+      `integrate/phase-ai-31-33`; a run is not called published before that
+      PR reaches the Pages publisher.
+- [ ] A pushed `.pending/<run_id>.json` intent exists before any build or
+      measurement and remains flaggable after `SIGKILL`, crash, or partition.
+- [ ] A second target is refused while any pending marker is outstanding;
+      the refusal is covered by a failed-push test.
+- [ ] Status is machine-classified: completed threshold failures are `FAIL`,
+      missing lifecycle phases are `INCOMPLETE`, and neither can be relabelled
+      to evade review.
+- [ ] Stable manifest-bound host labels reject per-attempt identity minting.
+- [ ] Every PASS, FAIL, and INCOMPLETE attempt emits immutable JSON, XHTML,
+      envelope, and raw evidence under the canonical host/run path.
+- [ ] The aggregate retains all historical FAIL/INCOMPLETE records, flags
+      intent-only runs, displays missing targets, and links all evidence.
+- [ ] The generated root `site/reports/index.html` contains browsable
+      benchmark, smoke, and fuzz sections in the generator-defined category
+      order, each sorted
+      newest-first; smoke/fuzz category and ordering behavior is verified
+      against the existing generator while nested benchmark links are tested.
+- [ ] CI prevents a second result writer/finalizer and validates nested
+      envelope paths and generated indexes.
+- [ ] AO2.7 and AO2.8 each have a checked `published via AO2.9 finalizer`
+      acceptance row and `must_follow: AO2.9` metadata.
+- [ ] ADR-054 is reviewed and the residual trust risk is explicit.
+- [ ] Quality-mgr reviews this corrected plan before implementation work or
+      physical benchmark execution is dispatched.
+
+## Test files and commands
+
+The implementation must add or update these named tests:
+
+- `.just/tests/test_benchmark_report.py` — template variables, schema/status,
+  failed/incomplete rendering, and immutable result writes.
+- `.just/tests/test_benchmark_publication.py` — intent push, two-phase lock,
+  branch/PR gate, host binding, failed-push recovery, and crash classification.
+- `.just/tests/test_benchmark_publication_boundary.py` — exactly one result
+  writer/finalizer and no alternate `git push` site publisher.
+- `.just/tests/test_benchmark_matrix.py` — macOS/Linux four targets and
+  Windows three-target rejection of UDS.
+- `.just/tests/test_generate_report_index.py` — nested paths, intent-only
+  incomplete rows, envelope safety, aggregate links, stale-index checks, and
+  a root-index fixture containing benchmark/smoke/fuzz entries that asserts
+  category sections plus newest-first ordering for the existing smoke/fuzz
+  producers.
+- `scripts/smoke/test_run_admission_capacity.py` — existing runner behavior.
+
+Required commands are:
+
+```text
+python3 -m unittest .just/tests/test_benchmark_report.py
+python3 -m unittest .just/tests/test_benchmark_publication.py
+python3 -m unittest .just/tests/test_benchmark_publication_boundary.py
+python3 -m unittest .just/tests/test_benchmark_matrix.py
+python3 -m unittest .just/tests/test_generate_report_index.py
+just reports-index --check
+just lint
+```
+
+No physical M5 or Windows execution is required to complete AO2.9 tooling;
+those runs belong to AO2.7/AO2.8 after this plan and implementation merge.
 
 ## References
 
@@ -232,6 +461,11 @@ only here and are not copied into either sprint document.
 - `scripts/smoke/benchmark_report.py`
 - `scripts/smoke/benchmark_schema.py`
 - `.just/generate_report_index.py`
-- `Justfile` (`benchmark`, `benchmark-report`, and `reports-index` recipes)
+- `Justfile` (`benchmark`, `reports-index`, and the finalizer wrapper)
+- `tools/benchmark-hosts.toml`
+- `docs/adr/ADR-044-public-verification-report-classification.md`
+- `docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md`
+- `docs/adr/ADR-054-benchmark-report-finalizer-trust-model.md`
+- `docs/github-pages.md`
 - `docs/plans/phase-ao2/sprint-AO2-7-m5-tcp-benchmark-parity.md`
 - `docs/plans/phase-ao2/sprint-AO2-8-windows-tcp-benchmark-parity.md`


### PR DESCRIPTION
## Summary
- Defines the single-run XHTML report template contract (front-matter variable table: title, artifact_id, generated_at, host_label, transport, frames_per_connection, run_duration_s, passed/failure/cleanup_failure, sample_html, direct_sqlite_html) built on the existing `templates/benchmark-report/*.j2` assets.
- Defines the authoritative per-OS target matrix (macOS/Linux: sqlite+uds+tcp+tcp-tls; Windows: sqlite+tcp+tcp-tls, no uds) and the immutable publication layout under `site/reports/benchmark/<host_label>/<run_id>/`.
- Specifies the mandatory finalizer lifecycle: durable pre-execution intent marker, remote `.pending/<run_id>.json` lock enforcing push-before-next-target, lifecycle-fact-driven FAIL vs INCOMPLETE classification, reviewed host-label allowlist with binding digest, and a new ADR-054 documenting the trust model.
- AO2.7/AO2.8 sprint docs defer to this document as the single source of truth for report mechanics rather than duplicating it.
- Hardened across 2 quality-mgr review rounds (critical-plan-reviewer + plan-scope-reviewer): round 1 found 4 blocking/10 important/2 minor, round 2 closed all blocking items with real mechanical enforcement (evidence-branch PR gating, CSPRNG nonce ownership, CI boundary test against a second independent writer); 2 important + 2 minor items remain and are being closed in a round-3 pass.

## Test plan
- [x] `critical-plan-reviewer` + `plan-scope-reviewer` round 1 and round 2 review passes (round 2: all 4 blocking findings verified closed)
- [ ] quality-mgr round-3 review closing remaining 2 important + 2 minor findings (in progress)
- [x] Merge-forward from `develop` (46dd5504e) resolved cleanly, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)