### PR TITLE
fix: scope benchmark daemon-switch preflight to owner UID

### DIFF
--- a/scripts/smoke/daemon_lifecycle.py
+++ b/scripts/smoke/daemon_lifecycle.py
@@ -42,8 +42,13 @@ def count_atm_daemon_processes() -> list[int]:
             if len(columns) > 1 and columns[1].isdigit():
                 pids.append(int(columns[1]))
         return pids
+    # A capacity run owns only the daemon processes started by its isolated OS
+    # account.  A different account's daemon has a separate ATM home, UDS
+    # path, and dynamically selected loopback endpoint, so rejecting it here
+    # would be a false positive (and must never lead to terminating it).
+    owner_uid = os.getuid()
     completed = subprocess.run(
-        ["ps", "-axo", "pid=,command="],
+        ["ps", "-axo", "uid=,pid=,command="],
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -58,12 +63,13 @@ def count_atm_daemon_processes() -> list[int]:
         stripped = line.strip()
         if not stripped:
             continue
-        parts = stripped.split(None, 1)
-        if len(parts) != 2 or not parts[0].isdigit():
+        parts = stripped.split(None, 2)
+        if len(parts) != 3 or not parts[0].isdigit() or not parts[1].isdigit():
             continue
-        pid = int(parts[0])
-        executable = parts[1].split(None, 1)[0]
-        if os.path.basename(executable) == daemon_name:
+        process_uid = int(parts[0])
+        pid = int(parts[1])
+        executable = parts[2].split(None, 1)[0]
+        if process_uid == owner_uid and os.path.basename(executable) == daemon_name:
             pids.append(pid)
     return pids
 

--- a/scripts/smoke/test_daemon_lifecycle.py
+++ b/scripts/smoke/test_daemon_lifecycle.py
@@ -1,4 +1,4 @@
-"""Regression tests for exact local daemon process detection."""
+"""Regression tests for exact, owner-scoped local daemon process detection."""
 from __future__ import annotations
 
 import subprocess
@@ -9,16 +9,27 @@ from scripts.smoke import daemon_lifecycle
 
 
 class DaemonLifecycleTests(unittest.TestCase):
-    def test_unix_detection_matches_only_the_executable_not_shell_arguments(self) -> None:
+    def test_unix_detection_matches_only_our_daemon_executable_not_shell_arguments(self) -> None:
         listing = "\n".join((
-            "42 /opt/homebrew/bin/atm-daemon",
-            "43 zsh -c python runner.py --daemon-link /opt/homebrew/bin/atm-daemon --yes",
+            "501 42 /opt/homebrew/bin/atm-daemon",
+            "501 43 zsh -c python runner.py --daemon-link /opt/homebrew/bin/atm-daemon --yes",
+            "502 44 /opt/homebrew/bin/atm-daemon",
         ))
         completed = subprocess.CompletedProcess(["ps"], 0, stdout=listing, stderr="")
         with mock.patch.object(daemon_lifecycle.os, "name", "posix"), mock.patch.object(
             daemon_lifecycle.subprocess, "run", return_value=completed
-        ):
+        ) as run, mock.patch.object(daemon_lifecycle.os, "getuid", return_value=501):
             self.assertEqual(daemon_lifecycle.count_atm_daemon_processes(), [42])
+        self.assertEqual(run.call_args.args[0], ["ps", "-axo", "uid=,pid=,command="])
+
+    def test_unix_detection_ignores_another_users_ambient_daemon(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["ps"], 0, stdout="501 42 /opt/homebrew/bin/atm-daemon", stderr="",
+        )
+        with mock.patch.object(daemon_lifecycle.os, "name", "posix"), mock.patch.object(
+            daemon_lifecycle.subprocess, "run", return_value=completed
+        ), mock.patch.object(daemon_lifecycle.os, "getuid", return_value=502):
+            self.assertEqual(daemon_lifecycle.count_atm_daemon_processes(), [])
 
 
 if __name__ == "__main__":

--- a/scripts/smoke/test_daemon_lifecycle.py
+++ b/scripts/smoke/test_daemon_lifecycle.py
@@ -18,7 +18,9 @@ class DaemonLifecycleTests(unittest.TestCase):
         completed = subprocess.CompletedProcess(["ps"], 0, stdout=listing, stderr="")
         with mock.patch.object(daemon_lifecycle.os, "name", "posix"), mock.patch.object(
             daemon_lifecycle.subprocess, "run", return_value=completed
-        ) as run, mock.patch.object(daemon_lifecycle.os, "getuid", return_value=501):
+        ) as run, mock.patch.object(
+            daemon_lifecycle.os, "getuid", return_value=501, create=True,
+        ):
             self.assertEqual(daemon_lifecycle.count_atm_daemon_processes(), [42])
         self.assertEqual(run.call_args.args[0], ["ps", "-axo", "uid=,pid=,command="])
 
@@ -28,7 +30,7 @@ class DaemonLifecycleTests(unittest.TestCase):
         )
         with mock.patch.object(daemon_lifecycle.os, "name", "posix"), mock.patch.object(
             daemon_lifecycle.subprocess, "run", return_value=completed
-        ), mock.patch.object(daemon_lifecycle.os, "getuid", return_value=502):
+        ), mock.patch.object(daemon_lifecycle.os, "getuid", return_value=502, create=True):
             self.assertEqual(daemon_lifecycle.count_atm_daemon_processes(), [])
 
 


### PR DESCRIPTION
## Summary
- The benchmark candidate runner's daemon-switch preflight rejected the atmbench run because it matched \`atm-daemon\` by process name across all users, tripping on an unrelated ambient daemon owned by a different account on the same M5 host.
- Confirmed no real resource collision exists (runner uses its own temp ATM_HOME, OS-selected loopback port, per-home UDS) -- this was strictly a false positive in the preflight check.
- Fix: preflight now parses \`ps uid,pid,command\` and counts only the runner account's own atm-daemon processes; ignores cross-user daemons. Windows behavior unchanged.

## Test plan
- [x] Regression test: same-user daemon detection
- [x] Regression test: shell-argument exclusion (doesn't match \`atm-daemon\` appearing in an unrelated command line)
- [x] Regression test: cross-user daemon exclusion (the actual bug)
- [x] \`python3 -m unittest scripts.smoke.test_daemon_lifecycle\` passes
- [ ] quality-mgr review

🤖 Generated with [Claude Code](https://claude.com/claude-code)