### PR TITLE
fix(bench): dedupe signing identity selection by certificate fingerprint

### DIFF
--- a/.just/tests/test_macos_development_signing.py
+++ b/.just/tests/test_macos_development_signing.py
@@ -58,6 +58,46 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
             with self.assertRaisesRegex(signing.SigningIdentityError, "exactly one"):
                 signing.resolve_apple_development_identity()
 
+    def test_default_resolution_deduplicates_repeated_keychain_certificate_rows(self) -> None:
+        selected = signing.SigningIdentity("A" * 40, "Apple Development: test")
+        with (
+            mock.patch.object(signing, "_valid_identities", return_value=(selected,) * 4),
+            mock.patch.object(
+                signing,
+                "_certificate_team_identifier",
+                return_value=signing.DEFAULT_TEAM_IDENTIFIER,
+            ),
+            mock.patch.dict(signing.os.environ, {}, clear=True),
+        ):
+            self.assertEqual(
+                signing.resolve_apple_development_identity(),
+                signing.SigningIdentity(
+                    selected.fingerprint,
+                    selected.common_name,
+                    signing.DEFAULT_TEAM_IDENTIFIER,
+                ),
+            )
+
+    def test_override_deduplicates_repeated_keychain_certificate_rows(self) -> None:
+        selected = signing.SigningIdentity("A" * 40, "Apple Development: test")
+        with (
+            mock.patch.object(signing, "_valid_identities", return_value=(selected,) * 4),
+            mock.patch.object(
+                signing,
+                "_certificate_team_identifier",
+                return_value=signing.DEFAULT_TEAM_IDENTIFIER,
+            ),
+            mock.patch.dict(signing.os.environ, {signing.SIGNING_IDENTITY_ENVIRONMENT_VARIABLE: selected.fingerprint}),
+        ):
+            self.assertEqual(
+                signing.resolve_apple_development_identity(),
+                signing.SigningIdentity(
+                    selected.fingerprint,
+                    selected.common_name,
+                    signing.DEFAULT_TEAM_IDENTIFIER,
+                ),
+            )
+
     def test_override_selects_the_matching_valid_identity(self) -> None:
         selected = signing.SigningIdentity("A" * 40, "Apple Development: alternate", "OTHERTEAM")
         with (

--- a/scripts/macos_development_signing.py
+++ b/scripts/macos_development_signing.py
@@ -85,6 +85,20 @@ def _identity_with_team_identifier(identity: SigningIdentity) -> SigningIdentity
     return SigningIdentity(identity.fingerprint, identity.common_name, team_identifier)
 
 
+def _distinct_fingerprints(identities: Sequence[SigningIdentity]) -> tuple[SigningIdentity, ...]:
+    """Return identities once per certificate fingerprint, preserving keychain order.
+
+    ``security find-identity`` may emit the same certificate once for every
+    keychain in the active search list.  Those rows are aliases for one signing
+    identity, not an ambiguous choice.  Different fingerprints deliberately
+    remain distinct so the caller continues to fail closed.
+    """
+    selected: dict[str, SigningIdentity] = {}
+    for identity in identities:
+        selected.setdefault(identity.fingerprint, identity)
+    return tuple(selected.values())
+
+
 def _identity_exists_but_is_not_valid() -> bool:
     result = _run(["security", "find-identity", "-p", "codesigning"])
     return result.returncode == 0 and any(
@@ -98,25 +112,25 @@ def resolve_apple_development_identity() -> SigningIdentity:
     override = os.environ.get(SIGNING_IDENTITY_ENVIRONMENT_VARIABLE, "").strip()
     valid_identities = _valid_identities()
     if override:
-        candidates = tuple(
+        candidates = _distinct_fingerprints(tuple(
             resolved
             for identity in valid_identities
             if override in {identity.fingerprint, identity.common_name}
             if (resolved := _identity_with_team_identifier(identity)) is not None
-        )
+        ))
         if len(candidates) == 1:
             return candidates[0]
         raise SigningIdentityError(
             f"{SIGNING_IDENTITY_ENVIRONMENT_VARIABLE} must identify exactly one valid signing identity."
         )
 
-    candidates = tuple(
+    candidates = _distinct_fingerprints(tuple(
         resolved
         for identity in valid_identities
         if identity.common_name.startswith(APPLE_DEVELOPMENT_PREFIX)
         if (resolved := _identity_with_team_identifier(identity)) is not None
         if resolved.team_identifier == DEFAULT_TEAM_IDENTIFIER
-    )
+    ))
     if len(candidates) == 1:
         return candidates[0]
     if not candidates and _identity_exists_but_is_not_valid():


### PR DESCRIPTION
## Summary
- `.just/sign_daemon_dev.py` deduped repeated `security find-identity` rows by exact certificate fingerprint before selection; previously 4 rows for the same fingerprint caused a false multi-identity refusal.
- Strict gate retained: genuinely distinct fingerprints still fail closed (no auto-pick between different identities).

## Evidence
- 16/16 signing unit tests + py_compile + diff check pass.
- Live M5 proof: release atm-daemon artifacts removed, rebuilt, signed -- codesign reports `Apple Development apple@randlee.com (N285DY5G36)`, TeamIdentifier=4869P2ZYC6.
- Follow-on no-arg `just benchmark` completed the full four-target matrix on isolated atmbench (sqlite/uds/tcp/tcp+tls); results published under site/reports/send-message-benchmark/ -- these are default-profile sanity numbers, not the parity-profile comparison (separate tracked work).

## Test plan
- [x] Live-verified on M5 (arch-ctm)
- [ ] quality-mgr review

🤖 Generated with [Claude Code](https://claude.com/claude-code)