### PR TITLE
AO2.10-AO2.13: benchmark-report simplification plan (supersedes AO2.9)

### DIFF
--- a/docs/plans/phase-ao2/benchmark-process-audit.md
+++ b/docs/plans/phase-ao2/benchmark-process-audit.md
@@ -1,0 +1,101 @@
+# Benchmark Run/Report Process Audit (pre-planning, AO2.10+)
+
+Date: 2026-08-23 · Author: fenix (planning) · Scope: the benchmarking and
+reporting **process** for the SQLite / UDS / TCP / TCP+TLS matrix on macOS and
+Windows. Not an audit of the code being benchmarked. Read-only; no code changes.
+
+Inputs: arch-ctm's read-only briefing (ATM 01M0QZAV05J892MVNXSAR63GXX), four
+codebase/data sweeps, AO2.9 reference worktree (`plan/ao2-9-benchmark-report-template`,
+PR #989), sprint docs AI.40 / AI.49 / AI.52 / AL.9 / AO2.5.4 / AO2.7 / AO2.8.
+
+## A. Process inconsistencies
+
+1. **No single canonical run procedure.** Five sprint docs each restate the
+   lifecycle with differences: artifact ownership (AI.40 defers publication to
+   AI.49; AI.52 has the operator `git add` directly), snapshot/restore
+   (mandatory and prescriptive in AO2.5.4; only implied in AI.52), hook-mode
+   pairs (required by AL.9, owned by no sprint), and failure triage left to
+   operator judgment (AO2.7). Agents running benchmarks must interpret, which
+   is exactly the observed drift.
+2. **Publication gap in the default path.** `just benchmark` ends with
+   `benchmark_report.py --rebuild`, which renders HTML but never writes
+   discovery envelopes; only the rarely-used `--input` path calls
+   `persist_result()`. Result: 134 compact JSON vs 97 envelopes; 20 (develop)
+   to 42 (integrate/phase-ao2) result files are invisible to
+   `site/reports/index.html`; the index's newest benchmark entry lags real runs.
+3. **Campaign identity is not persisted.** Campaign membership is *inferred* at
+   render time from newest host/transport/revision grouping
+   (`benchmark_report.py:235-263`) and appears only in rendered HTML. There is
+   no machine-readable campaign/run summary JSON, so regenerating reports can
+   silently regroup history, and "one run = one computer × 3-4 targets" has no
+   artifact.
+4. **Schema drift in published data.** At least four distinct compact-JSON
+   shapes coexist (23-key mac, 25-key windows, 26-key local+direct-sqlite,
+   35-key phase-ao2 with `benchmark_target`/`hook_mode`/`peer_wire_security`).
+   The runner writes `schema_version: 2`, the canonical Pydantic model is v3,
+   migration runs on every load, and `benchmark_policy` still special-cases v2.
+5. **Three competing baseline models.**
+   - Static constants in `benchmark_report.py:49-54` (45k / 24k / 22.5k / 22.5k).
+   - Empirical M5 historical baseline in `historical-imports.json`
+     (37,483 / 18,937 / 18,116 / 17,934; 95% retention) — which exists **only on
+     the unmerged `fix/ao2-7-report-provenance` branch**, not on develop or
+     integrate/phase-ao2.
+   - Ad-hoc `--baseline <file>` argument pointing at an arbitrary prior run.
+   Additionally `run_admission_capacity.py:1556,1584` hardcodes Windows
+   comparison defaults (`mac-arm64-01`, comparison optional on Windows) that
+   conflict with AO2.8's mandatory 80%-of-M5 floor.
+6. **Pass/fail is computed once and split across layers.** Thresholds are
+   evaluated at run time (`benchmark_policy.evaluate_profile_thresholds`),
+   cross-checked by schema validation, and only *echoed* at render; runner and
+   report each have independent comparison/grouping logic that can diverge.
+7. **Duplicated derivations.** Artifact-id timestamp munging is implemented
+   twice (`run_admission_capacity.py:1086-1098`, `benchmark_report.py:136-139`);
+   host-label sanitization exists in three places with different rules.
+
+## B. Overly complicated / dead result-processing code
+
+- `benchmark_suite.py` defines an intent/ledger/threshold model that the normal
+  path never uses beyond `TargetResult` validation — a second, unused seam.
+- Dual render paths (`--rebuild` vs `--input`) duplicating render+index logic,
+  with envelope creation only on one path (root cause of A.2).
+- v1/v2→v3 migration executed on every load of every file, forever, because the
+  writer still emits v2 (A.4).
+- Dead code: `parse_utc`, `safe_label` in `benchmark_report.py`.
+- The AO2.9 reference design (PR #989) layers a two-phase git-publication
+  protocol on top: pre-run `intent.json` commit+push, `.pending/<run_id>.json`
+  remote lock, push-gated finalizer, host-manifest binding digests, evidence
+  branch + PR gates (ADR-054). That is far heavier than "validated JSON array →
+  sc-compose render", and it contains no campaign JSON, no phase-level report,
+  no graph, and no wyvern step. Per operator direction PR #989 will be closed
+  in favor of the new plan.
+
+Worth **keeping** from AO2.9: immutable per-run result JSON; machine-classified
+PASS/FAIL/INCOMPLETE (never caller-selected); OS-specific target matrix
+(Windows has no UDS); permanent retention of failed runs; sc-compose as the
+sole rendering seam; extending (not replacing) `.just/generate_report_index.py`.
+
+## C. Gaps vs the target design (operator expectations)
+
+Target: each run emits one simple JSON array of results validated against a
+Pydantic model → sc-compose j2 render to an XHTML panel → phase-level final
+HTML aggregating all panels of the current phase (newest first) with a
+candlestick chart of history per computer → read-only versioned baseline JSON
+changed only with quality-mgr approval → historical JSON normalized to the same
+schema (values unchanged) so reports can be regenerated without re-running.
+
+Missing today: campaign/run-level JSON (A.3); phase-level report; any chart;
+wyvern display step; single reviewed baseline file (A.5); normalized history
+(A.4); envelope/index publication in the default path (A.2).
+
+## D. Open questions (awaiting operator answers before plan finalization)
+
+1. Baseline seed values and pass rule (which numbers, what retention %).
+2. Do measurement-less INCOMPLETE attempts appear as phase-report panels or
+   only in an attempt ledger?
+3. Candlestick semantics: metric (TCP f8 p50 vs all four targets), one chart
+   per target vs grouped, candle field mapping.
+4. Location/name of the phase report and fate of `send-message-benchmark.html`.
+5. Historical migration scope: all files vs final/best per historical campaign.
+6. Disposition of `historical-imports.json` (unmerged branch) into the new
+   baseline file.
+7. Exact wyvern invocation expected for "display latest panel on demand".

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -58,6 +58,16 @@ report-provenance fixes merged into it by PR #1003 (head branch
 instead). Neither `integrate/phase-ao2` nor develop has the matrix runner
 today; all four sprint docs assume it as their starting point.
 
+Dispatch evidence (recorded 2026-08-23, per quality-mgr ATM-QA-002):
+`git merge-base --is-ancestor c1335cb1775c9a556cb1f02aac9725f4d2d92edc
+origin/fix/ao2-7-direct-peer-benchmark-harness` succeeds — the PR #1003 head
+(`fix/ao2-7-report-provenance` @ `c1335cb17`) is an ancestor of the harness
+branch, whose tip `69cf6d3a1` is itself the PR #1003 merge commit
+("Merge pull request #1003 from randlee/fix/ao2-7-report-provenance"); the
+branch also already contains a merge of `origin/integrate/phase-ao2`
+(`aad0af7bd`). The provenance fixes are therefore contained in the
+precondition branch.
+
 Rationale for the split: AO2.10 closes the data/schema seam, AO2.11 closes
 rendering, AO2.12 closes history, AO2.13 closes operator procedure. Each is a
 distinct closure type with non-intersecting primary files; merging any two
@@ -83,6 +93,8 @@ the benchmarked runtime.
 | 3 | plan-scope-reviewer (sonnet) | `ba5ade5a` | FAIL — round-2 closures confirmed; 1 Important (D12 had no owning sprint or enforcing AC), 1 minor (QA-history table split in two) | Fixed in round-3 commit: D12 cited in AO2.10 (machine-id half, plus-form grep gate in AC #4) and AO2.11 (display-label half, new AC #9); tables merged. |
 
 | 4 | plan-scope-reviewer (sonnet) | `ec9a29e5` | **PASS** — D12 ownership/enforcement and QA-table merge verified closed; no new findings; all four sprints PASS | Hardening complete; ready for quality-mgr gate. |
+
+| 5 | quality-mgr gate (ruthless-boundary-qa + req-qa + arch-qa) | `5fc6853f` | FAIL — 1 Blocking (RBQA-F001: `evaluate_profile_thresholds()` left as a live second pass/fail decision owner with unported cross-transport comparison), 1 Important (RBQA-F002: status logic belongs in `benchmark_policy.py`, not `benchmark_schema.py`), 1 Important (ATM-QA-002: branch-ancestry dispatch evidence missing), 1 minor (ATM-QA-001: stale line-number locator). arch-qa PASS; rust reviewers N/A | Fixed in round-5 commit: AO2.10 deliverable 3 makes `classify_status()` in `benchmark_policy.py` the single decision owner and explicitly retires (deletes, not ports) `evaluate_profile_thresholds()` + all cross-transport comparison machinery, with deliverable 8 and AC #4 grep gates extended (`evaluate_profile_thresholds`, `comparison_*` banned under `scripts/smoke/`); schema keeps only a cross-check validator; ancestry evidence recorded under the Base-branch precondition; locator converted to `TARGET_MSG_PER_SECOND` grep. |
 
 Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
 Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -1,0 +1,68 @@
+# Benchmark Reporting Consolidation — Plan Overview (AO2.10–AO2.13)
+
+Date: 2026-08-23 · Author: fenix · Status: draft for quality-mgr review
+Basis: [benchmark-process-audit.md](./benchmark-process-audit.md) and operator
+answers of 2026-08-23. Supersedes the AO2.9 design (PR #989, to be closed).
+
+## Target architecture
+
+```
+run (one computer, 3–4 targets)
+  └─ campaign JSON  (array of per-target results, Pydantic-validated, immutable)
+        └─ sc-compose render ─ per-run XHTML panel (one per campaign)
+              └─ sc-compose render ─ phase report HTML (all panels of the phase,
+                 newest first, 2×2 candlestick grid at top)
+                    └─ sc-compose render ─ index.html (latest graphs +
+                       links to historical phase reports)
+baselines.json  (read-only, versioned, quality-mgr-approved changes only)
+historical-record.json (all prior campaigns, normalized, values unchanged)
+```
+
+Every rendered artifact is regenerable from JSON alone; no rendering step ever
+re-runs a benchmark or mutates result data.
+
+## Operator decisions (binding for all four sprints)
+
+| # | Decision |
+|---|----------|
+| D1 | Baseline seed (macOS M5): sqlite 35,000 · uds 18,000 · tcp 17,500 · tcp+tls 17,500 msg/s p50. Windows seeds derived from its best historical passing runs during AO2.12, quality-mgr approved. |
+| D2 | PASS requires **100% durable writes** (every requested message admitted and durable) AND p50 ≥ baseline. There is no retention percentage. |
+| D3 | Baselines may only increase over time (ratchet), and only via quality-mgr-approved change to `baselines.json`. |
+| D4 | INCOMPLETE runs are rendered (panel with reason note at the bottom), committed and pushed, viewable in wyvern — but excluded from the candlestick and from the historical record. Periodic cleanup deletes them later; never silently discard. |
+| D5 | Candlestick: 4 charts in a 2×2 grid — tcp, tcp+tls on top; uds, sqlite below. One series per computer. Historical campaigns contribute only their final/best run; the current phase contributes all measured runs. |
+| D6 | Phase report file: `site/reports/send-message-benchmark/phase-<id>.html` (e.g. `phase-ao2.html`). `site/reports/send-message-benchmark/index.html` shows the latest graphs plus links to historical phase reports. The legacy `site/reports/send-message-benchmark.html` aggregate is retired. |
+| D7 | ALL historical result JSON is normalized to the new schema with values and timestamps unchanged. One `historical-record.json` is the single historical record; quality-mgr is responsible for verifying its values/dates are accurate. |
+| D8 | Historical pass/fail display uses the ratchet: baseline-as-of-run = best passing p50 seen so far for that (host, target); best runs show PASS, dips from best show FAIL. |
+| D9 | Wyvern displays the most recent panel on demand. Wyvern lacks `.xhtml` suffix support today — [randlee/wyvern#115](https://github.com/randlee/wyvern/issues/115) filed; interim: render/copy an `.html` twin for viewing. |
+| D10 | sc-compose j2 templates carry all formatting; agents never hand-author report output. validated JSON → `sc-compose render` → output. |
+
+## Sprint map
+
+| Sprint | Title | Depends | Recommended |
+|--------|-------|---------|-------------|
+| AO2.10 | Benchmark data contract and runner emission | AO2.6 merged (must_follow) | arch-ctm / deep-reasoning |
+| AO2.11 | Rendering pipeline: panels, phase report, candlestick, index | must_follow AO2.10 | arch-ctm / deep-reasoning |
+| AO2.12 | Historical data migration and single historical record | must_follow AO2.10, AO2.11 | Cipher-311d / fast |
+| AO2.13 | Canonical benchmark-run skill and operator workflow | must_follow AO2.11; parallel_safe with AO2.12 | Cipher-311d / fast |
+
+Rationale for the split: AO2.10 closes the data/schema seam, AO2.11 closes
+rendering, AO2.12 closes history, AO2.13 closes operator procedure. Each is a
+distinct closure type with non-intersecting primary files; merging any two
+would mix closure types and blur ownership (sprint-planning-guidelines: Split
+Early).
+
+All sprint PRs target `integrate/phase-ao2`. Standing constraint (memory:
+findings-never-regress-hit-numbers): no change may regress the achieved
+AO2.7/AO2.8 benchmark numbers; this plan touches only run/report tooling, not
+the benchmarked runtime.
+
+## Out of scope
+
+- Any change to the Rust runtime, daemon, writer, TLS, or client framing.
+- The AO2.9 two-phase git-lock publication protocol (intent.json, `.pending`
+  remote locks, evidence-branch PR gate, host-manifest binding digests). PR
+  #989 is closed in favor of this plan; ADR-054's trust discussion is retained
+  as background only.
+- Independent result verification by a second host (explicitly deferred, as in
+  ADR-054).
+- Deleting INCOMPLETE-run artifacts (future periodic cleanup task).

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -25,7 +25,7 @@ re-runs a benchmark or mutates result data.
 
 | # | Decision |
 |---|----------|
-| D1 | Baseline seed (macOS M5): sqlite 35,000 · uds 18,000 · tcp 17,500 · tcp+tls 17,500 msg/s p50. Windows seeds derived from its best historical passing runs during AO2.12, quality-mgr approved. |
+| D1 | Baseline seed (macOS M5): sqlite 35,000 · uds 18,000 · tcp 17,500 · tcp+tls 17,500 msg/s p50. These are deliberately ~5–8% below the best recorded empirical M5 values (37,483 / 18,937 / 18,116 / 17,934) — an explicit operator decision to absorb run-to-run variance at seed time; the ratchet (D3) closes the gap as passing runs land, and the candlestick keeps best-achieved values visible so a dip below them is never hidden. quality-mgr confirms the seed against the recorded AO2.7/AO2.8 figures when approving `baselines.json` revision 1. Windows seeds derived from its best historical passing runs during AO2.12, quality-mgr approved. |
 | D2 | PASS requires **100% durable writes** (every requested message admitted and durable) AND p50 ≥ baseline. There is no retention percentage. |
 | D3 | Baselines may only increase over time (ratchet), and only via quality-mgr-approved change to `baselines.json`. |
 | D4 | INCOMPLETE runs are rendered (panel with reason note at the bottom), committed and pushed, viewable in wyvern — but excluded from the candlestick and from the historical record. Periodic cleanup deletes them later; never silently discard. |
@@ -35,6 +35,7 @@ re-runs a benchmark or mutates result data.
 | D8 | Historical pass/fail display uses the ratchet: baseline-as-of-run = best passing p50 seen so far for that (host, target); best runs show PASS, dips from best show FAIL. |
 | D9 | Wyvern displays the most recent panel on demand. Wyvern lacks `.xhtml` suffix support today — [randlee/wyvern#115](https://github.com/randlee/wyvern/issues/115) filed; interim: render/copy an `.html` twin for viewing. |
 | D10 | sc-compose j2 templates carry all formatting; agents never hand-author report output. validated JSON → `sc-compose render` → output. |
+| D11 | All timestamps in JSON artifacts are UTC (ISO-8601, `Z` suffix). Rendered XHTML/HTML displays times human-formatted in 24-hour style: each timestamp is emitted as `<time datetime="<UTC>">Aug 23, 2026 · 11:59 PDT</time>` with the text pre-rendered in `America/Los_Angeles`, and a small inline script (no external dependencies) upgrades the text to the viewer's local zone at view time; with scripts unavailable the Pacific fallback text stands. Sorting/grouping always uses the UTC values; stored data is never localized. |
 
 ## Sprint map
 
@@ -44,6 +45,14 @@ re-runs a benchmark or mutates result data.
 | AO2.11 | Rendering pipeline: panels, phase report, candlestick, index | must_follow AO2.10 | arch-ctm / deep-reasoning |
 | AO2.12 | Historical data migration and single historical record | must_follow AO2.10, AO2.11 | Cipher-311d / fast |
 | AO2.13 | Canonical benchmark-run skill and operator workflow | must_follow AO2.11; parallel_safe with AO2.12 | Cipher-311d / fast |
+
+**Base-branch precondition (blocking for AO2.10 dispatch):** the four-target
+matrix runner (`BENCHMARK_TARGETS`: sqlite, uds, tcp, tcp+tls; one unskippable
+matrix per `just benchmark`) exists only on `fix/ao2-7-report-provenance`
+(PR #1003, merged to `origin/fix/ao2-7-direct-peer-benchmark-harness`), not on
+`integrate/phase-ao2` or develop, whose runner is still single-transport. That
+branch must merge into `integrate/phase-ao2` before AO2.10 development starts;
+all four sprint docs assume the matrix runner as their starting point.
 
 Rationale for the split: AO2.10 closes the data/schema seam, AO2.11 closes
 rendering, AO2.12 closes history, AO2.13 closes operator procedure. Each is a
@@ -55,6 +64,17 @@ All sprint PRs target `integrate/phase-ao2`. Standing constraint (memory:
 findings-never-regress-hit-numbers): no change may regress the achieved
 AO2.7/AO2.8 benchmark numbers; this plan touches only run/report tooling, not
 the benchmarked runtime.
+
+## Plan QA history
+
+| Round | Reviewer | Commit reviewed | Result | Disposition |
+|-------|----------|-----------------|--------|-------------|
+| 1 | plan-scope-reviewer (sonnet) | `eead638e` | FAIL — 1 Blocking (missing normative `HistoricalRecord` contract), 2 Important (AO2.11↔AO2.13 dependency mislabeled `parallel_safe`; AI.49/AO2.5.4 dropped from supersession list), 1 minor (`benchmark-report` recipe disposition unstated) | All fixed in round-1 fix commit: `HistoricalRecord` contract added to AO2.12 with implementation ownership in AO2.11; dependency relabeled must_follow; supersession list expanded to seven docs; recipe note added. |
+| 1 | critical-plan-reviewer (sonnet) | `eead638e` | FAIL — 5 Blocking (matrix runner absent from base branch; AC didn't pin N=4/3; campaign target-coverage roll-up unenforced; missing-BaselineEntry behavior undefined; D1 seed below recorded empirical baseline unjustified), 2 Important (sqlite-target metrics shape undefined; `HistoricalRecord` stub ownership), 2 minor | All fixed in round-1 fix commit: base-branch precondition added (merge `fix/ao2-7-report-provenance` before AO2.10); AC #2 pins 4/3 via real matrix run; `BenchmarkCampaign` coverage `model_validator` + truth-table case; missing baseline = hard emission error + test + seeded-label live-verify rule; D1 justification added (deliberate variance headroom, quality-mgr confirms vs AO2.7/AO2.8 figures at revision 1); sqlite variant rule (network fields None, validator-enforced); implementation-ownership rule for `HistoricalRecord`; Windows textual-verification defined; line-number refs replaced with grep locators. |
+
+Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
+Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local
+time by a small inline script).
 
 ## Out of scope
 

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -25,17 +25,18 @@ re-runs a benchmark or mutates result data.
 
 | # | Decision |
 |---|----------|
-| D1 | Baseline seed (macOS M5): sqlite 35,000 · uds 18,000 · tcp 17,500 · tcp+tls 17,500 msg/s p50. These are deliberately ~5–8% below the best recorded empirical M5 values (37,483 / 18,937 / 18,116 / 17,934) — an explicit operator decision to absorb run-to-run variance at seed time; the ratchet (D3) closes the gap as passing runs land, and the candlestick keeps best-achieved values visible so a dip below them is never hidden. quality-mgr confirms the seed against the recorded AO2.7/AO2.8 figures when approving `baselines.json` revision 1. Windows seeds derived from its best historical passing runs during AO2.12, quality-mgr approved. |
+| D1 | Baseline seed (macOS M5): sqlite 35,000 · uds 18,000 · tcp 17,500 · tcp-tls 17,500 msg/s p50. These are deliberately below the best recorded empirical M5 values (37,483 / 18,937 / 18,116 / 17,934) — per-target headroom: sqlite ~6.6%, uds ~4.9%, tcp ~3.4%, tcp-tls ~2.4% — an explicit operator decision to absorb run-to-run variance at seed time; the ratchet (D3) closes the gap as passing runs land, and the candlestick keeps best-achieved values visible so a dip below them is never hidden. quality-mgr confirms the seed against the recorded AO2.7/AO2.8 figures when approving `baselines.json` revision 1. Windows seeds derived from its best historical passing runs during AO2.12, quality-mgr approved. |
 | D2 | PASS requires **100% durable writes** (every requested message admitted and durable) AND p50 ≥ baseline. There is no retention percentage. |
 | D3 | Baselines may only increase over time (ratchet), and only via quality-mgr-approved change to `baselines.json`. |
 | D4 | INCOMPLETE runs are rendered (panel with reason note at the bottom), committed and pushed, viewable in wyvern — but excluded from the candlestick and from the historical record. Periodic cleanup deletes them later; never silently discard. |
-| D5 | Candlestick: 4 charts in a 2×2 grid — tcp, tcp+tls on top; uds, sqlite below. One series per computer. Historical campaigns contribute only their final/best run; the current phase contributes all measured runs. |
+| D5 | Candlestick: 4 charts in a 2×2 grid — tcp, tcp-tls on top; uds, sqlite below. One series per computer. Historical campaigns contribute only their final/best run; the current phase contributes all measured runs. |
 | D6 | Phase report file: `site/reports/send-message-benchmark/phase-<id>.html` (e.g. `phase-ao2.html`). `site/reports/send-message-benchmark/index.html` shows the latest graphs plus links to historical phase reports. The legacy `site/reports/send-message-benchmark.html` aggregate is retired. |
 | D7 | ALL historical result JSON is normalized to the new schema with values and timestamps unchanged. One `historical-record.json` is the single historical record; quality-mgr is responsible for verifying its values/dates are accurate. |
 | D8 | Historical pass/fail display uses the ratchet: baseline-as-of-run = best passing p50 seen so far for that (host, target); best runs show PASS, dips from best show FAIL. |
 | D9 | Wyvern displays the most recent panel on demand. Wyvern lacks `.xhtml` suffix support today — [randlee/wyvern#115](https://github.com/randlee/wyvern/issues/115) filed; interim: render/copy an `.html` twin for viewing. |
 | D10 | sc-compose j2 templates carry all formatting; agents never hand-author report output. validated JSON → `sc-compose render` → output. |
-| D11 | All timestamps in JSON artifacts are UTC (ISO-8601, `Z` suffix). Rendered XHTML/HTML displays times human-formatted in 24-hour style: each timestamp is emitted as `<time datetime="<UTC>">Aug 23, 2026 · 11:59 PDT</time>` with the text pre-rendered in `America/Los_Angeles`, and a small inline script (no external dependencies) upgrades the text to the viewer's local zone at view time; with scripts unavailable the Pacific fallback text stands. Sorting/grouping always uses the UTC values; stored data is never localized. |
+| D11 | All timestamps in JSON artifacts are UTC (ISO-8601, `Z` suffix). Rendered XHTML/HTML displays times human-formatted in 24-hour style: each timestamp is emitted as `<time datetime="<UTC>">Aug 23, 2026 · 11:59 PDT</time>` with the text pre-rendered in `America/Los_Angeles`, and a small inline script (no external dependencies) upgrades the text to the viewer's local zone at view time; with scripts unavailable the Pacific fallback text stands. In `.xhtml` output (strict XML, `xmlns` declared) the inline script MUST be `<![CDATA[...]]>`-wrapped so `<`/`&` in script code cannot break well-formedness, and rendered `.xhtml` must pass a strict XML parse gate. Sorting/grouping always uses the UTC values; stored data is never localized. |
+| D12 | Target naming: the machine identifier is `tcp-tls` everywhere in code, schemas, filenames, and JSON — matching the base-branch matrix runner (`BENCHMARK_TARGETS`), whose identifiers are never renamed. Rendered reports may display the human label “TCP + TLS”; the `+` form never appears in data or code. |
 
 ## Sprint map
 
@@ -46,13 +47,16 @@ re-runs a benchmark or mutates result data.
 | AO2.12 | Historical data migration and single historical record | must_follow AO2.10, AO2.11 | Cipher-311d / fast |
 | AO2.13 | Canonical benchmark-run skill and operator workflow | must_follow AO2.11; parallel_safe with AO2.12 | Cipher-311d / fast |
 
-**Base-branch precondition (blocking for AO2.10 dispatch):** the four-target
-matrix runner (`BENCHMARK_TARGETS`: sqlite, uds, tcp, tcp+tls; one unskippable
-matrix per `just benchmark`) exists only on `fix/ao2-7-report-provenance`
-(PR #1003, merged to `origin/fix/ao2-7-direct-peer-benchmark-harness`), not on
-`integrate/phase-ao2` or develop, whose runner is still single-transport. That
-branch must merge into `integrate/phase-ao2` before AO2.10 development starts;
-all four sprint docs assume the matrix runner as their starting point.
+**Base-branch precondition (blocking for AO2.10 dispatch):** the branch
+**`origin/fix/ao2-7-direct-peer-benchmark-harness`** must merge into
+`integrate/phase-ao2` before AO2.10 development starts. That branch — and only
+that branch — is the precondition's single source of truth: it carries the
+four-target matrix runner (`BENCHMARK_TARGETS`: sqlite, uds, tcp, tcp-tls; one
+unskippable matrix per `just benchmark`) and already contains the
+report-provenance fixes merged into it by PR #1003 (head branch
+`fix/ao2-7-report-provenance`, now behind it — do not merge that head branch
+instead). Neither `integrate/phase-ao2` nor develop has the matrix runner
+today; all four sprint docs assume it as their starting point.
 
 Rationale for the split: AO2.10 closes the data/schema seam, AO2.11 closes
 rendering, AO2.12 closes history, AO2.13 closes operator procedure. Each is a
@@ -75,6 +79,11 @@ the benchmarked runtime.
 Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
 Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local
 time by a small inline script).
+
+| Round | Reviewer | Commit reviewed | Result | Disposition |
+|-------|----------|-----------------|--------|-------------|
+| 2 | plan-scope-reviewer (sonnet) | `19eeeda0` | FAIL — round-1 closures confirmed; new: 1 Blocking (base-branch precondition named two branches ambiguously), 3 Important (stale "five docs" restatement in AO2.13 deliverable 3; D11 had no AC; `HistoricalRecord` implementation outside AO2.11's deliverables list), 1 minor (duplicate deliverable numbering) | All fixed in round-2 fix commit: precondition unified on `origin/fix/ao2-7-direct-peer-benchmark-harness` (single source of truth, both docs); AO2.13 deliverable 3 now cross-references deliverable 1's seven-doc list; AO2.11 AC #7 (time display) added; `HistoricalRecord` implementation promoted to AO2.11 deliverable 7 + AC #8; deliverables renumbered 1–7. |
+| 2 | critical-plan-reviewer (sonnet) | `19eeeda0` | FAIL — all 10 round-1 findings verified closed; new: 2 Blocking (`tcp+tls` in docs vs `tcp-tls` in the base branch's code/schemas/filenames — zero `tcp+tls` occurrences there; inline time script would break strict-XHTML well-formedness with no CDATA rule or XML-parse gate), 1 minor (D1 "~5–8%" headroom claim vs actual ~2.4–6.6%) | All fixed in round-2 fix commit: canonical identifier `tcp-tls` adopted across all docs + new D12 (machine id never renamed; "TCP + TLS" is display-label only); D11/AO2.11 now require `<![CDATA[...]]>` wrapping in `.xhtml` output and a strict XML parse gate in AC #7; D1 states per-target headroom percentages. |
 
 ## Out of scope
 

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -82,6 +82,8 @@ the benchmarked runtime.
 | 3 | critical-plan-reviewer (sonnet) | `ba5ade5a` | **PASS** — all round-2 findings verified closed against live doc text and the base branch's `BENCHMARK_TARGETS`; 1 minor wording (AO2.12 deliverable-2 prose predated the ownership move) | Wording fixed in round-3 commit. |
 | 3 | plan-scope-reviewer (sonnet) | `ba5ade5a` | FAIL — round-2 closures confirmed; 1 Important (D12 had no owning sprint or enforcing AC), 1 minor (QA-history table split in two) | Fixed in round-3 commit: D12 cited in AO2.10 (machine-id half, plus-form grep gate in AC #4) and AO2.11 (display-label half, new AC #9); tables merged. |
 
+| 4 | plan-scope-reviewer (sonnet) | `ec9a29e5` | **PASS** — D12 ownership/enforcement and QA-table merge verified closed; no new findings; all four sprints PASS | Hardening complete; ready for quality-mgr gate. |
+
 Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
 Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local
 time by a small inline script). After round 2: D12 (canonical `tcp-tls`

--- a/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
+++ b/docs/plans/phase-ao2/benchmark-reporting-plan-overview.md
@@ -76,14 +76,16 @@ the benchmarked runtime.
 | 1 | plan-scope-reviewer (sonnet) | `eead638e` | FAIL — 1 Blocking (missing normative `HistoricalRecord` contract), 2 Important (AO2.11↔AO2.13 dependency mislabeled `parallel_safe`; AI.49/AO2.5.4 dropped from supersession list), 1 minor (`benchmark-report` recipe disposition unstated) | All fixed in round-1 fix commit: `HistoricalRecord` contract added to AO2.12 with implementation ownership in AO2.11; dependency relabeled must_follow; supersession list expanded to seven docs; recipe note added. |
 | 1 | critical-plan-reviewer (sonnet) | `eead638e` | FAIL — 5 Blocking (matrix runner absent from base branch; AC didn't pin N=4/3; campaign target-coverage roll-up unenforced; missing-BaselineEntry behavior undefined; D1 seed below recorded empirical baseline unjustified), 2 Important (sqlite-target metrics shape undefined; `HistoricalRecord` stub ownership), 2 minor | All fixed in round-1 fix commit: base-branch precondition added (merge `fix/ao2-7-report-provenance` before AO2.10); AC #2 pins 4/3 via real matrix run; `BenchmarkCampaign` coverage `model_validator` + truth-table case; missing baseline = hard emission error + test + seeded-label live-verify rule; D1 justification added (deliberate variance headroom, quality-mgr confirms vs AO2.7/AO2.8 figures at revision 1); sqlite variant rule (network fields None, validator-enforced); implementation-ownership rule for `HistoricalRecord`; Windows textual-verification defined; line-number refs replaced with grep locators. |
 
-Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
-Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local
-time by a small inline script).
-
-| Round | Reviewer | Commit reviewed | Result | Disposition |
-|-------|----------|-----------------|--------|-------------|
 | 2 | plan-scope-reviewer (sonnet) | `19eeeda0` | FAIL — round-1 closures confirmed; new: 1 Blocking (base-branch precondition named two branches ambiguously), 3 Important (stale "five docs" restatement in AO2.13 deliverable 3; D11 had no AC; `HistoricalRecord` implementation outside AO2.11's deliverables list), 1 minor (duplicate deliverable numbering) | All fixed in round-2 fix commit: precondition unified on `origin/fix/ao2-7-direct-peer-benchmark-harness` (single source of truth, both docs); AO2.13 deliverable 3 now cross-references deliverable 1's seven-doc list; AO2.11 AC #7 (time display) added; `HistoricalRecord` implementation promoted to AO2.11 deliverable 7 + AC #8; deliverables renumbered 1–7. |
 | 2 | critical-plan-reviewer (sonnet) | `19eeeda0` | FAIL — all 10 round-1 findings verified closed; new: 2 Blocking (`tcp+tls` in docs vs `tcp-tls` in the base branch's code/schemas/filenames — zero `tcp+tls` occurrences there; inline time script would break strict-XHTML well-formedness with no CDATA rule or XML-parse gate), 1 minor (D1 "~5–8%" headroom claim vs actual ~2.4–6.6%) | All fixed in round-2 fix commit: canonical identifier `tcp-tls` adopted across all docs + new D12 (machine id never renamed; "TCP + TLS" is display-label only); D11/AO2.11 now require `<![CDATA[...]]>` wrapping in `.xhtml` output and a strict XML parse gate in AC #7; D1 states per-target headroom percentages. |
+
+| 3 | critical-plan-reviewer (sonnet) | `ba5ade5a` | **PASS** — all round-2 findings verified closed against live doc text and the base branch's `BENCHMARK_TARGETS`; 1 minor wording (AO2.12 deliverable-2 prose predated the ownership move) | Wording fixed in round-3 commit. |
+| 3 | plan-scope-reviewer (sonnet) | `ba5ade5a` | FAIL — round-2 closures confirmed; 1 Important (D12 had no owning sprint or enforcing AC), 1 minor (QA-history table split in two) | Fixed in round-3 commit: D12 cited in AO2.10 (machine-id half, plus-form grep gate in AC #4) and AO2.11 (display-label half, new AC #9); tables merged. |
+
+Operator additions after round 1: D11 (UTC-only JSON; rendered reports show
+Pacific 24-hour fallback inside `<time>` elements upgraded to viewer-local
+time by a small inline script). After round 2: D12 (canonical `tcp-tls`
+machine identifier; “TCP + TLS” display-only).
 
 ## Out of scope
 

--- a/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
+++ b/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
@@ -17,35 +17,48 @@ are binding.
    (per-target) and `BenchmarkCampaign` (per computer-run, holding the array
    of 3–4 results). `SUMMARY_SCHEMA_VERSION = 4`. Both `extra="forbid"`,
    `frozen=True`.
-2. **Runner emits v4 directly.** `scripts/smoke/run_admission_capacity.py`
-   writes per-target compact JSON already valid against `BenchmarkRunResult`
-   (no post-hoc migration), and at end of a full matrix run writes one
-   campaign file `site/reports/send-message-benchmark/<campaign_id>.campaign.json`
-   valid against `BenchmarkCampaign`.
+2. **Runner emits v4 directly.** Starting point is the four-target matrix
+   runner (`BENCHMARK_TARGETS`: sqlite/uds/tcp/tcp+tls, one unskippable
+   matrix per invocation) from `fix/ao2-7-report-provenance`, whose merge
+   into `integrate/phase-ao2` is a dispatch precondition for this sprint
+   (see overview, Base-branch precondition) — this sprint changes its
+   *emission*, it does not build matrix execution. The runner writes
+   per-target compact JSON already valid against `BenchmarkRunResult` (no
+   post-hoc migration), and at end of the matrix writes one campaign file
+   `site/reports/send-message-benchmark/<campaign_id>.campaign.json` valid
+   against `BenchmarkCampaign`.
 3. **Machine-classified status.** `status` is computed, never caller-supplied:
    `INCOMPLETE` when any lifecycle stage is missing (with mandatory
    `incomplete_reason`); otherwise `PASS` iff `messages_durable ==
    messages_admitted == messages_requested` (100% durable writes, D2) and
    `metrics.admissions_per_second.p50 >= baseline.value`; otherwise `FAIL`.
-4. **Single reviewed baseline file**
+4. **Missing baseline is a hard error.** If `baselines.json` has no entry for
+   the run's `(host_label, target)`, result emission fails with an explicit
+   operator-facing error naming the missing pair — never a silent None,
+   skipped comparison, or defaulted PASS. (The runner's `host_label` default
+   of `local` therefore fails fast unless `local` is deliberately seeded.)
+5. **Single reviewed baseline file**
    `site/reports/send-message-benchmark/baselines.json`, validated by a
    `BaselineSet` Pydantic model. Seed macOS values per D1
    (35000/18000/17500/17500). Ratchet rule (D3) documented in the file header
    and enforced by a unit test: a new baselines.json revision may only raise
    values. The runner and report read baselines ONLY from this file; the
    static constants at `benchmark_report.py:49-54`, the `--baseline <file>`
-   argument path, and the hardcoded Windows comparison defaults
-   (`run_admission_capacity.py:1554-1557,1584`) are removed.
-5. **One artifact-id/campaign-id derivation helper** in
+   argument path, and the hardcoded Windows comparison defaults in
+   `run_admission_capacity.py` (locate by the `mac-arm64-01` literal and the
+   `comparison_required` OS branch, per AC #4's grep gate — line numbers
+   drift) are removed.
+6. **One artifact-id/campaign-id derivation helper** in
    `benchmark_schema.py`, used by both runner and report (removes the
    duplicated timestamp munging at `run_admission_capacity.py:1086-1098` and
    `benchmark_report.py:136-139`).
-6. **Default path publishes completely.** `just benchmark` (no args) produces,
-   for the run: 4 per-target JSON + 1 campaign JSON + envelope(s) consumable
+7. **Default path publishes completely.** `just benchmark` (no args) produces,
+   for the run: one per-target JSON per OS-required target (4 on
+   macOS/Linux, 3 on Windows) + 1 campaign JSON + envelope(s) consumable
    by `.just/generate_report_index.py`, and fails nonzero if any publication
    artifact cannot be written. Envelope creation no longer depends on the
    `--input` flag.
-7. **Deletions:** the unused intent/ledger model in
+8. **Deletions:** the unused intent/ledger model in
    `scripts/smoke/benchmark_suite.py` (retain only what `TargetResult`
    validation actually needs, or fold it into `benchmark_schema.py` and delete
    the module); dead helpers `parse_utc` and `safe_label` in
@@ -99,22 +112,43 @@ class BenchmarkCampaign(BaseModel, frozen=True, extra="forbid"):
     status: Literal["PASS", "FAIL", "INCOMPLETE"]  # roll-up, machine-derived
 ```
 
+All `datetime` fields across these models are UTC with `Z` suffix (D11); a
+validator rejects naive or non-UTC offsets.
+
+**sqlite-target variant rule:** for `target == "sqlite"` (direct storage
+writer, no connections or wire frames), `frames_per_connection` is `0` and
+the network-only fields of `BenchmarkMetrics` (connection rates, frame rates,
+wire-byte counts) are `None`; a `model_validator` requires those fields to be
+present for network targets and absent for sqlite — implementers never invent
+degenerate network values.
+
 Target matrix is OS-derived, not caller-chosen: macOS/Linux = sqlite, uds,
 tcp, tcp+tls; Windows = sqlite, tcp, tcp+tls (uds rejected). Roll-up status:
 INCOMPLETE if any result INCOMPLETE or a required target missing; else FAIL if
-any result FAIL; else PASS.
+any result FAIL; else PASS. This is enforced in code, not prose: a
+`model_validator` on `BenchmarkCampaign` checks `results` covers the
+OS-derived required target set and forces the roll-up to INCOMPLETE (with a
+synthesized reason naming the missing target) when any required target is
+absent — a campaign whose present results all PASS but which never attempted
+a required target must not validate as PASS.
 
 ## Acceptance criteria
 
 1. `python3 -c` round-trip: every file the runner writes validates against the
    v4 models with `extra="forbid"`; a mutated key or extra field fails.
-2. `just benchmark` on this branch produces exactly: N per-target JSON, one
-   `.campaign.json`, envelopes, and exits nonzero when the report/index step
-   fails (verified by an injected-failure test).
+2. `just benchmark` on this branch produces exactly **4** per-target JSON on
+   macOS/Linux and **3** on Windows (verified by an actual matrix run, not a
+   single-transport invocation), one `.campaign.json`, envelopes, and exits
+   nonzero when the report/index step fails (injected-failure test).
 3. Unit tests: status classification truth table (lifecycle-missing →
    INCOMPLETE; durable < requested → FAIL even above baseline; p50 below floor
-   → FAIL; both satisfied → PASS); Windows matrix rejects uds; ratchet test
-   rejects a baselines.json revision that lowers any value.
+   → FAIL; both satisfied → PASS; **required target entirely absent from a
+   campaign — e.g. tcp+tls never ran on a macOS campaign — → campaign
+   roll-up INCOMPLETE**; **missing `BaselineEntry` for (host_label, target) →
+   hard emission error, not PASS/FAIL**); Windows matrix rejects uds;
+   sqlite-variant validator (network fields required for network targets,
+   forbidden for sqlite); ratchet test rejects a baselines.json revision that
+   lowers any value.
 4. `grep`-gate: no occurrence of `DEFAULT_TARGETS *=` static baseline
    constants in `benchmark_report.py`; no `--baseline` argument in
    `run_admission_capacity.py`; no `mac-arm64-01` literal in the runner.
@@ -126,7 +160,10 @@ any result FAIL; else PASS.
 
 - `just test` (workspace) and `.just/tests` python suite, both CI platforms.
 - One live macOS `just benchmark` producing a v4 campaign file, committed as
-  evidence on the sprint branch.
+  evidence on the sprint branch. The run must use a seeded `host_label`
+  (D1 seeds `rand-m5`; running under any unseeded label, including the
+  runner's `local` default, must demonstrate the hard error instead) and the
+  evidence note must state which label was used.
 - quality-mgr review includes explicit sign-off on `baselines.json` contents.
 
 ## Non-closure / out of scope
@@ -141,4 +178,7 @@ any result FAIL; else PASS.
 
 - must_follow: AO2.6 (writer-batching regression) — merged; benchmark numbers
   achieved there must not regress (standing constraint).
+- must_follow: merge of `fix/ao2-7-report-provenance` (four-target matrix
+  runner, PR #1003 lineage) into `integrate/phase-ao2` — hard dispatch
+  precondition; this sprint modifies that runner's emission.
 - parallel_safe: none — AO2.11/12/13 all consume this contract.

--- a/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
+++ b/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
@@ -1,0 +1,144 @@
+# Sprint AO2.10 — Benchmark Data Contract and Runner Emission
+
+Status: draft · Branch: `feature/ao2-10-benchmark-data-contract` off
+`integrate/phase-ao2` · PR target: `integrate/phase-ao2`
+recommended_agent: arch-ctm · recommended_model: deep-reasoning
+
+Fixes audit findings A.2 (envelope/publication gap), A.3 (campaign identity
+not persisted), A.4 (schema drift, v2-writer/v3-model), A.5 (competing
+baselines), A.7 (duplicated derivations), B (dead code, unused ledger seam).
+Decisions D1–D3 from
+[benchmark-reporting-plan-overview.md](./benchmark-reporting-plan-overview.md)
+are binding.
+
+## Deliverables
+
+1. **Schema v4** in `scripts/smoke/benchmark_schema.py`: `BenchmarkRunResult`
+   (per-target) and `BenchmarkCampaign` (per computer-run, holding the array
+   of 3–4 results). `SUMMARY_SCHEMA_VERSION = 4`. Both `extra="forbid"`,
+   `frozen=True`.
+2. **Runner emits v4 directly.** `scripts/smoke/run_admission_capacity.py`
+   writes per-target compact JSON already valid against `BenchmarkRunResult`
+   (no post-hoc migration), and at end of a full matrix run writes one
+   campaign file `site/reports/send-message-benchmark/<campaign_id>.campaign.json`
+   valid against `BenchmarkCampaign`.
+3. **Machine-classified status.** `status` is computed, never caller-supplied:
+   `INCOMPLETE` when any lifecycle stage is missing (with mandatory
+   `incomplete_reason`); otherwise `PASS` iff `messages_durable ==
+   messages_admitted == messages_requested` (100% durable writes, D2) and
+   `metrics.admissions_per_second.p50 >= baseline.value`; otherwise `FAIL`.
+4. **Single reviewed baseline file**
+   `site/reports/send-message-benchmark/baselines.json`, validated by a
+   `BaselineSet` Pydantic model. Seed macOS values per D1
+   (35000/18000/17500/17500). Ratchet rule (D3) documented in the file header
+   and enforced by a unit test: a new baselines.json revision may only raise
+   values. The runner and report read baselines ONLY from this file; the
+   static constants at `benchmark_report.py:49-54`, the `--baseline <file>`
+   argument path, and the hardcoded Windows comparison defaults
+   (`run_admission_capacity.py:1554-1557,1584`) are removed.
+5. **One artifact-id/campaign-id derivation helper** in
+   `benchmark_schema.py`, used by both runner and report (removes the
+   duplicated timestamp munging at `run_admission_capacity.py:1086-1098` and
+   `benchmark_report.py:136-139`).
+6. **Default path publishes completely.** `just benchmark` (no args) produces,
+   for the run: 4 per-target JSON + 1 campaign JSON + envelope(s) consumable
+   by `.just/generate_report_index.py`, and fails nonzero if any publication
+   artifact cannot be written. Envelope creation no longer depends on the
+   `--input` flag.
+7. **Deletions:** the unused intent/ledger model in
+   `scripts/smoke/benchmark_suite.py` (retain only what `TargetResult`
+   validation actually needs, or fold it into `benchmark_schema.py` and delete
+   the module); dead helpers `parse_utc` and `safe_label` in
+   `benchmark_report.py`.
+
+## Contract (normative signatures)
+
+```python
+class BaselineEntry(BaseModel, frozen=True, extra="forbid"):
+    host_label: str          # SAFE_LABEL pattern
+    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    p50_floor: float         # msg/s; ratchet: may only increase across revisions
+    approved_by: str         # quality-mgr approval reference
+    effective_from: datetime # UTC
+
+class BaselineSet(BaseModel, frozen=True, extra="forbid"):
+    schema_version: Literal[1]
+    revision: int            # monotonically increasing
+    entries: tuple[BaselineEntry, ...]
+
+class BenchmarkRunResult(BaseModel, frozen=True, extra="forbid"):
+    schema_version: Literal[4]
+    campaign_id: str
+    host_label: str
+    os: Literal["macos", "windows", "linux"]
+    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    status: Literal["PASS", "FAIL", "INCOMPLETE"]
+    incomplete_reason: str | None      # required iff status == INCOMPLETE
+    generated_at: datetime             # UTC, ISO-8601
+    source_revision: str               # git SHA
+    binary_hashes: dict[str, str]
+    frames_per_connection: int
+    messages_requested: int
+    messages_admitted: int
+    messages_durable: int
+    metrics: BenchmarkMetrics          # existing model, carried forward
+    baseline: BaselineRef              # {revision, p50_floor} snapshot used
+    durability_after_restart: DurabilityAfterRestart | None
+    direct_sqlite_message_write: DirectSQLiteMessageWrite | None
+
+class BenchmarkCampaign(BaseModel, frozen=True, extra="forbid"):
+    schema_version: Literal[4]
+    campaign_id: str                   # <UTC-stamp>-<host_label>
+    host_label: str
+    os: Literal["macos", "windows", "linux"]
+    phase: str                         # e.g. "ao2"
+    started_at: datetime
+    completed_at: datetime | None
+    source_revision: str
+    results: tuple[BenchmarkRunResult, ...]   # 4 on macOS/Linux, 3 on Windows
+    status: Literal["PASS", "FAIL", "INCOMPLETE"]  # roll-up, machine-derived
+```
+
+Target matrix is OS-derived, not caller-chosen: macOS/Linux = sqlite, uds,
+tcp, tcp+tls; Windows = sqlite, tcp, tcp+tls (uds rejected). Roll-up status:
+INCOMPLETE if any result INCOMPLETE or a required target missing; else FAIL if
+any result FAIL; else PASS.
+
+## Acceptance criteria
+
+1. `python3 -c` round-trip: every file the runner writes validates against the
+   v4 models with `extra="forbid"`; a mutated key or extra field fails.
+2. `just benchmark` on this branch produces exactly: N per-target JSON, one
+   `.campaign.json`, envelopes, and exits nonzero when the report/index step
+   fails (verified by an injected-failure test).
+3. Unit tests: status classification truth table (lifecycle-missing →
+   INCOMPLETE; durable < requested → FAIL even above baseline; p50 below floor
+   → FAIL; both satisfied → PASS); Windows matrix rejects uds; ratchet test
+   rejects a baselines.json revision that lowers any value.
+4. `grep`-gate: no occurrence of `DEFAULT_TARGETS *=` static baseline
+   constants in `benchmark_report.py`; no `--baseline` argument in
+   `run_admission_capacity.py`; no `mac-arm64-01` literal in the runner.
+5. `.just/tests/` suite passes on macOS and Windows CI lanes.
+6. `baselines.json` present with D1 seed values, revision 1, and a
+   quality-mgr approval reference recorded in the PR.
+
+## Required validation
+
+- `just test` (workspace) and `.just/tests` python suite, both CI platforms.
+- One live macOS `just benchmark` producing a v4 campaign file, committed as
+  evidence on the sprint branch.
+- quality-mgr review includes explicit sign-off on `baselines.json` contents.
+
+## Non-closure / out of scope
+
+- Rendering changes (AO2.11) — this sprint may leave HTML output temporarily
+  rendering from v4 via the existing templates' compatible fields.
+- Historical files remain unmigrated until AO2.12; `load_result()` keeps
+  read-only v1–v3 migration acceptance until AO2.12 lands, then it is removed.
+- Windows baseline seed values (AO2.12, D1).
+
+## Dependencies
+
+- must_follow: AO2.6 (writer-batching regression) — merged; benchmark numbers
+  achieved there must not regress (standing constraint).
+- parallel_safe: none — AO2.11/12/13 all consume this contract.

--- a/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
+++ b/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
@@ -28,11 +28,26 @@ are binding.
    post-hoc migration), and at end of the matrix writes one campaign file
    `site/reports/send-message-benchmark/<campaign_id>.campaign.json` valid
    against `BenchmarkCampaign`.
-3. **Machine-classified status.** `status` is computed, never caller-supplied:
-   `INCOMPLETE` when any lifecycle stage is missing (with mandatory
-   `incomplete_reason`); otherwise `PASS` iff `messages_durable ==
-   messages_admitted == messages_requested` (100% durable writes, D2) and
-   `metrics.admissions_per_second.p50 >= baseline.value`; otherwise `FAIL`.
+3. **Machine-classified status with one decision owner.** `status` is
+   computed, never caller-supplied, by a single function
+   `classify_status()` implemented in `scripts/smoke/benchmark_policy.py`
+   (which already docstrings itself as the acceptance/baseline policy
+   module — `benchmark_schema.py` stays purely structural, its
+   `model_validator` only cross-checks that a stored `status` equals the
+   `classify_status()` output): `INCOMPLETE` when any lifecycle stage is
+   missing (with mandatory `incomplete_reason`); otherwise `PASS` iff
+   `messages_durable == messages_admitted == messages_requested` (100%
+   durable writes, D2) and `metrics.admissions_per_second.p50 >=
+   baseline.value`; otherwise `FAIL`.
+   The legacy decision path `evaluate_profile_thresholds()` (and its
+   cross-transport comparison concept — `comparison_ratio` /
+   `comparison_strict` / `comparison_required`, e.g. tcp needing a ratio of
+   another transport's median) is **explicitly retired, not ported**: the
+   per-(host, target) floors in `baselines.json` (D1–D3) replace
+   cross-transport ratios as the sole acceptance rule, so the v4 contract
+   deliberately has no comparison fields. `evaluate_profile_thresholds()`
+   and every call site (including the runner's threshold evaluation and
+   comparison-reference loading) are deleted in this sprint.
 4. **Missing baseline is a hard error.** If `baselines.json` has no entry for
    the run's `(host_label, target)`, result emission fails with an explicit
    operator-facing error naming the missing pair — never a silent None,
@@ -48,7 +63,9 @@ are binding.
    argument path, and the hardcoded Windows comparison defaults in
    `run_admission_capacity.py` (locate by the `mac-arm64-01` literal and the
    `comparison_required` OS branch, per AC #4's grep gate — line numbers
-   drift) are removed.
+   drift) are removed. The static per-target constants in
+   `benchmark_report.py` (locate by the `TARGET_MSG_PER_SECOND` dict; never
+   by line number) are removed with them.
 6. **One artifact-id/campaign-id derivation helper** in
    `benchmark_schema.py`, used by both runner and report (removes the
    duplicated timestamp munging at `run_admission_capacity.py:1086-1098` and
@@ -63,7 +80,11 @@ are binding.
    `scripts/smoke/benchmark_suite.py` (retain only what `TargetResult`
    validation actually needs, or fold it into `benchmark_schema.py` and delete
    the module); dead helpers `parse_utc` and `safe_label` in
-   `benchmark_report.py`.
+   `benchmark_report.py`; `evaluate_profile_thresholds()` in
+   `benchmark_policy.py` plus all its call sites and the cross-transport
+   comparison machinery (`comparison_ratio`/`comparison_strict`/
+   `comparison_required`, comparison-reference loading) per deliverable 3 —
+   `classify_status()` is the single surviving decision owner.
 
 ## Contract (normative signatures)
 
@@ -150,9 +171,13 @@ a required target must not validate as PASS.
    sqlite-variant validator (network fields required for network targets,
    forbidden for sqlite); ratchet test rejects a baselines.json revision that
    lowers any value.
-4. `grep`-gate: no occurrence of `DEFAULT_TARGETS *=` static baseline
-   constants in `benchmark_report.py`; no `--baseline` argument in
+4. `grep`-gate: no occurrence of `TARGET_MSG_PER_SECOND` in
+   `benchmark_report.py`; no `--baseline` argument in
    `run_admission_capacity.py`; no `mac-arm64-01` literal in the runner;
+   no `evaluate_profile_thresholds` and no `comparison_ratio` /
+   `comparison_strict` / `comparison_required` identifiers anywhere under
+   `scripts/smoke/` (single decision owner is `classify_status()` in
+   `benchmark_policy.py`);
    D12: no `tcp+tls` (plus-form) string anywhere under `scripts/smoke/`,
    test fixtures, or emitted JSON artifacts — the machine identifier is
    `tcp-tls` only.

--- a/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
+++ b/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
@@ -7,7 +7,8 @@ recommended_agent: arch-ctm · recommended_model: deep-reasoning
 Fixes audit findings A.2 (envelope/publication gap), A.3 (campaign identity
 not persisted), A.4 (schema drift, v2-writer/v3-model), A.5 (competing
 baselines), A.7 (duplicated derivations), B (dead code, unused ledger seam).
-Decisions D1–D3 from
+Decisions D1–D3, D11 (UTC-only storage), and D12 (machine-identifier half:
+`tcp-tls` in all code, schemas, filenames, and JSON) from
 [benchmark-reporting-plan-overview.md](./benchmark-reporting-plan-overview.md)
 are binding.
 
@@ -151,7 +152,10 @@ a required target must not validate as PASS.
    lowers any value.
 4. `grep`-gate: no occurrence of `DEFAULT_TARGETS *=` static baseline
    constants in `benchmark_report.py`; no `--baseline` argument in
-   `run_admission_capacity.py`; no `mac-arm64-01` literal in the runner.
+   `run_admission_capacity.py`; no `mac-arm64-01` literal in the runner;
+   D12: no `tcp+tls` (plus-form) string anywhere under `scripts/smoke/`,
+   test fixtures, or emitted JSON artifacts — the machine identifier is
+   `tcp-tls` only.
 5. `.just/tests/` suite passes on macOS and Windows CI lanes.
 6. `baselines.json` present with D1 seed values, revision 1, and a
    quality-mgr approval reference recorded in the PR.

--- a/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
+++ b/docs/plans/phase-ao2/sprint-AO2-10-benchmark-data-contract.md
@@ -18,10 +18,10 @@ are binding.
    of 3–4 results). `SUMMARY_SCHEMA_VERSION = 4`. Both `extra="forbid"`,
    `frozen=True`.
 2. **Runner emits v4 directly.** Starting point is the four-target matrix
-   runner (`BENCHMARK_TARGETS`: sqlite/uds/tcp/tcp+tls, one unskippable
-   matrix per invocation) from `fix/ao2-7-report-provenance`, whose merge
-   into `integrate/phase-ao2` is a dispatch precondition for this sprint
-   (see overview, Base-branch precondition) — this sprint changes its
+   runner (`BENCHMARK_TARGETS`: sqlite/uds/tcp/tcp-tls, one unskippable
+   matrix per invocation) from `origin/fix/ao2-7-direct-peer-benchmark-harness`,
+   whose merge into `integrate/phase-ao2` is a dispatch precondition for this
+   sprint (see overview, Base-branch precondition) — this sprint changes its
    *emission*, it does not build matrix execution. The runner writes
    per-target compact JSON already valid against `BenchmarkRunResult` (no
    post-hoc migration), and at end of the matrix writes one campaign file
@@ -69,7 +69,7 @@ are binding.
 ```python
 class BaselineEntry(BaseModel, frozen=True, extra="forbid"):
     host_label: str          # SAFE_LABEL pattern
-    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    target: Literal["sqlite", "uds", "tcp", "tcp-tls"]
     p50_floor: float         # msg/s; ratchet: may only increase across revisions
     approved_by: str         # quality-mgr approval reference
     effective_from: datetime # UTC
@@ -84,7 +84,7 @@ class BenchmarkRunResult(BaseModel, frozen=True, extra="forbid"):
     campaign_id: str
     host_label: str
     os: Literal["macos", "windows", "linux"]
-    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    target: Literal["sqlite", "uds", "tcp", "tcp-tls"]
     status: Literal["PASS", "FAIL", "INCOMPLETE"]
     incomplete_reason: str | None      # required iff status == INCOMPLETE
     generated_at: datetime             # UTC, ISO-8601
@@ -123,7 +123,7 @@ present for network targets and absent for sqlite — implementers never invent
 degenerate network values.
 
 Target matrix is OS-derived, not caller-chosen: macOS/Linux = sqlite, uds,
-tcp, tcp+tls; Windows = sqlite, tcp, tcp+tls (uds rejected). Roll-up status:
+tcp, tcp-tls; Windows = sqlite, tcp, tcp-tls (uds rejected). Roll-up status:
 INCOMPLETE if any result INCOMPLETE or a required target missing; else FAIL if
 any result FAIL; else PASS. This is enforced in code, not prose: a
 `model_validator` on `BenchmarkCampaign` checks `results` covers the
@@ -143,7 +143,7 @@ a required target must not validate as PASS.
 3. Unit tests: status classification truth table (lifecycle-missing →
    INCOMPLETE; durable < requested → FAIL even above baseline; p50 below floor
    → FAIL; both satisfied → PASS; **required target entirely absent from a
-   campaign — e.g. tcp+tls never ran on a macOS campaign — → campaign
+   campaign — e.g. tcp-tls never ran on a macOS campaign — → campaign
    roll-up INCOMPLETE**; **missing `BaselineEntry` for (host_label, target) →
    hard emission error, not PASS/FAIL**); Windows matrix rejects uds;
    sqlite-variant validator (network fields required for network targets,
@@ -178,7 +178,9 @@ a required target must not validate as PASS.
 
 - must_follow: AO2.6 (writer-batching regression) — merged; benchmark numbers
   achieved there must not regress (standing constraint).
-- must_follow: merge of `fix/ao2-7-report-provenance` (four-target matrix
-  runner, PR #1003 lineage) into `integrate/phase-ao2` — hard dispatch
-  precondition; this sprint modifies that runner's emission.
+- must_follow: merge of `origin/fix/ao2-7-direct-peer-benchmark-harness`
+  (four-target matrix runner; already contains PR #1003's provenance fixes)
+  into `integrate/phase-ao2` — hard dispatch precondition; this sprint
+  modifies that runner's emission. Branch name per the overview's Base-branch
+  precondition, which is authoritative.
 - parallel_safe: none — AO2.11/12/13 all consume this contract.

--- a/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
+++ b/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
@@ -1,0 +1,113 @@
+# Sprint AO2.11 — Rendering Pipeline: Panels, Phase Report, Candlestick, Index
+
+Status: draft · Branch: `feature/ao2-11-benchmark-rendering` off
+`integrate/phase-ao2` (after AO2.10 merge-forward) · PR target:
+`integrate/phase-ao2`
+recommended_agent: arch-ctm · recommended_model: deep-reasoning
+
+Implements decisions D4–D6, D9, D10 of
+[benchmark-reporting-plan-overview.md](./benchmark-reporting-plan-overview.md).
+Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
+(no phase report, no chart, no wyvern step).
+
+## Deliverables
+
+1. **Three sc-compose j2 templates** under `templates/benchmark-report/`
+   (replacing the current two):
+   - `benchmark-run.xhtml.j2` — one panel per campaign: campaign header
+     (host, phase, revision, roll-up status), one row per target with p50 /
+     p95 / p99, durable-write proof, baseline floor and margin. If status is
+     INCOMPLETE, a visible note block at the BOTTOM of the panel with
+     `incomplete_reason` (D4).
+   - `benchmark-phase-report.html.j2` — `phase-<id>.html`: 2×2 candlestick
+     grid at top (tcp, tcp+tls / uds, sqlite — D5), then every panel of the
+     phase embedded newest-first by `started_at` descending.
+   - `benchmark-index.html.j2` — `index.html` in
+     `site/reports/send-message-benchmark/`: the latest phase's 2×2 grid plus
+     a links list to all historical phase reports, newest first (D6).
+2. **Chart data preparation** in `scripts/smoke/benchmark_report.py`: a pure
+   function computes candlestick geometry as plain JSON variables; the j2
+   template emits self-contained inline SVG. No external JS/CSS dependencies;
+   the site must render offline.
+3. **Single render path.** `benchmark_report.py` exposes exactly one flow:
+   read validated JSON (campaign files + `historical-record.json` when
+   present) → render panels → render phase report(s) → render index → run
+   `just reports-index`. The `--input`/`--rebuild` split is removed;
+   `--rebuild` remains as the only (default) verb. Rendering never mutates
+   result JSON (regeneration property).
+4. **Wyvern preview.** `just benchmark-show` renders/copies the newest
+   campaign panel to an `.html` twin under
+   `artifacts/benchmark/preview/latest.html` and opens it with `wyvern`
+   (interim for [randlee/wyvern#115](https://github.com/randlee/wyvern/issues/115);
+   switch to direct `.xhtml` when that lands). `just benchmark` prints the
+   exact `just benchmark-show` command at the end of every run.
+5. **Retire** `site/reports/send-message-benchmark.html` (delete file and its
+   generation code path); `index.html` and `phase-<id>.html` replace it (D6).
+
+## Candlestick contract (normative)
+
+- One chart per target; grid order: row 1 = tcp, tcp+tls; row 2 = uds, sqlite.
+  Windows series simply absent from the uds chart.
+- One series (color) per `host_label`; x-axis = campaign `started_at`
+  (chronological); y-axis = admissions/sec.
+- Candle mapping from `metrics.admissions_per_second` (MetricDistribution):
+  wick low = `min`, wick high = `max`, body spans `p50`–`p95`, with the p50
+  edge emphasized. Body fill: PASS = series color, FAIL = red outline.
+- Point inclusion (D5): campaigns in `historical-record.json` contribute only
+  the entry flagged `final_best`; current-phase campaigns all appear except
+  status INCOMPLETE (D4). Baseline floor drawn as a horizontal reference line
+  per series at the current `baselines.json` value.
+
+```python
+def candlestick_series(
+    charts: Sequence[Literal["tcp", "tcp+tls", "uds", "sqlite"]],
+    historical: HistoricalRecord,      # AO2.12 model; empty pre-AO2.12
+    phase_campaigns: Sequence[BenchmarkCampaign],
+    baselines: BaselineSet,
+) -> dict[str, ChartVars]:             # JSON-serializable j2 vars only
+    ...
+```
+
+## Acceptance criteria
+
+1. `python3 scripts/smoke/benchmark_report.py --rebuild` regenerates every
+   panel, `phase-ao2.html`, and `index.html` from JSON alone; a second
+   invocation is byte-identical (deterministic; no timestamps-of-generation
+   in output bodies).
+2. Panels for INCOMPLETE campaigns render with the reason note at the bottom
+   and are absent from every candlestick (template test with fixture data).
+3. Phase report orders panels strictly by `started_at` descending (test with
+   ≥3 fixture campaigns out of filename order).
+4. SVG charts: fixture-driven golden test rendering 2 hosts × 4 targets ×
+   mixed PASS/FAIL, asserting candle count, series count, FAIL styling, and
+   baseline line presence; page contains no `<script src=` / external URL
+   (grep gate).
+5. `just benchmark-show` opens the newest panel in wyvern on macOS (manual
+   evidence: operator-visible screenshot or wyvern stdout committed to the
+   sprint evidence notes).
+6. `site/reports/send-message-benchmark.html` no longer exists on the branch
+   and nothing regenerates it (grep gate on the filename).
+7. `.just/tests` suite green on macOS and Windows CI lanes.
+
+## Required validation
+
+- `.just/tests` python suite both platforms; golden-SVG fixtures committed.
+- One live macOS `just benchmark` followed by `--rebuild` twice proving
+  determinism, evidence committed on the sprint branch.
+- Live-verify gate (memory: live-verify-before-QA): operator confirms the
+  wyvern display and phase report visually before quality-mgr dispatch.
+
+## Non-closure / out of scope
+
+- Historical candlestick points: charts show only current-phase campaigns
+  until AO2.12 delivers `historical-record.json` (function accepts it empty).
+- No change to runner/schema (AO2.10 owns) or run procedure docs (AO2.13).
+- Wyvern `.xhtml` native support (external, wyvern#115).
+
+## Dependencies
+
+- must_follow: AO2.10 (consumes v4 models, baselines.json, campaign files).
+  Merge-forward trigger: AO2.10 dev push.
+- parallel_safe: AO2.13 may start once templates/`just benchmark-show` names
+  are fixed by this doc, but its PR must not merge first (it documents this
+  sprint's commands).

--- a/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
+++ b/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
@@ -5,7 +5,9 @@ Status: draft · Branch: `feature/ao2-11-benchmark-rendering` off
 `integrate/phase-ao2`
 recommended_agent: arch-ctm · recommended_model: deep-reasoning
 
-Implements decisions D4–D6, D9, D10 of
+Implements decisions D4–D6, D9, D10, D11 (rendered time display), and D12
+(display-label half: “TCP + TLS” as human label for the `tcp-tls` machine id)
+of
 [benchmark-reporting-plan-overview.md](./benchmark-reporting-plan-overview.md).
 Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
 (no phase report, no chart, no wyvern step).
@@ -132,7 +134,12 @@ stub shapes.
 8. `HistoricalRecord` classes exist in `benchmark_schema.py`, field-for-field
    equal to AO2.12's normative contract (docstring cross-references it), and
    the empty-record fixture round-trips through model validation.
-9. `.just/tests` suite green on macOS and Windows CI lanes.
+9. Target labels (D12): template tests assert panels, phase report, and
+   index render the human label “TCP + TLS” for the `tcp-tls` target, while
+   machine contexts — `datetime`/`id`/`class` attributes, filenames, and
+   JSON-embedded chart variables — retain the hyphenated `tcp-tls` id and
+   contain no plus-form string.
+10. `.just/tests` suite green on macOS and Windows CI lanes.
 
 ## Required validation
 

--- a/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
+++ b/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
@@ -20,7 +20,7 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
      INCOMPLETE, a visible note block at the BOTTOM of the panel with
      `incomplete_reason` (D4).
    - `benchmark-phase-report.html.j2` — `phase-<id>.html`: 2×2 candlestick
-     grid at top (tcp, tcp+tls / uds, sqlite — D5), then every panel of the
+     grid at top (tcp, tcp-tls / uds, sqlite — D5), then every panel of the
      phase embedded newest-first by `started_at` descending.
    - `benchmark-index.html.j2` — `index.html` in
      `site/reports/send-message-benchmark/`: the latest phase's 2×2 grid plus
@@ -32,13 +32,17 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
    helper feeding the j2 variables. One small **inline** script per page
    (allowed by the no-external-URL gate, which forbids only `<script src=`)
    rewrites each `<time>` text to the viewer's local zone, same 24-hour
-   format; without script execution the Pacific text stands. Sorting and
-   grouping always use the UTC values.
+   format; without script execution the Pacific text stands. In the
+   `.xhtml.j2` panel template (strict XHTML: `xmlns` declared, parsed as
+   XML), the inline script body MUST be wrapped in `<![CDATA[ ... ]]>` so
+   `<` and `&` in script code cannot break XML well-formedness; the `.html`
+   templates need no wrapping. Sorting and grouping always use the UTC
+   values.
 3. **Chart data preparation** in `scripts/smoke/benchmark_report.py`: a pure
    function computes candlestick geometry as plain JSON variables; the j2
    template emits self-contained inline SVG. No external JS/CSS dependencies;
    the site must render offline.
-3. **Single render path.** `benchmark_report.py` exposes exactly one flow:
+4. **Single render path.** `benchmark_report.py` exposes exactly one flow:
    read validated JSON (campaign files + `historical-record.json` when
    present) → render panels → render phase report(s) → render index → run
    `just reports-index`. The `--input`/`--rebuild` split is removed;
@@ -47,18 +51,25 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
    recipe is kept as a thin passthrough to this single flow and its comment
    is updated to describe the post-AO2.11 behavior (the retired aggregate is
    no longer mentioned).
-4. **Wyvern preview.** `just benchmark-show` renders/copies the newest
+5. **Wyvern preview.** `just benchmark-show` renders/copies the newest
    campaign panel to an `.html` twin under
    `artifacts/benchmark/preview/latest.html` and opens it with `wyvern`
    (interim for [randlee/wyvern#115](https://github.com/randlee/wyvern/issues/115);
    switch to direct `.xhtml` when that lands). `just benchmark` prints the
    exact `just benchmark-show` command at the end of every run.
-5. **Retire** `site/reports/send-message-benchmark.html` (delete file and its
+6. **Retire** `site/reports/send-message-benchmark.html` (delete file and its
    generation code path); `index.html` and `phase-<id>.html` replace it (D6).
+7. **`HistoricalRecord` model classes.** Implement `RatchetPoint`,
+   `HistoricalResultEntry`, `HistoricalCampaignEntry`, `UnattributedEntry`,
+   and `HistoricalRecord` in `scripts/smoke/benchmark_schema.py` exactly per
+   the normative contract in
+   [sprint-AO2-12-historical-data-migration.md](./sprint-AO2-12-historical-data-migration.md)
+   § "HistoricalRecord contract", plus an empty-record fixture used for
+   pre-AO2.12 rendering. AO2.12 consumes these classes unchanged.
 
 ## Candlestick contract (normative)
 
-- One chart per target; grid order: row 1 = tcp, tcp+tls; row 2 = uds, sqlite.
+- One chart per target; grid order: row 1 = tcp, tcp-tls; row 2 = uds, sqlite.
   Windows series simply absent from the uds chart.
 - One series (color) per `host_label`; x-axis = campaign `started_at`
   (chronological); y-axis = admissions/sec.
@@ -72,7 +83,7 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
 
 ```python
 def candlestick_series(
-    charts: Sequence[Literal["tcp", "tcp+tls", "uds", "sqlite"]],
+    charts: Sequence[Literal["tcp", "tcp-tls", "uds", "sqlite"]],
     historical: HistoricalRecord,      # normative model defined in AO2.12
     phase_campaigns: Sequence[BenchmarkCampaign],
     baselines: BaselineSet,
@@ -108,7 +119,20 @@ stub shapes.
    sprint evidence notes).
 6. `site/reports/send-message-benchmark.html` no longer exists on the branch
    and nothing regenerates it (grep gate on the filename).
-7. `.just/tests` suite green on macOS and Windows CI lanes.
+7. Time display (D11): template/unit tests assert every rendered timestamp
+   is a `<time datetime="<UTC ISO Z>">` element whose text is the Pacific
+   24-hour format; a fixture with campaigns whose UTC order differs from
+   their Pacific calendar-date order proves sorting/grouping uses the UTC
+   values; a DOM/grep check asserts exactly one inline (non-`src`) time
+   upgrade script per page; every rendered `.xhtml` panel (including an
+   INCOMPLETE-status fixture and one containing the inline script) passes a
+   strict XML parse (`xml.etree.ElementTree.parse` or equivalent) as an
+   automated test — a well-formedness failure fails the suite, not just a
+   grep gate.
+8. `HistoricalRecord` classes exist in `benchmark_schema.py`, field-for-field
+   equal to AO2.12's normative contract (docstring cross-references it), and
+   the empty-record fixture round-trips through model validation.
+9. `.just/tests` suite green on macOS and Windows CI lanes.
 
 ## Required validation
 

--- a/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
+++ b/docs/plans/phase-ao2/sprint-AO2-11-benchmark-rendering-pipeline.md
@@ -25,7 +25,16 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
    - `benchmark-index.html.j2` — `index.html` in
      `site/reports/send-message-benchmark/`: the latest phase's 2×2 grid plus
      a links list to all historical phase reports, newest first (D6).
-2. **Chart data preparation** in `scripts/smoke/benchmark_report.py`: a pure
+2. **Time display (D11):** every timestamp shown in panels, phase reports,
+   the index, and chart axes is emitted as a `<time datetime="<UTC ISO>">`
+   element whose text is pre-rendered in `America/Los_Angeles`, 24-hour
+   format (e.g. `Aug 23, 2026 · 11:59 PDT`), by a single shared formatting
+   helper feeding the j2 variables. One small **inline** script per page
+   (allowed by the no-external-URL gate, which forbids only `<script src=`)
+   rewrites each `<time>` text to the viewer's local zone, same 24-hour
+   format; without script execution the Pacific text stands. Sorting and
+   grouping always use the UTC values.
+3. **Chart data preparation** in `scripts/smoke/benchmark_report.py`: a pure
    function computes candlestick geometry as plain JSON variables; the j2
    template emits self-contained inline SVG. No external JS/CSS dependencies;
    the site must render offline.
@@ -34,7 +43,10 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
    present) → render panels → render phase report(s) → render index → run
    `just reports-index`. The `--input`/`--rebuild` split is removed;
    `--rebuild` remains as the only (default) verb. Rendering never mutates
-   result JSON (regeneration property).
+   result JSON (regeneration property). The `benchmark-report` Justfile
+   recipe is kept as a thin passthrough to this single flow and its comment
+   is updated to describe the post-AO2.11 behavior (the retired aggregate is
+   no longer mentioned).
 4. **Wyvern preview.** `just benchmark-show` renders/copies the newest
    campaign panel to an `.html` twin under
    `artifacts/benchmark/preview/latest.html` and opens it with `wyvern`
@@ -61,12 +73,21 @@ Fixes audit findings B (dual `--rebuild`/`--input` render paths) and C
 ```python
 def candlestick_series(
     charts: Sequence[Literal["tcp", "tcp+tls", "uds", "sqlite"]],
-    historical: HistoricalRecord,      # AO2.12 model; empty pre-AO2.12
+    historical: HistoricalRecord,      # normative model defined in AO2.12
     phase_campaigns: Sequence[BenchmarkCampaign],
     baselines: BaselineSet,
 ) -> dict[str, ChartVars]:             # JSON-serializable j2 vars only
     ...
 ```
+
+`HistoricalRecord` (with `HistoricalCampaignEntry.final_best`, the `ratchet`
+trace, `evidence_gap`, and `unattributed`) is defined normatively in
+[sprint-AO2-12-historical-data-migration.md](./sprint-AO2-12-historical-data-migration.md)
+§ "HistoricalRecord contract". This sprint **implements** those model classes
+in `scripts/smoke/benchmark_schema.py` exactly per that normative section
+(plus an empty-record fixture for pre-AO2.12 rendering); AO2.12 consumes them
+unchanged. Fixtures must validate against the implemented model — no ad-hoc
+stub shapes.
 
 ## Acceptance criteria
 
@@ -108,6 +129,6 @@ def candlestick_series(
 
 - must_follow: AO2.10 (consumes v4 models, baselines.json, campaign files).
   Merge-forward trigger: AO2.10 dev push.
-- parallel_safe: AO2.13 may start once templates/`just benchmark-show` names
-  are fixed by this doc, but its PR must not merge first (it documents this
-  sprint's commands).
+- AO2.13 is a must_follow child of this sprint (PR-completion trigger: this
+  sprint's PR merges first) — see AO2.13's Dependencies section, which is
+  authoritative for that relation.

--- a/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
+++ b/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
@@ -55,7 +55,7 @@ preserved bit-exactly; only structure is normalized.
 ```python
 class RatchetPoint(BaseModel, frozen=True, extra="forbid"):
     host_label: str
-    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    target: Literal["sqlite", "uds", "tcp", "tcp-tls"]
     effective_from: datetime           # UTC; start of this baseline value
     p50_floor: float                   # best passing p50 seen so far (non-decreasing)
     source_campaign_id: str            # campaign that set this value

--- a/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
+++ b/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
@@ -1,0 +1,104 @@
+# Sprint AO2.12 — Historical Data Migration and Single Historical Record
+
+Status: draft · Branch: `feature/ao2-12-benchmark-history-migration` off
+`integrate/phase-ao2` (after AO2.10+AO2.11 merge-forward) · PR target:
+`integrate/phase-ao2`
+recommended_agent: Cipher-311d · recommended_model: fast
+
+Implements decisions D1 (Windows seeds), D7, D8 of
+[benchmark-reporting-plan-overview.md](./benchmark-reporting-plan-overview.md).
+Fixes audit findings A.4 (four coexisting shapes), A.5 (baseline scattered
+across branches — folds `historical-imports.json` from the unmerged
+`fix/ao2-7-report-provenance` branch), A.8 (orphaned files invisible to the
+index). We are not rewriting history: every measured value and timestamp is
+preserved bit-exactly; only structure is normalized.
+
+## Deliverables
+
+1. **Migration tool** `scripts/smoke/migrate_benchmark_history.py` (one-shot,
+   idempotent): reads every legacy JSON under
+   `site/reports/send-message-benchmark/` (v1–v3, all four observed shapes),
+   groups them into campaigns using the current inference rules
+   (host/transport/revision + timestamp adjacency), and emits v4
+   `BenchmarkRunResult`/`BenchmarkCampaign` records with `generated_at`,
+   metric values, counts, and revisions copied unchanged.
+2. **`historical-record.json`** — the single historical record (D7), validated
+   by a `HistoricalRecord` Pydantic model: all migrated campaigns, each entry
+   carrying `final_best: bool` (the final/best run of its campaign group, the
+   only point AO2.11 charts), and a per-(host, target) running-best baseline
+   trace implementing the retroactive ratchet (D8): baseline-as-of-run =
+   best passing p50 seen so far; each historical result's displayed status is
+   re-derived against that value plus the 100%-durable rule where the legacy
+   data records counts (where counts are absent, status carries
+   `evidence_gap: "durability-counts-missing"` rather than a guessed PASS).
+3. **Windows baseline seeds** (D1): computed from the best historical passing
+   Windows runs, written into `baselines.json` as a new ratchet-compliant
+   revision alongside the macOS D1 seeds.
+4. **Verification diff report** emitted by the tool
+   (`artifacts/benchmark/migration-audit.json` + rendered summary): for every
+   legacy file → migrated record, the exact value/timestamp mapping, so
+   quality-mgr can verify accuracy (D7 makes quality-mgr responsible for the
+   record's values/dates).
+5. **Legacy cleanup on the branch:** migrated per-run legacy JSON files are
+   replaced by their v4 equivalents; `historical-imports.json` content is
+   folded in and the file removed; `load_result()` v1–v3 migration acceptance
+   in `benchmark_report.py` is deleted (per AO2.10 non-closure note); orphaned
+   files either join a campaign or are recorded in `historical-record.json`
+   under `unattributed` with reason.
+6. **Full regeneration:** run `benchmark_report.py --rebuild` so all panels,
+   `phase-*.html`, `index.html`, and the report index reflect the migrated
+   data — candlesticks now show historical final/best points (closing
+   AO2.11's non-closure).
+
+## Migration tool contract
+
+```
+python3 scripts/smoke/migrate_benchmark_history.py \
+    --reports-dir site/reports/send-message-benchmark \
+    [--check]        # validate + emit audit diff, write nothing
+```
+
+Idempotency: a second run over migrated data is a no-op with exit 0.
+Any legacy file it cannot classify is a hard error naming the file — no
+silent skips (memory: dont-dismiss-gap-warnings).
+
+## Acceptance criteria
+
+1. Value preservation: automated test asserts, for every legacy fixture and
+   for the real tree, that each migrated record's p50/p95/p99/min/max,
+   counts, `generated_at`, and `source_revision` are equal to the source
+   (string-exact for timestamps, numeric-exact for values).
+2. `historical-record.json` validates against `HistoricalRecord`; exactly one
+   `final_best` per historical campaign group; ratchet trace is
+   non-decreasing per (host, target).
+3. `--check` mode passes on the migrated tree; a deliberately corrupted value
+   in a fixture makes it fail naming the file.
+4. Post-migration `--rebuild` is deterministic and the report index lists the
+   newest benchmark entries (audit A.2/A.8 orphan counts drop to zero:
+   verified by a test that every campaign in the record or phase dir is
+   reachable from `index.html`).
+5. `baselines.json` new revision adds Windows entries and lowers nothing
+   (ratchet test from AO2.10 passes).
+6. `.just/tests` green on macOS and Windows CI lanes.
+
+## Required validation
+
+- Fixture suite covering all four observed legacy shapes (23/25/26/35-key)
+  plus one v1 file.
+- quality-mgr explicitly reviews `migration-audit.json` and signs off on
+  values/dates and on the Windows baseline seeds (D1, D7) — this sign-off is
+  a merge gate for the sprint PR.
+
+## Non-closure / out of scope
+
+- Deleting INCOMPLETE-run artifacts (future cleanup, D4).
+- Any change to templates or chart code beyond consuming
+  `historical-record.json` (AO2.11 owns rendering).
+- Raw traces under `artifacts/benchmark/` (gitignored, untouched).
+
+## Dependencies
+
+- must_follow: AO2.10 (v4 models), AO2.11 (`HistoricalRecord` consumer and
+  regeneration path). Merge-forward trigger: parent dev push.
+- parallel_safe: AO2.13 (disjoint files: migration tool + data vs skill doc +
+  Justfile recipes; no shared public contract beyond names fixed in AO2.11).

--- a/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
+++ b/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
@@ -50,6 +50,56 @@ preserved bit-exactly; only structure is normalized.
    data — candlesticks now show historical final/best points (closing
    AO2.11's non-closure).
 
+## HistoricalRecord contract (normative — owned here, consumed by AO2.11)
+
+```python
+class RatchetPoint(BaseModel, frozen=True, extra="forbid"):
+    host_label: str
+    target: Literal["sqlite", "uds", "tcp", "tcp+tls"]
+    effective_from: datetime           # UTC; start of this baseline value
+    p50_floor: float                   # best passing p50 seen so far (non-decreasing)
+    source_campaign_id: str            # campaign that set this value
+
+class HistoricalResultEntry(BaseModel, frozen=True, extra="forbid"):
+    result: BenchmarkRunResult         # v4, values/timestamps bit-exact from source
+    displayed_status: Literal["PASS", "FAIL", "INCOMPLETE"]  # re-derived per D8
+    evidence_gap: Literal["durability-counts-missing"] | None
+    source_files: tuple[str, ...]      # legacy filenames this entry was migrated from
+
+class HistoricalCampaignEntry(BaseModel, frozen=True, extra="forbid"):
+    campaign: BenchmarkCampaign        # v4
+    final_best: bool                   # exactly one True per campaign group
+    results: tuple[HistoricalResultEntry, ...]
+
+class UnattributedEntry(BaseModel, frozen=True, extra="forbid"):
+    source_file: str
+    reason: str                        # why it joined no campaign group
+
+class HistoricalRecord(BaseModel, frozen=True, extra="forbid"):
+    schema_version: Literal[1]
+    generated_from_commit: str         # SHA the migration ran against
+    campaigns: tuple[HistoricalCampaignEntry, ...]   # started_at ascending
+    ratchet: tuple[RatchetPoint, ...]  # per (host,target), effective_from ascending
+    unattributed: tuple[UnattributedEntry, ...]
+```
+
+Notes on the contract:
+
+- `HistoricalResultEntry` **wraps `BenchmarkRunResult` unmodified** — the
+  result's closed `status` Literal from AO2.10 is untouched;
+  `displayed_status` (the D8 ratchet re-derivation) and `evidence_gap` live
+  on the wrapper, never inside the v4 result. No amendment to the AO2.10
+  contract is required.
+- **Implementation ownership:** these model classes are *implemented* in
+  `scripts/smoke/benchmark_schema.py` during **AO2.11** (which needs them to
+  type and test `candlestick_series()`), exactly as specified here; AO2.11
+  ships them alongside an empty-record fixture. AO2.12 consumes the classes
+  unchanged. Any divergence AO2.12 discovers is a plan amendment to this
+  section plus an AO2.11-compatible code change — never a silent fork.
+
+AO2.11's `candlestick_series()` consumes this model exactly as defined here;
+AO2.11 fixture data must validate against it.
+
 ## Migration tool contract
 
 ```
@@ -68,7 +118,10 @@ silent skips (memory: dont-dismiss-gap-warnings).
    for the real tree, that each migrated record's p50/p95/p99/min/max,
    counts, `generated_at`, and `source_revision` are equal to the source
    (string-exact for timestamps, numeric-exact for values).
-2. `historical-record.json` validates against `HistoricalRecord`; exactly one
+2. This sprint uses the `HistoricalRecord` classes shipped by AO2.11
+   without modification (grep gate: no class redefinition outside
+   `benchmark_schema.py`); `historical-record.json` validates against
+   `HistoricalRecord`; exactly one
    `final_best` per historical campaign group; ratchet trace is
    non-decreasing per (host, target).
 3. `--check` mode passes on the migrated tree; a deliberately corrupted value

--- a/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
+++ b/docs/plans/phase-ao2/sprint-AO2-12-historical-data-migration.md
@@ -22,8 +22,9 @@ preserved bit-exactly; only structure is normalized.
    (host/transport/revision + timestamp adjacency), and emits v4
    `BenchmarkRunResult`/`BenchmarkCampaign` records with `generated_at`,
    metric values, counts, and revisions copied unchanged.
-2. **`historical-record.json`** — the single historical record (D7), validated
-   by a `HistoricalRecord` Pydantic model: all migrated campaigns, each entry
+2. **`historical-record.json`** — the single historical record (D7),
+   populated into a `HistoricalRecord` instance (classes implemented in
+   AO2.11, consumed here unchanged): all migrated campaigns, each entry
    carrying `final_best: bool` (the final/best run of its campaign group, the
    only point AO2.11 charts), and a per-(host, target) running-best baseline
    trace implementing the retroactive ratchet (D8): baseline-as-of-run =

--- a/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
+++ b/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
@@ -41,8 +41,8 @@ authoritative source; agents follow it mechanically.
    so the manual step list in the skill is two commands + push.
 3. **Docs alignment:** `docs/cross-platform-guidelines.md` gains the
    Windows-benchmark specifics currently only in AI.52 (host label, TCP-only,
-   native invocation, symlink daemon-switch); the five superseded sprint docs
-   get their pointer lines; `docs/plans/phase-ao2/README` (or phase index, if
+   native invocation, symlink daemon-switch); the superseded sprint docs
+   (deliverable 1's seven-doc list) get their pointer lines; `docs/plans/phase-ao2/README` (or phase index, if
    present) links the skill.
 
 ## Skill outline (normative structure)

--- a/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
+++ b/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
@@ -1,0 +1,95 @@
+# Sprint AO2.13 — Canonical Benchmark-Run Skill and Operator Workflow
+
+Status: draft · Branch: `feature/ao2-13-benchmark-run-skill` off
+`integrate/phase-ao2` (after AO2.11 merge-forward) · PR target:
+`integrate/phase-ao2`
+recommended_agent: Cipher-311d · recommended_model: fast
+
+Fixes audit finding A.1 (no canonical procedure; five sprint docs with
+diverging lifecycles left to agent interpretation). Implements D4, D9, D10.
+After this sprint, "how to run and publish a benchmark" has exactly one
+authoritative source; agents follow it mechanically.
+
+## Deliverables
+
+1. **Repo skill** `.claude/skills/benchmark-run/SKILL.md` — the single
+   canonical procedure, superseding the procedural text in AI.40, AI.52,
+   AL.9, AO2.7, and AO2.8 (those docs remain as history; the skill states the
+   supersession and each of those five docs gains a one-line pointer to the
+   skill). The skill covers, for macOS and Windows:
+   - Preconditions: dedicated benchmark account (ADR-052), daemon-switch
+     status check, clean git state, current branch expectations.
+   - The run: exact command (`just benchmark`), required environment
+     (`ATM_CAPACITY_HOST_LABEL` values per host, e.g. `rand-m5`,
+     `windows-x64-01`), OS target matrix (Windows: no uds).
+   - Publication: `git add` of the per-target JSON, `.campaign.json`,
+     panels, phase report, index, envelopes; commit message convention;
+     push; `just reports-index --check` must pass before push.
+   - INCOMPLETE runs (D4): still rendered, committed, and pushed with the
+     reason note; never deleted ad hoc; never counted as evidence.
+   - Review step (D9): run `just benchmark-show` and display the newest
+     panel in wyvern for the operator immediately after every run — this is
+     a required step, not optional.
+   - Failure handling: below-baseline is a FAIL result to publish, not a
+     reason to withhold (memory: benchmark-ledger publish gap — every
+     attempt is committed); harness errors before measurement are fixed and
+     rerun silently, only measured results are reported.
+2. **Justfile completion:** `just benchmark` performs the full flow
+   (build → sign → run → render → index-check) and `just benchmark-show`
+   (from AO2.11) is documented; a new `just benchmark-publish` recipe stages
+   exactly the report artifacts and runs `just reports-index --check`,
+   so the manual step list in the skill is two commands + push.
+3. **Docs alignment:** `docs/cross-platform-guidelines.md` gains the
+   Windows-benchmark specifics currently only in AI.52 (host label, TCP-only,
+   native invocation, symlink daemon-switch); the five superseded sprint docs
+   get their pointer lines; `docs/plans/phase-ao2/README` (or phase index, if
+   present) links the skill.
+
+## Skill outline (normative structure)
+
+```markdown
+# benchmark-run
+1. Preflight (account, daemon-switch status, git state)
+2. Run: ATM_CAPACITY_HOST_LABEL=<host> just benchmark
+3. Review: just benchmark-show   # wyvern displays newest panel (required)
+4. Publish: just benchmark-publish && git commit ... && git push
+5. INCOMPLETE handling
+6. Failure classification and rerun policy
+7. Windows appendix (matrix, env, daemon-switch symlinks)
+```
+
+## Acceptance criteria
+
+1. The skill contains every command an agent needs, copy-pastable, for both
+   OSes; no step says "as appropriate" or defers to another document for a
+   command (req-qa can verify by enumerating steps 1–7 against the
+   deliverable list).
+2. `just benchmark-publish` stages only report artifacts (test: dirty
+   unrelated file is not staged) and fails when `reports-index --check`
+   fails.
+3. Each of the five superseded docs contains the pointer line (grep gate:
+   `benchmark-run/SKILL.md` appears in all five).
+4. A dry-run transcript of the full skill executed on macOS (steps 1–4
+   against a real run) is committed as sprint evidence.
+5. `.just/tests` green on macOS and Windows CI lanes.
+
+## Required validation
+
+- Live macOS end-to-end: one real `just benchmark` following the skill text
+  verbatim, including the wyvern display step (live-verify gate before
+  quality-mgr dispatch).
+- Windows walkthrough may be textual-verified by CI lane + review if no
+  Windows operator slot is available this sprint; if so, that is recorded as
+  an explicit follow-up validation row, not silently waived.
+
+## Non-closure / out of scope
+
+- Automated scheduled benchmark runs (not requested).
+- Deleting INCOMPLETE artifacts (future cleanup).
+- Rewriting the superseded sprint docs beyond the pointer line.
+
+## Dependencies
+
+- must_follow: AO2.11 (documents its `just benchmark-show` and template
+  outputs). Merge-forward trigger: AO2.11 dev push; AO2.11 PR merges first.
+- parallel_safe: AO2.12 (disjoint files; see AO2.12 doc).

--- a/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
+++ b/docs/plans/phase-ao2/sprint-AO2-13-benchmark-run-skill.md
@@ -13,10 +13,10 @@ authoritative source; agents follow it mechanically.
 ## Deliverables
 
 1. **Repo skill** `.claude/skills/benchmark-run/SKILL.md` — the single
-   canonical procedure, superseding the procedural text in AI.40, AI.52,
-   AL.9, AO2.7, and AO2.8 (those docs remain as history; the skill states the
-   supersession and each of those five docs gains a one-line pointer to the
-   skill). The skill covers, for macOS and Windows:
+   canonical procedure, superseding the procedural text in AI.40, AI.49,
+   AI.52, AL.9, AO2.5.4, AO2.7, and AO2.8 (those docs remain as history; the
+   skill states the supersession and each of those seven docs gains a
+   one-line pointer to the skill). The skill covers, for macOS and Windows:
    - Preconditions: dedicated benchmark account (ADR-052), daemon-switch
      status check, clean git state, current branch expectations.
    - The run: exact command (`just benchmark`), required environment
@@ -67,8 +67,9 @@ authoritative source; agents follow it mechanically.
 2. `just benchmark-publish` stages only report artifacts (test: dirty
    unrelated file is not staged) and fails when `reports-index --check`
    fails.
-3. Each of the five superseded docs contains the pointer line (grep gate:
-   `benchmark-run/SKILL.md` appears in all five).
+3. Each of the seven superseded docs (AI.40, AI.49, AI.52, AL.9, AO2.5.4,
+   AO2.7, AO2.8) contains the pointer line (grep gate:
+   `benchmark-run/SKILL.md` appears in all seven).
 4. A dry-run transcript of the full skill executed on macOS (steps 1–4
    against a real run) is committed as sprint evidence.
 5. `.just/tests` green on macOS and Windows CI lanes.
@@ -78,15 +79,20 @@ authoritative source; agents follow it mechanically.
 - Live macOS end-to-end: one real `just benchmark` following the skill text
   verbatim, including the wyvern display step (live-verify gate before
   quality-mgr dispatch).
-- Windows walkthrough may be textual-verified by CI lane + review if no
-  Windows operator slot is available this sprint; if so, that is recorded as
-  an explicit follow-up validation row, not silently waived.
+- If no Windows operator slot is available this sprint, Windows verification
+  is: (a) the Windows CI lane green on `.just/tests` for this branch, and
+  (b) a named reviewer's step-by-step walkthrough of the skill's Windows
+  appendix recorded as a PR review comment confirming every command is valid
+  for `os.name == "nt"`. A live Windows execution is then recorded as an
+  explicit follow-up validation row in this doc — not silently waived.
 
 ## Non-closure / out of scope
 
 - Automated scheduled benchmark runs (not requested).
 - Deleting INCOMPLETE artifacts (future cleanup).
-- Rewriting the superseded sprint docs beyond the pointer line.
+- Rewriting the seven superseded sprint docs beyond the pointer line. (The
+  AO2.5.4 snapshot/restore *mechanism* remains mandatory and unchanged; only
+  its operator-procedure text is superseded by the skill.)
 
 ## Dependencies
 

--- a/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
+++ b/docs/plans/phase-ao2/sprint-AO2-9-benchmark-report-template-and-procedure.md
@@ -1,0 +1,34 @@
+---
+phase: AO2
+sprint: AO2.9
+title: Benchmark report template, publication, and aggregate procedure
+status: superseded
+superseded_by: AO2.10, AO2.11, AO2.12, AO2.13
+superseded_at: 2026-08-23
+---
+
+# AO2.9 — Benchmark report template, publication, and aggregate procedure (SUPERSEDED)
+
+**Status: superseded.** This sprint's design (originally on branch
+`plan/ao2-9-benchmark-report-template`, PR #989) is replaced in full by the
+AO2.10-AO2.13 benchmark-report sprint plan in this worktree
+(`docs/plans/phase-ao2/{benchmark-process-audit.md, benchmark-reporting-plan-overview.md,
+sprint-AO2-10-benchmark-data-contract.md, sprint-AO2-11-benchmark-rendering-pipeline.md,
+sprint-AO2-12-historical-data-migration.md, sprint-AO2-13-benchmark-run-skill.md}`).
+
+PR #989 was closed (not merged) by explicit operator direction on 2026-08-23.
+See `benchmark-reporting-plan-overview.md` for the full rationale: AO2.9's
+two-phase git-lock publication protocol (pre-run `intent.json` commit+push,
+`.pending/<run_id>.json` remote lock, push-gated finalizer, host-manifest
+binding digests, evidence branch + PR gates per ADR-054) is replaced by a
+simpler contract — one JSON array per run validated against a Pydantic model,
+rendered via sc-compose, aggregated into a phase-level report.
+
+Kept from the AO2.9 design and carried forward into the new plan: immutable
+per-run result JSON; machine-classified PASS/FAIL/INCOMPLETE (never
+caller-selected); OS-specific target matrix (Windows has no UDS); permanent
+retention of failed runs; sc-compose as the sole rendering seam; extending
+(not replacing) `.just/generate_report_index.py`.
+
+Do not resume work against this sprint. Any residual scope belongs to
+AO2.10-AO2.13.


### PR DESCRIPTION
## Summary
- Benchmark process audit (`benchmark-process-audit.md`) identifying 7 process inconsistencies, a publication gap in the default `just benchmark` path, unpersisted campaign identity, schema drift across 4 JSON shapes, and 3 competing baseline models.
- New AO2.10-AO2.13 sprint plan replacing the AO2.9 design (PR #989, closed): one JSON array per run validated against a Pydantic model → sc-compose render → phase-level aggregate report with history candlesticks → single reviewed baseline file.
- Marks AO2.9 as superseded in-place (`sprint-AO2-9-benchmark-report-template-and-procedure.md`).
- 5 hardening rounds recorded inline: plan-scope-reviewer + critical-plan-reviewer (rounds 1-4, PASS), quality-mgr full plan-doc QA (round 5: FAIL then PASS after fixing the blocking PASS/FAIL dual-decision-owner finding).

## Test plan
- [x] quality-mgr plan-doc QA: PASS (arch-qa, req-qa, ruthless-boundary-qa; rust reviewers N/A — Python-only tooling plan)
- [x] Round-5 re-verify confirmed all 4 findings resolved with no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)