### PR TITLE
fix(ci): remove bootstrap source-build wall-clock regression

### DIFF
--- a/.claude/lib/sc_compose_dependency.py
+++ b/.claude/lib/sc_compose_dependency.py
@@ -5,18 +5,12 @@ from __future__ import annotations
 import re
 
 
-SC_COMPOSE_SOURCE_REV = "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661"
-MIN_SC_COMPOSE = (1, 4, 0)
-MIN_SC_COMPOSE_TEXT = (
-    ">= 1.4.0 (released v1.4.0 source revision "
-    f"{SC_COMPOSE_SOURCE_REV})"
-)
+SC_COMPOSE_PIN = "1.5.0"
+MIN_SC_COMPOSE = (1, 5, 0)
+MIN_SC_COMPOSE_TEXT = ">= 1.5.0 (pinned prebuilt release binary)"
 MIN_SC_COMPOSE_BINDING = (1, 2, 0)
 MIN_SC_COMPOSE_BINDING_TEXT = ">= 1.2.0"
-SC_COMPOSE_INSTALL = (
-    "cargo install --git https://github.com/randlee/sc-compose.git "
-    f"--rev {SC_COMPOSE_SOURCE_REV} --locked --bin sc-compose"
-)
+SC_COMPOSE_INSTALL = f"download sc-compose v{SC_COMPOSE_PIN} prebuilt release asset and verify SHA256"
 SC_COMPOSE_BINDING_INSTALL = (
     "python3 -m pip install --user --break-system-packages "
     "'sc-compose>=1.2.0'"

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -6,7 +6,7 @@ repo: atm-core
 requires:
   cli:
     - name: sc-compose
-      minimum_version: 1.4.0
+      minimum_version: 1.5.0
     - name: jq
   python:
     - package: rdflib
@@ -45,7 +45,7 @@ the phase, invoking an agent, reading the cursor, or appending a TTL event:
 .claude/skills/graph-orchestration/scripts/preflight
 ```
 
-It checks the pinned released v1.4.0 `sc-compose` CLI, the matching `sc_compose >= 1.2.0`
+It checks the pinned released v1.5.0 `sc-compose` CLI, the matching `sc_compose >= 1.2.0`
 Python/maturin binding, `jq`, and a `python3` interpreter that can import
 `rdflib`. The command always emits a structured JSON result and exits `0`
 only when all runtime checks pass; exit `2` is an operational dependency error

--- a/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
+++ b/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
@@ -27,7 +27,7 @@ The required runtime dependencies are:
 
 | Dependency | Minimum | Used for |
 |---|---:|---|
-| `sc-compose` CLI | **released v1.4.0 source revision `6a8af1f`** | Rendering fenced Jinja templates and agent prompts |
+| `sc-compose` CLI | **released v1.5.0 prebuilt release binary** | Rendering fenced Jinja templates and agent prompts |
 | `sc_compose` Python binding | **1.2.0** | Python/maturin rendering integrations and wrappers |
 | Python + `rdflib` | **3.11+** | RDF/Turtle parsing and SPARQL queries |
 | `jq` | any current release | Reading the JSON cursor contract |
@@ -71,11 +71,13 @@ The executable and Python binding are separate artifacts.  Installing the
 PyPI wheel does **not** guarantee that a `sc-compose` executable is on `PATH`.
 Install both and keep them at the same minimum version.
 
-For the CLI, use the pinned source revision required by the report templates:
+For the CLI, use the pinned prebuilt release asset required by the report templates:
 
 ```bash
-cargo install --git https://github.com/randlee/sc-compose.git \
-  --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+Download the platform-matching v1.5.0 archive from `randlee/sc-compose`,
+verify its SHA256 against `checksums.txt`, and unpack `sc-compose` into the
+bootstrap tools directory. `just bootstrap` performs this hard-fail check;
+never compile the CLI from source.
 ```
 
 For the Python/maturin binding (a one-time per-machine setup; no activation
@@ -101,7 +103,7 @@ sudo apt-get install jq                 # Debian/Ubuntu; use the native package 
 ```
 
 The PyPI package supplies the `sc_compose` Python binding, not the standalone
-CLI. Install the CLI from the pinned source revision above, then rerun
+CLI. Install the prebuilt CLI from the pinned release above, then rerun
 preflight.
 
 The pip wheel above is the Python binding and is not a CLI installation; use
@@ -113,7 +115,8 @@ one-time install command and in the preflight.
 
 ```powershell
 py -m pip install --user --break-system-packages "sc-compose>=1.2.0"
-cargo install --git https://github.com/randlee/sc-compose.git --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+Download and verify the platform-matching v1.5.0 release archive as described
+above; do not compile the CLI from source.
 winget install jqlang.jq
 ```
 
@@ -129,13 +132,13 @@ python3 -m pytest .claude/skills/graph-orchestration/scripts/test_validate_findi
 ```
 
 The first command must return `"success": true` and report
-the pinned released v1.4.0 `sc-compose` build. A test pass does not override a failed
+the pinned released v1.5.0 `sc-compose` build. A test pass does not override a failed
 preflight: dependency errors are distinct from expected validation failures.
 
 ## Known issues
 
 - **The v1.3.0 CLI is rejected for current templates.** Install the pinned
-  source revision above; the Python binding remains a separate `>=1.2.0`
+  v1.5.0 prebuilt release above; the Python binding remains a separate `>=1.2.0`
   artifact.
 - **`rdflib` import fails although it was installed.** `pip` and `python3`
   often point at different interpreters.  Compare `command -v python3` with

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -28,7 +28,7 @@ def _module():
 def test_version_floor_is_semver_and_inclusive():
     preflight = _module()
     assert preflight._version("sc-compose 1.2.0") == (1, 2, 0)
-    assert preflight._version("sc-compose 1.4.1") > preflight.MIN_SC_COMPOSE
+    assert preflight._version("sc-compose 1.5.1") > preflight.MIN_SC_COMPOSE
     assert preflight._version("sc-compose 1.2.9") < preflight.MIN_SC_COMPOSE
     assert preflight._version("unknown") is None
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -5,7 +5,7 @@ description: Orchestrate pre-dispatch QA finding triage as team-lead. Launch one
 requires:
   cli:
     - name: sc-compose
-      minimum_version: 1.4.0
+      minimum_version: 1.5.0
     - name: oxigraph
     - name: rg
   python:
@@ -34,7 +34,7 @@ record:
 python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
 ```
 
-The preflight requires the released v1.4.0 `sc-compose` CLI at the pinned source revision and
+The preflight requires the released v1.5.0 `sc-compose` CLI prebuilt release binary and
 the Python `sc_compose` binding at `>= 1.2.0`, plus `oxigraph`, `rg`, and Python `rdflib`. It checks PATH plus
 common Homebrew/Cargo/user-install locations and returns a structured result.
 A non-zero result is a hard stop; read

--- a/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
+++ b/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
@@ -5,7 +5,7 @@ requires:
 
 | Dependency | Minimum | Purpose |
 |---|---:|---|
-| `sc-compose` CLI | **released v1.4.0 source revision `6a8af1f`** | Render canonical Turtle records |
+| `sc-compose` CLI | **released v1.5.0 prebuilt release binary** | Render canonical Turtle records |
 | Python `sc_compose` binding | **1.2.0** | Native Python rendering/API tests |
 | `oxigraph` | supported installed release | Parse/validate rendered Turtle |
 | `rg` | installed | Sweep source worktrees |
@@ -29,8 +29,10 @@ macOS (one-time per-machine setup):
 ```bash
 python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
 # The CLI pin below is required for the current report/template contract.
-cargo install --git https://github.com/randlee/sc-compose.git \
-  --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+Download the platform-matching `sc-compose` v1.5.0 release archive from
+`randlee/sc-compose`, verify its SHA256 against the release `checksums.txt`,
+and unpack the executable into the bootstrap tools directory. `just bootstrap`
+performs this verification automatically; do not compile it with Cargo.
 cargo install oxigraph-cli
 ```
 
@@ -39,16 +41,16 @@ The `--user` target avoids Homebrew-managed site-packages and
 user-owned wheel. Do not create or activate a venv for this setup. The PyPI
 package supplies the `sc_compose` Python binding (Python 3.11+; prebuilt
 platform wheels); it does not replace the standalone `sc-compose` CLI. On
-Linux without Homebrew, install the CLI from the pinned source revision
+Linux without Homebrew, install the CLI from the pinned release
 shown above.
 
 Linux:
 
 ```bash
 python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
-# Install the standalone CLI from the pinned source revision:
-cargo install --git https://github.com/randlee/sc-compose.git \
-  --rev 6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661 --locked --bin sc-compose
+# Install the pinned released standalone CLI:
+Download and verify the platform-matching v1.5.0 release archive as described
+above; do not compile the CLI with Cargo.
 cargo install oxigraph-cli
 ```
 
@@ -96,7 +98,7 @@ host-specific absolute checkout path in a canonical Turtle record.
 ## Validate after setup
 
 ```bash
-sc-compose --version       # CLI must be the pinned released v1.4.0 build
+sc-compose --version       # CLI must be the pinned released v1.5.0 build
 oxigraph --version
 rg --version
 python3 -c 'import rdflib; print(rdflib.__version__)'
@@ -107,7 +109,7 @@ python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
 ## Known issues
 
 - The v1.3.0 CLI is insufficient for the current templates. Install the pinned
-  source revision above; do not lower the requirement or substitute a release
+  v1.5.0 prebuilt release above; do not lower the requirement or substitute an older release
   binary.
 - Installing with one Python and invoking the skill with another leaves
   `rdflib` unavailable. Compare `python3 -c 'import sys; print(sys.executable)'`

--- a/.claude/skills/triaging-findings/tests/test_check_dependencies.py
+++ b/.claude/skills/triaging-findings/tests/test_check_dependencies.py
@@ -20,7 +20,7 @@ def test_version_parser():
 
 def test_preflight_passes_in_current_environment(monkeypatch):
     monkeypatch.setattr(check_dependencies, "_find", lambda name: Path("/bin/true"))
-    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("tool 1.4.0", "tool 1.4.0"))
+    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("tool 1.5.0", "tool 1.5.0"))
     monkeypatch.setattr(check_dependencies, "_python_binding_entry", lambda: {"name": "sc_compose", "ok": True})
     result = check_dependencies.run()
     assert result["success"] is True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           tool: just@1.58.0
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
         with:
           version: "1.22.0"
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Install cargo-binstall
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
         with:
           version: "1.22.0"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           tool: just@1.58.0
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
         with:
           version: "1.22.0"
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Install cargo-binstall
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
         with:
           version: "1.22.0"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,28 @@ jobs:
       - name: Expose Cargo binaries on PATH
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
+      - name: Cache bootstrap outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/binstall
+            .bootstrap-venv
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/bootstrap.toml', 'tools/bootstrap-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
+
       - name: Install just
         uses: taiki-e/install-action@v2
         with:
           tool: just@1.58.0
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+        with:
+          version: "1.22.0"
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
@@ -183,10 +201,6 @@ jobs:
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
-      - name: Bootstrap exact repository tools
-        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        run: just bootstrap
-
       - name: Cache cargo registry
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         uses: actions/cache@v4
@@ -207,6 +221,30 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache bootstrap outputs
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/binstall
+            .bootstrap-venv
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/bootstrap.toml', 'tools/bootstrap-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
+
+      - name: Install cargo-binstall
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        uses: cargo-bins/cargo-binstall@main
+        with:
+          version: "1.22.0"
+
+      - name: Bootstrap exact repository tools
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        run: just bootstrap
 
       - name: Build workspace
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           tool: just@1.58.0
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
         with:
           version: "1.22.0"
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Install cargo-binstall
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
-        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
         with:
           version: "1.22.0"
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-bootstrap-
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
         with:
           version: "1.22.0"
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -57,6 +57,24 @@ jobs:
       - name: Expose Cargo binaries on PATH
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
+      - name: Cache bootstrap outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/binstall
+            .bootstrap-venv
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/bootstrap.toml', 'tools/bootstrap-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+        with:
+          version: "1.22.0"
+
       - name: Bootstrap exact repository tools
         run: just bootstrap
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-bootstrap-
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@7eefb2120c193890ad0a44c3714f73a1f621b35a # v1.15.0
         with:
           version: "1.22.0"
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-bootstrap-
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # main @ 2026-08-25
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
         with:
           version: "1.22.0"
 

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -129,6 +129,54 @@ class BootstrapTests(unittest.TestCase):
             self.assertTrue(bootstrap.binstall_tool_matches("cargo-audit", "0.22.2"))
             self.assertFalse(bootstrap.binstall_tool_matches("cargo-audit", "0.22.3"))
 
+    def test_ci_rejects_registry_compile_fallback(self) -> None:
+        manifest = bootstrap.load_manifest()
+        calls: list[tuple[list[str], bool]] = []
+
+        def failed_binstall(command: list[str], *, dry_run: bool, allow_failure: bool = False) -> bool:
+            calls.append((command, allow_failure))
+            return False
+
+        with (
+            mock.patch.dict("os.environ", {"CI": "true"}),
+            mock.patch.object(bootstrap, "synchronize_macos_seed_tools"),
+            mock.patch.object(bootstrap, "verify_seed_tools"),
+            mock.patch.object(bootstrap, "ensure_bootstrap_venv", return_value=Path("/tmp/bootstrap-python")),
+            mock.patch.object(bootstrap, "registry_tool_matches", return_value=False),
+            mock.patch.object(bootstrap, "binstall_tool_matches", return_value=False),
+            mock.patch.object(bootstrap, "cargo_binstall_available", return_value=True),
+            mock.patch.object(bootstrap, "run", side_effect=failed_binstall),
+        ):
+            with self.assertRaisesRegex(bootstrap.BootstrapError, "could not install the exact prebuilt cargo-deny"):
+                bootstrap.bootstrap(manifest, dry_run=False)
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(calls[0][1])
+
+    def test_local_bootstrap_keeps_registry_fallback(self) -> None:
+        manifest = bootstrap.load_manifest()
+        calls: list[tuple[list[str], bool]] = []
+
+        def failed_binstall(command: list[str], *, dry_run: bool, allow_failure: bool = False) -> bool:
+            calls.append((command, allow_failure))
+            return False
+
+        with (
+            mock.patch.dict("os.environ", {"CI": ""}),
+            mock.patch.object(bootstrap, "synchronize_macos_seed_tools"),
+            mock.patch.object(bootstrap, "verify_seed_tools"),
+            mock.patch.object(bootstrap, "ensure_bootstrap_venv", return_value=Path("/tmp/bootstrap-python")),
+            mock.patch.object(bootstrap, "registry_tool_matches", return_value=False),
+            mock.patch.object(bootstrap, "binstall_tool_matches", return_value=False),
+            mock.patch.object(bootstrap, "cargo_binstall_available", return_value=True),
+            mock.patch.object(bootstrap, "sc_compose_matches", return_value=True),
+            mock.patch.object(bootstrap, "verify_installed_tools"),
+            mock.patch.object(bootstrap, "run", side_effect=failed_binstall),
+        ):
+            bootstrap.bootstrap(manifest, dry_run=False)
+        self.assertEqual(calls[0][0][1], "binstall")
+        self.assertTrue(calls[0][1])
+        self.assertEqual(calls[1][0][:2], ["cargo", "install"])
+
     def test_ci_uses_the_shared_bootstrap_recipe(self) -> None:
         workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
         self.assertIn('python-version: "3.14.7"', workflow)

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -71,7 +71,7 @@ class BootstrapTests(unittest.TestCase):
     def test_registry_receipt_rejects_an_unpinned_release(self) -> None:
         receipt = {"cargo-shear 1.13.2 (registry+https://example.test/index)": {"rustc": "release: 1.94.1"}}
         with mock.patch.object(bootstrap, "cargo_receipts", return_value=receipt):
-            self.assertFalse(bootstrap.registry_tool_matches("cargo-shear", "1.12.0", "1.94.1"))
+            self.assertFalse(bootstrap.registry_tool_matches("cargo-shear", "1.13.3", "1.94.1"))
 
     def test_manifest_uses_current_compatible_stable_releases(self) -> None:
         manifest = bootstrap.load_manifest()
@@ -80,7 +80,7 @@ class BootstrapTests(unittest.TestCase):
         self.assertEqual(dict(manifest.cargo_tools), {
             "cargo-deny": "0.20.2",
             "cargo-audit": "0.22.2",
-            "cargo-shear": "1.12.0",
+            "cargo-shear": "1.13.3",
             "cargo-modules": "0.26.0",
         })
         self.assertEqual(dict(manifest.cargo_allowed_strategies), {

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -50,6 +50,15 @@ class BootstrapTests(unittest.TestCase):
             "--disable-strategies", "quick-install,compile", "--force", "cargo-audit@0.22.2",
         ])
 
+    def test_cargo_modules_uses_quick_install_without_compile(self) -> None:
+        command = bootstrap.cargo_binstall_command(
+            "cargo-modules", "0.26.0", force=True, allow_quick_install=True
+        )
+        self.assertEqual(command, [
+            "cargo", "binstall", "--no-confirm", "--disable-telemetry",
+            "--disable-strategies", "compile", "--force", "cargo-modules@0.26.0",
+        ])
+
     def test_registry_tools_are_exact_and_locked(self) -> None:
         command = bootstrap.cargo_install_command("cargo-audit", "0.22.2", force=True)
         self.assertEqual(command, ["cargo", "install", "--locked", "--force", "--version", "0.22.2", "cargo-audit"])

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -23,11 +23,18 @@ class BootstrapTests(unittest.TestCase):
         versions.extend(version for _, version in manifest.python_packages)
         self.assertTrue(all("*" not in version and ">" not in version and "<" not in version for version in versions))
 
-    def test_sc_compose_uses_the_repository_authoritative_revision(self) -> None:
+    def test_sc_compose_uses_the_exact_released_registry_version(self) -> None:
         manifest = bootstrap.load_manifest()
-        command = bootstrap.sc_compose_install_command(manifest.sc_compose_rev, force=True)
-        self.assertIn(manifest.sc_compose_rev, command)
+        command = bootstrap.sc_compose_install_command(manifest.sc_compose, force=True)
+        self.assertEqual(command, ["cargo", "install", "--locked", "--force", "--version", "1.4.0", "sc-compose"])
         self.assertIn("--locked", command)
+
+    def test_binstall_uses_prebuilt_only_and_exact_version(self) -> None:
+        command = bootstrap.cargo_binstall_command("cargo-audit", "0.22.2", force=True)
+        self.assertEqual(command, [
+            "cargo", "binstall", "--no-confirm", "--disable-telemetry",
+            "--disable-strategies", "quick-install,compile", "--force", "cargo-audit@0.22.2",
+        ])
 
     def test_registry_tools_are_exact_and_locked(self) -> None:
         command = bootstrap.cargo_install_command("cargo-audit", "0.22.2", force=True)
@@ -53,6 +60,7 @@ class BootstrapTests(unittest.TestCase):
             "cargo-shear": "1.12.0",
             "cargo-modules": "0.26.0",
         })
+        self.assertEqual(manifest.sc_compose, "1.4.0")
         self.assertEqual(dict(manifest.python_packages)["maturin"], "1.14.1")
 
     def test_macos_homebrew_seed_formula_is_derived_from_the_exact_python_pin(self) -> None:
@@ -100,19 +108,11 @@ class BootstrapTests(unittest.TestCase):
             with self.assertRaisesRegex(bootstrap.BootstrapError, "Python must be exactly"):
                 bootstrap.verify_seed_tools(manifest)
 
-    def test_sc_compose_receipt_requires_the_exact_git_revision(self) -> None:
-        manifest = bootstrap.load_manifest()
-        expected_key = (
-            "sc-compose 1.4.0 "
-            f"(git+{bootstrap.SC_COMPOSE_REPOSITORY}?rev={manifest.sc_compose_rev}#{manifest.sc_compose_rev})"
-        )
-        with mock.patch.object(bootstrap, "cargo_receipts", return_value={expected_key: {"rustc": "release: 1.94.1"}}):
-            bootstrap.verify_sc_compose_receipt(manifest.sc_compose_rev)
-
-    def test_sc_compose_receipt_rejects_a_different_revision(self) -> None:
-        with mock.patch.object(bootstrap, "cargo_receipts", return_value={"sc-compose 1.4.0": {"rustc": "release: 1.94.1"}}):
-            with self.assertRaisesRegex(bootstrap.BootstrapError, "exact source revision"):
-                bootstrap.verify_sc_compose_receipt("expected-revision")
+    def test_binstall_receipt_proves_exact_prebuilt_version(self) -> None:
+        receipt = [{"crate_info": {"name": "cargo-audit", "current_version": "0.22.2"}}]
+        with mock.patch.object(bootstrap, "binstall_receipts", return_value=receipt):
+            self.assertTrue(bootstrap.binstall_tool_matches("cargo-audit", "0.22.2"))
+            self.assertFalse(bootstrap.binstall_tool_matches("cargo-audit", "0.22.3"))
 
     def test_ci_uses_the_shared_bootstrap_recipe(self) -> None:
         workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
@@ -135,7 +135,7 @@ class BootstrapTests(unittest.TestCase):
         self.assertIn("run: just test-admission-capacity", workflow)
         self.assertNotIn("run: python -m unittest scripts/smoke/test_run_admission_capacity.py", workflow)
         self.assertNotIn("pydantic>=2,<3", workflow)
-        self.assertEqual(workflow.count("tools/bootstrap-requirements.txt"), 3)
+        self.assertGreaterEqual(workflow.count("tools/bootstrap-requirements.txt"), 3)
 
     def test_seed_python_preserves_ci_python_precedence(self) -> None:
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -123,7 +123,8 @@ class BootstrapTests(unittest.TestCase):
                 bootstrap.verify_seed_tools(manifest)
 
     def test_binstall_receipt_proves_exact_prebuilt_version(self) -> None:
-        receipt = [{"crate_info": {"name": "cargo-audit", "current_version": "0.22.2"}}]
+        # Binstall's crates-v1.json flattens CrateInfo fields into each record.
+        receipt = [{"name": "cargo-audit", "current_version": "0.22.2"}]
         with mock.patch.object(bootstrap, "binstall_receipts", return_value=receipt):
             self.assertTrue(bootstrap.binstall_tool_matches("cargo-audit", "0.22.2"))
             self.assertFalse(bootstrap.binstall_tool_matches("cargo-audit", "0.22.3"))

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -52,7 +52,7 @@ class BootstrapTests(unittest.TestCase):
 
     def test_cargo_modules_uses_quick_install_without_compile(self) -> None:
         command = bootstrap.cargo_binstall_command(
-            "cargo-modules", "0.26.0", force=True, allow_quick_install=True
+            "cargo-modules", "0.26.0", force=True, allowed_strategies=("quick-install",)
         )
         self.assertEqual(command, [
             "cargo", "binstall", "--no-confirm", "--disable-telemetry",
@@ -82,6 +82,12 @@ class BootstrapTests(unittest.TestCase):
             "cargo-audit": "0.22.2",
             "cargo-shear": "1.12.0",
             "cargo-modules": "0.26.0",
+        })
+        self.assertEqual(dict(manifest.cargo_allowed_strategies), {
+            "cargo-deny": (),
+            "cargo-audit": ("quick-install",),
+            "cargo-shear": (),
+            "cargo-modules": ("quick-install",),
         })
         self.assertEqual(manifest.sc_compose, "1.5.0")
         self.assertEqual(dict(manifest.python_packages)["maturin"], "1.14.1")

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -132,6 +132,7 @@ class BootstrapTests(unittest.TestCase):
         workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
         self.assertIn('python-version: "3.14.7"', workflow)
         self.assertIn("tool: just@1.58.0", workflow)
+        self.assertIn("cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c", workflow)
         self.assertGreaterEqual(workflow.count("run: just bootstrap"), 2)
 
     def test_just_recipes_propagate_the_bootstrap_python_to_children(self) -> None:

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -23,11 +23,25 @@ class BootstrapTests(unittest.TestCase):
         versions.extend(version for _, version in manifest.python_packages)
         self.assertTrue(all("*" not in version and ">" not in version and "<" not in version for version in versions))
 
-    def test_sc_compose_uses_the_exact_released_registry_version(self) -> None:
+    def test_sc_compose_uses_the_exact_prebuilt_release_asset(self) -> None:
         manifest = bootstrap.load_manifest()
-        command = bootstrap.sc_compose_install_command(manifest.sc_compose, force=True)
-        self.assertEqual(command, ["cargo", "install", "--locked", "--force", "--version", "1.4.0", "sc-compose"])
-        self.assertIn("--locked", command)
+        asset, url = bootstrap.sc_compose_install_command(manifest.sc_compose, "aarch64-apple-darwin")
+        self.assertEqual(asset, "sc-compose_1.5.0_aarch64-apple-darwin.tar.gz")
+        self.assertEqual(url, "https://github.com/randlee/sc-compose/releases/download/v1.5.0/" + asset)
+        self.assertEqual(dict(manifest.sc_compose_checksums)["aarch64-apple-darwin"], "7751631cd86e6644e88cfcf3dd80f352779350f9f24f891f52983c8da0ed4620")
+
+    def test_sc_compose_install_never_uses_cargo(self) -> None:
+        source = (SCRIPT.parents[1] / "tools" / "bootstrap.py").read_text(encoding="utf-8")
+        self.assertNotIn('cargo", "install", "--locked", "--version", version, "sc-compose"', source)
+
+    def test_sc_compose_checksum_mismatch_is_a_hard_failure(self) -> None:
+        manifest = bootstrap.load_manifest()
+        with (
+            mock.patch.object(bootstrap, "sc_compose_target", return_value="aarch64-apple-darwin"),
+            mock.patch.object(bootstrap, "_download_release", return_value=b"tampered"),
+        ):
+            with self.assertRaisesRegex(bootstrap.BootstrapError, "checksum mismatch"):
+                bootstrap.install_sc_compose_release(manifest, dry_run=False)
 
     def test_binstall_uses_prebuilt_only_and_exact_version(self) -> None:
         command = bootstrap.cargo_binstall_command("cargo-audit", "0.22.2", force=True)
@@ -60,7 +74,7 @@ class BootstrapTests(unittest.TestCase):
             "cargo-shear": "1.12.0",
             "cargo-modules": "0.26.0",
         })
-        self.assertEqual(manifest.sc_compose, "1.4.0")
+        self.assertEqual(manifest.sc_compose, "1.5.0")
         self.assertEqual(dict(manifest.python_packages)["maturin"], "1.14.1")
 
     def test_macos_homebrew_seed_formula_is_derived_from_the_exact_python_pin(self) -> None:

--- a/docs/development/bootstrap.md
+++ b/docs/development/bootstrap.md
@@ -8,9 +8,18 @@ closure is in [`tools/bootstrap-requirements.txt`](../../tools/bootstrap-require
 
 The recipe deliberately does not select a latest release, a version range, or
 an M5-specific installation path. It installs the manifest's exact Cargo tools
-and source revision, creates a repository-local `.bootstrap-venv`, installs the
-exact Python packages there with `--no-deps`,
-then verifies every reported version.
+from verified prebuilt artifacts when `cargo-binstall` is available, falls back
+to locked crates.io installs when an artifact is unavailable, and installs the
+released `sc-compose` CLI from crates.io (never a Git revision). It creates a
+repository-local `.bootstrap-venv`, installs the exact Python packages there
+with `--no-deps`, then verifies every reported version against Cargo or
+Binstall's installation receipt.
+
+CI restores the bootstrap outputs (`~/.cargo/bin`, Cargo/Binstall receipts, and
+`.bootstrap-venv`) with a key derived from this manifest and the Python
+requirements before invoking `just bootstrap`. The test jobs restore their
+Cargo registry/index/build caches first as well, so a genuine registry
+fallback remains bounded and never runs ahead of a warm workspace cache.
 
 ## Seed contract
 

--- a/docs/development/bootstrap.md
+++ b/docs/development/bootstrap.md
@@ -10,10 +10,14 @@ The recipe deliberately does not select a latest release, a version range, or
 an M5-specific installation path. It installs the manifest's exact Cargo tools
 from verified prebuilt artifacts when `cargo-binstall` is available, falls back
 to locked crates.io installs when an artifact is unavailable, and installs the
-released `sc-compose` CLI from crates.io (never a Git revision). It creates a
+released `sc-compose` CLI from its platform-matching GitHub release archive
+(never Cargo source or a Git revision). The release archive SHA256 is pinned in
+`tools/bootstrap.toml` and checked against the release `checksums.txt`; a mismatch
+or missing asset is a hard failure. It creates a
 repository-local `.bootstrap-venv`, installs the exact Python packages there
 with `--no-deps`, then verifies every reported version against Cargo or
-Binstall's installation receipt.
+Binstall's installation receipt; the sc-compose release binary is verified by
+its pinned SHA256 and its `--version` output.
 
 CI restores the bootstrap outputs (`~/.cargo/bin`, Cargo/Binstall receipts, and
 `.bootstrap-venv`) with a key derived from this manifest and the Python

--- a/docs/development/bootstrap.md
+++ b/docs/development/bootstrap.md
@@ -69,8 +69,7 @@ binary, run `daemon-switch`, start a daemon, or touch an ATM database.
 ## Version-selection policy
 
 Every manifest entry pins the newest stable release compatible with the
-repository's pinned Rust and Python baselines. The current exceptions are
-`cargo-shear` `1.12.0` (upstream `1.13.4` requires Rust `1.95.0`) and
+repository's pinned Rust and Python baselines. The current exception is
 `cargo-modules` `0.26.0` (upstream `0.27.0` requires Rust `1.95.0`), while this
 repository deliberately pins Rust `1.94.1`. Compatibility exceptions must be
 documented here and re-evaluated whenever the seed Rust version changes.

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -13,8 +14,13 @@ import re
 import shutil
 import subprocess
 import sys
+import tarfile
+import tempfile
 import tomllib
 from typing import Sequence
+import urllib.error
+import urllib.request
+import zipfile
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -34,6 +40,7 @@ class BootstrapManifest:
     just: str
     cargo_tools: tuple[tuple[str, str], ...]
     sc_compose: str
+    sc_compose_checksums: tuple[tuple[str, str], ...]
     python_packages: tuple[tuple[str, str], ...]
 
 
@@ -42,6 +49,7 @@ def load_manifest(path: Path = MANIFEST_PATH) -> BootstrapManifest:
     raw = tomllib.loads(path.read_text(encoding="utf-8"))
     toolchain = raw["toolchain"]
     cargo = raw["cargo"]
+    sc_compose = raw["sc-compose"]
     python = raw["python"]
     return BootstrapManifest(
         rust=toolchain["rust"],
@@ -53,7 +61,8 @@ def load_manifest(path: Path = MANIFEST_PATH) -> BootstrapManifest:
             ("cargo-shear", cargo["cargo-shear"]),
             ("cargo-modules", cargo["cargo-modules"]),
         ),
-        sc_compose=cargo["sc-compose"],
+        sc_compose=sc_compose["version"],
+        sc_compose_checksums=tuple(sorted(sc_compose["checksums"].items())),
         python_packages=tuple(sorted(python.items())),
     )
 
@@ -150,12 +159,40 @@ def cargo_install_command(name: str, version: str, *, force: bool) -> list[str]:
     return [*command, "--version", version, name]
 
 
-def sc_compose_install_command(version: str, *, force: bool) -> list[str]:
-    """Return the registry install command for the released sc-compose CLI."""
-    command = ["cargo", "install", "--locked"]
-    if force:
-        command.append("--force")
-    return [*command, "--version", version, "sc-compose"]
+SC_COMPOSE_RELEASE_REPOSITORY = "randlee/sc-compose"
+
+
+def sc_compose_target() -> str:
+    """Map the runner to a release target with a published prebuilt asset."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "darwin":
+        if machine in {"arm64", "aarch64"}:
+            return "aarch64-apple-darwin"
+        if machine in {"x86_64", "amd64"}:
+            return "x86_64-apple-darwin"
+    elif system == "linux" and machine in {"x86_64", "amd64"}:
+        return "x86_64-unknown-linux-gnu"
+    elif system == "windows" and machine in {"x86_64", "amd64"}:
+        return "x86_64-pc-windows-msvc"
+    raise BootstrapError(f"sc-compose has no prebuilt release asset for {platform.system()} {platform.machine()}.")
+
+
+def sc_compose_asset_name(version: str, target: str) -> str:
+    """Return the exact release asset filename for a target triple."""
+    suffix = ".zip" if "windows" in target else ".tar.gz"
+    return f"sc-compose_{version}_{target}{suffix}"
+
+
+def sc_compose_release_url(version: str, asset: str) -> str:
+    """Return the immutable GitHub release URL for one pinned asset."""
+    return f"https://github.com/{SC_COMPOSE_RELEASE_REPOSITORY}/releases/download/v{version}/{asset}"
+
+
+def sc_compose_install_command(version: str, target: str) -> tuple[str, str]:
+    """Describe the pinned prebuilt release install for dry-run/tests."""
+    asset = sc_compose_asset_name(version, target)
+    return (asset, sc_compose_release_url(version, asset))
 
 
 def cargo_binstall_command(name: str, version: str, *, force: bool) -> list[str]:
@@ -218,6 +255,86 @@ def cargo_bin_path(name: str) -> Path:
     cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo"))
     suffix = ".exe" if sys.platform == "win32" else ""
     return cargo_home / "bin" / f"{name}{suffix}"
+
+
+def _release_checksum(manifest: BootstrapManifest, target: str) -> str:
+    checksums = dict(manifest.sc_compose_checksums)
+    try:
+        return checksums[target]
+    except KeyError as error:
+        raise BootstrapError(f"sc-compose manifest has no checksum for release target {target}.") from error
+
+
+def _download_release(url: str) -> bytes:
+    """Download one release asset without invoking a shell or package manager."""
+    try:
+        with urllib.request.urlopen(url, timeout=120) as response:
+            return response.read()
+    except (OSError, urllib.error.URLError) as error:
+        raise BootstrapError(f"unable to download pinned sc-compose release asset {url}: {error}") from error
+
+
+def _safe_member_name(name: str) -> str:
+    path = Path(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise BootstrapError(f"sc-compose release archive contains unsafe path {name!r}.")
+    return path.as_posix()
+
+
+def _extract_sc_compose(archive: bytes, asset: str, destination: Path) -> None:
+    """Extract only the expected executable from a verified release archive."""
+    executable_name = "sc-compose.exe" if asset.endswith(".zip") else "sc-compose"
+    with tempfile.TemporaryDirectory(prefix="atm-sc-compose-") as temp_dir:
+        archive_path = Path(temp_dir) / asset
+        archive_path.write_bytes(archive)
+        if asset.endswith(".zip"):
+            with zipfile.ZipFile(archive_path) as package:
+                members = { _safe_member_name(name): name for name in package.namelist() }
+                member = next((original for safe, original in members.items() if Path(safe).name == executable_name), None)
+                if member is None:
+                    raise BootstrapError(f"verified sc-compose archive does not contain {executable_name}.")
+                binary = package.read(member)
+        else:
+            with tarfile.open(archive_path, mode="r:gz") as package:
+                member = next(
+                    (item for item in package.getmembers() if Path(_safe_member_name(item.name)).name == executable_name),
+                    None,
+                )
+                if member is None or not member.isfile():
+                    raise BootstrapError(f"verified sc-compose archive does not contain {executable_name}.")
+                extracted = package.extractfile(member)
+                if extracted is None:
+                    raise BootstrapError("verified sc-compose executable could not be read from the archive.")
+                binary = extracted.read()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+    temporary.write_bytes(binary)
+    if sys.platform != "win32":
+        temporary.chmod(0o755)
+    os.replace(temporary, destination)
+
+
+def install_sc_compose_release(manifest: BootstrapManifest, *, dry_run: bool) -> None:
+    """Install the pinned GitHub release asset; never compile or fall back."""
+    target = sc_compose_target()
+    asset, url = sc_compose_install_command(manifest.sc_compose, target)
+    expected = _release_checksum(manifest, target)
+    destination = cargo_bin_path("sc-compose")
+    print(f"+ download {url} -> {destination}")
+    if dry_run:
+        return
+    archive = _download_release(url)
+    actual = hashlib.sha256(archive).hexdigest()
+    if actual != expected:
+        raise BootstrapError(
+            f"sc-compose release checksum mismatch for {asset}: expected {expected}, found {actual}."
+        )
+    checksums_url = sc_compose_release_url(manifest.sc_compose, "checksums.txt")
+    checksums = _download_release(checksums_url).decode("utf-8", errors="strict")
+    listed = next((parts[0] for line in checksums.splitlines() if (parts := line.split()) and len(parts) >= 2 and parts[-1] == asset), None)
+    if listed != expected:
+        raise BootstrapError(f"checksums.txt does not confirm the pinned checksum for {asset}.")
+    _extract_sc_compose(archive, asset, destination)
 
 
 def cargo_receipts() -> dict[str, object]:
@@ -307,8 +424,12 @@ def registry_tool_matches(name: str, version: str, rust: str) -> bool:
 
 
 def sc_compose_matches(manifest: BootstrapManifest) -> bool:
-    """Prove the released sc-compose CLI is installed from the registry."""
-    return registry_tool_matches("sc-compose", manifest.sc_compose, manifest.rust)
+    """Prove the installed release binary reports the exact pinned version."""
+    try:
+        require_version("sc-compose", command_output([str(cargo_bin_path("sc-compose")), "--version"]), manifest.sc_compose)
+    except (BootstrapError, OSError):
+        return False
+    return True
 
 
 def cargo_binstall_available() -> bool:
@@ -346,7 +467,7 @@ def verify_installed_tools(manifest: BootstrapManifest, python: Path) -> None:
     sc_compose = cargo_bin_path("sc-compose")
     command_output([str(sc_compose), "--version"])
     if not sc_compose_matches(manifest):
-        raise BootstrapError(f"sc-compose is not the exact released registry version {manifest.sc_compose}.")
+        raise BootstrapError(f"sc-compose is not the exact pinned prebuilt release version {manifest.sc_compose}.")
     for package, version in manifest.python_packages:
         try:
             actual = python_package_version(python, package)
@@ -375,7 +496,7 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
         if not installed:
             run(cargo_install_command(name, version, force=True), dry_run=dry_run)
     if not sc_compose_matches(manifest):
-        run(sc_compose_install_command(manifest.sc_compose, force=True), dry_run=dry_run)
+        install_sc_compose_release(manifest, dry_run=dry_run)
     run(pip_install_command(python), dry_run=dry_run)
     if not dry_run:
         verify_installed_tools(manifest, python)

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -195,21 +195,28 @@ def sc_compose_install_command(version: str, target: str) -> tuple[str, str]:
     return (asset, sc_compose_release_url(version, asset))
 
 
-def cargo_binstall_command(name: str, version: str, *, force: bool) -> list[str]:
+def cargo_binstall_command(
+    name: str,
+    version: str,
+    *,
+    force: bool,
+    allow_quick_install: bool = False,
+) -> list[str]:
     """Return a non-compiling cargo-binstall command for one registry tool.
 
-    Disable Binstall's compile strategy so an unavailable artifact takes the
-    explicit Cargo registry fallback below instead of silently rebuilding from
-    source.  The quick-install strategy is also disabled: CI must consume the
-    tool's own release artifact or use the verified registry fallback.
+    Disable Binstall's compile strategy so an unavailable artifact cannot
+    silently rebuild from source.  The quick-install strategy is disabled for
+    tools with first-party release assets; cargo-modules explicitly enables it
+    because its upstream project publishes tags but no GitHub releases.
     """
+    disabled_strategies = "compile" if allow_quick_install else "quick-install,compile"
     command = [
         "cargo",
         "binstall",
         "--no-confirm",
         "--disable-telemetry",
         "--disable-strategies",
-        "quick-install,compile",
+        disabled_strategies,
     ]
     if force:
         command.append("--force")
@@ -495,8 +502,15 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
             continue
         installed = False
         if cargo_binstall_available():
+            # cargo-modules has no first-party release assets; permit only
+            # Binstall's third-party quick-install archive, never compilation.
             installed = run(
-                cargo_binstall_command(name, version, force=True),
+                cargo_binstall_command(
+                    name,
+                    version,
+                    force=True,
+                    allow_quick_install=name == "cargo-modules",
+                ),
                 dry_run=dry_run,
                 allow_failure=not ci,
             )

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -39,6 +39,7 @@ class BootstrapManifest:
     python: str
     just: str
     cargo_tools: tuple[tuple[str, str], ...]
+    cargo_allowed_strategies: tuple[tuple[str, tuple[str, ...]], ...]
     sc_compose: str
     sc_compose_checksums: tuple[tuple[str, str], ...]
     python_packages: tuple[tuple[str, str], ...]
@@ -49,17 +50,30 @@ def load_manifest(path: Path = MANIFEST_PATH) -> BootstrapManifest:
     raw = tomllib.loads(path.read_text(encoding="utf-8"))
     toolchain = raw["toolchain"]
     cargo = raw["cargo"]
+    cargo_allowed = raw["cargo-allowed-strategies"]
     sc_compose = raw["sc-compose"]
     python = raw["python"]
+    cargo_tools = (
+        ("cargo-deny", cargo["cargo-deny"]),
+        ("cargo-audit", cargo["cargo-audit"]),
+        ("cargo-shear", cargo["cargo-shear"]),
+        ("cargo-modules", cargo["cargo-modules"]),
+    )
+    if set(cargo_allowed) != {name for name, _version in cargo_tools}:
+        raise BootstrapError("cargo-allowed-strategies must name every cargo tool exactly once.")
+    if any(
+        not isinstance(strategies, list)
+        or any(strategy != "quick-install" for strategy in strategies)
+        for strategies in cargo_allowed.values()
+    ):
+        raise BootstrapError("cargo-allowed-strategies may contain only quick-install.")
     return BootstrapManifest(
         rust=toolchain["rust"],
         python=toolchain["python"],
         just=toolchain["just"],
-        cargo_tools=(
-            ("cargo-deny", cargo["cargo-deny"]),
-            ("cargo-audit", cargo["cargo-audit"]),
-            ("cargo-shear", cargo["cargo-shear"]),
-            ("cargo-modules", cargo["cargo-modules"]),
+        cargo_tools=cargo_tools,
+        cargo_allowed_strategies=tuple(
+            sorted((name, tuple(strategies)) for name, strategies in cargo_allowed.items())
         ),
         sc_compose=sc_compose["version"],
         sc_compose_checksums=tuple(sorted(sc_compose["checksums"].items())),
@@ -200,7 +214,7 @@ def cargo_binstall_command(
     version: str,
     *,
     force: bool,
-    allow_quick_install: bool = False,
+    allowed_strategies: Sequence[str] = (),
 ) -> list[str]:
     """Return a non-compiling cargo-binstall command for one registry tool.
 
@@ -209,7 +223,7 @@ def cargo_binstall_command(
     tools with first-party release assets; cargo-modules explicitly enables it
     because its upstream project publishes tags but no GitHub releases.
     """
-    disabled_strategies = "compile" if allow_quick_install else "quick-install,compile"
+    disabled_strategies = "compile" if "quick-install" in allowed_strategies else "quick-install,compile"
     command = [
         "cargo",
         "binstall",
@@ -497,19 +511,18 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
         verify_seed_tools(manifest)
     python = ensure_bootstrap_venv(manifest, dry_run=dry_run)
     ci = running_in_ci()
+    allowed_strategies = dict(manifest.cargo_allowed_strategies)
     for name, version in manifest.cargo_tools:
         if registry_tool_matches(name, version, manifest.rust) or binstall_tool_matches(name, version):
             continue
         installed = False
         if cargo_binstall_available():
-            # cargo-modules has no first-party release assets; permit only
-            # Binstall's third-party quick-install archive, never compilation.
             installed = run(
                 cargo_binstall_command(
                     name,
                     version,
                     force=True,
-                    allow_quick_install=name == "cargo-modules",
+                    allowed_strategies=allowed_strategies[name],
                 ),
                 dry_run=dry_run,
                 allow_failure=not ci,

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -390,9 +390,10 @@ def _version_text(value: object) -> str:
 def binstall_tool_matches(name: str, version: str) -> bool:
     """Prove a prebuilt tool came from Binstall at the exact requested version."""
     for record in binstall_receipts():
-        info = record.get("crate_info")
-        if not isinstance(info, dict):
-            continue
+        # `crates-v1.json` serializes `CrateInfo` with flattened fields; accept
+        # the nested shape too so older locally retained receipts remain usable.
+        nested = record.get("crate_info")
+        info = nested if isinstance(nested, dict) else record
         if info.get("name") == name and _version_text(info.get("current_version")) == version:
             return True
     return False

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -20,7 +21,6 @@ ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = ROOT / "tools" / "bootstrap.toml"
 REQUIREMENTS_PATH = ROOT / "tools" / "bootstrap-requirements.txt"
 VENV_PATH = ROOT / ".bootstrap-venv"
-SC_COMPOSE_REPOSITORY = "https://github.com/randlee/sc-compose.git"
 
 
 class BootstrapError(RuntimeError):
@@ -33,7 +33,7 @@ class BootstrapManifest:
     python: str
     just: str
     cargo_tools: tuple[tuple[str, str], ...]
-    sc_compose_rev: str
+    sc_compose: str
     python_packages: tuple[tuple[str, str], ...]
 
 
@@ -53,7 +53,7 @@ def load_manifest(path: Path = MANIFEST_PATH) -> BootstrapManifest:
             ("cargo-shear", cargo["cargo-shear"]),
             ("cargo-modules", cargo["cargo-modules"]),
         ),
-        sc_compose_rev=cargo["sc-compose-rev"],
+        sc_compose=cargo["sc-compose"],
         python_packages=tuple(sorted(python.items())),
     )
 
@@ -150,20 +150,33 @@ def cargo_install_command(name: str, version: str, *, force: bool) -> list[str]:
     return [*command, "--version", version, name]
 
 
-def sc_compose_install_command(revision: str, *, force: bool) -> list[str]:
-    """Return the authoritative sc-compose source-revision install command."""
+def sc_compose_install_command(version: str, *, force: bool) -> list[str]:
+    """Return the registry install command for the released sc-compose CLI."""
+    command = ["cargo", "install", "--locked"]
+    if force:
+        command.append("--force")
+    return [*command, "--version", version, "sc-compose"]
+
+
+def cargo_binstall_command(name: str, version: str, *, force: bool) -> list[str]:
+    """Return a non-compiling cargo-binstall command for one registry tool.
+
+    Disable Binstall's compile strategy so an unavailable artifact takes the
+    explicit Cargo registry fallback below instead of silently rebuilding from
+    source.  The quick-install strategy is also disabled: CI must consume the
+    tool's own release artifact or use the verified registry fallback.
+    """
     command = [
         "cargo",
-        "install",
-        "--git",
-        SC_COMPOSE_REPOSITORY,
-        "--rev",
-        revision,
-        "--locked",
+        "binstall",
+        "--no-confirm",
+        "--disable-telemetry",
+        "--disable-strategies",
+        "quick-install,compile",
     ]
     if force:
         command.append("--force")
-    return [*command, "--bin", "sc-compose"]
+    return [*command, f"{name}@{version}"]
 
 
 def venv_python_path() -> Path:
@@ -208,7 +221,7 @@ def cargo_bin_path(name: str) -> Path:
 
 
 def cargo_receipts() -> dict[str, object]:
-    """Load Cargo's installation receipt for exact Git-source verification."""
+    """Load Cargo's installation receipt for exact registry verification."""
     receipt = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")) / ".crates2.json"
     try:
         raw = json.loads(receipt.read_text(encoding="utf-8"))
@@ -218,6 +231,54 @@ def cargo_receipts() -> dict[str, object]:
     if not isinstance(installs, dict):
         raise BootstrapError(f"Cargo installation receipt has no installs map: {receipt}")
     return installs
+
+
+def binstall_receipts() -> list[dict[str, object]]:
+    """Load Binstall's concatenated JSON installation receipt records."""
+    path = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")) / "binstall" / "crates-v1.json"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    decoder = json.JSONDecoder()
+    records: list[dict[str, object]] = []
+    offset = 0
+    while offset < len(text):
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset == len(text):
+            break
+        try:
+            record, offset = decoder.raw_decode(text, offset)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _version_text(value: object) -> str:
+    """Normalize Binstall's string or structured SemVer receipt value."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        base = ".".join(str(value.get(part, 0)) for part in ("major", "minor", "patch"))
+        pre = value.get("pre")
+        if isinstance(pre, str) and pre:
+            base += f"-{pre}"
+        return base
+    return ""
+
+
+def binstall_tool_matches(name: str, version: str) -> bool:
+    """Prove a prebuilt tool came from Binstall at the exact requested version."""
+    for record in binstall_receipts():
+        info = record.get("crate_info")
+        if not isinstance(info, dict):
+            continue
+        if info.get("name") == name and _version_text(info.get("current_version")) == version:
+            return True
+    return False
 
 
 def receipt_matches(key_prefix: str, *, required_fragments: Sequence[str]) -> bool:
@@ -245,35 +306,28 @@ def registry_tool_matches(name: str, version: str, rust: str) -> bool:
     )
 
 
-def verify_sc_compose_receipt(revision: str) -> None:
-    """Prove Cargo installed sc-compose from the manifest's exact Git revision."""
-    if not receipt_matches(
-        "sc-compose ",
-        required_fragments=(f"git+{SC_COMPOSE_REPOSITORY}", revision),
-    ):
-        raise BootstrapError(f"sc-compose was not installed from the exact source revision {revision}.")
-
-
 def sc_compose_matches(manifest: BootstrapManifest) -> bool:
-    """Prove the Git source and compiler match before omitting a rebuild."""
-    return receipt_matches(
-        "sc-compose ",
-        required_fragments=(
-            f"git+{SC_COMPOSE_REPOSITORY}",
-            manifest.sc_compose_rev,
-            f"release: {manifest.rust}",
-        ),
-    )
+    """Prove the released sc-compose CLI is installed from the registry."""
+    return registry_tool_matches("sc-compose", manifest.sc_compose, manifest.rust)
 
 
-def run(command: Sequence[str], *, dry_run: bool) -> None:
+def cargo_binstall_available() -> bool:
+    """Return whether the CI/local environment has the prebuilt installer."""
+    return shutil.which("cargo-binstall") is not None
+
+
+def run(command: Sequence[str], *, dry_run: bool, allow_failure: bool = False) -> bool:
     """Execute one deterministic installation step or render it for review."""
     print("+", " ".join(command))
     if dry_run:
-        return
+        return True
     result = subprocess.run(command, check=False, cwd=ROOT)
     if result.returncode != 0:
+        if allow_failure:
+            print(f"bootstrap: {' '.join(command)} unavailable; using registry fallback", file=sys.stderr)
+            return False
         raise BootstrapError(f"bootstrap install command failed with exit {result.returncode}: {' '.join(command)}")
+    return True
 
 
 def python_package_version(python: Path, package: str) -> str:
@@ -287,13 +341,12 @@ def verify_installed_tools(manifest: BootstrapManifest, python: Path) -> None:
     for name, version in manifest.cargo_tools:
         binary = cargo_bin_path(name)
         command_output([str(binary), "--version"])
-        if not registry_tool_matches(name, version, manifest.rust):
-            raise BootstrapError(f"{name} is not the exact pinned version built by Rust {manifest.rust}.")
+        if not (registry_tool_matches(name, version, manifest.rust) or binstall_tool_matches(name, version)):
+            raise BootstrapError(f"{name} is not the exact pinned registry/prebuilt version {version}.")
     sc_compose = cargo_bin_path("sc-compose")
     command_output([str(sc_compose), "--version"])
-    verify_sc_compose_receipt(manifest.sc_compose_rev)
     if not sc_compose_matches(manifest):
-        raise BootstrapError(f"sc-compose was not built by the pinned Rust {manifest.rust} toolchain.")
+        raise BootstrapError(f"sc-compose is not the exact released registry version {manifest.sc_compose}.")
     for package, version in manifest.python_packages:
         try:
             actual = python_package_version(python, package)
@@ -310,8 +363,19 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
         verify_seed_tools(manifest)
     python = ensure_bootstrap_venv(manifest, dry_run=dry_run)
     for name, version in manifest.cargo_tools:
-        run(cargo_install_command(name, version, force=not registry_tool_matches(name, version, manifest.rust)), dry_run=dry_run)
-    run(sc_compose_install_command(manifest.sc_compose_rev, force=not sc_compose_matches(manifest)), dry_run=dry_run)
+        if registry_tool_matches(name, version, manifest.rust) or binstall_tool_matches(name, version):
+            continue
+        installed = False
+        if cargo_binstall_available():
+            installed = run(
+                cargo_binstall_command(name, version, force=True),
+                dry_run=dry_run,
+                allow_failure=True,
+            )
+        if not installed:
+            run(cargo_install_command(name, version, force=True), dry_run=dry_run)
+    if not sc_compose_matches(manifest):
+        run(sc_compose_install_command(manifest.sc_compose, force=True), dry_run=dry_run)
     run(pip_install_command(python), dry_run=dry_run)
     if not dry_run:
         verify_installed_tools(manifest, python)

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -438,6 +438,11 @@ def cargo_binstall_available() -> bool:
     return shutil.which("cargo-binstall") is not None
 
 
+def running_in_ci() -> bool:
+    """Return whether bootstrap is running in a CI environment."""
+    return os.environ.get("CI", "").strip().lower() in {"1", "true", "yes"}
+
+
 def run(command: Sequence[str], *, dry_run: bool, allow_failure: bool = False) -> bool:
     """Execute one deterministic installation step or render it for review."""
     print("+", " ".join(command))
@@ -484,6 +489,7 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
     if not dry_run:
         verify_seed_tools(manifest)
     python = ensure_bootstrap_venv(manifest, dry_run=dry_run)
+    ci = running_in_ci()
     for name, version in manifest.cargo_tools:
         if registry_tool_matches(name, version, manifest.rust) or binstall_tool_matches(name, version):
             continue
@@ -492,9 +498,11 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
             installed = run(
                 cargo_binstall_command(name, version, force=True),
                 dry_run=dry_run,
-                allow_failure=True,
+                allow_failure=not ci,
             )
         if not installed:
+            if ci:
+                raise BootstrapError(f"cargo-binstall could not install the exact prebuilt {name} {version} in CI.")
             run(cargo_install_command(name, version, force=True), dry_run=dry_run)
     if not sc_compose_matches(manifest):
         install_sc_compose_release(manifest, dry_run=dry_run)

--- a/tools/bootstrap.toml
+++ b/tools/bootstrap.toml
@@ -10,7 +10,15 @@ cargo-deny = "0.20.2"
 cargo-audit = "0.22.2"
 cargo-shear = "1.12.0"
 cargo-modules = "0.26.0"
-sc-compose = "1.4.0"
+
+[sc-compose]
+version = "1.5.0"
+
+[sc-compose.checksums]
+aarch64-apple-darwin = "7751631cd86e6644e88cfcf3dd80f352779350f9f24f891f52983c8da0ed4620"
+x86_64-apple-darwin = "618bf0d856aa00dcdfb271ca098db6c5a4c228c6778b2cf2c7d7dbc7ff70966e"
+x86_64-pc-windows-msvc = "d1dcabae4f429483ce52d6821b293f4a4f40dd3884f99879e3c01c08d5b0a3ab"
+x86_64-unknown-linux-gnu = "1830bd70194832c5a6ef310c555e575a38922c6bb03141b51a2ab5ca1f3a509e"
 
 [python]
 codespell = "2.4.3"

--- a/tools/bootstrap.toml
+++ b/tools/bootstrap.toml
@@ -11,6 +11,15 @@ cargo-audit = "0.22.2"
 cargo-shear = "1.12.0"
 cargo-modules = "0.26.0"
 
+# Binstall strategies allowed for each cargo tool.  `compile` is never allowed
+# in CI; cargo-audit and cargo-modules need Binstall's third-party quick-install
+# archives because their upstream release layouts are not resolvable uniformly.
+[cargo-allowed-strategies]
+cargo-deny = []
+cargo-audit = ["quick-install"]
+cargo-shear = []
+cargo-modules = ["quick-install"]
+
 [sc-compose]
 version = "1.5.0"
 

--- a/tools/bootstrap.toml
+++ b/tools/bootstrap.toml
@@ -8,7 +8,7 @@ just = "1.58.0"
 [cargo]
 cargo-deny = "0.20.2"
 cargo-audit = "0.22.2"
-cargo-shear = "1.12.0"
+cargo-shear = "1.13.3"
 cargo-modules = "0.26.0"
 
 # Binstall strategies allowed for each cargo tool.  `compile` is never allowed

--- a/tools/bootstrap.toml
+++ b/tools/bootstrap.toml
@@ -10,7 +10,7 @@ cargo-deny = "0.20.2"
 cargo-audit = "0.22.2"
 cargo-shear = "1.12.0"
 cargo-modules = "0.26.0"
-sc-compose-rev = "6a8af1ff46ccd64ae9cc40d7d5c815aa9b0a4661"
+sc-compose = "1.4.0"
 
 [python]
 codespell = "2.4.3"


### PR DESCRIPTION
## Summary

- restore bootstrap outputs before tool setup and move `just bootstrap` after Cargo caches in the Test matrix
- install the four auxiliary Cargo tools from verified cargo-binstall prebuilt artifacts, with an explicit locked crates.io fallback
- pin `sc-compose` to the released crates.io `1.4.0` package; remove the Git-revision install path
- verify both Cargo and Binstall receipts, and cache the receipts alongside binaries and `.bootstrap-venv`

## Validation

- `python3 -m unittest discover -s .just/tests -p 'test_*.py'` (415 passed)
- `cargo fmt --all --check`
- `git diff --check`
