### PR TITLE
perf(search): omit unused FTS5 column sizes + wire sqlite/UDS into default benchmark matrix

### DIFF
--- a/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
+++ b/crates/atm-daemon-bootstrap/src/bin/atm-daemon-benchmark.rs
@@ -35,6 +35,8 @@ enum BenchmarkInvocation {
     DirectCoreWrite {
         messages: NonZeroUsize,
         workers: NonZeroUsize,
+        minimum_intervals: NonZeroUsize,
+        target_duration_seconds: u64,
     },
 }
 
@@ -47,8 +49,19 @@ async fn main() {
         Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers }) => {
             run_direct_storage_admission(messages, workers).await
         }
-        Ok(BenchmarkInvocation::DirectCoreWrite { messages, workers }) => {
-            run_direct_core_write(messages, workers).await
+        Ok(BenchmarkInvocation::DirectCoreWrite {
+            messages,
+            workers,
+            minimum_intervals,
+            target_duration_seconds,
+        }) => {
+            run_direct_core_write(
+                messages,
+                workers,
+                minimum_intervals,
+                target_duration_seconds,
+            )
+            .await
         }
         Err(error) => Err(error),
     };
@@ -91,12 +104,14 @@ fn parse_benchmark_invocation(
             Ok(BenchmarkInvocation::DirectStorageAdmission { messages, workers })
         }
         Some("--direct-core-write") => {
-            let (messages, workers) = parse_concurrent_arguments(
-                args,
-                "direct-core-write",
-                "usage: atm-daemon-benchmark --direct-core-write <count> --workers <count>",
-            )?;
-            Ok(BenchmarkInvocation::DirectCoreWrite { messages, workers })
+            let (messages, workers, minimum_intervals, target_duration_seconds) =
+                parse_direct_core_write_arguments(args)?;
+            Ok(BenchmarkInvocation::DirectCoreWrite {
+                messages,
+                workers,
+                minimum_intervals,
+                target_duration_seconds,
+            })
         }
         _ => Err(AtmError::config(
             "usage: atm-daemon-benchmark --hook-mode <active|disabled> | --direct-storage-admission <count> --workers <count> | --direct-core-write <count> --workers <count>",
@@ -118,6 +133,44 @@ fn parse_concurrent_arguments(
         return Err(AtmError::config(usage));
     }
     Ok((messages, workers))
+}
+
+fn parse_direct_core_write_arguments(
+    mut args: impl Iterator<Item = String>,
+) -> Result<(NonZeroUsize, NonZeroUsize, NonZeroUsize, u64), AtmError> {
+    let usage = "usage: atm-daemon-benchmark --direct-core-write <count> --workers <count> [--intervals <count> --seconds <count>]";
+    let messages = parse_nonzero_argument(args.next(), "direct-core-write message count")?;
+    if args.next().as_deref() != Some("--workers") {
+        return Err(AtmError::config(usage));
+    }
+    let workers = parse_nonzero_argument(args.next(), "direct-core-write worker count")?;
+    let Some(option) = args.next() else {
+        return Ok((messages, workers, NonZeroUsize::MIN, 0));
+    };
+    if option != "--intervals" {
+        return Err(AtmError::config(usage));
+    }
+    let minimum_intervals =
+        parse_nonzero_argument(args.next(), "direct-core-write interval count")?;
+    if args.next().as_deref() != Some("--seconds") {
+        return Err(AtmError::config(usage));
+    }
+    let target_duration_seconds = args
+        .next()
+        .ok_or_else(|| AtmError::config("direct-core-write duration is required"))?
+        .parse::<u64>()
+        .map_err(|_| {
+            AtmError::config("direct-core-write duration must be a non-negative integer")
+        })?;
+    if args.next().is_some() {
+        return Err(AtmError::config(usage));
+    }
+    Ok((
+        messages,
+        workers,
+        minimum_intervals,
+        target_duration_seconds,
+    ))
 }
 
 fn parse_nonzero_argument(value: Option<String>, name: &str) -> Result<NonZeroUsize, AtmError> {
@@ -238,15 +291,67 @@ fn direct_storage_message(run_id: &str, sequence: usize) -> Message {
 async fn run_direct_core_write(
     messages: NonZeroUsize,
     workers: NonZeroUsize,
+    minimum_intervals: NonZeroUsize,
+    target_duration_seconds: u64,
 ) -> Result<(), AtmError> {
     let runtime = atm_daemon_bootstrap::assemble_default_runtime()?
         .for_daemon()
         .service_runtime;
     let home = atm_core::home::atm_home()?;
+    let started = Instant::now();
+    let mut accepted = 0_usize;
+    let mut intervals = Vec::new();
+    while intervals.len() < minimum_intervals.get()
+        || started.elapsed().as_secs() < target_duration_seconds
+    {
+        let (interval_accepted, interval_seconds) = run_direct_core_write_interval(
+            runtime.clone(),
+            home.clone(),
+            messages,
+            workers,
+            intervals.len() * messages.get(),
+        )
+        .await?;
+        accepted += interval_accepted;
+        intervals.push(serde_json::json!({
+            "requested_count": messages.get(),
+            "accepted_count": interval_accepted,
+            "elapsed_seconds": interval_seconds,
+            "admissions_per_second": interval_accepted as f64 / interval_seconds,
+        }));
+    }
+    let elapsed_seconds = started.elapsed().as_secs_f64();
+    let requested = messages.get() * intervals.len();
+    if accepted != requested {
+        return Err(AtmError::daemon_unavailable(format!(
+            "direct core-write benchmark accepted {accepted} of {requested} messages"
+        )));
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "kind": "canonical_core_write",
+            "requested_count": requested,
+            "accepted_count": accepted,
+            "worker_count": workers.get(),
+            "elapsed_seconds": elapsed_seconds,
+            "admissions_per_second": accepted as f64 / elapsed_seconds,
+            "intervals": intervals,
+        })
+    );
+    Ok(())
+}
+
+async fn run_direct_core_write_interval(
+    runtime: atm_core::LocalServiceRuntime,
+    home: std::path::PathBuf,
+    messages: NonZeroUsize,
+    workers: NonZeroUsize,
+    sequence_offset: usize,
+) -> Result<(usize, f64), AtmError> {
     let next = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();
     let mut tasks = JoinSet::new();
-
     for _ in 0..workers.get() {
         let runtime = runtime.clone();
         let home = home.clone();
@@ -259,7 +364,7 @@ async fn run_direct_core_write(
                     return Ok::<usize, AtmError>(accepted);
                 }
                 prepare_write_with_async_runtime(
-                    direct_core_write_request(&home, sequence)?,
+                    direct_core_write_request(&home, sequence_offset + sequence)?,
                     &NullObservability,
                     &runtime,
                 )
@@ -268,7 +373,6 @@ async fn run_direct_core_write(
             }
         });
     }
-
     let mut accepted = 0_usize;
     while let Some(result) = tasks.join_next().await {
         accepted += result.map_err(|error| {
@@ -277,25 +381,13 @@ async fn run_direct_core_write(
             ))
         })??;
     }
-    let elapsed_seconds = started.elapsed().as_secs_f64();
     if accepted != messages.get() {
         return Err(AtmError::daemon_unavailable(format!(
             "direct core-write benchmark accepted {accepted} of {} messages",
             messages.get()
         )));
     }
-    println!(
-        "{}",
-        serde_json::json!({
-            "kind": "canonical_core_write",
-            "requested_count": messages.get(),
-            "accepted_count": accepted,
-            "worker_count": workers.get(),
-            "elapsed_seconds": elapsed_seconds,
-            "admissions_per_second": accepted as f64 / elapsed_seconds,
-        })
-    );
-    Ok(())
+    Ok((accepted, started.elapsed().as_secs_f64()))
 }
 
 fn direct_core_write_request(
@@ -404,8 +496,31 @@ mod tests {
         .expect("core invocation parses");
         assert!(matches!(
             core,
-            BenchmarkInvocation::DirectCoreWrite { messages, workers }
-                if messages.get() == 10_000 && workers.get() == 64
+            BenchmarkInvocation::DirectCoreWrite {
+                messages, workers, minimum_intervals, target_duration_seconds,
+            }
+                if messages.get() == 10_000
+                    && workers.get() == 64
+                    && minimum_intervals.get() == 1
+                    && target_duration_seconds == 0
+        ));
+
+        let intervalled = parse_benchmark_invocation([
+            "--direct-core-write".to_owned(),
+            "1000".to_owned(),
+            "--workers".to_owned(),
+            "64".to_owned(),
+            "--intervals".to_owned(),
+            "10".to_owned(),
+            "--seconds".to_owned(),
+            "20".to_owned(),
+        ])
+        .expect("intervalled core invocation parses");
+        assert!(matches!(
+            intervalled,
+            BenchmarkInvocation::DirectCoreWrite {
+                minimum_intervals, target_duration_seconds, ..
+            } if minimum_intervals.get() == 10 && target_duration_seconds == 20
         ));
     }
 

--- a/crates/atm-storage-rusqlite/src/search_schema.rs
+++ b/crates/atm-storage-rusqlite/src/search_schema.rs
@@ -27,7 +27,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS mail_messages_fts USING fts5(
     body_text, summary, tags, var_values, from_agent,
     content='mail_message_search_documents',
     content_rowid='search_rowid',
-    tokenize='unicode61 remove_diacritics 2'
+    tokenize='unicode61 remove_diacritics 2',
+    columnsize=0
 );
 CREATE TRIGGER IF NOT EXISTS mail_message_search_documents_ai
 AFTER INSERT ON mail_message_search_documents BEGIN
@@ -82,6 +83,8 @@ CREATE TABLE IF NOT EXISTS search_projection_schema (
 );
 "#;
 
+const SEARCH_SCHEMA_VERSION: i64 = 2;
+
 pub(crate) fn ensure_schema(
     connection: &SqliteConnection,
     target: &SharedDbTarget,
@@ -107,22 +110,76 @@ pub(crate) fn ensure_schema(
                 error,
             )
         })?;
-    if current != Some(1) {
-        rebuild(connection, target)?;
-        connection
-            .execute(
-                "INSERT INTO search_projection_schema(singleton, version) VALUES (1, 1)
-                 ON CONFLICT(singleton) DO UPDATE SET version = excluded.version",
-                [],
-            )
-            .map_err(|error| {
-                sqlite_error(
-                    target,
-                    "failed to record SQLite search projection version",
-                    error,
-                )
-            })?;
+    match current {
+        Some(SEARCH_SCHEMA_VERSION) => {}
+        Some(1) => {
+            migrate_message_fts_to_columnsize_zero(connection, target)?;
+            record_schema_version(connection, target)?;
+        }
+        _ => {
+            rebuild(connection, target)?;
+            record_schema_version(connection, target)?;
+        }
     }
+    Ok(())
+}
+
+/// Rebuild only the message FTS index from its durable projection table.
+///
+/// The source projection is already committed and immediately searchable.  We
+/// therefore retain it while replacing the FTS shadow tables with the
+/// lower-write-amplification `columnsize=0` variant.  Leaving the schema
+/// version unchanged until the rebuild succeeds makes a failed startup retry
+/// this idempotent migration rather than claiming a partially migrated index.
+fn migrate_message_fts_to_columnsize_zero(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), atm_storage::AtmError> {
+    connection
+        .execute_batch(
+            "DROP TRIGGER IF EXISTS mail_message_search_documents_ai;
+             DROP TRIGGER IF EXISTS mail_message_search_documents_ad;
+             DROP TRIGGER IF EXISTS mail_message_search_documents_au;
+             DROP TABLE IF EXISTS mail_messages_fts;",
+        )
+        .map_err(|error| {
+            sqlite_error(target, "failed to replace SQLite message FTS index", error)
+        })?;
+    connection.execute_batch(SEARCH_DDL).map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to recreate SQLite message FTS index with columnsize disabled",
+            error,
+        )
+    })?;
+    connection
+        .execute(
+            "INSERT INTO mail_messages_fts(mail_messages_fts) VALUES ('rebuild')",
+            [],
+        )
+        .map_err(|error| {
+            sqlite_error(target, "failed to rebuild SQLite message FTS index", error)
+        })?;
+    Ok(())
+}
+
+fn record_schema_version(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), atm_storage::AtmError> {
+    connection
+        .execute(
+            "INSERT INTO search_projection_schema(singleton, version) VALUES (1, ?1)
+             ON CONFLICT(singleton) DO UPDATE SET version = excluded.version",
+            [SEARCH_SCHEMA_VERSION],
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to record SQLite search projection version",
+                error,
+            )
+        })?;
     Ok(())
 }
 
@@ -518,7 +575,10 @@ use rusqlite::OptionalExtension;
 
 #[cfg(test)]
 mod tests {
-    use super::flatten_json_text;
+    use rusqlite::Connection;
+
+    use super::{SEARCH_DDL, SEARCH_SCHEMA_VERSION, ensure_schema, flatten_json_text};
+    use crate::shared_db::SharedDbTarget;
 
     #[test]
     fn json_flattening_is_key_sorted_and_array_stable() {
@@ -526,5 +586,71 @@ mod tests {
             flatten_json_text(r#"{"z":["last", {"b":2,"a":1}], "a":true}"#).expect("valid JSON"),
             "true last 1 2"
         );
+    }
+
+    #[test]
+    fn v1_message_fts_migration_keeps_immediate_match_and_snippet_behavior() {
+        let connection = Connection::open_in_memory().expect("open SQLite database");
+        let target = SharedDbTarget::InMemory {
+            uri: "file:search-schema-columnsize-migration?mode=memory&cache=shared".to_owned(),
+        };
+        let legacy_ddl = SEARCH_DDL.replace(",\n    columnsize=0", "");
+        connection
+            .execute_batch(&legacy_ddl)
+            .expect("create version-one search schema");
+        connection
+            .execute(
+                "INSERT INTO search_projection_schema(singleton, version) VALUES (1, 1)",
+                [],
+            )
+            .expect("record version one schema");
+        connection
+            .execute(
+                "INSERT INTO mail_message_search_documents(
+                     team, agent, message_key, message_at, body_text, from_agent
+                 ) VALUES ('atm-dev', 'arch-ctm', 'atm:needle', '2026-08-23T00:00:00Z',
+                           'columnsize migration needle', 'arch-ctm')",
+                [],
+            )
+            .expect("seed legacy immediate search projection");
+
+        ensure_schema(&connection, &target).expect("migrate version-one message FTS index");
+
+        let schema: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'mail_messages_fts'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read migrated FTS schema");
+        assert!(schema.contains("columnsize=0"));
+        let version: i64 = connection
+            .query_row(
+                "SELECT version FROM search_projection_schema WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read migrated schema version");
+        assert_eq!(version, SEARCH_SCHEMA_VERSION);
+        let snippet: String = connection
+            .query_row(
+                "SELECT snippet(mail_messages_fts, -1, '[', ']', '…', 16)
+                 FROM mail_messages_fts WHERE mail_messages_fts MATCH 'needle'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("migrated index must retain immediate snippet search");
+        assert!(snippet.contains("[needle]"));
+        let highlighted: String = connection
+            .query_row(
+                "SELECT highlight(mail_messages_fts, 0, '[', ']')
+                 FROM mail_messages_fts WHERE mail_messages_fts MATCH 'needle'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("migrated index must retain immediate highlight search");
+        assert!(highlighted.contains("[needle]"));
+
+        ensure_schema(&connection, &target).expect("repeat migration check is idempotent");
     }
 }

--- a/scripts/smoke/benchmark_schema.py
+++ b/scripts/smoke/benchmark_schema.py
@@ -122,7 +122,7 @@ class DirectSQLiteMessageWrite(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    kind: Literal["async_storage_admission"] = "async_storage_admission"
+    kind: Literal["async_storage_admission", "canonical_core_write"] = "async_storage_admission"
     requested_count: int = Field(gt=0)
     accepted_count: int = Field(ge=0)
     worker_count: int = Field(gt=0)
@@ -145,9 +145,9 @@ class BenchmarkSummary(BaseModel):
     artifact_kind: Literal["send_message_benchmark_summary"] = "send_message_benchmark_summary"
     generated_at: str = Field(min_length=1)
     host_label: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
-    transport: Literal["uds", "tcp"]
+    transport: Literal["sqlite", "uds", "tcp"]
     peer_wire_security: Optional[Literal["mutual-tls", "plaintext-test"]] = None
-    benchmark_target: Optional[Literal["tcp", "tcp-tls"]] = None
+    benchmark_target: Optional[Literal["sqlite", "uds", "tcp", "tcp-tls"]] = None
     hook_mode: Optional[Literal["active"]] = None
     frames_per_connection: Literal[1, 2, 4, 8, 16, 64]
     messages_per_connection: int = Field(gt=0)
@@ -161,7 +161,7 @@ class BenchmarkSummary(BaseModel):
     host_os: Optional[str] = None
     host_arch: Optional[str] = None
     command: Optional[str] = None
-    execution_daemon: Optional[Literal["shipped_atm_daemon"]] = None
+    execution_daemon: Optional[Literal["shipped_atm_daemon", "direct_production_writer"]] = None
     comparison_source_revision: Optional[str] = Field(default=None, pattern=r"^[0-9a-f]{40}$")
     comparison_host_label: Optional[str] = Field(
         default=None, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
@@ -190,6 +190,10 @@ class BenchmarkSummary(BaseModel):
 
     @model_validator(mode="after")
     def run_matches_metrics(self) -> "BenchmarkSummary":
+        if self.benchmark_target == "sqlite" and self.transport != "sqlite":
+            raise ValueError("sqlite target must use the direct production-writer profile")
+        if self.benchmark_target == "uds" and self.transport != "uds":
+            raise ValueError("uds target must use the public UDS profile")
         if self.benchmark_target == "tcp" and (
             self.transport != "tcp" or self.peer_wire_security != "plaintext-test"
         ):

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -90,6 +90,8 @@ DAEMON_OUTPUT_TAIL_LINES = 200
 GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
 PEER_WIRE_SECURITY_MODES = ("mutual-tls", "plaintext-test")
 BENCHMARK_TARGETS = {
+    "sqlite": ("sqlite", None),
+    "uds": ("uds", "mutual-tls"),
     "tcp": ("tcp", "plaintext-test"),
     "tcp-tls": ("tcp", "mutual-tls"),
 }
@@ -624,6 +626,38 @@ def release_binary(name: str) -> Path:
     return path
 
 
+def canonical_writer_probe() -> Path:
+    """Build the existing direct canonical-writer probe when sqlite needs it.
+
+    The normal benchmark recipe still starts only the shipped Tokio/Axum
+    daemon.  This feature-gated helper does not create a second daemon: its
+    sole invocation is ``--direct-core-write``, which measures the existing
+    async admission/writer/commit path without an HTTP codec.
+    """
+    suffix = ".exe" if os.name == "nt" else ""
+    probe = ROOT / "target" / "release" / f"atm-daemon-benchmark{suffix}"
+    if probe.is_file():
+        return probe
+    try:
+        result = subprocess.run(
+            [
+                "cargo", "build", "--release", "-p", "atm-daemon-bootstrap",
+                "--features", "benchmark-harness", "--bin", "atm-daemon-benchmark",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=600.0,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SmokeError(f"could not build canonical sqlite writer probe: {error}") from error
+    if result.returncode != 0 or not probe.is_file():
+        detail = result.stderr.strip() or result.stdout.strip() or "no executable produced"
+        raise SmokeError(f"could not build canonical sqlite writer probe: {detail}")
+    return probe
+
+
 def source_revision() -> str:
     """Bind retained benchmark evidence to the checkout that built the daemon."""
     result = subprocess.run(
@@ -834,10 +868,10 @@ def cached_roster_heartbeat_body(
 
 def validate_transport(transport: str) -> str:
     """Keep platform transport selection explicit and comparable."""
-    if transport not in {"uds", "tcp"}:
-        raise SmokeError("capacity transport must be `uds` or `tcp`")
-    if os.name == "nt" and transport != "tcp":
-        raise SmokeError("Windows capacity benchmarking supports only `tcp`")
+    if transport not in {"sqlite", "uds", "tcp"}:
+        raise SmokeError("capacity transport must be `sqlite`, `uds`, or `tcp`")
+    if os.name == "nt" and transport == "uds":
+        raise SmokeError("Windows capacity benchmarking does not support UDS")
     return transport
 
 
@@ -853,7 +887,7 @@ def validate_peer_wire_security(value: str) -> str:
 def resolve_benchmark_target(
     target: str | None,
     transport: str | None,
-) -> tuple[str, str, str | None]:
+) -> tuple[str, str | None, str | None]:
     """Resolve public targets without inventing a benchmark-only transport.
 
     `tcp` deliberately selects the existing direct plaintext pipeline and
@@ -874,6 +908,8 @@ def resolve_benchmark_target(
 def local_endpoint(transport: str) -> LocalEndpoint:
     """Resolve the documented UDS/TCP public API without a dispatcher seam."""
     runtime = os_account_home() / ".atm" / "daemon"
+    if transport == "sqlite":
+        raise SmokeError("sqlite capacity target has no public socket endpoint")
     if transport == "uds":
         return LocalEndpoint("uds", str(runtime / "atm-daemon.sock"))
     try:
@@ -1149,6 +1185,103 @@ def run_profile(
     }
 
 
+def run_direct_production_writer_profile(
+    benchmark_binary: Path,
+    environment: dict[str, str],
+    roster: CapacityRoster,
+    requested_messages: int,
+    sample_count: int,
+    workers: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Measure the canonical Tokio admission writer without raw SQL or HTTP.
+
+    The benchmark-owned daemon first creates the disposable roster and is then
+    stopped.  The direct binary calls ``prepare_write_with_async_runtime`` so
+    this lane includes the canonical write preparation, writer queue, batch
+    transaction, commit, and post-commit response decision; it excludes only
+    the public socket/codec measured by UDS and TCP.
+    """
+    direct_environment = dict(environment)
+    direct_environment.update(
+        {
+            "ATM_CAPACITY_CORE_TEAM": roster.team,
+            "ATM_CAPACITY_CORE_AGENT": roster.agent,
+            "ATM_CAPACITY_CORE_RECIPIENT": roster.recipient,
+        }
+    )
+    result = subprocess.run(
+        [
+            str(benchmark_binary), "--direct-core-write", str(requested_messages),
+            "--workers", str(workers), "--intervals", str(sample_count),
+            "--seconds", str(int(TARGET_PROFILE_DURATION_SECONDS)),
+        ],
+        cwd=ROOT,
+        env=direct_environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=TARGET_PROFILE_DURATION_SECONDS + 60.0,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise SmokeError(f"direct production-writer benchmark failed: {detail}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SmokeError("direct production-writer benchmark returned malformed JSON") from error
+    if not isinstance(payload, dict) or payload.get("kind") != "canonical_core_write":
+        raise SmokeError("direct production-writer benchmark returned the wrong measurement kind")
+    direct_intervals = payload.get("intervals")
+    if not isinstance(direct_intervals, list) or len(direct_intervals) < sample_count:
+        raise SmokeError("direct production-writer benchmark returned too few intervals")
+    intervals: list[dict[str, Any]] = []
+    for index, item in enumerate(direct_intervals, start=1):
+        if not isinstance(item, dict):
+            raise SmokeError("direct production-writer interval is malformed")
+        accepted = int(item.get("accepted_count", -1))
+        requested = int(item.get("requested_count", -1))
+        elapsed = float(item.get("elapsed_seconds", 0.0))
+        rate = float(item.get("admissions_per_second", 0.0))
+        if requested != requested_messages or accepted < 0 or accepted > requested or elapsed <= 0 or rate < 0:
+            raise SmokeError("direct production-writer interval has invalid counts or timing")
+        intervals.append(
+            {
+                "interval": index,
+                "accepted_count": accepted,
+                "response_count": accepted,
+                "elapsed_seconds": elapsed,
+                "admissions_per_second": rate,
+                "latency_ms": {"min": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0},
+                "connections": 0,
+                "connection_workers": 0,
+                "request_frames_per_second": rate,
+                "connections_per_second": 0.0,
+                "requested_count": requested,
+                "time_to_send_1k_s": elapsed * (1_000 / max(accepted, 1)),
+                "application_wire_bytes": {"request": 0, "response": 0, "total": 0},
+                "application_wire_bytes_per_second": 0.0,
+                "error_free": accepted == requested,
+                "bytes_per_second": 0.0,
+                "first_failure": None if accepted == requested else "direct production writer accepted fewer messages than requested",
+                "passed": accepted == requested,
+            }
+        )
+    return (
+        {
+            "operation": "canonical_production_writer",
+            "recipient": f"{roster.recipient}@{roster.team}",
+            "requested_messages_per_sample": requested_messages,
+            "minimum_sample_count": sample_count,
+            "sample_count": len(intervals),
+            "target_duration_s": TARGET_PROFILE_DURATION_SECONDS,
+            "run_duration_s": sum(float(item["elapsed_seconds"]) for item in intervals),
+            "intervals": intervals,
+            "passed": all(item["passed"] for item in intervals),
+        },
+        payload,
+    )
+
+
 def run_cached_roster_heartbeat_probe(
     endpoint: LocalEndpoint,
     home: Path,
@@ -1339,7 +1472,15 @@ def run_capacity(
         )
     benchmark_account = require_capacity_benchmark_account()
     transport = validate_transport(transport)
-    peer_wire_security = validate_peer_wire_security(peer_wire_security)
+    if transport == "sqlite":
+        if peer_wire_security is not None:
+            raise SmokeError("sqlite capacity target must not select a peer-wire security mode")
+        launch_peer_wire_security = "mutual-tls"
+    else:
+        if peer_wire_security is None:
+            raise SmokeError("public capacity target requires an explicit peer-wire security mode")
+        peer_wire_security = validate_peer_wire_security(peer_wire_security)
+        launch_peer_wire_security = peer_wire_security
     if frames_per_connection not in SPARSE_FRAMES_PER_CONNECTION:
         raise SmokeError(f"frames per connection must be one of {SPARSE_FRAMES_PER_CONNECTION}")
     if requested_messages <= 0:
@@ -1350,6 +1491,7 @@ def run_capacity(
     home = validate_capacity_home(atm_home)
     atm = release_binary("atm")
     daemon = release_binary("atm-daemon")
+    direct_writer = canonical_writer_probe() if transport == "sqlite" else None
     roster = CapacityRoster.unique()
     env = runtime_environment(home, roster)
     target_command = (
@@ -1383,7 +1525,9 @@ def run_capacity(
         "host_arch": platform.machine().lower(),
         "command": target_command,
         "release": {"atm": str(atm), "atm_daemon": str(daemon)},
-        "execution_daemon": "shipped_atm_daemon",
+        "execution_daemon": (
+            "direct_production_writer" if transport == "sqlite" else "shipped_atm_daemon"
+        ),
         "atm_home": str(home),
         "host_state_isolation": isolation_mode,
         "managed_log_level": managed_log_level,
@@ -1424,7 +1568,9 @@ def run_capacity(
     def start_and_doctor() -> None:
         """Start the exact released daemon and require its public ready response."""
         nonlocal process, daemon_output
-        process, daemon_output = start_capacity_daemon(daemon, home, env, peer_wire_security)
+        process, daemon_output = start_capacity_daemon(
+            daemon, home, env, launch_peer_wire_security,
+        )
         doctor = command_result(
             [str(atm), "doctor", "--json"],
             timeout=10.0,
@@ -1442,7 +1588,7 @@ def run_capacity(
         )
         before = count_atm_daemon_processes()
         home.mkdir(parents=True, exist_ok=False)
-        if peer_wire_security == "mutual-tls":
+        if launch_peer_wire_security == "mutual-tls":
             fingerprint = run_lifecycle_phase(
                 evidence,
                 "snapshot",
@@ -1465,28 +1611,47 @@ def run_capacity(
         run_lifecycle_phase(
             evidence, "profile", lambda: prepare_capacity_roster(atm, env, home, roster),
         )
-        endpoint = local_endpoint(transport)
-        evidence["endpoint"] = {
-            "transport": endpoint.kind,
-            "address": endpoint.address,
-        }
-        if endpoint.kind == "uds" and not Path(str(endpoint.address)).exists():
-            raise SmokeError(f"daemon did not publish public local socket {endpoint.address}")
-        evidence["operational_checks"]["cached_roster_heartbeat"] = run_lifecycle_phase(
-            evidence,
-            "profile",
-            lambda: run_cached_roster_heartbeat_probe(
-                endpoint, home, frames_per_connection, workers, roster,
-            ),
-        )
-        profile = run_lifecycle_phase(
-            evidence,
-            "profile",
-            lambda: run_profile(
-                endpoint, home, frames_per_connection, requested_messages,
-                sample_count, workers, roster=roster,
-            ),
-        )
+        if transport == "sqlite":
+            if direct_writer is None:
+                raise SmokeError("direct production-writer binary is unavailable")
+            run_lifecycle_phase(evidence, "stop", stop_owned_daemon)
+            profile, direct_measurement = run_lifecycle_phase(
+                evidence,
+                "profile",
+                lambda: run_direct_production_writer_profile(
+                    direct_writer, env, roster, requested_messages, sample_count, workers,
+                ),
+            )
+            evidence["direct_sqlite_message_write"] = {
+                field: direct_measurement[field]
+                for field in (
+                    "kind", "requested_count", "accepted_count", "worker_count",
+                    "elapsed_seconds", "admissions_per_second",
+                )
+            }
+        else:
+            endpoint = local_endpoint(transport)
+            evidence["endpoint"] = {
+                "transport": endpoint.kind,
+                "address": endpoint.address,
+            }
+            if endpoint.kind == "uds" and not Path(str(endpoint.address)).exists():
+                raise SmokeError(f"daemon did not publish public local socket {endpoint.address}")
+            evidence["operational_checks"]["cached_roster_heartbeat"] = run_lifecycle_phase(
+                evidence,
+                "profile",
+                lambda: run_cached_roster_heartbeat_probe(
+                    endpoint, home, frames_per_connection, workers, roster,
+                ),
+            )
+            profile = run_lifecycle_phase(
+                evidence,
+                "profile",
+                lambda: run_profile(
+                    endpoint, home, frames_per_connection, requested_messages,
+                    sample_count, workers, roster=roster,
+                ),
+            )
         evidence["runs"] = [profile]
         evidence["sample_count"] = profile["sample_count"]
         evidence["target_duration_s"] = profile["target_duration_s"]
@@ -1588,6 +1753,38 @@ def run_capacity(
     return (0 if evidence.get("passed") else 1), evidence_path
 
 
+def run_default_f8_matrix(args: argparse.Namespace) -> int:
+    """Run the ordinary four-target f8 suite in its fixed, comparable order."""
+    codes: list[int] = []
+    for position, (target, (transport, peer_wire_security)) in enumerate(
+        BENCHMARK_TARGETS.items(), start=1,
+    ):
+        if args.atm_home is None:
+            with tempfile.TemporaryDirectory(prefix="atm-capacity-parent-") as temporary:
+                home = Path(temporary) / f"{CAPACITY_ROOT_PREFIX}{position}"
+                code, evidence = run_capacity(
+                    home, args.evidence_dir, transport, 8,
+                    workers=args.workers,
+                    comparison_required=False,
+                    raw_evidence_directory=args.raw_evidence_dir,
+                    peer_wire_security=peer_wire_security,
+                    benchmark_target=target,
+                )
+        else:
+            home = args.atm_home / f"{CAPACITY_ROOT_PREFIX}{position}"
+            code, evidence = run_capacity(
+                home, args.evidence_dir, transport, 8,
+                workers=args.workers,
+                comparison_required=False,
+                raw_evidence_directory=args.raw_evidence_dir,
+                peer_wire_security=peer_wire_security,
+                benchmark_target=target,
+            )
+        codes.append(code)
+        print(f"{'PASS' if code == 0 else 'FAIL'} f8 target {target}: {evidence}")
+    return 0 if all(code == 0 for code in codes) else 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -1610,8 +1807,8 @@ def main() -> int:
         "--target",
         choices=tuple(BENCHMARK_TARGETS),
         help=(
-            "public peer-wire benchmark target: `tcp` selects plaintext-test; "
-            "`tcp-tls` selects mutual TLS"
+            "one focused benchmark target; without a target the ordinary command runs "
+            "the required sqlite, UDS, plaintext TCP, and mTLS TCP f8 matrix"
         ),
     )
     parser.add_argument("--transport")
@@ -1643,6 +1840,8 @@ def main() -> int:
             raise SmokeError(f"benchmark-account bootstrap failed: {error}") from error
         print(f"benchmark-account manifest created: {account.manifest_path}")
         return 0
+    if not any((args.target, args.transport, args.frames_per_connection, args.sustained, args.baseline)):
+        return run_default_f8_matrix(args)
     transport, peer_wire_security, benchmark_target = resolve_benchmark_target(
         args.target, args.transport,
     )
@@ -1679,7 +1878,7 @@ def main() -> int:
                     raise SmokeError("UDS multi-frame profile requires the current UDS one-frame reference")
                 comparison_median = uds_one_frame_median
                 comparison_strict = True
-        else:
+        elif transport == "tcp":
             # Connection setup dominates one/two-frame TCP.  Keep an explicit
             # short-frame floor instead of hiding it, while retaining the
             # stricter batching-parity floor where frames amortize setup.

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -1,6 +1,7 @@
 """Focused unit tests for the AI.33 public admission-capacity runner."""
 from __future__ import annotations
 
+import argparse
 import contextlib
 import importlib.util
 import inspect
@@ -1207,6 +1208,41 @@ class AdmissionCapacityTests(unittest.TestCase):
             50_000.0,
         )
 
+    def test_direct_writer_profile_requires_and_preserves_real_intervals(self):
+        payload = {
+            "kind": "canonical_core_write",
+            "requested_count": 2_000,
+            "accepted_count": 2_000,
+            "worker_count": 64,
+            "elapsed_seconds": 0.1,
+            "admissions_per_second": 20_000.0,
+            "intervals": [
+                {
+                    "requested_count": 1_000,
+                    "accepted_count": 1_000,
+                    "elapsed_seconds": 0.05,
+                    "admissions_per_second": 20_000.0,
+                },
+                {
+                    "requested_count": 1_000,
+                    "accepted_count": 1_000,
+                    "elapsed_seconds": 0.05,
+                    "admissions_per_second": 20_000.0,
+                },
+            ],
+        }
+        completed = mock.Mock(returncode=0, stdout=json.dumps(payload), stderr="")
+        roster = RUNNER.CapacityRoster("test", "team", "agent", "recipient")
+        with mock.patch.object(RUNNER.subprocess, "run", return_value=completed) as run:
+            profile, measurement = RUNNER.run_direct_production_writer_profile(
+                Path("/tmp/atm-daemon-benchmark"), {}, roster, 1_000, 2, 64,
+            )
+        self.assertEqual(measurement, payload)
+        self.assertEqual(profile["sample_count"], 2)
+        self.assertEqual(profile["intervals"][0]["admissions_per_second"], 20_000.0)
+        self.assertIn("--direct-core-write", run.call_args.args[0])
+        self.assertIn("--intervals", run.call_args.args[0])
+
     def test_profile_schema_distinguishes_minimum_from_actual_sample_count(self):
         interval = {"passed": True, "elapsed_seconds": 0.6}
         with mock.patch.object(RUNNER, "run_interval", return_value=interval):
@@ -1332,9 +1368,42 @@ class AdmissionCapacityTests(unittest.TestCase):
             mock.patch.object(sys, "argv", ["run_admission_capacity.py", "--transport", "invalid"]),
             mock.patch.object(RUNNER, "selected_profiles") as selected,
         ):
-            with self.assertRaisesRegex(RUNNER.SmokeError, "must be `uds` or `tcp`"):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "must be `sqlite`, `uds`, or `tcp`"):
                 RUNNER.main()
         selected.assert_not_called()
+
+    def test_plain_benchmark_command_dispatches_the_required_four_target_matrix(self):
+        with (
+            mock.patch.object(sys, "argv", ["run_admission_capacity.py"]),
+            mock.patch.object(RUNNER, "run_default_f8_matrix", return_value=0) as matrix,
+        ):
+            self.assertEqual(RUNNER.main(), 0)
+        matrix.assert_called_once()
+
+    def test_default_f8_matrix_runs_targets_in_fixed_order(self):
+        observed: list[tuple[str, str | None]] = []
+
+        def run_capacity(*_args, **kwargs):
+            observed.append((kwargs["benchmark_target"], kwargs["peer_wire_security"]))
+            return 0, Path("evidence.json")
+
+        args = argparse.Namespace(
+            atm_home=None,
+            evidence_dir=Path("evidence"),
+            raw_evidence_dir=Path("raw"),
+            workers=64,
+        )
+        with mock.patch.object(RUNNER, "run_capacity", side_effect=run_capacity):
+            self.assertEqual(RUNNER.run_default_f8_matrix(args), 0)
+        self.assertEqual(
+            observed,
+            [
+                ("sqlite", None),
+                ("uds", "mutual-tls"),
+                ("tcp", "plaintext-test"),
+                ("tcp-tls", "mutual-tls"),
+            ],
+        )
 
     def test_main_allows_windows_tcp_without_a_comparison_reference(self):
         captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- `9384f91d5`: FTS5 schema change (`columnsize=0`) removing per-column token-count storage, since current search does not use bm25/rank. Schema-versioned migration (V1→V2), preserves external content, immediate transactional projection, MATCH, highlight, and snippet.
- `94b75a3ea`: wires sqlite and UDS transports into the default `just benchmark` / `run_admission_capacity` matrix (previously only tcp/tcp-tls were exercised; the direct storage benchmark binary existed but was unused).

## Evidence (M5 atmbench, f8/512, byte-exact restore on every run)
- No-policy baseline (B): sqlite 33,987.02/s, UDS 17,948.36/s
- Candidate run 1: sqlite 36,018.14/s (+6.0%), UDS 18,752.56/s (+4.5%), TCP 18,019.97/s, TLS 17,964.58/s
- Candidate repeat: sqlite 36,252.30/s (+6.7%), UDS 18,760.91/s (+4.5%), TCP 17,738.65/s, TLS 17,226.89/s
- Local: migration fixture preserves V1→V2 immediate MATCH/highlight/snippet; atm-storage-rusqlite 66/66 tests + clippy clean; runner tests 96 passed.

Historical sqlite (~45k) / UDS (~23.6k-24.75k) parity targets predate the FTS5 search feature (commit 1135ef7ce, AN.5) and are not directly comparable; this candidate is a real, repeatable gain over the current post-FTS baseline, not a claim of full historical parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)