### PR TITLE
ci: trigger PR checks on fix/*, feature/*, sprint/* base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [develop, main, "integrate/*"]
+    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*"]
   push:
     branches: [develop, main]
 


### PR DESCRIPTION
## Summary
- Widens `.github/workflows/ci.yml`'s `pull_request.branches` filter from `[develop, main, integrate/*]` to also include `fix/*`, `feature/*`, `sprint/*`.
- GitHub Actions has no head/source-branch filter for `pull_request` triggers — only a base-branch filter — so stacked PRs (a fix branch opened against another open PR's branch, e.g. PR #1007 → `fix/ao2-7-direct-peer-benchmark-harness`) were getting zero CI checks.

## Why
PR #1007 (stacked on PR #988) reported `0 checks` because its base branch wasn't in the allowlist. This closes that gap for all future stacked/sprint PRs, not just this one.

## Test plan
- [ ] Confirm this PR itself gets CI checks (base is `develop`, already covered — sanity check only)
- [ ] Once merged to `develop`, merge-forward into `integrate/phase-ao2` and `fix/ao2-7-direct-peer-benchmark-harness` so PR #1007 picks up checks