### PR TITLE
fix(bootstrap): synchronize local macOS seed tools on version drift

### DIFF
--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -59,6 +59,7 @@ class BootstrapTests(unittest.TestCase):
         manifest = bootstrap.load_manifest()
         self.assertEqual(bootstrap.homebrew_python_formula(manifest), "python@3.14")
 
+    @unittest.skipUnless(sys.platform == "darwin", "Homebrew seed paths are macOS-specific")
     def test_macos_homebrew_seed_commands_update_only_declared_seed_packages(self) -> None:
         manifest = bootstrap.load_manifest()
         commands = bootstrap.homebrew_seed_commands(manifest, Path("/opt/homebrew/bin/brew"))

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -55,9 +55,22 @@ class BootstrapTests(unittest.TestCase):
         })
         self.assertEqual(dict(manifest.python_packages)["maturin"], "1.14.1")
 
+    def test_macos_homebrew_seed_formula_is_derived_from_the_exact_python_pin(self) -> None:
+        manifest = bootstrap.load_manifest()
+        self.assertEqual(bootstrap.homebrew_python_formula(manifest), "python@3.14")
+
+    def test_macos_homebrew_seed_commands_update_only_declared_seed_packages(self) -> None:
+        manifest = bootstrap.load_manifest()
+        commands = bootstrap.homebrew_seed_commands(manifest, Path("/opt/homebrew/bin/brew"))
+        self.assertEqual(commands, (
+            ("/opt/homebrew/bin/brew", "install", "python@3.14", "just"),
+            ("/opt/homebrew/bin/brew", "upgrade", "python@3.14", "just"),
+        ))
+
     def test_dry_run_never_executes_installers(self) -> None:
         manifest = bootstrap.load_manifest()
         with (
+            mock.patch.object(bootstrap, "synchronize_macos_seed_tools"),
             mock.patch.object(bootstrap, "verify_seed_tools"),
             mock.patch.object(bootstrap, "ensure_bootstrap_venv", return_value=Path("/tmp/bootstrap-python")),
             mock.patch.object(bootstrap, "verify_installed_tools") as verify,

--- a/docs/development/bootstrap.md
+++ b/docs/development/bootstrap.md
@@ -15,19 +15,27 @@ then verifies every reported version.
 ## Seed contract
 
 `just` cannot install itself and Python must exist before a Python recipe can
-run. A runner therefore supplies these exact seed tools before it invokes the
-shared recipe:
+run. GitHub CI supplies these exact seed tools before it invokes the shared
+recipe:
 
 - Rust `1.94.1`, with `clippy` and `rustfmt`;
 - Python `3.14.7`; and
 - `just` `1.58.0`.
 
-GitHub CI provisions those seeds explicitly and then runs `just bootstrap`.
-An operator provisioning a benchmark account must supply the same three exact
-versions and run the same command from a clean checkout. If any seed version is
-different, the recipe refuses before it installs or modifies any dependent
-tool. The bootstrap never writes packages into the system Python; every other
-Python-backed `just` recipe runs through `.bootstrap-venv` after setup. Its
+On a local macOS account, `just bootstrap` makes this seed contract
+reproducible through Homebrew: if Python or `just` differs from the exact
+manifest value, it installs/upgrades only `python@<manifest major.minor>` and
+`just`, then re-executes through the Homebrew Python. Homebrew is preferred
+because it keeps the host on its current stable bottle as pins advance; the
+bootstrap still rejects a Homebrew release that does not exactly match the
+manifest. CI is excluded from this host-package action and continues to
+provision its own seeds explicitly.
+
+An operator provisioning a non-macOS benchmark account must supply the same
+three exact versions and run the same command from a clean checkout. If any
+seed version is different, the recipe refuses before it installs or modifies
+any dependent tool. The bootstrap never writes packages into the system Python;
+every other Python-backed `just` recipe runs through `.bootstrap-venv` after setup. Its
 `bin`/`Scripts` directory is also first on child-process `PATH`, so PyO3 and
 other helpers cannot accidentally select an unrelated account-level Python.
 

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -73,6 +73,68 @@ def require_version(label: str, actual: str, expected: str) -> None:
         raise BootstrapError(f"{label} must be exactly {expected}; found {actual or 'no version output'}.")
 
 
+def homebrew_python_formula(manifest: BootstrapManifest) -> str:
+    """Return the Homebrew formula for the manifest's Python major/minor line."""
+    major, minor, _patch = manifest.python.split(".")
+    return f"python@{major}.{minor}"
+
+
+def homebrew_seed_commands(manifest: BootstrapManifest, brew: Path) -> tuple[tuple[str, ...], ...]:
+    """Return the only mutable local-macOS seed synchronization commands."""
+    formula = homebrew_python_formula(manifest)
+    return (
+        (str(brew), "install", formula, "just"),
+        (str(brew), "upgrade", formula, "just"),
+    )
+
+
+def seed_tool_matches(label: str, actual: str, expected: str) -> bool:
+    """Return whether a seed tool has the exact manifest version."""
+    try:
+        require_version(label, actual, expected)
+    except BootstrapError:
+        return False
+    return True
+
+
+def synchronize_macos_seed_tools(manifest: BootstrapManifest, *, dry_run: bool) -> None:
+    """Repair local Homebrew seed drift before enforcing the exact contract.
+
+    GitHub Actions supplies its own pinned seeds and must never mutate a runner's
+    package manager. Local macOS development instead uses Homebrew's current
+    stable bottle for the manifest-derived major/minor Python formula and just.
+    The exact patch still remains an explicit postcondition below.
+    """
+    if sys.platform != "darwin" or os.environ.get("CI"):
+        return
+
+    python_matches = seed_tool_matches("Python", platform.python_version(), manifest.python)
+    try:
+        just_matches = seed_tool_matches("just", command_output(["just", "--version"]), manifest.just)
+    except BootstrapError:
+        just_matches = False
+    if python_matches and just_matches:
+        return
+
+    brew = next((candidate for candidate in (Path("/opt/homebrew/bin/brew"), Path("/usr/local/bin/brew")) if candidate.is_file()), None)
+    if brew is None:
+        raise BootstrapError(
+            "macOS seed tools drifted and Homebrew was not found at /opt/homebrew/bin/brew or /usr/local/bin/brew. "
+            "Install Homebrew, then rerun just bootstrap."
+        )
+    for command in homebrew_seed_commands(manifest, brew):
+        run(command, dry_run=dry_run)
+    if dry_run:
+        return
+
+    formula = homebrew_python_formula(manifest)
+    prefix = Path(command_output([str(brew), "--prefix", formula]))
+    major, minor, _patch = manifest.python.split(".")
+    python = prefix / "bin" / f"python{major}.{minor}"
+    require_version("Homebrew Python", command_output([str(python), "--version"]), manifest.python)
+    os.execv(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]])
+
+
 def verify_seed_tools(manifest: BootstrapManifest) -> None:
     """Verify the minimal tools that must exist before a Just recipe can run."""
     require_version("Python", platform.python_version(), manifest.python)
@@ -243,7 +305,9 @@ def verify_installed_tools(manifest: BootstrapManifest, python: Path) -> None:
 
 def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
     """Install the complete contract, then verify it rather than trusting installs."""
-    verify_seed_tools(manifest)
+    synchronize_macos_seed_tools(manifest, dry_run=dry_run)
+    if not dry_run:
+        verify_seed_tools(manifest)
     python = ensure_bootstrap_venv(manifest, dry_run=dry_run)
     for name, version in manifest.cargo_tools:
         run(cargo_install_command(name, version, force=not registry_tool_matches(name, version, manifest.rust)), dry_run=dry_run)


### PR DESCRIPTION
## Summary
- `just bootstrap` now detects Homebrew Python/just seed-version drift against the manifest-pinned versions and synchronizes them automatically before re-execing through the exact pinned Python, instead of hard-failing.
- Root cause: M4 and M5 dev machines had stale Homebrew-seeded Python (3.14.4) and outdated `just`, while `tools/bootstrap.toml` pins exact patch `3.14.7`. CI is unaffected (already installs 3.14.7 via actions/setup-python@v5).

## Test plan
- [x] `just bootstrap` passes locally (macOS)
- [x] `just lint` passes locally (28/28 checks)
- [x] `just test` passes locally
- [x] New `.just/tests/test_bootstrap.py` coverage for the drift-sync path