### PR TITLE
docs: replace tmux send-keys nudge with atm send re-dispatch guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,25 +202,21 @@ atm read
 atm inbox
 ```
 
-**Nudge ARCH-CTM to check inbox** (when he hasn't replied):
+**Re-dispatch ARCH-CTM** (when he hasn't replied):
 
-This manual tmux nudge is a steer-kind nudge (immediate, out-of-band prompt
-injection) — it is not a queue-kind nudge and does not wait for harness
-readiness.
-
-ARCH-CTM runs in a tmux pane. Discover the pane, then send-keys:
-```bash
-# Find arch-ctm's pane
-tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_title} #{pane_current_command}'
-
-# Send nudge (use the correct pane ID from above)
-tmux send-keys -t <pane-id> -l "You have unread ATM messages. Run: atm read --team atm-dev" && sleep 0.5 && tmux send-keys -t <pane-id> Enter
-```
+- Never `tmux send-keys`. Resend via `atm send`, including the current j2
+  template task assignment (same rendered content).
+- ⚠️ **A codex agent-idle nudge is not informational — it is a stop condition.**
+  A codex agent (e.g. arch-ctm) WILL NOT resume or restart work on its own
+  after going idle. Do not treat idle as "still working" or defer action —
+  the ONLY way it does more work is if team-lead sends a task assignment via
+  `atm send`. Ignoring or deferring on an idle nudge stalls the agent
+  indefinitely.
 
 ### Communication Rules
 
 1. **No broadcast messages** — all communications are direct (team-lead ↔ specific agent)
-2. **Poll for replies** — after sending to arch-ctm, wait 30-60s then `atm read`. If no reply after 2 minutes, nudge via tmux send-keys
+2. **Poll for replies** — after sending to arch-ctm, wait 30-60s then `atm read`. If no reply after 2 minutes, resend the task assignment via `atm send`
 3. **arch-ctm is async** — he processes messages on his next turn. Do not block waiting; continue other work and check back
 
 ### ATM CLI Quick Reference


### PR DESCRIPTION
## Summary
- Removes the ADR-054 "steer-kind nudge" tmux `send-keys` pattern from CLAUDE.md's team-agent communication section — never inject text into a teammate's tmux pane, only `atm send`.
- Re-dispatch guidance now: resend the current j2 template task assignment via `atm send`.
- Calls out codex-agent idle explicitly as a **stop condition** — the agent will not resume/restart without a new task assignment sent by team-lead. This has been observed to get overlooked in practice.

## Test plan
- [x] Doc-only change; no code/test impact
- [x] Diff reviewed for remaining `tmux` references (only the unrelated ARCH-CTM identity-env note remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)