### PR TITLE
fix(ao2-7): close minimal benchmark harness QA findings

### DIFF
--- a/scripts/smoke/benchmark_mtls.py
+++ b/scripts/smoke/benchmark_mtls.py
@@ -97,6 +97,7 @@ def regenerate_mtls_identity(account: BenchmarkAccount, atm: Path) -> str:
             "generate a benchmark mTLS certificate",
         )
         try:
+            os.chmod(private_key, 0o600)
             bundle_bytes = certificate.read_bytes() + private_key.read_bytes()
             if not bundle_bytes:
                 raise OSError("generated PEM files were empty")

--- a/scripts/smoke/benchmark_mtls.py
+++ b/scripts/smoke/benchmark_mtls.py
@@ -6,7 +6,7 @@ This module owns only a disposable account's PEM bundle and records its path
 through the ordinary ``atm peer certificate init`` command; it owns no peer
 trust, listener, or runtime lifecycle.
 
-Each regeneration creates a self-signed certificate solely for a temporary,
+Each regeneration creates a self-signed mTLS/TLS certificate solely for a temporary,
 account-scoped benchmark daemon.  The two-day validity period deliberately
 limits the fixture's lifetime; the runner regenerates it for each mTLS
 benchmark campaign.  It is never a production identity, certificate authority,

--- a/scripts/smoke/benchmark_mtls.py
+++ b/scripts/smoke/benchmark_mtls.py
@@ -5,6 +5,12 @@ Its identity must therefore outlive the runner's temporary ``ATM_HOME``.
 This module owns only a disposable account's PEM bundle and records its path
 through the ordinary ``atm peer certificate init`` command; it owns no peer
 trust, listener, or runtime lifecycle.
+
+Each regeneration creates a self-signed certificate solely for a temporary,
+account-scoped benchmark daemon.  The two-day validity period deliberately
+limits the fixture's lifetime; the runner regenerates it for each mTLS
+benchmark campaign.  It is never a production identity, certificate authority,
+or reusable trust anchor.
 """
 from __future__ import annotations
 

--- a/scripts/smoke/test_benchmark_mtls.py
+++ b/scripts/smoke/test_benchmark_mtls.py
@@ -41,6 +41,7 @@ class BenchmarkMtlsTests(unittest.TestCase):
             with (
                 mock.patch.object(MTLS.shutil, "which", return_value="/usr/bin/openssl"),
                 mock.patch.object(MTLS.subprocess, "run", side_effect=run),
+                mock.patch.object(MTLS.os, "chmod", wraps=os.chmod) as chmod,
             ):
                 fingerprint = MTLS.regenerate_mtls_identity(self._account(home), atm)
 
@@ -49,6 +50,9 @@ class BenchmarkMtlsTests(unittest.TestCase):
             self.assertEqual(bundle.read_text(encoding="utf-8"), "CERTKEY")
             if os.name != "nt":
                 self.assertEqual(bundle.stat().st_mode & 0o777, 0o600)
+            chmod_calls = [(Path(call.args[0]).name, call.args[1]) for call in chmod.call_args_list]
+            self.assertIn(("private-key.pem", 0o600), chmod_calls)
+            self.assertIn((MTLS.IDENTITY_BUNDLE_NAME, 0o600), chmod_calls)
             self.assertEqual(commands[-1][-1], "--yes")
             self.assertIn(str(bundle), commands[-1])
             self.assertIn(fingerprint, commands[-1])

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -1550,6 +1550,24 @@ class AdmissionCapacityTests(unittest.TestCase):
             ],
         )
 
+    def test_default_f8_matrix_fails_closed_when_one_required_target_fails(self):
+        observed: list[str] = []
+        outcomes = iter((0, 0, 1, 0))
+
+        def run_capacity(*_args, **kwargs):
+            observed.append(kwargs["benchmark_target"])
+            return next(outcomes), Path(f"{kwargs['benchmark_target']}.json")
+
+        args = argparse.Namespace(
+            atm_home=None,
+            evidence_dir=Path("evidence"),
+            raw_evidence_dir=Path("raw"),
+            workers=64,
+        )
+        with mock.patch.object(RUNNER, "run_capacity", side_effect=run_capacity):
+            self.assertEqual(RUNNER.run_default_f8_matrix(args), 1)
+        self.assertEqual(observed, ["sqlite", "uds", "tcp", "tcp-tls"])
+
     def test_plaintext_baseline_bootstrap_runs_the_complete_required_set(self):
         observed: list[tuple[int, bool, str, str]] = []
 


### PR DESCRIPTION
Stacked on #988. This PR intentionally contains only the minimum QA findings: F002 required four-target suite failure-path test; F003 0600 temporary mTLS private-key enforcement with test; F004 temporary self-signed certificate contract documentation. It deliberately excludes benchmark implementation, reports, performance work, database/snapshot work, CI changes, and merge-forward commits.