### PR TITLE
fix(graph-orchestration): branch-scoped open-findings ignores stale legacy Resolution/status

### DIFF
--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -2,12 +2,19 @@
 #
 # Parameters: $SPRINT. A terminal triage:status excludes a finding in the
 # legacy origin-sprint mode. When $BRANCH is bound, the query instead uses
-# occurrence-level state: a finding is returned only when its own occurrence on
-# that branch is still open. This lets triage-report count downstream
-# promotions on their branch without keeping a closed origin sprint blocked.
-# Resolution events are honored in both modes. Results are ordered for dispatch
-# review: invalid severity first (fail closed), then Blocking, Important, and
-# Minor; ties use foundAt.
+# occurrence-level state exclusively: a finding is returned only when its own
+# occurrence on that branch is still open. This lets triage-report count
+# downstream promotions on their branch without keeping a closed origin sprint
+# blocked. The finding-level triage:status terminal check and any
+# triage:Resolution event are honored ONLY in legacy origin-sprint mode — in
+# branch-scoped mode they are ignored in favor of the branch occurrence's own
+# closed/status fields, which are the authoritative per-branch signal. This
+# was fixed 2026-08-24: a stale/incorrect Resolution event (or finding-level
+# status) previously suppressed a finding across every branch permanently,
+# even one where its occurrence was still genuinely open — see
+# AO212-MIGRATE-F001..F006. Results are ordered for dispatch review: invalid
+# severity first (fail closed), then Blocking, Important, and Minor; ties use
+# foundAt.
 
 PREFIX triage: <urn:atm:triage:>
 
@@ -39,12 +46,16 @@ SELECT ?finding ?findingId ?severity ?rawSeverity ?status ?foundAt ?description 
     })
   )
 
-  FILTER NOT EXISTS {
-    ?resolution a triage:Resolution ;
-                triage:resolves ?finding .
-  }
   FILTER (
-    !BOUND(?status)
+    BOUND(?BRANCH)
+    || NOT EXISTS {
+      ?resolution a triage:Resolution ;
+                  triage:resolves ?finding .
+    }
+  )
+  FILTER (
+    BOUND(?BRANCH)
+    || !BOUND(?status)
     || !(
       LCASE(STR(?status)) IN (
         "absent", "accepted", "closed", "dismissed", "false_positive",

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -172,6 +172,55 @@ triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage
             ("M-1", "minor", "MINOR"),
         ]
 
+    def test_branch_scoped_occurrence_open_survives_stale_resolution(self):
+        """A finding whose branch occurrence is genuinely still open must be
+        returned in branch-scoped mode even when a (mistaken) triage:Resolution
+        event already exists for it — the branch occurrence's own closed/status
+        fields are authoritative in this mode, not a blanket Resolution filter.
+
+        Regression test for 2026-08-24: AO212-MIGRATE-F002/F003/F004 had a
+        Resolution event recorded before their fix commits ever landed on the
+        certified branch, which silently and permanently suppressed them from
+        every branch-scoped open-findings query even though their occurrence
+        on that branch was correctly still marked open."""
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ;
+    triage:description "still broken on this branch" ;
+    triage:hasOccurrence triage:occ1 .
+triage:occ1 triage:branch "feature/x" ; triage:closed false ; triage:status "open" .
+triage:r1 a triage:Resolution ; triage:resolves triage:f1 ;
+    triage:resolvedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+"""
+        from rdflib import Literal
+        g = Graph()
+        g.parse(data=findings, format="turtle")
+        rows = list(g.query(
+            (SCRIPTS / "open-findings-for-sprint.sparql").read_text(),
+            initBindings={"SPRINT": URIRef(f"{TRIAGE}S1"), "BRANCH": Literal("feature/x")},
+        ))
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "F-1"
+
+    def test_branch_scoped_occurrence_closed_still_excluded(self):
+        """Sanity check: branch-scoped mode still excludes a finding whose
+        occurrence on that specific branch is actually closed."""
+        from rdflib import Literal
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ;
+    triage:description "fixed on this branch" ;
+    triage:hasOccurrence triage:occ1 .
+triage:occ1 triage:branch "feature/x" ; triage:closed true ; triage:status "fixed" .
+"""
+        g = Graph()
+        g.parse(data=findings, format="turtle")
+        rows = list(g.query(
+            (SCRIPTS / "open-findings-for-sprint.sparql").read_text(),
+            initBindings={"SPRINT": URIRef(f"{TRIAGE}S1"), "BRANCH": Literal("feature/x")},
+        ))
+        assert len(rows) == 0
+
 
 # ── validate-structure tests ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `open-findings-for-sprint.sparql` applied its legacy-mode terminal-status check and Resolution-existence filter unconditionally, even in branch-scoped (`$BRANCH` bound) mode.
- A single mistaken `triage:Resolution` event permanently suppressed a finding from every branch's open-findings report, independent of that branch's own occurrence state — this actually happened on `integrate/phase-ao2` on 2026-08-24 (AO212-MIGRATE-F001..F006, Resolution events r20-r25 recorded before the fix commits existed on any branch).
- Branch-scoped mode now relies solely on the occurrence's own `closed`/`status` fields, matching this query's own documented intent. Legacy origin-sprint mode is unchanged.

## Test plan
- [x] `python3 -m pytest .claude/skills/graph-orchestration/scripts/test_queries.py -v` — 37/37 pass, including two new regression tests (`test_branch_scoped_occurrence_open_survives_stale_resolution`, `test_branch_scoped_occurrence_closed_still_excluded`)
- [x] Verified against real `integrate/phase-ao2` data: patched query now correctly returns AO212-MIGRATE-F001..F008 as open on `feature/ao2-12-historical-data-migration` and `feature/ao2-13-benchmark-run-skill`, despite the stale Resolution events

🤖 Generated with [Claude Code](https://claude.com/claude-code)