### PR TITLE
fix(benchmark): publish provenance-bound historical results

### DIFF
--- a/.just/tests/test_benchmark_report.py
+++ b/.just/tests/test_benchmark_report.py
@@ -73,6 +73,38 @@ class BenchmarkReportTests(unittest.TestCase):
             with self.assertRaisesRegex(REPORT.BenchmarkReportError, "source_revision"):
                 REPORT.load_result(source)
 
+    def test_hash_bound_historical_import_is_rendered_without_rewriting_raw_artifact(self) -> None:
+        payload = json.loads(self.fixture("success-uds-f1.json").read_text(encoding="utf-8"))
+        payload.update({
+            "benchmark_target": "uds",
+            "source_revision": "a" * 40,
+            "host_label": "local",
+        })
+        with tempfile.TemporaryDirectory() as directory:
+            report_dir = Path(directory) / "send-message-benchmark"
+            report_dir.mkdir()
+            artifact = report_dir / "historical.json"
+            artifact.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            manifest = {
+                "schema_version": 1,
+                "imports": [{
+                    "filename": "historical.json",
+                    "sha256": REPORT.file_sha256(artifact),
+                    "campaign_id": "historical-20260823-aaaaaaaaaaaa",
+                    "display_host_label": "m5-atmbench",
+                    "provenance_note": "Exact imported source artifact.",
+                }],
+            }
+            (report_dir / REPORT.HISTORICAL_IMPORTS_NAME).write_text(json.dumps(manifest), encoding="utf-8")
+            records = REPORT.evidence_records(report_dir)
+            self.assertEqual(REPORT.campaign_id(records[0]), "historical-20260823-aaaaaaaaaaaa")
+            self.assertEqual(records[0]["_report_display_host_label"], "m5-atmbench")
+            with mock.patch.object(REPORT, "ROOT", ROOT):
+                output = REPORT.render_aggregate(records, Path(directory))
+            text = output.read_text(encoding="utf-8")
+        self.assertIn("m5-atmbench", text)
+        self.assertIn("Exact imported source artifact.", text)
+
     def test_failed_run_is_retained(self) -> None:
         result = REPORT.load_result(self.fixture("failed-tcp-f8.json"))
         self.assertFalse(result["passed"])
@@ -108,8 +140,8 @@ class BenchmarkReportTests(unittest.TestCase):
             self.assertEqual(set(envelope), {"schema_version", "report_type", "generated_at", "host_label", "report_html"})
             self.assertEqual(envelope["report_type"], "benchmark")
 
-    def test_rebuild_promotes_legacy_result_to_canonical_json_identity(self) -> None:
-        """Campaign summary links must target an artifact created by rebuild."""
+    def test_rebuild_does_not_rewrite_existing_raw_evidence(self) -> None:
+        """A rendering rebuild must not normalize or replace immutable raw JSON."""
         payload = json.loads(self.fixture("failed-tcp-f8.json").read_text(encoding="utf-8"))
         payload.update({
             "campaign_id": "20260822T200000Z-aaaaaaaaaaaa",
@@ -121,7 +153,7 @@ class BenchmarkReportTests(unittest.TestCase):
             report_dir.mkdir()
             (report_dir / "legacy-run.json").write_text(json.dumps(payload), encoding="utf-8")
             result = REPORT.load_result(report_dir / "legacy-run.json")
-            artifact_id = REPORT.result_id(result)
+            original = (report_dir / "legacy-run.json").read_text(encoding="utf-8")
             with (
                 mock.patch.object(REPORT, "REPORT_DIR", report_dir),
                 mock.patch.object(REPORT, "evidence_records", return_value=[result]),
@@ -131,7 +163,7 @@ class BenchmarkReportTests(unittest.TestCase):
                 mock.patch.object(REPORT, "regenerate_index"),
             ):
                 self.assertEqual(REPORT.process([]), 0)
-            self.assertTrue((report_dir / f"{artifact_id}.json").is_file())
+            self.assertEqual((report_dir / "legacy-run.json").read_text(encoding="utf-8"), original)
 
     def test_envelope_for_uses_the_validated_result_identity(self) -> None:
         result = REPORT.load_result(self.fixture("success-uds-f1.json"))
@@ -219,8 +251,17 @@ class BenchmarkReportTests(unittest.TestCase):
             output = REPORT.render_campaign(campaign_id, targets, Path(directory))
             text = output.read_text(encoding="utf-8")
         self.assertIn("Result msg/sec", text)
-        self.assertIn("Baseline msg/sec", text)
+        self.assertIn("Target msg/sec", text)
         self.assertIn("tcp-tls", text)
+
+    def test_campaign_table_refuses_to_mix_source_revisions(self) -> None:
+        base = REPORT.load_result(self.fixture("success-uds-f1.json"))
+        records = [
+            {**base, "benchmark_target": "tcp", "source_revision": "a" * 40},
+            {**base, "benchmark_target": "tcp-tls", "source_revision": "b" * 40},
+        ]
+        with self.assertRaisesRegex(REPORT.BenchmarkReportError, "mix source revisions"):
+            REPORT.campaign_target_rows(records)
 
     def test_bounded_benchmark_failure_code_is_rendered(self) -> None:
         failed = {

--- a/scripts/smoke/benchmark_report.py
+++ b/scripts/smoke/benchmark_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timezone
 from html import escape
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -30,6 +31,7 @@ REPORTS_ROOT = ROOT / "site" / "reports"
 REPORT_NAME = "send-message-benchmark"
 REPORT_HTML = f"{REPORT_NAME}.html"
 REPORT_DIR = REPORTS_ROOT / REPORT_NAME
+HISTORICAL_IMPORTS_NAME = "historical-imports.json"
 ENVELOPE_SCHEMA_VERSION = 1
 AI40_SCHEMA_VERSION = SUMMARY_SCHEMA_VERSION
 SUPPORTED_TRANSPORTS = frozenset({"uds", "tcp"})
@@ -39,9 +41,10 @@ SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
 CAMPAIGN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
-# AO2.8's approved M5 f8-v1 expectations.  A report makes the comparison
-# visible; it never substitutes a cosmetic PASS for a below-baseline result.
-TARGET_BASELINES = {
+# AO2.8's approved M5 f8-v1 performance targets.  These are expectations,
+# not measurements from a comparison run, so reports must never call them a
+# baseline.  An empirical baseline needs its own raw artifact and provenance.
+TARGET_MSG_PER_SECOND = {
     "sqlite": 45_000.0,
     "uds": 24_000.0,
     "tcp": 22_500.0,
@@ -155,7 +158,7 @@ def result_id(result: dict[str, Any], _source: Path | None = None) -> str:
 
 def campaign_id(result: dict[str, Any]) -> str | None:
     """Return the validated campaign label, excluding pre-campaign history."""
-    value = result.get("campaign_id")
+    value = result.get("_report_campaign_id", result.get("campaign_id"))
     return value if isinstance(value, str) and CAMPAIGN_ID.fullmatch(value) else None
 
 
@@ -176,15 +179,67 @@ def compose(template: Path, variables: dict[str, Any], output: Path) -> None:
             variables_path.unlink(missing_ok=True)
 
 
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def historical_imports(report_dir: Path) -> dict[str, dict[str, str]]:
+    """Load hash-bound display metadata for immutable historical artifacts."""
+    manifest = report_dir / HISTORICAL_IMPORTS_NAME
+    if not manifest.exists():
+        return {}
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BenchmarkReportError(f"{manifest}: invalid historical-import manifest") from error
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise BenchmarkReportError(f"{manifest}: unsupported historical-import manifest")
+    entries = payload.get("imports")
+    if not isinstance(entries, list):
+        raise BenchmarkReportError(f"{manifest}: imports must be a list")
+    imported: dict[str, dict[str, str]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise BenchmarkReportError(f"{manifest}: import must be an object")
+        filename = entry.get("filename")
+        digest = entry.get("sha256")
+        identifier = entry.get("campaign_id")
+        display_host = entry.get("display_host_label")
+        note = entry.get("provenance_note")
+        if (
+            not isinstance(filename, str) or Path(filename).name != filename or not filename.endswith(".json")
+            or not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest)
+            or not isinstance(identifier, str) or not CAMPAIGN_ID.fullmatch(identifier)
+            or not isinstance(display_host, str) or not SAFE_ID.fullmatch(display_host)
+            or not isinstance(note, str) or not note.strip()
+        ):
+            raise BenchmarkReportError(f"{manifest}: invalid historical import entry")
+        artifact = report_dir / filename
+        if not artifact.is_file() or file_sha256(artifact) != digest:
+            raise BenchmarkReportError(f"{manifest}: hash mismatch for {filename}")
+        if filename in imported:
+            raise BenchmarkReportError(f"{manifest}: duplicate import for {filename}")
+        imported[filename] = {
+            "campaign_id": identifier,
+            "display_host_label": display_host,
+            "provenance_note": note.strip(),
+        }
+    return imported
+
+
 def evidence_records(report_dir: Path = REPORT_DIR) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     if not report_dir.is_dir():
         return records
+    imported = historical_imports(report_dir)
     for path in sorted(report_dir.glob("*.json")):
-        if path.name.endswith(".envelope.json"):
+        if path.name.endswith(".envelope.json") or path.name == HISTORICAL_IMPORTS_NAME:
             continue
         try:
-            records.append(load_result(path))
+            record = load_result(path)
+            if metadata := imported.get(path.name):
+                record.update({f"_report_{key}": value for key, value in metadata.items()})
+            records.append(record)
         except BenchmarkReportError:
             continue
     return sorted(records, key=lambda item: (item["generated_at"], item["host_label"], item["transport"], item["frames_per_connection"]))
@@ -281,7 +336,11 @@ def campaign_groups(records: Iterable[dict[str, Any]]) -> dict[str, list[dict[st
 
 
 def campaign_target_rows(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Return the requested four-row result/baseline/verdict table for one host."""
+    """Return one revision-homogeneous four-target result/target/verdict table."""
+    records = list(records)
+    revisions = {record.get("source_revision") for record in records}
+    if len(revisions) > 1:
+        raise BenchmarkReportError("campaign target table cannot mix source revisions")
     newest: dict[str, dict[str, Any]] = {}
     for result in records:
         target = result.get("benchmark_target")
@@ -292,7 +351,7 @@ def campaign_target_rows(records: Iterable[dict[str, Any]]) -> list[dict[str, An
     rows: list[dict[str, Any]] = []
     for target in TARGET_ORDER:
         result = newest.get(target)
-        baseline = TARGET_BASELINES[target]
+        target_msg_per_second = TARGET_MSG_PER_SECOND[target]
         metrics = result.get("metrics") if result else None
         metric = metrics.get("admissions_per_second", {}) if isinstance(metrics, dict) else {}
         value = metric.get("p50") if isinstance(metric, dict) else None
@@ -302,12 +361,12 @@ def campaign_target_rows(records: Iterable[dict[str, Any]]) -> list[dict[str, An
             isinstance(value, (int, float))
             and isinstance(accepted, int)
             and accepted == requested
-            and float(value) >= baseline
+            and float(value) >= target_msg_per_second
         )
         rows.append({
             "test": target,
             "result_msg_per_second": None if value is None else float(value),
-            "baseline_msg_per_second": baseline,
+            "target_msg_per_second": target_msg_per_second,
             "passed": passed,
             "artifact_id": result_id(result) if result else None,
             "json_href": f"{result_id(result)}.json" if result else None,
@@ -316,23 +375,33 @@ def campaign_target_rows(records: Iterable[dict[str, Any]]) -> list[dict[str, An
     return rows
 
 
-def render_campaign(identifier: str, records: Iterable[dict[str, Any]], report_dir: Path = REPORT_DIR) -> Path:
-    """Render one date/version campaign as XHTML with one table per host."""
-    by_host: dict[str, list[dict[str, Any]]] = {}
+def campaign_panels(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return one provenance-preserving panel per rendered host and revision."""
+    by_host_revision: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for result in records:
-        by_host.setdefault(result["host_label"], []).append(result)
+        source_revision = result.get("source_revision") or "unversioned"
+        display_host = result.get("_report_display_host_label", result["host_label"])
+        by_host_revision.setdefault((display_host, source_revision), []).append(result)
     host_panels = []
-    for host_label, host_records in sorted(by_host.items()):
+    for (host_label, source_revision), host_records in sorted(by_host_revision.items()):
         rows = campaign_target_rows(host_records)
         host_panels.append({
             "host_label": host_label,
-            "source_revision": host_records[-1].get("source_revision") or "unversioned",
+            "source_revision": source_revision,
             "daemon_version": host_records[-1].get("daemon_version") or "unknown",
             "host_os": host_records[-1].get("host_os") or "unknown",
             "host_arch": host_records[-1].get("host_arch") or "unknown",
+            "raw_host_label": host_records[-1]["host_label"],
+            "provenance_note": host_records[-1].get("_report_provenance_note"),
             "rows": rows,
             "passed": all(row["passed"] for row in rows),
         })
+    return host_panels
+
+
+def render_campaign(identifier: str, records: Iterable[dict[str, Any]], report_dir: Path = REPORT_DIR) -> Path:
+    """Render one date/version campaign as XHTML with one panel per host/revision."""
+    host_panels = campaign_panels(records)
     report_dir.mkdir(parents=True, exist_ok=True)
     output = report_dir / f"{identifier}.xhtml"
     compose(
@@ -414,10 +483,13 @@ def render_aggregate(records: Iterable[dict[str, Any]], report_root: Path = REPO
         host_labels = sorted({record["host_label"] for record in campaign})
         campaigns.append({
             "campaign_id": identifier,
-            "host_labels": ", ".join(host_labels),
+            "host_labels": ", ".join(
+                sorted({record.get("_report_display_host_label", record["host_label"]) for record in campaign})
+            ),
             "source_revision": campaign[-1].get("source_revision") or "unversioned",
             "generated_at": campaign[-1]["generated_at"],
             "xhtml_href": f"{REPORT_NAME}/{identifier}.xhtml",
+            "host_panels": campaign_panels(campaign),
         })
     output = report_root / REPORT_HTML
     template = ROOT / "templates" / "benchmark-report" / "benchmark-report.html.j2"
@@ -464,7 +536,11 @@ def process(inputs: list[Path]) -> int:
         try:
             records = evidence_records()
             for result in records:
-                artifact_id = persist_result(result)
+                # Rebuild is a rendering operation: evidence is immutable and
+                # must never be normalized, renamed, or rewritten merely to
+                # regenerate HTML.  New inputs are persisted in the input
+                # branch below before they enter this path.
+                artifact_id = result_id(result)
                 render_run(result, artifact_id)
             for identifier, campaign in campaign_groups(records).items():
                 render_campaign(identifier, campaign)

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -95,11 +95,10 @@ DIRECT_PEER_TCP_PORT = 43_101
 CAPACITY_DIRECT_PEER_PORT_ENV = "ATM_CAPACITY_DIRECT_PEER_PORT"
 CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 BENCHMARK_TARGETS = {
-    # SQLite and UDS do not cross the peer wire.  They must stay independent
-    # of the optional mTLS control plane so they measure their own production
-    # boundaries rather than a peer-configuration precondition.
-    "sqlite": ("sqlite", "plaintext-test"),
-    "uds": ("uds", "plaintext-test"),
+    # SQLite is a direct-storage target, so it does not select a peer-wire
+    # mode. The daemon itself still starts in its normal secure default.
+    "sqlite": ("sqlite", None),
+    "uds": ("uds", "mutual-tls"),
     "tcp": ("tcp", "plaintext-test"),
     "tcp-tls": ("tcp", "mutual-tls"),
 }

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -1474,6 +1474,14 @@ class AdmissionCapacityTests(unittest.TestCase):
                 RUNNER.main()
         selected.assert_not_called()
 
+    def test_plain_benchmark_command_dispatches_the_required_four_target_matrix(self):
+        with (
+            mock.patch.object(sys, "argv", ["run_admission_capacity.py"]),
+            mock.patch.object(RUNNER, "run_required_f8_suite", return_value=0) as matrix,
+        ):
+            self.assertEqual(RUNNER.main(), 0)
+        matrix.assert_called_once()
+
     def test_main_allows_windows_tcp_without_a_comparison_reference(self):
         captured: dict[str, object] = {}
 
@@ -1568,14 +1576,14 @@ class AdmissionCapacityTests(unittest.TestCase):
             RUNNER.MISSING_PLAINTEXT_BASELINE,
         )
 
-    def test_matrix_keeps_local_targets_independent_of_the_peer_wire(self):
+    def test_matrix_uses_the_documented_secure_default_for_local_daemon_targets(self):
         self.assertEqual(
             RUNNER.resolve_benchmark_target("sqlite", None),
-            ("sqlite", "plaintext-test", "sqlite"),
+            ("sqlite", None, "sqlite"),
         )
         self.assertEqual(
             RUNNER.resolve_benchmark_target("uds", None),
-            ("uds", "plaintext-test", "uds"),
+            ("uds", "mutual-tls", "uds"),
         )
 
     def test_tcp_target_uses_explicit_direct_peer_listener_not_local_http_record(self):

--- a/site/reports/send-message-benchmark.html
+++ b/site/reports/send-message-benchmark.html
@@ -16,19 +16,68 @@
 </head>
 <body>
   <h1>ATM local transport benchmark</h1>
-  <p class="meta">Generated 2026-08-22T21:29:07.399872Z</p>
-  <p>Each campaign is an immutable date/version report. Open it to see one four-target table for every benchmarked host.</p>
+  <p class="meta">Generated 2026-08-23T17:45:48.299928Z</p>
+  <p>Each campaign is an immutable date/version report. The full target table is shown below and the XHTML link is supplemental detail.</p>
   <h2>Benchmark campaigns</h2>
   <table>
     <thead><tr><th>Campaign</th><th>UTC timestamp</th><th>Source revision</th><th>Hosts</th><th>Report</th></tr></thead>
     <tbody>
       <tr>
+        <td>historical-20260823-ff9329dc1083</td>
+        <td><time datetime="2026-08-23T12:02:15.579235Z">2026-08-23T12:02:15.579235Z</time></td>
+        <td>ff9329dc108327c693649b3fcb67d7cf4f6b1558</td>
+        <td>m5-atmbench</td>
+        <td><a href="send-message-benchmark/historical-20260823-ff9329dc1083.xhtml">XHTML detail</a></td>
+      </tr>
+      <tr>
+        <td>historical-20260823-94b75a3ea2e9</td>
+        <td><time datetime="2026-08-23T11:05:10.260883Z">2026-08-23T11:05:10.260883Z</time></td>
+        <td>94b75a3ea2e929e7afc9d63cb50bfd03003b1022</td>
+        <td>m5-atmbench</td>
+        <td><a href="send-message-benchmark/historical-20260823-94b75a3ea2e9.xhtml">XHTML detail</a></td>
+      </tr>
+      <tr>
         <td>ao2-7-final-20260822T212211Z-66fbdf88</td>
         <td><time datetime="2026-08-22T21:23:15.853287Z">2026-08-22T21:23:15.853287Z</time></td>
         <td>66fbdf881dbfa308a272e4e783df5e4c9b6c9759</td>
         <td>m5-atmbench</td>
-        <td><a href="send-message-benchmark/ao2-7-final-20260822T212211Z-66fbdf88.xhtml">XHTML report</a></td>
+        <td><a href="send-message-benchmark/ao2-7-final-20260822T212211Z-66fbdf88.xhtml">XHTML detail</a></td>
       </tr>
+    </tbody>
+  </table>
+  <h2>historical-20260823-ff9329dc1083</h2>
+  <h3>m5-atmbench · <code>ff9329dc108327c693649b3fcb67d7cf4f6b1558</code></h3>
+  <p class="meta">Historical import: Exact imported TCP-only confirmation artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields; SQLite and UDS were not run in this provenance set. Raw artifact host label: <code>m5-atmbench</code>.</p>
+  <table>
+    <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th></tr></thead>
+    <tbody>
+      <tr><td>sqlite</td><td>n/a</td><td>45000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>uds</td><td>n/a</td><td>24000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp</td><td>22113.98</td><td>22500.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp-tls</td><td>22297.31</td><td>22500.00</td><td class="fail">FAIL</td></tr>
+    </tbody>
+  </table>
+  <h2>historical-20260823-94b75a3ea2e9</h2>
+  <h3>m5-atmbench · <code>94b75a3ea2e929e7afc9d63cb50bfd03003b1022</code></h3>
+  <p class="meta">Historical import: Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence. Raw artifact host label: <code>local</code>.</p>
+  <table>
+    <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th></tr></thead>
+    <tbody>
+      <tr><td>sqlite</td><td>37483.10</td><td>45000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>uds</td><td>18937.17</td><td>24000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp</td><td>18116.50</td><td>22500.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp-tls</td><td>17934.37</td><td>22500.00</td><td class="fail">FAIL</td></tr>
+    </tbody>
+  </table>
+  <h2>ao2-7-final-20260822T212211Z-66fbdf88</h2>
+  <h3>m5-atmbench · <code>66fbdf881dbfa308a272e4e783df5e4c9b6c9759</code></h3>
+  <table>
+    <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th></tr></thead>
+    <tbody>
+      <tr><td>sqlite</td><td>8142.81</td><td>45000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>uds</td><td>9679.34</td><td>24000.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp</td><td>8827.55</td><td>22500.00</td><td class="fail">FAIL</td></tr>
+      <tr><td>tcp-tls</td><td>7649.91</td><td>22500.00</td><td class="fail">FAIL</td></tr>
     </tbody>
   </table>
   <p class="meta">123 pre-campaign artifacts remain in the immutable evidence directory but are not used as campaign results.</p>

--- a/site/reports/send-message-benchmark/20260823-110402.419746-local-sqlite-f8.json
+++ b/site/reports/send-message-benchmark/20260823-110402.419746-local-sqlite-f8.json
@@ -1,0 +1,112 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "sqlite",
+  "cleanup_failure": null,
+  "command": "just benchmark --target sqlite",
+  "comparison_host_label": null,
+  "comparison_source_revision": null,
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": {
+    "accepted_count": 738000,
+    "admissions_per_second": 36877.18600447656,
+    "elapsed_seconds": 20.012372959,
+    "kind": "canonical_core_write",
+    "requested_count": 738000,
+    "worker_count": 512
+  },
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "direct_production_writer",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T11:04:02.419746Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "local",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 738000,
+    "admissions_per_second": {
+      "max": 48503.95610391973,
+      "min": 7819.459135361898,
+      "p50": 37483.10371189342,
+      "p95": 42858.13900274511,
+      "p99": 45304.2178226793
+    },
+    "application_wire_bytes": {
+      "request": 0,
+      "response": 0,
+      "total": 0
+    },
+    "application_wire_bytes_per_second": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "connection_count": 0,
+    "connections_per_second": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "first_failure": null,
+    "interval_count": 738,
+    "interval_latency_ms": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "passed_interval_count": 738,
+    "request_frames_per_second": {
+      "max": 48503.95610391973,
+      "min": 7819.459135361898,
+      "p50": 37483.10371189342,
+      "p95": 42858.13900274511,
+      "p99": 45304.2178226793
+    },
+    "requested_count": 738000,
+    "response_count": 738000,
+    "time_to_send_1k_s": {
+      "max": 0.127886083,
+      "min": 0.020616875,
+      "p50": 0.0266786875,
+      "p95": 0.030994958,
+      "p99": 0.036835958
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": null,
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.011405244,
+  "sample_count": 738,
+  "schema_version": 3,
+  "source_revision": "94b75a3ea2e929e7afc9d63cb50bfd03003b1022",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_required": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 37483.10371189342,
+    "passed": true
+  },
+  "transport": "sqlite",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-110402.419746-local-sqlite-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-110402.419746-local-sqlite-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-110402.419746-local-sqlite-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T11:04:02.419746Z</dd>
+    <dt>Host label</dt><dd>local</dd>
+    <dt>Transport</dt><dd>sqlite</dd>
+    <dt>Peer-wire security</dt><dd>legacy-unverified</dd>
+    <dt>Benchmark target</dt><dd>sqlite</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target sqlite</dd>
+    <dt>Execution daemon</dt><dd>direct_production_writer</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.011405244</dd>
+    <dt>Artifact</dt><dd>20260823-110402.419746-local-sqlite-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>738</td><td>738000</td><td>738000</td><td>7819.46 / 37483.10 / 42858.14 / 45304.22 / 48503.96</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<table><thead><tr><th>Requested</th><th>Accepted</th><th>Workers</th><th>Elapsed seconds</th><th>Messages/second</th></tr></thead><tbody><tr><td>738000</td><td>738000</td><td>512</td><td>20.012</td><td>36877.19</td></tr></tbody></table>
+</section>

--- a/site/reports/send-message-benchmark/20260823-110423.475063-local-uds-mutual-tls-f8.json
+++ b/site/reports/send-message-benchmark/20260823-110423.475063-local-uds-mutual-tls-f8.json
@@ -1,0 +1,105 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "uds",
+  "cleanup_failure": null,
+  "command": "just benchmark --target uds",
+  "comparison_host_label": null,
+  "comparison_source_revision": null,
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T11:04:23.475063Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "local",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 377000,
+    "admissions_per_second": {
+      "max": 20993.004376048986,
+      "min": 12580.449458410585,
+      "p50": 18937.167028411335,
+      "p95": 20084.5729229243,
+      "p99": 20595.66069596322
+    },
+    "application_wire_bytes": {
+      "request": 264684265,
+      "response": 155354265,
+      "total": 420038530
+    },
+    "application_wire_bytes_per_second": {
+      "max": 23359965.619448513,
+      "min": 14024056.033763198,
+      "p50": 21106793.08303811,
+      "p95": 22389277.665829863,
+      "p99": 22942100.766199104
+    },
+    "connection_count": 47125,
+    "connections_per_second": {
+      "max": 2624.1255470061233,
+      "min": 1572.5561823013231,
+      "p50": 2367.145878551417,
+      "p95": 2510.5716153655376,
+      "p99": 2574.4575869954024
+    },
+    "first_failure": null,
+    "interval_count": 377,
+    "interval_latency_ms": {
+      "max": 73.56316699952004,
+      "min": 0.8033329977479298,
+      "p50": 22.11587499914458,
+      "p95": 44.28529199867626,
+      "p99": 54.178667000087444
+    },
+    "passed_interval_count": 377,
+    "request_frames_per_second": {
+      "max": 20993.004376048986,
+      "min": 12580.449458410585,
+      "p50": 18937.167028411335,
+      "p95": 20084.5729229243,
+      "p99": 20595.66069596322
+    },
+    "requested_count": 377000,
+    "response_count": 377000,
+    "time_to_send_1k_s": {
+      "max": 0.07948841599863954,
+      "min": 0.04763491599806002,
+      "p50": 0.052806209001573734,
+      "p95": 0.05693374999827938,
+      "p99": 0.06482224999854225
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "mutual-tls",
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.02089637500103,
+  "sample_count": 377,
+  "schema_version": 3,
+  "source_revision": "94b75a3ea2e929e7afc9d63cb50bfd03003b1022",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_required": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 18937.167028411335,
+    "passed": true
+  },
+  "transport": "uds",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-110423.475063-local-uds-mutual-tls-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-110423.475063-local-uds-mutual-tls-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-110423.475063-local-uds-mutual-tls-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T11:04:23.475063Z</dd>
+    <dt>Host label</dt><dd>local</dd>
+    <dt>Transport</dt><dd>uds</dd>
+    <dt>Peer-wire security</dt><dd>mutual-tls</dd>
+    <dt>Benchmark target</dt><dd>uds</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target uds</dd>
+    <dt>Execution daemon</dt><dd>shipped_atm_daemon</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.02089637500103</dd>
+    <dt>Artifact</dt><dd>20260823-110423.475063-local-uds-mutual-tls-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>377</td><td>377000</td><td>377000</td><td>12580.45 / 18937.17 / 20084.57 / 20595.66 / 20993.00</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<p>Not captured by this historical run.</p>
+</section>

--- a/site/reports/send-message-benchmark/20260823-110446.929025-local-tcp-plaintext-test-f8.json
+++ b/site/reports/send-message-benchmark/20260823-110446.929025-local-tcp-plaintext-test-f8.json
@@ -1,0 +1,105 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "tcp",
+  "cleanup_failure": null,
+  "command": "just benchmark --target tcp",
+  "comparison_host_label": null,
+  "comparison_source_revision": null,
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T11:04:46.929025Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "local",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 360000,
+    "admissions_per_second": {
+      "max": 20306.52702535017,
+      "min": 12657.273265475791,
+      "p50": 18116.496059881923,
+      "p95": 19298.034013400586,
+      "p99": 19680.955183964677
+    },
+    "application_wire_bytes": {
+      "request": 277583890,
+      "response": 148343890,
+      "total": 425927780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 23997238.312207565,
+      "min": 14983047.228006966,
+      "p50": 21428161.543814383,
+      "p95": 22844047.76336294,
+      "p99": 23257717.933468748
+    },
+    "connection_count": 45000,
+    "connections_per_second": {
+      "max": 2538.315878168771,
+      "min": 1582.1591581844739,
+      "p50": 2264.5620074852404,
+      "p95": 2412.254251675073,
+      "p99": 2460.1193979955847
+    },
+    "first_failure": null,
+    "interval_count": 360,
+    "interval_latency_ms": {
+      "max": 68.43162500081235,
+      "min": 0.8255829998233821,
+      "p50": 21.760229249593976,
+      "p95": 45.45845800021198,
+      "p99": 57.01204199795029
+    },
+    "passed_interval_count": 360,
+    "request_frames_per_second": {
+      "max": 20306.52702535017,
+      "min": 12657.273265475791,
+      "p50": 18116.496059881923,
+      "p95": 19298.034013400586,
+      "p99": 19680.955183964677
+    },
+    "requested_count": 360000,
+    "response_count": 360000,
+    "time_to_send_1k_s": {
+      "max": 0.07900595799947041,
+      "min": 0.04924525000024005,
+      "p50": 0.05519831250057905,
+      "p95": 0.06111412500104052,
+      "p99": 0.07151974999942468
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "plaintext-test",
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.033911322992935,
+  "sample_count": 360,
+  "schema_version": 3,
+  "source_revision": "94b75a3ea2e929e7afc9d63cb50bfd03003b1022",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_required": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 18116.496059881923,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-110446.929025-local-tcp-plaintext-test-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-110446.929025-local-tcp-plaintext-test-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-110446.929025-local-tcp-plaintext-test-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T11:04:46.929025Z</dd>
+    <dt>Host label</dt><dd>local</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Peer-wire security</dt><dd>plaintext-test</dd>
+    <dt>Benchmark target</dt><dd>tcp</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target tcp</dd>
+    <dt>Execution daemon</dt><dd>shipped_atm_daemon</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.033911322992935</dd>
+    <dt>Artifact</dt><dd>20260823-110446.929025-local-tcp-plaintext-test-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>360</td><td>360000</td><td>360000</td><td>12657.27 / 18116.50 / 19298.03 / 19680.96 / 20306.53</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<p>Not captured by this historical run.</p>
+</section>

--- a/site/reports/send-message-benchmark/20260823-110510.260883-local-tcp-mutual-tls-f8.json
+++ b/site/reports/send-message-benchmark/20260823-110510.260883-local-tcp-mutual-tls-f8.json
@@ -1,0 +1,105 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "tcp-tls",
+  "cleanup_failure": null,
+  "command": "just benchmark --target tcp-tls",
+  "comparison_host_label": null,
+  "comparison_source_revision": null,
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T11:05:10.260883Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "local",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 354000,
+    "admissions_per_second": {
+      "max": 20168.050279274084,
+      "min": 11748.223815232688,
+      "p50": 17934.37208477593,
+      "p95": 19132.592173211586,
+      "p99": 19712.380209042676
+    },
+    "application_wire_bytes": {
+      "request": 272955640,
+      "response": 145869640,
+      "total": 418825280
+    },
+    "application_wire_bytes_per_second": {
+      "max": 23833593.41753215,
+      "min": 13906959.941281695,
+      "p50": 21224720.917425312,
+      "p95": 22609940.800692793,
+      "p99": 23334530.07245427
+    },
+    "connection_count": 44250,
+    "connections_per_second": {
+      "max": 2521.0062849092606,
+      "min": 1468.527976904086,
+      "p50": 2241.796510596991,
+      "p95": 2391.574021651448,
+      "p99": 2464.0475261303345
+    },
+    "first_failure": null,
+    "interval_count": 354,
+    "interval_latency_ms": {
+      "max": 73.57141699685599,
+      "min": 0.8325000017066486,
+      "p50": 21.69992699964496,
+      "p95": 44.95837499780464,
+      "p99": 66.1021250016347
+    },
+    "passed_interval_count": 354,
+    "request_frames_per_second": {
+      "max": 20168.050279274084,
+      "min": 11748.223815232688,
+      "p50": 17934.37208477593,
+      "p95": 19132.592173211586,
+      "p99": 19712.380209042676
+    },
+    "requested_count": 354000,
+    "response_count": 354000,
+    "time_to_send_1k_s": {
+      "max": 0.0851192500012985,
+      "min": 0.049583374999201624,
+      "p50": 0.05575885449979978,
+      "p95": 0.061900374999822816,
+      "p99": 0.08017312500305707
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "mutual-tls",
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.008965659995738,
+  "sample_count": 354,
+  "schema_version": 3,
+  "source_revision": "94b75a3ea2e929e7afc9d63cb50bfd03003b1022",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_required": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 17934.37208477593,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-110510.260883-local-tcp-mutual-tls-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-110510.260883-local-tcp-mutual-tls-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-110510.260883-local-tcp-mutual-tls-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T11:05:10.260883Z</dd>
+    <dt>Host label</dt><dd>local</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Peer-wire security</dt><dd>mutual-tls</dd>
+    <dt>Benchmark target</dt><dd>tcp-tls</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target tcp-tls</dd>
+    <dt>Execution daemon</dt><dd>shipped_atm_daemon</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.008965659995734</dd>
+    <dt>Artifact</dt><dd>20260823-110510.260883-local-tcp-mutual-tls-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>354</td><td>354000</td><td>354000</td><td>11748.22 / 17934.37 / 19132.59 / 19712.38 / 20168.05</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<p>Not captured by this historical run.</p>
+</section>

--- a/site/reports/send-message-benchmark/20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.json
+++ b/site/reports/send-message-benchmark/20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.json
@@ -1,0 +1,105 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "tcp",
+  "cleanup_failure": null,
+  "command": "just benchmark --target tcp",
+  "comparison_host_label": "m5-atmbench",
+  "comparison_source_revision": "ff9329dc108327c693649b3fcb67d7cf4f6b1558",
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T12:01:26.729783Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "m5-atmbench",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 450000,
+    "admissions_per_second": {
+      "max": 23225.8858871853,
+      "min": 20958.073911737614,
+      "p50": 22113.98248465269,
+      "p95": 22906.890077692504,
+      "p99": 23225.8858871853
+    },
+    "application_wire_bytes": {
+      "request": 347007640,
+      "response": 185457640,
+      "total": 532465280
+    },
+    "application_wire_bytes_per_second": {
+      "max": 27395582.728739902,
+      "min": 24809119.993019402,
+      "p50": 26177426.766207624,
+      "p95": 27070217.349313118,
+      "p99": 27395582.728739902
+    },
+    "connection_count": 56250,
+    "connections_per_second": {
+      "max": 2903.2357358981626,
+      "min": 2619.759238967202,
+      "p50": 2764.2478105815862,
+      "p95": 2863.361259711563,
+      "p99": 2903.2357358981626
+    },
+    "first_failure": null,
+    "interval_count": 45,
+    "interval_latency_ms": {
+      "max": 103.19808299755096,
+      "min": 1.006624999718042,
+      "p50": 43.14529200019024,
+      "p95": 75.20833300077356,
+      "p99": 95.48704200278735
+    },
+    "passed_interval_count": 45,
+    "request_frames_per_second": {
+      "max": 23225.8858871853,
+      "min": 20958.073911737614,
+      "p50": 22113.98248465269,
+      "p95": 22906.890077692504,
+      "p99": 23225.8858871853
+    },
+    "requested_count": 450000,
+    "response_count": 450000,
+    "time_to_send_1k_s": {
+      "max": 0.04771430830005557,
+      "min": 0.043055408299915145,
+      "p50": 0.04522025830010534,
+      "p95": 0.046679375000167056,
+      "p99": 0.04771430830005557
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "plaintext-test",
+  "requested_messages_per_sample": 10000,
+  "run_duration_s": 20.37666450198958,
+  "sample_count": 45,
+  "schema_version": 3,
+  "source_revision": "ff9329dc108327c693649b3fcb67d7cf4f6b1558",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": 18070.819650465415,
+    "comparison_passed": true,
+    "comparison_ratio": 0.9,
+    "comparison_required": true,
+    "comparison_strict": false,
+    "comparison_target_admissions_per_second": 16263.737685418873,
+    "median_admissions_per_second": 22113.98248465269,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T12:01:26.729783Z</dd>
+    <dt>Host label</dt><dd>m5-atmbench</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Peer-wire security</dt><dd>plaintext-test</dd>
+    <dt>Benchmark target</dt><dd>tcp</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target tcp</dd>
+    <dt>Execution daemon</dt><dd>shipped_atm_daemon</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.37666450198958</dd>
+    <dt>Artifact</dt><dd>20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>45</td><td>450000</td><td>450000</td><td>20958.07 / 22113.98 / 22906.89 / 23225.89 / 23225.89</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<p>Not captured by this historical run.</p>
+</section>

--- a/site/reports/send-message-benchmark/20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.json
+++ b/site/reports/send-message-benchmark/20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.json
@@ -1,0 +1,105 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_evidence_failure_code": null,
+  "benchmark_target": "tcp-tls",
+  "cleanup_failure": null,
+  "command": "just benchmark --target tcp-tls",
+  "comparison_host_label": "m5-atmbench",
+  "comparison_source_revision": null,
+  "daemon_version": "atm 1.4.4",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": null,
+  "doctor_status": "passed",
+  "durability_after_restart": null,
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-23T12:02:15.579235Z",
+  "hook_mode": "active",
+  "host_arch": "arm64",
+  "host_label": "m5-atmbench",
+  "host_os": "darwin",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 8,
+  "metrics": {
+    "accepted_count": 450000,
+    "admissions_per_second": {
+      "max": 23444.641017825357,
+      "min": 20829.711610678405,
+      "p50": 22297.314622881986,
+      "p95": 22928.268494823908,
+      "p99": 23444.641017825357
+    },
+    "application_wire_bytes": {
+      "request": 347007640,
+      "response": 185457640,
+      "total": 532465280
+    },
+    "application_wire_bytes_per_second": {
+      "max": 27653610.530473508,
+      "min": 24657171.11914056,
+      "p50": 26394446.184836548,
+      "p95": 27095481.29375815,
+      "p99": 27653610.530473508
+    },
+    "connection_count": 56250,
+    "connections_per_second": {
+      "max": 2930.5801272281697,
+      "min": 2603.7139513348006,
+      "p50": 2787.1643278602482,
+      "p95": 2866.0335618529884,
+      "p99": 2930.5801272281697
+    },
+    "first_failure": null,
+    "interval_count": 45,
+    "interval_latency_ms": {
+      "max": 104.65225000007194,
+      "min": 0.843166999402456,
+      "p50": 42.72170850163093,
+      "p95": 75.71591700252611,
+      "p99": 95.6200840009842
+    },
+    "passed_interval_count": 45,
+    "request_frames_per_second": {
+      "max": 23444.641017825357,
+      "min": 20829.711610678405,
+      "p50": 22297.314622881986,
+      "p95": 22928.268494823908,
+      "p99": 23444.641017825357
+    },
+    "requested_count": 450000,
+    "response_count": 450000,
+    "time_to_send_1k_s": {
+      "max": 0.04800834589987062,
+      "min": 0.04265367080006399,
+      "p50": 0.04484845000006317,
+      "p95": 0.047054587499951596,
+      "p99": 0.04800834589987062
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "mutual-tls",
+  "requested_messages_per_sample": 10000,
+  "run_duration_s": 20.26482949998899,
+  "sample_count": 45,
+  "schema_version": 3,
+  "source_revision": "ff9329dc108327c693649b3fcb67d7cf4f6b1558",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_required": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 22297.314622881986,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 512
+}

--- a/site/reports/send-message-benchmark/20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-23T12:02:15.579235Z</dd>
+    <dt>Host label</dt><dd>m5-atmbench</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Peer-wire security</dt><dd>mutual-tls</dd>
+    <dt>Benchmark target</dt><dd>tcp-tls</dd>
+    <dt>Hook mode</dt><dd>active</dd>
+    <dt>Daemon/client version</dt><dd>atm 1.4.4</dd>
+    <dt>Host profile</dt><dd>darwin / arm64</dd>
+    <dt>Command</dt><dd>just benchmark --target tcp-tls</dd>
+    <dt>Execution daemon</dt><dd>shipped_atm_daemon</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20.26482949998899</dd>
+    <dt>Artifact</dt><dd>20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / p99 / max)</th><th>Status</th></tr></thead><tbody><tr><td>45</td><td>450000</td><td>450000</td><td>20829.71 / 22297.31 / 22928.27 / 23444.64 / 23444.64</td><td>PASS</td></tr></tbody></table>
+  <h2>Direct SQLite message-write ceiling</h2>
+<p>Not captured by this historical run.</p>
+</section>

--- a/site/reports/send-message-benchmark/historical-20260823-94b75a3ea2e9.xhtml
+++ b/site/reports/send-message-benchmark/historical-20260823-94b75a3ea2e9.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-  <title>ATM benchmark campaign — ao2-7-final-20260822T212211Z-66fbdf88</title>
+  <title>ATM benchmark campaign — historical-20260823-94b75a3ea2e9</title>
   <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
   <style type="text/css">
     body { font-family: sans-serif; color: #1f2937; margin: 2rem auto; max-width: 75rem; padding: 0 1rem; }
@@ -13,41 +13,42 @@
   </style>
 </head>
 <body>
-  <h1>ATM benchmark campaign — ao2-7-final-20260822T212211Z-66fbdf88</h1>
-  <p class="meta">Campaign <code>ao2-7-final-20260822T212211Z-66fbdf88</code> · rendered 2026-08-23T17:45:48.276829Z.</p>
+  <h1>ATM benchmark campaign — historical-20260823-94b75a3ea2e9</h1>
+  <p class="meta">Campaign <code>historical-20260823-94b75a3ea2e9</code> · rendered 2026-08-23T17:45:48.285455Z.</p>
   <section>
     <h2>m5-atmbench</h2>
-    <p class="meta">darwin / arm64 · daemon atm 1.4.4 · source <code>66fbdf881dbfa308a272e4e783df5e4c9b6c9759</code></p>
+    <p class="meta">darwin / arm64 · daemon atm 1.4.4 · source <code>94b75a3ea2e929e7afc9d63cb50bfd03003b1022</code></p>
+    <p class="meta">Historical import: Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence. Raw artifact host label: <code>local</code>.</p>
     <table>
       <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th><th>Evidence</th></tr></thead>
       <tbody>
         <tr>
           <td>sqlite</td>
-          <td>8142.81</td>
+          <td>37483.10</td>
           <td>45000.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212211.483406-m5-atmbench-sqlite-plaintext-test-f8.json">JSON</a> · <a href="20260822-212211.483406-m5-atmbench-sqlite-plaintext-test-f8.xhtml">panel</a></td>
+          <td><a href="20260823-110402.419746-local-sqlite-f8.json">JSON</a> · <a href="20260823-110402.419746-local-sqlite-f8.xhtml">panel</a></td>
         </tr>
         <tr>
           <td>uds</td>
-          <td>9679.34</td>
+          <td>18937.17</td>
           <td>24000.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212232.234806-m5-atmbench-uds-plaintext-test-f8.json">JSON</a> · <a href="20260822-212232.234806-m5-atmbench-uds-plaintext-test-f8.xhtml">panel</a></td>
+          <td><a href="20260823-110423.475063-local-uds-mutual-tls-f8.json">JSON</a> · <a href="20260823-110423.475063-local-uds-mutual-tls-f8.xhtml">panel</a></td>
         </tr>
         <tr>
           <td>tcp</td>
-          <td>8827.55</td>
+          <td>18116.50</td>
           <td>22500.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212255.586698-m5-atmbench-tcp-plaintext-test-f8.json">JSON</a> · <a href="20260822-212255.586698-m5-atmbench-tcp-plaintext-test-f8.xhtml">panel</a></td>
+          <td><a href="20260823-110446.929025-local-tcp-plaintext-test-f8.json">JSON</a> · <a href="20260823-110446.929025-local-tcp-plaintext-test-f8.xhtml">panel</a></td>
         </tr>
         <tr>
           <td>tcp-tls</td>
-          <td>7649.91</td>
+          <td>17934.37</td>
           <td>22500.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212315.853287-m5-atmbench-tcp-mutual-tls-f8.json">JSON</a> · <a href="20260822-212315.853287-m5-atmbench-tcp-mutual-tls-f8.xhtml">panel</a></td>
+          <td><a href="20260823-110510.260883-local-tcp-mutual-tls-f8.json">JSON</a> · <a href="20260823-110510.260883-local-tcp-mutual-tls-f8.xhtml">panel</a></td>
         </tr>
       </tbody>
     </table>

--- a/site/reports/send-message-benchmark/historical-20260823-ff9329dc1083.xhtml
+++ b/site/reports/send-message-benchmark/historical-20260823-ff9329dc1083.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-  <title>ATM benchmark campaign — ao2-7-final-20260822T212211Z-66fbdf88</title>
+  <title>ATM benchmark campaign — historical-20260823-ff9329dc1083</title>
   <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
   <style type="text/css">
     body { font-family: sans-serif; color: #1f2937; margin: 2rem auto; max-width: 75rem; padding: 0 1rem; }
@@ -13,41 +13,42 @@
   </style>
 </head>
 <body>
-  <h1>ATM benchmark campaign — ao2-7-final-20260822T212211Z-66fbdf88</h1>
-  <p class="meta">Campaign <code>ao2-7-final-20260822T212211Z-66fbdf88</code> · rendered 2026-08-23T17:45:48.276829Z.</p>
+  <h1>ATM benchmark campaign — historical-20260823-ff9329dc1083</h1>
+  <p class="meta">Campaign <code>historical-20260823-ff9329dc1083</code> · rendered 2026-08-23T17:45:48.292497Z.</p>
   <section>
     <h2>m5-atmbench</h2>
-    <p class="meta">darwin / arm64 · daemon atm 1.4.4 · source <code>66fbdf881dbfa308a272e4e783df5e4c9b6c9759</code></p>
+    <p class="meta">darwin / arm64 · daemon atm 1.4.4 · source <code>ff9329dc108327c693649b3fcb67d7cf4f6b1558</code></p>
+    <p class="meta">Historical import: Exact imported TCP-only confirmation artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields; SQLite and UDS were not run in this provenance set. Raw artifact host label: <code>m5-atmbench</code>.</p>
     <table>
       <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th><th>Evidence</th></tr></thead>
       <tbody>
         <tr>
           <td>sqlite</td>
-          <td>8142.81</td>
+          <td>n/a</td>
           <td>45000.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212211.483406-m5-atmbench-sqlite-plaintext-test-f8.json">JSON</a> · <a href="20260822-212211.483406-m5-atmbench-sqlite-plaintext-test-f8.xhtml">panel</a></td>
+          <td>missing</td>
         </tr>
         <tr>
           <td>uds</td>
-          <td>9679.34</td>
+          <td>n/a</td>
           <td>24000.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212232.234806-m5-atmbench-uds-plaintext-test-f8.json">JSON</a> · <a href="20260822-212232.234806-m5-atmbench-uds-plaintext-test-f8.xhtml">panel</a></td>
+          <td>missing</td>
         </tr>
         <tr>
           <td>tcp</td>
-          <td>8827.55</td>
+          <td>22113.98</td>
           <td>22500.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212255.586698-m5-atmbench-tcp-plaintext-test-f8.json">JSON</a> · <a href="20260822-212255.586698-m5-atmbench-tcp-plaintext-test-f8.xhtml">panel</a></td>
+          <td><a href="20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.json">JSON</a> · <a href="20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.xhtml">panel</a></td>
         </tr>
         <tr>
           <td>tcp-tls</td>
-          <td>7649.91</td>
+          <td>22297.31</td>
           <td>22500.00</td>
           <td class="fail">FAIL</td>
-          <td><a href="20260822-212315.853287-m5-atmbench-tcp-mutual-tls-f8.json">JSON</a> · <a href="20260822-212315.853287-m5-atmbench-tcp-mutual-tls-f8.xhtml">panel</a></td>
+          <td><a href="20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.json">JSON</a> · <a href="20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.xhtml">panel</a></td>
         </tr>
       </tbody>
     </table>

--- a/site/reports/send-message-benchmark/historical-imports.json
+++ b/site/reports/send-message-benchmark/historical-imports.json
@@ -1,0 +1,47 @@
+{
+  "imports": [
+    {
+      "campaign_id": "historical-20260823-94b75a3ea2e9",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-110402.419746-local-sqlite-f8.json",
+      "provenance_note": "Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence.",
+      "sha256": "d6178233f611214d868751d9b7f76f7d095cd34c68fbc7a2121d87b558da9a36"
+    },
+    {
+      "campaign_id": "historical-20260823-94b75a3ea2e9",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-110423.475063-local-uds-mutual-tls-f8.json",
+      "provenance_note": "Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence.",
+      "sha256": "af56ea89981049f965067aeddde2d96ad41753294ada86ed73080ccebd613cfb"
+    },
+    {
+      "campaign_id": "historical-20260823-94b75a3ea2e9",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-110446.929025-local-tcp-plaintext-test-f8.json",
+      "provenance_note": "Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence.",
+      "sha256": "78cdfae09f2acd65a8ace188af323fcaeccfcacff432a5131d19532c45f2e5ba"
+    },
+    {
+      "campaign_id": "historical-20260823-94b75a3ea2e9",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-110510.260883-local-tcp-mutual-tls-f8.json",
+      "provenance_note": "Exact imported source artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields, so it is a historical measurement and not accepted-candidate evidence.",
+      "sha256": "f7b471e89709bceaac733095982b1bd826519fe1d238a28b7367406e49f2c014"
+    },
+    {
+      "campaign_id": "historical-20260823-ff9329dc1083",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-120126.729783-m5-atmbench-tcp-plaintext-test-f8.json",
+      "provenance_note": "Exact imported TCP-only confirmation artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields; SQLite and UDS were not run in this provenance set.",
+      "sha256": "11d6a4a0d2d162f060dadfc6463a39c33185c91946c79ad752bdd10f66299b99"
+    },
+    {
+      "campaign_id": "historical-20260823-ff9329dc1083",
+      "display_host_label": "m5-atmbench",
+      "filename": "20260823-120215.579235-m5-atmbench-tcp-mutual-tls-f8.json",
+      "provenance_note": "Exact imported TCP-only confirmation artifact. The original summary has no campaign ID or snapshot/restore lifecycle fields; SQLite and UDS were not run in this provenance set.",
+      "sha256": "689b261fc389af7e8f3e7b16f08402e40912f1184d6a11c6fe6f01079b9ecf8c"
+    }
+  ],
+  "schema_version": 1
+}

--- a/templates/benchmark-report/benchmark-report.html.j2
+++ b/templates/benchmark-report/benchmark-report.html.j2
@@ -27,7 +27,7 @@ required_variables:
 <body>
   <h1>{{ title | e }}</h1>
   <p class="meta">Generated {{ generated_at | e }}</p>
-  <p>Each campaign is an immutable date/version report. Open it to see one four-target table for every benchmarked host.</p>
+  <p>Each campaign is an immutable date/version report. The full target table is shown below and the XHTML link is supplemental detail.</p>
   <h2>Benchmark campaigns</h2>
   <table>
     <thead><tr><th>Campaign</th><th>UTC timestamp</th><th>Source revision</th><th>Hosts</th><th>Report</th></tr></thead>
@@ -38,11 +38,28 @@ required_variables:
         <td><time datetime="{{ campaign.generated_at | e }}">{{ campaign.generated_at | e }}</time></td>
         <td>{{ campaign.source_revision | e }}</td>
         <td>{{ campaign.host_labels | e }}</td>
-        <td><a href="{{ campaign.xhtml_href | e }}">XHTML report</a></td>
+        <td><a href="{{ campaign.xhtml_href | e }}">XHTML detail</a></td>
       </tr>
 {% endfor %}
     </tbody>
   </table>
+{% for campaign in campaigns %}
+  <h2>{{ campaign.campaign_id | e }}</h2>
+{% for panel in campaign.host_panels %}
+  <h3>{{ panel.host_label | e }} · <code>{{ panel.source_revision | e }}</code></h3>
+{% if panel.provenance_note %}
+  <p class="meta">Historical import: {{ panel.provenance_note | e }} Raw artifact host label: <code>{{ panel.raw_host_label | e }}</code>.</p>
+{% endif %}
+  <table>
+    <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th></tr></thead>
+    <tbody>
+{% for row in panel.rows %}
+      <tr><td>{{ row.test | e }}</td><td>{{ 'n/a' if row.result_msg_per_second is none else '%.2f' | format(row.result_msg_per_second) }}</td><td>{{ '%.2f' | format(row.target_msg_per_second) }}</td><td class="{{ 'pass' if row.passed else 'fail' }}">{{ 'PASS' if row.passed else 'FAIL' }}</td></tr>
+{% endfor %}
+    </tbody>
+  </table>
+{% endfor %}
+{% endfor %}
   <p class="meta">{{ legacy_count }} pre-campaign artifacts remain in the immutable evidence directory but are not used as campaign results.</p>
 </body>
 </html>

--- a/templates/benchmark-report/benchmark-report.xhtml.j2
+++ b/templates/benchmark-report/benchmark-report.xhtml.j2
@@ -29,14 +29,17 @@ required_variables:
   <section>
     <h2>{{ panel.host_label | e }}</h2>
     <p class="meta">{{ panel.host_os | e }} / {{ panel.host_arch | e }} · daemon {{ panel.daemon_version | e }} · source <code>{{ panel.source_revision | e }}</code></p>
+{% if panel.provenance_note %}
+    <p class="meta">Historical import: {{ panel.provenance_note | e }} Raw artifact host label: <code>{{ panel.raw_host_label | e }}</code>.</p>
+{% endif %}
     <table>
-      <thead><tr><th>Test</th><th>Result msg/sec</th><th>Baseline msg/sec</th><th>Pass/Fail</th><th>Evidence</th></tr></thead>
+      <thead><tr><th>Test</th><th>Result msg/sec</th><th>Target msg/sec</th><th>Pass/Fail</th><th>Evidence</th></tr></thead>
       <tbody>
 {% for row in panel.rows %}
         <tr>
           <td>{{ row.test | e }}</td>
           <td>{{ 'n/a' if row.result_msg_per_second is none else '%.2f' | format(row.result_msg_per_second) }}</td>
-          <td>{{ '%.2f' | format(row.baseline_msg_per_second) }}</td>
+          <td>{{ '%.2f' | format(row.target_msg_per_second) }}</td>
           <td class="{{ 'pass' if row.passed else 'fail' }}">{{ 'PASS' if row.passed else 'FAIL' }}</td>
           <td>{% if row.artifact_id %}<a href="{{ row.json_href | e }}">JSON</a> · <a href="{{ row.xhtml_href | e }}">panel</a>{% else %}missing{% endif %}</td>
         </tr>


### PR DESCRIPTION
## Summary
- Hash-binds and publishes the raw M5 artifacts without rerun or mutation
- Renders tables directly in site/reports/send-message-benchmark.html
- Historical imports (94b75a3, ff9329d) are visibly disclosed as lacking campaign/snapshot lifecycle fields — historical measurement, not accepted-candidate evidence
- Provenance stays separate from the accepted AO2.7 candidate result

## Test plan
- [x] benchmark_report: 18/18 passing
- [x] admission/boundary suite: 119 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)