### PR TITLE
fix(sprint-report): render all 10 triage_report.py fields in table mode

### DIFF
--- a/.claude/skills/sprint-report/report.md.j2
+++ b/.claude/skills/sprint-report/report.md.j2
@@ -13,8 +13,10 @@ required_variables:
 ────────────────────────────────────────
 {{ integration_row }}
 {% else %}
-| Sprint | DEV | QA | CI | PR |
-|--------|-----|----|----|-----|
+| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
+|--------|-----|----|----|-----|---|---|---|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
+{{ current_integration_summary }}
+{{ stale_occurrences_summary }}
 {% endif %}


### PR DESCRIPTION
## Summary
- `report.md.j2`'s table-mode header declared only 5 columns (Sprint/DEV/QA/CI/PR) while `triage_report.py`'s `sprint_rows` output emits 10 fields per row (adds B/I/M counts and Ready/OK flags) — a template/script version-drift bug that garbled the rendered table.
- Extended the header to match, and surfaced `current_integration_summary`/`stale_occurrences_summary`, which were already computed by the script but never rendered.

## Test plan
- [x] Rendered via `sc-compose render --file .claude/skills/sprint-report/report.md.j2 --var-file <live AO2 vars>` — table now renders cleanly with all 10 columns aligned.