### PR TITLE
Consolidate sprint-report/triage-report fixes + FLAGS column

### DIFF
--- a/.claude/skills/sprint-report/report.md.j2
+++ b/.claude/skills/sprint-report/report.md.j2
@@ -13,8 +13,10 @@ required_variables:
 ────────────────────────────────────────
 {{ integration_row }}
 {% else %}
-| Sprint | DEV | QA | CI | PR |
-|--------|-----|----|----|-----|
+| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
+|--------|-----|----|----|-----|---|---|---|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
+{{ current_integration_summary }}
+{{ stale_occurrences_summary }}
 {% endif %}

--- a/.claude/skills/sprint-report/report.md.j2
+++ b/.claude/skills/sprint-report/report.md.j2
@@ -13,8 +13,8 @@ required_variables:
 ────────────────────────────────────────
 {{ integration_row }}
 {% else %}
-| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
-|--------|-----|----|----|-----|---|---|---|-------|----|
+| Sprint | DEV | QA | CI | PR | FLAGS | Ready | OK |
+|--------|-----|----|----|-----|-------|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
 {{ current_integration_summary }}

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -7,8 +7,8 @@ required_variables:
   - sprint_rows
   - integration_row
 ---
-| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
-|--------|-----|----|----|----|---|---|---|-------|----|
+| Sprint | DEV | QA | CI | PR | FLAGS | Ready | OK |
+|--------|-----|----|----|----|-------|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
 

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -241,6 +241,9 @@ def _dev_states(events: Graph | None) -> dict[str, dict[str, Any]]:
     return states
 
 
+QA_VERDICT_ENUM = frozenset({"PASS", "FAIL", "BLOCKING", "SUPERSEDED"})
+
+
 def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
     if master is None:
         return {}
@@ -255,6 +258,13 @@ def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
         sprint = run.get("aich_sprint")
         if not sprint:
             continue
+        verdict = run.get("verdict")
+        if verdict is not None and verdict not in QA_VERDICT_ENUM:
+            raise ReportError(
+                f"QA evidence master run {run.get('run_id')!r} has invalid verdict "
+                f"{verdict!r}; verdict must be one of {sorted(QA_VERDICT_ENUM)}. "
+                "Qualifier/detail text belongs in the evidence field, not verdict."
+            )
         candidate = _timestamp(run.get("result_time_utc") or run.get("assignment_time_utc"))
         previous = latest.get(sprint)
         previous_dt = _timestamp(previous.get("result_time_utc")) if previous else None
@@ -1047,10 +1057,7 @@ def build_report(
         )
         row["dev_icon"] = ICONS.get(row["dev_status"], "—")
         qa_value = row["qa"]["verdict"]
-        qa_passed = bool(qa_value) and (
-            qa_value.upper().startswith("PASS") or qa_value.upper() == "CLEAR"
-        )
-        row["qa_icon"] = "✅" if qa_passed else (ICONS["fail"] if qa_value else "—")
+        row["qa_icon"] = "✅" if qa_value == "PASS" else (ICONS["fail"] if qa_value else "—")
         row["ci_icon"] = _status_icon(row["ci_status"])
         row["ready_icon"] = _gate_icon(row["ready_to_merge"])
         row["ok_icon"] = _gate_icon(row["ok_to_merge"])

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -321,6 +321,13 @@ def _gate_icon(value: bool | None) -> str:
     return "?"
 
 
+def _flags_cell(q: dict[str, Any]) -> str:
+    blockers = q["blockers"] if q["blockers"] is not None else "?"
+    important = q["important"] if q["important"] is not None else "?"
+    minor = q["minor"] if q["minor"] is not None else "?"
+    return f"{blockers}:{important}:{minor}"
+
+
 def _pr_cell(meta: dict[str, Any]) -> str:
     number = meta.get("pr_number")
     if isinstance(number, int) and not isinstance(number, bool):
@@ -1070,8 +1077,7 @@ def build_report(
         marker = " ⚠️" if row.get("diagnostics") else ""
         lines.append(
             f"| {row['id']} ({phase_sprint}){marker} | {row['dev_icon']} | {row['qa_icon']} | "
-            f"{row['ci_icon']} | {_pr_cell(row)} | {q['blockers'] if q['blockers'] is not None else '?'} | "
-            f"{q['important'] if q['important'] is not None else '?'} | {q['minor'] if q['minor'] is not None else '?'} | "
+            f"{row['ci_icon']} | {_pr_cell(row)} | {_flags_cell(q)} | "
             f"{row['ready_icon']} | {row['ok_icon']} |"
         )
         detail = (
@@ -1094,10 +1100,10 @@ def build_report(
                 f"- {_diagnostic_text(item)}" for item in row["diagnostics"]
             )
         detailed.append(detail)
-    integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
+    integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — |"
     table = (
-        "| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |\n"
-        "|--------|-----|----|----|----|--------|--------|--------|-------|----|\n"
+        "| Sprint | DEV | QA | CI | PR | FLAGS | Ready | OK |\n"
+        "|--------|-----|----|----|----|-------|-------|----|\n"
         + "\n".join(lines) + "\n" + integration_row
     )
     if diagnostics:

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -1047,7 +1047,10 @@ def build_report(
         )
         row["dev_icon"] = ICONS.get(row["dev_status"], "—")
         qa_value = row["qa"]["verdict"]
-        row["qa_icon"] = "✅" if qa_value and qa_value.upper() == "PASS" else (ICONS["fail"] if qa_value else "—")
+        qa_passed = bool(qa_value) and (
+            qa_value.upper().startswith("PASS") or qa_value.upper() == "CLEAR"
+        )
+        row["qa_icon"] = "✅" if qa_passed else (ICONS["fail"] if qa_value else "—")
         row["ci_icon"] = _status_icon(row["ci_status"])
         row["ready_icon"] = _gate_icon(row["ready_to_merge"])
         row["ok_icon"] = _gate_icon(row["ok_to_merge"])

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -139,6 +139,28 @@ def test_missing_qa_snapshot_does_not_hide_live_sprint_counts(tmp_path):
     assert "QA evidence master not found" in report["data_gaps"][0]
 
 
+def test_invalid_qa_verdict_is_report_error(tmp_path):
+    root, qa_path = _inputs(tmp_path)
+    master = json.loads(qa_path.read_text())
+    master["runs"][0]["verdict"] = "CLEAR"
+    qa_path.write_text(json.dumps(master))
+    with pytest.raises(triage_report.ReportError) as excinfo:
+        triage_report.build_report(root, "AICH", qa_path)
+    message = str(excinfo.value)
+    assert "CLEAR" in message
+    assert "'BLOCKING', 'FAIL', 'PASS', 'SUPERSEDED'" in message
+
+
+def test_valid_qa_verdicts_drive_icon_without_fuzzy_matching(tmp_path):
+    root, qa_path = _inputs(tmp_path)
+    report = triage_report.build_report(root, "AICH", qa_path)
+    first, second = report["rows"]
+    assert first["qa"]["verdict"] == "FAIL"
+    assert first["qa_icon"] == triage_report.ICONS["fail"]
+    assert second["qa"]["verdict"] == "PASS"
+    assert second["qa_icon"] == "✅"
+
+
 def test_in_progress_sprint_with_no_pr_yet_is_not_a_data_gap(tmp_path, monkeypatch):
     """An assigned-but-not-completed sprint has no QA run or PR/CI state to
     observe yet -- that is the normal in-flight state, not lost evidence, and

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -116,8 +116,8 @@ def test_live_ttl_counts_drive_sprint_gates(tmp_path):
     assert second["ready_to_merge"] is True
     assert second["previous_sprints_merged"] is True
     assert second["ok_to_merge"] is True
-    assert "| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |" in report["table"]
-    assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 |" in report["table"]
+    assert "| Sprint | DEV | QA | CI | PR | FLAGS | Ready | OK |" in report["table"]
+    assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 | 1:0:1 |" in report["table"]
 
 
 def test_github_state_replaces_manual_metadata(tmp_path):


### PR DESCRIPTION
## Summary
- Supersedes #1000 (sprint-report column-count mismatch) and #1001 (QA-icon verdict enum validation gate + regression tests), combined here into one branch to avoid competing/duplicate fixes on develop.
- New on top of both: collapses the separate Blocking/Important/Minor columns into a single `FLAGS` column rendered as `b:i:m` (e.g. `1:0:1`) in both `sprint-report/report.md.j2` and `triage-report/report.md.j2`, narrowing the table from 10 columns to 8.

## Test plan
- [x] `python3 -m pytest .claude/skills/triage-report/tests/test_triage_report.py -q` — 27/27 passed
- [x] Rendered both templates against live AO2 phase data via `sc-compose render` — both produce correctly aligned 8-column tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)