### PR TITLE
fix(benchmark): bootstrap dedicated-account six-frame plaintext baseline

### DIFF
--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -1785,12 +1785,59 @@ def run_default_f8_matrix(args: argparse.Namespace) -> int:
     return 0 if all(code == 0 for code in codes) else 1
 
 
+def run_plaintext_baseline_bootstrap(args: argparse.Namespace) -> int:
+    """Establish the explicit six-frame TCP baseline for a clean benchmark account.
+
+    This is deliberately a one-time, opt-in bootstrap.  Ordinary focused TCP
+    runs continue to require this accepted same-host evidence; otherwise the
+    first new benchmark account could never create the complete comparison set
+    that the gate requires.
+    """
+    codes: list[int] = []
+    for position, frames_per_connection in enumerate(TCP_COMPARISON_FRAMES, start=1):
+        if args.atm_home is None:
+            with tempfile.TemporaryDirectory(prefix="atm-capacity-parent-") as temporary:
+                home = Path(temporary) / f"{CAPACITY_ROOT_PREFIX}{position}"
+                code, evidence = run_capacity(
+                    home, args.evidence_dir, "tcp", frames_per_connection,
+                    workers=args.workers,
+                    comparison_required=False,
+                    raw_evidence_directory=args.raw_evidence_dir,
+                    peer_wire_security="plaintext-test",
+                    benchmark_target="tcp",
+                )
+        else:
+            home = args.atm_home / f"{CAPACITY_ROOT_PREFIX}{position}"
+            code, evidence = run_capacity(
+                home, args.evidence_dir, "tcp", frames_per_connection,
+                workers=args.workers,
+                comparison_required=False,
+                raw_evidence_directory=args.raw_evidence_dir,
+                peer_wire_security="plaintext-test",
+                benchmark_target="tcp",
+            )
+        codes.append(code)
+        print(
+            f"{'PASS' if code == 0 else 'FAIL'} plaintext baseline "
+            f"f{frames_per_connection}: {evidence}"
+        )
+    return 0 if all(code == 0 for code in codes) else 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--bootstrap-benchmark-account",
         action="store_true",
         help="create the account-local benchmark manifest; refuses an account with existing ATM state",
+    )
+    parser.add_argument(
+        "--bootstrap-plaintext-baseline",
+        action="store_true",
+        help=(
+            "one-time dedicated-account bootstrap for the complete six-frame "
+            "same-host plaintext TCP comparison set"
+        ),
     )
     parser.add_argument("--atm-home", type=Path)
     parser.add_argument(
@@ -1840,6 +1887,12 @@ def main() -> int:
             raise SmokeError(f"benchmark-account bootstrap failed: {error}") from error
         print(f"benchmark-account manifest created: {account.manifest_path}")
         return 0
+    if args.bootstrap_plaintext_baseline:
+        if any((
+            args.target, args.transport, args.frames_per_connection, args.sustained, args.baseline,
+        )):
+            parser.error("--bootstrap-plaintext-baseline cannot be combined with target/profile options")
+        return run_plaintext_baseline_bootstrap(args)
     if not any((args.target, args.transport, args.frames_per_connection, args.sustained, args.baseline)):
         return run_default_f8_matrix(args)
     transport, peer_wire_security, benchmark_target = resolve_benchmark_target(

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -1405,6 +1405,41 @@ class AdmissionCapacityTests(unittest.TestCase):
             ],
         )
 
+    def test_plaintext_baseline_bootstrap_runs_the_complete_required_set(self):
+        observed: list[tuple[int, bool, str, str]] = []
+
+        def run_capacity(*_args, **kwargs):
+            observed.append((
+                _args[3], kwargs["comparison_required"], kwargs["peer_wire_security"],
+                kwargs["benchmark_target"],
+            ))
+            return 0, Path("evidence.json")
+
+        args = argparse.Namespace(
+            atm_home=None,
+            evidence_dir=Path("evidence"),
+            raw_evidence_dir=Path("raw"),
+            workers=64,
+        )
+        with mock.patch.object(RUNNER, "run_capacity", side_effect=run_capacity):
+            self.assertEqual(RUNNER.run_plaintext_baseline_bootstrap(args), 0)
+        self.assertEqual(
+            observed,
+            [(frame, False, "plaintext-test", "tcp") for frame in RUNNER.TCP_COMPARISON_FRAMES],
+        )
+
+    def test_plaintext_baseline_bootstrap_dispatches_only_when_explicit(self):
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                ["run_admission_capacity.py", "--bootstrap-plaintext-baseline"],
+            ),
+            mock.patch.object(RUNNER, "run_plaintext_baseline_bootstrap", return_value=0) as bootstrap,
+        ):
+            self.assertEqual(RUNNER.main(), 0)
+        bootstrap.assert_called_once()
+
     def test_main_allows_windows_tcp_without_a_comparison_reference(self):
         captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- Adds the minimal dedicated-account six-frame (f1/f2/f4/f8/f16/f64) plaintext comparison-baseline bootstrap needed before the focused TCP f8/sustained-10k benchmark invocation can establish its own accepted baseline and pass. The default matrix only publishes f8 with comparison disabled, so the fresh M5 atmbench host had no path to a first complete plaintext baseline.
- Harness-only change, one commit atop `e250ac2bc` (post-#997 integrate/phase-ao2 head). No production/daemon code touched.

## Evidence (AO2.7/AO2.8 TCP/TCP+TLS parity)
Live M5 validation on the signed release candidate at `ff9329dc1`, dedicated atmbench account:
- All six bootstrap plaintext baseline frames (f1/f2/f4/f8/f16/f64) passed.
- Requested f8/sustained-10k pair on the merged head:
  - TCP plaintext: 22,113.98 msg/s (1.72% below the 22.5k sustained target — within the ±5% parity tolerance)
  - TCP+TLS: 22,297.31 msg/s (0.90% below the 22.5k sustained target — within the ±5% parity tolerance)
- Every final profile: byte-identical clean-baseline == restored-clean == restored-live-database hashes.
- Unit suite: 98 passed.

This closes the AO2.7/AO2.8 TCP/TCP+TLS parity determination (both within tolerance of the M5 historical baseline).

## Test plan
- [x] Unit suite (98 passed)
- [x] Live M5 six-frame plaintext baseline bootstrap
- [x] Live M5 f8/sustained-10k TCP + TCP+TLS measurement, byte-exact restore verified