### PR TITLE
fix(benchmark): remove mutating daemon start from post-restore readiness check

### DIFF
--- a/scripts/smoke/benchmark_snapshot.py
+++ b/scripts/smoke/benchmark_snapshot.py
@@ -338,6 +338,35 @@ def verify_completed_snapshot(snapshot_id: str) -> VerifiedSnapshot:
     return _parse_verified_snapshot(account, snapshot_id)
 
 
+def verify_active_snapshot(snapshot_id: str) -> VerifiedSnapshot:
+    """Prove the stopped benchmark account exactly matches a verified snapshot.
+
+    This performs only read-only SQLite and filesystem checks. It must never
+    start a daemon after restore: doing so can create SQLite sidecars or alter
+    the restored database, invalidating the clean-baseline guarantee.
+    """
+    try:
+        account = require_benchmark_account()
+    except BenchmarkAccountError as error:
+        raise BenchmarkSnapshotError(str(error)) from error
+    snapshot = _parse_verified_snapshot(account, snapshot_id)
+    live_database = _mail_database(account)
+    _assert_restore_sidecars_absent(live_database)
+    _fsync_file(live_database, "active database")
+    user_version, page_count = _database_facts(live_database, "active database")
+    byte_count, sha256 = _sha256(live_database)
+    if (user_version, page_count, byte_count, sha256) != (
+        snapshot.user_version,
+        snapshot.page_count,
+        snapshot.byte_count,
+        snapshot.sha256,
+    ):
+        raise BenchmarkSnapshotError(
+            "active benchmark database does not match the verified restored snapshot"
+        )
+    return snapshot
+
+
 def _assert_restore_sidecars_absent(database: Path) -> None:
     sidecars = [database.with_name(f"{database.name}{suffix}") for suffix in ("-wal", "-shm")]
     present = [str(path) for path in sidecars if path.exists() or path.is_symlink()]

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -54,7 +54,7 @@ from scripts.smoke.benchmark_snapshot import (
     VerifiedSnapshot,
     create_verified_snapshot,
     restore_verified_snapshot,
-    verify_completed_snapshot,
+    verify_active_snapshot,
 )
 
 if os.name != "nt":
@@ -1495,10 +1495,14 @@ def run_capacity(
                 evidence["restored_clean_baseline"] = snapshot_evidence(restored)
 
                 def verify_clean_baseline() -> None:
-                    start_and_doctor()
-                    verified = verify_completed_snapshot(snapshot.snapshot_id)
+                    # Keep the daemon stopped: a post-restore start can recreate
+                    # SQLite sidecars and invalidate the exact clean baseline.
+                    verified = verify_active_snapshot(snapshot.snapshot_id)
                     evidence["post_restore_snapshot"] = snapshot_evidence(verified)
-                    evidence["doctor_after_restore"] = {"status": "passed"}
+                    evidence["restored_live_database"] = {
+                        **snapshot_evidence(verified),
+                        "sidecars_absent": True,
+                    }
 
                 run_lifecycle_phase(evidence, "post_restore_verify", verify_clean_baseline)
                 run_lifecycle_phase(evidence, "cleanup", stop_owned_daemon)

--- a/scripts/smoke/test_benchmark_snapshot.py
+++ b/scripts/smoke/test_benchmark_snapshot.py
@@ -38,6 +38,10 @@ class BenchmarkSnapshotTests(unittest.TestCase):
         with mock.patch.object(SNAPSHOT, "require_benchmark_account", return_value=account):
             return SNAPSHOT.verify_completed_snapshot(snapshot_id)
 
+    def _verify_active(self, account: ACCOUNT.BenchmarkAccount, snapshot_id: str) -> SNAPSHOT.VerifiedSnapshot:
+        with mock.patch.object(SNAPSHOT, "require_benchmark_account", return_value=account):
+            return SNAPSHOT.verify_active_snapshot(snapshot_id)
+
     def test_snapshot_is_sqlite_verified_hashed_and_account_bound(self):
         with tempfile.TemporaryDirectory() as temporary:
             account = self._account(Path(temporary))
@@ -92,6 +96,33 @@ class BenchmarkSnapshotTests(unittest.TestCase):
             self.assertEqual(observed, (1,))
             self.assertEqual(restored, snapshot)
             self.assertEqual(list(account.durable_state_root.glob(".mail.db.restore-staging-*")), [])
+
+    def test_active_verification_proves_exact_bytes_without_creating_sidecars(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            account = self._account(Path(temporary))
+            database = self._database(account, 1)
+            snapshot = self._snapshot(account)
+            with closing(sqlite3.connect(database)) as connection:
+                connection.execute("INSERT INTO entries(value) VALUES (99)")
+                connection.commit()
+            with mock.patch.object(SNAPSHOT, "require_benchmark_account", return_value=account):
+                SNAPSHOT.restore_verified_snapshot(snapshot.snapshot_id)
+
+            self.assertEqual(self._verify_active(account, snapshot.snapshot_id), snapshot)
+            self.assertFalse(database.with_name(f"{database.name}-wal").exists())
+            self.assertFalse(database.with_name(f"{database.name}-shm").exists())
+
+    def test_active_verification_rejects_any_live_byte_drift(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            account = self._account(Path(temporary))
+            database = self._database(account, 1)
+            snapshot = self._snapshot(account)
+            with closing(sqlite3.connect(database)) as connection:
+                connection.execute("INSERT INTO entries(value) VALUES (99)")
+                connection.commit()
+
+            with self.assertRaisesRegex(SNAPSHOT.BenchmarkSnapshotError, "does not match"):
+                self._verify_active(account, snapshot.snapshot_id)
 
     def test_restore_refuses_tampered_snapshot_without_changing_live_database(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -157,6 +188,7 @@ class BenchmarkSnapshotTests(unittest.TestCase):
         for operation in (
             SNAPSHOT.create_verified_snapshot,
             lambda: SNAPSHOT.verify_completed_snapshot("snapshot-20260822T011500Z-0123456789abcdef"),
+            lambda: SNAPSHOT.verify_active_snapshot("snapshot-20260822T011500Z-0123456789abcdef"),
             lambda: SNAPSHOT.restore_verified_snapshot("snapshot-20260822T011500Z-0123456789abcdef"),
         ):
             with (

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -173,7 +173,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                         return_value=snapshot,
                     ),
                 )
-                stack.enter_context(mock.patch.object(RUNNER, "verify_completed_snapshot", return_value=snapshot))
+                stack.enter_context(mock.patch.object(RUNNER, "verify_active_snapshot", return_value=snapshot))
                 calls["reap"] = stack.enter_context(
                     mock.patch.object(
                         RUNNER,
@@ -205,6 +205,7 @@ class AdmissionCapacityTests(unittest.TestCase):
         self.assertEqual(captured["clean_baseline_snapshot"]["snapshot_id"], "snapshot-20260822T000000Z-0123456789abcdef")
         self.assertEqual(captured["post_restore_snapshot"]["snapshot_id"], "snapshot-20260822T000000Z-0123456789abcdef")
         self.assertTrue(all(item["duration_s"] >= 0 for entries in captured["lifecycle"].values() for item in entries))
+        self.assertEqual(calls["start"].call_count, 2)
 
     def test_real_snapshot_lifecycle_never_touches_interactive_root(self):
         """Exercise the real account-bound snapshot APIs through ``run_capacity``.
@@ -1114,7 +1115,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                     RUNNER,
                     create_verified_snapshot=mock.DEFAULT,
                     restore_verified_snapshot=mock.DEFAULT,
-                    verify_completed_snapshot=mock.DEFAULT,
+                    verify_active_snapshot=mock.DEFAULT,
                 ) as snapshot_api,
                 mock.patch.object(RUNNER, "write_raw_evidence", return_value=root / "raw.json"),
                 mock.patch.object(
@@ -1125,7 +1126,7 @@ class AdmissionCapacityTests(unittest.TestCase):
             ):
                 snapshot_api["create_verified_snapshot"].return_value = snapshot
                 snapshot_api["restore_verified_snapshot"].return_value = snapshot
-                snapshot_api["verify_completed_snapshot"].return_value = snapshot
+                snapshot_api["verify_active_snapshot"].return_value = snapshot
                 code, _evidence = RUNNER.run_capacity(
                     home, root, "tcp", 1, sample_count=1,
                     raw_evidence_directory=root,
@@ -1134,7 +1135,7 @@ class AdmissionCapacityTests(unittest.TestCase):
                 )
 
         self.assertEqual(code, 1)
-        self.assertEqual(start.call_count, 3)
+        self.assertEqual(start.call_count, 2)
         self.assertEqual(captured["runs"], [profile])
         self.assertEqual(captured["clean_baseline_snapshot"]["snapshot_id"], snapshot.snapshot_id)
         self.assertEqual(captured["post_restore_snapshot"]["snapshot_id"], snapshot.snapshot_id)


### PR DESCRIPTION
## Summary
- The benchmark runner's post-restore readiness check previously started a daemon against the just-restored DB to confirm readiness, which mutates the DB and undermines the byte-identical restore guarantee that all AO2.7/AO2.8 throughput numbers rely on.
- Replaces it with a non-mutating check: byte/hash comparison against the snapshot + SQLite metadata check + sidecar (WAL/SHM) absence check. No daemon is started as part of readiness verification.

## Root cause
Found by arch-ctm while investigating matrix reproducibility on M5: DB was confirmed byte-identical immediately after restore, but the readiness check that ran next mutated it before the benchmark proper began.

## Test plan
- [x] `python3 -m unittest scripts.smoke.test_benchmark_snapshot scripts.smoke.test_run_admission_capacity` (103 passed, 8 skipped)
- [x] `git diff --check`

Matrix runs remain halted pending this fix landing.