### PR TITLE
AU.1: boundary code fixes (easy wave) — retire 11 sc-boundary findings

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -122,7 +122,7 @@ allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstr
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "getrandom", "interprocess", "libc", "parking_lot", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "getrandom", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-error/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "interprocess",
  "libc",
  "parking_lot",
+ "sc-lint-attributes",
  "semver",
  "serde",
  "serde_json",

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -36,6 +36,7 @@ getrandom.workspace = true
 semver.workspace = true
 fs4 = "0.13"
 async-trait.workspace = true
+sc-lint-attributes = { path = "../sc-lint-attributes", version = "1.4.4" }
 
 [dev-dependencies]
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use sc_lint_attributes::sc_lint;
 use serde::de::Error as DeError;
 use serde::ser::{Error as SerError, SerializeMap};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -333,6 +334,7 @@ impl<'de> Deserialize<'de> for AtmJsonNumber {
 }
 
 /// ATM-owned recursive JSON-value wrapper used by the observability boundary.
+#[sc_lint(boundary.allow("cycle.recursive_value_container"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LogFieldValue {
     Null,
@@ -432,6 +434,7 @@ impl<'de> Deserialize<'de> for LogFieldValue {
 }
 
 /// ATM-owned map wrapper used by public observability record projections.
+#[sc_lint(boundary.allow("cycle.recursive_value_container"))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LogFieldMap {
     entries: Vec<(LogFieldKey, LogFieldValue)>,

--- a/crates/atm-core/src/search.rs
+++ b/crates/atm-core/src/search.rs
@@ -259,12 +259,12 @@ impl SearchInput {
             cursor: self.cursor.clone().map(SearchCursor::new).transpose()?,
         })
     }
+}
 
-    /// Wraps this public input for a CLI or HTTP transport hop.
-    #[must_use]
-    pub fn into_request(self) -> SearchRequest {
-        SearchRequest {
-            query: self,
+impl From<SearchInput> for SearchRequest {
+    fn from(query: SearchInput) -> Self {
+        Self {
+            query,
             lifecycle: None,
         }
     }
@@ -891,7 +891,7 @@ mod tests {
         };
         let cli_query = input.compile_query().expect("CLI compiler");
         let http_request: SearchRequest =
-            serde_json::from_slice(&serde_json::to_vec(&input.into_request()).expect("JSON"))
+            serde_json::from_slice(&serde_json::to_vec(&SearchRequest::from(input)).expect("JSON"))
                 .expect("HTTP request JSON");
         assert_eq!(
             http_request.compile_query().expect("HTTP compiler"),

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -103,14 +103,14 @@ impl ReceiverRecoveryCircuit {
 #[derive(Debug)]
 struct HelperThreadBudget {
     max_inflight: usize,
-    inflight: AtomicUsize,
+    inflight: Arc<AtomicUsize>,
 }
 
 impl HelperThreadBudget {
-    const fn new(max_inflight: usize) -> Self {
+    fn new(max_inflight: usize) -> Self {
         Self {
             max_inflight,
-            inflight: AtomicUsize::new(0),
+            inflight: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -136,7 +136,7 @@ impl HelperThreadBudget {
             ) {
                 Ok(_) => {
                     return Some(HelperThreadPermit {
-                        budget: Arc::clone(self),
+                        inflight: Arc::clone(&self.inflight),
                     });
                 }
                 Err(observed) => current = observed,
@@ -146,12 +146,12 @@ impl HelperThreadBudget {
 }
 
 struct HelperThreadPermit {
-    budget: Arc<HelperThreadBudget>,
+    inflight: Arc<AtomicUsize>,
 }
 
 impl Drop for HelperThreadPermit {
     fn drop(&mut self) {
-        self.budget.inflight.fetch_sub(1, Ordering::SeqCst);
+        self.inflight.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -216,19 +216,6 @@ struct BoundedHostNudgeInjector {
 
 impl crate::HostNudgeInjector for BoundedHostNudgeInjector {
     fn inject_nudge(&self, nudge: &HostNudge) -> Result<(), AtmError> {
-        Self::inject_nudge(self, nudge)
-    }
-}
-
-impl BoundedHostNudgeInjector {
-    fn spawn(injector: Arc<dyn HostNudgeInjector>) -> Self {
-        Self {
-            injector,
-            helper_budget: Arc::new(HelperThreadBudget::new(MAX_HOST_NUDGE_HELPERS)),
-        }
-    }
-
-    fn inject_nudge(&self, nudge: &HostNudge) -> Result<(), AtmError> {
         let helper_permit = acquire_host_nudge_helper_permit(&self.helper_budget)?;
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         spawn_host_nudge_helper(
@@ -238,6 +225,15 @@ impl BoundedHostNudgeInjector {
             result_tx,
         )?;
         receive_host_nudge_result(result_rx, &self.helper_budget)
+    }
+}
+
+impl BoundedHostNudgeInjector {
+    fn spawn(injector: Arc<dyn HostNudgeInjector>) -> Self {
+        Self {
+            injector,
+            helper_budget: Arc::new(HelperThreadBudget::new(MAX_HOST_NUDGE_HELPERS)),
+        }
     }
 }
 
@@ -774,7 +770,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc;
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, Barrier, Mutex, RwLock};
     use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
@@ -782,7 +778,7 @@ mod tests {
 
     use super::{
         BoundedHostNudgeInjector, GRAFT_RECEIVER_RECOVERY_MAX_DURATION,
-        GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY, GraftReceiverLoopContext,
+        GRAFT_RECEIVER_RECOVERY_WARN_INITIAL_DELAY, GraftReceiverLoopContext, HelperThreadBudget,
         MAX_HOST_NUDGE_HELPERS, RECEIVE_LOOP_READY_DEADLINE, ReceiverReadyLatch,
         ReceiverRecoveryCircuit, handle_graft_receiver_connection, join_receive_loop_with_deadline,
         load_graft_config, read_snapshot, recover_after_poll_accept_error, recover_graft_receiver,
@@ -1039,6 +1035,71 @@ mod tests {
             .expect("second delivery should use a fresh helper thread");
 
         gate_tx.send(()).expect("release blocked first helper");
+    }
+
+    #[test]
+    fn helper_budget_failed_acquire_leaves_inflight_unchanged() {
+        let budget = Arc::new(HelperThreadBudget::new(0));
+        assert!(budget.try_acquire().is_none());
+        assert_eq!(budget.inflight(), 0);
+    }
+
+    #[test]
+    fn helper_budget_concurrent_acquires_never_exceed_limit() {
+        let budget = Arc::new(HelperThreadBudget::new(MAX_HOST_NUDGE_HELPERS));
+        let workers = MAX_HOST_NUDGE_HELPERS * 4;
+        let start = Arc::new(Barrier::new(workers + 1));
+        let release = Arc::new(Barrier::new(workers + 1));
+        let (result_tx, result_rx) = mpsc::channel();
+        let mut handles = Vec::with_capacity(workers);
+        for _ in 0..workers {
+            let budget = Arc::clone(&budget);
+            let start = Arc::clone(&start);
+            let release = Arc::clone(&release);
+            let result_tx = result_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                start.wait();
+                let permit = budget.try_acquire();
+                result_tx
+                    .send(permit.is_some())
+                    .expect("send acquire result");
+                release.wait();
+                drop(permit);
+            }));
+        }
+        start.wait();
+        drop(result_tx);
+        let acquired = (0..workers)
+            .map(|_| result_rx.recv().expect("receive acquire result"))
+            .filter(|acquired| *acquired)
+            .count();
+        assert!(acquired <= MAX_HOST_NUDGE_HELPERS);
+        assert_eq!(budget.inflight(), acquired);
+        release.wait();
+        for handle in handles {
+            handle.join().expect("join acquire worker");
+        }
+        assert_eq!(budget.inflight(), 0);
+    }
+
+    #[test]
+    fn helper_permit_drop_releases_exactly_one_slot() {
+        let budget = Arc::new(HelperThreadBudget::new(2));
+        let permit = budget.try_acquire().expect("first permit");
+        assert_eq!(budget.inflight(), 1);
+        drop(permit);
+        assert_eq!(budget.inflight(), 0);
+    }
+
+    #[test]
+    fn helper_permit_survives_budget_drop() {
+        let budget = Arc::new(HelperThreadBudget::new(1));
+        let inflight = Arc::clone(&budget.inflight);
+        let permit = budget.try_acquire().expect("permit");
+        drop(budget);
+        assert_eq!(inflight.load(Ordering::SeqCst), 1);
+        drop(permit);
+        assert_eq!(inflight.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/crates/atm-runtime/src/legacy_storage_adapters.rs
+++ b/crates/atm-runtime/src/legacy_storage_adapters.rs
@@ -73,27 +73,6 @@ impl BoundaryMailStoreView {
         }
     }
 
-    fn mailbox_row(message: SharedMessage) -> MailStoreMailboxMetadataRow {
-        let ack_requirement = derive_ack_requirement(&message.envelope);
-        MailStoreMailboxMetadataRow {
-            message_key: message.message_key.clone(),
-            message_id: message.envelope.message_id,
-            parent_message_id: message.envelope.parent_message_id,
-            thread_mode: message.envelope.thread_mode,
-            from_agent: message.envelope.from,
-            source_chat_id: message.envelope.source_chat_id,
-            destination_chat_id: message.envelope.destination_chat_id,
-            summary: message.envelope.summary,
-            message_at: message.envelope.timestamp,
-            read: message.envelope.read,
-            requires_ack: !matches!(ack_requirement, AckRequirementState::NotRequired),
-            pending_ack: matches!(ack_requirement, AckRequirementState::RequiredPending),
-            acknowledged_at: message.envelope.acknowledged_at,
-            expires_at: message.envelope.expires_at,
-            task_id: message.envelope.task_id,
-        }
-    }
-
     fn load_matching_message(
         &self,
         team: &TeamName,
@@ -159,7 +138,7 @@ impl MailStore for BoundaryMailStoreView {
     ) -> Result<Vec<MailStoreMailboxMetadataRow>, AtmError> {
         self.store
             .list_messages(&Self::shared_query(team, agent, limit))
-            .map(|messages| messages.into_iter().map(Self::mailbox_row).collect())
+            .map(|messages| messages.into_iter().map(mailbox_row).collect())
     }
 
     fn query_mailbox_metadata_counts(
@@ -242,6 +221,27 @@ impl MailStore for BoundaryMailStoreView {
             read_message_count: rows.iter().filter(|row| row.read).count() as u64,
             latest_message_timestamp,
         })
+    }
+}
+
+fn mailbox_row(message: SharedMessage) -> MailStoreMailboxMetadataRow {
+    let ack_requirement = derive_ack_requirement(&message.envelope);
+    MailStoreMailboxMetadataRow {
+        message_key: message.message_key.clone(),
+        message_id: message.envelope.message_id,
+        parent_message_id: message.envelope.parent_message_id,
+        thread_mode: message.envelope.thread_mode,
+        from_agent: message.envelope.from,
+        source_chat_id: message.envelope.source_chat_id,
+        destination_chat_id: message.envelope.destination_chat_id,
+        summary: message.envelope.summary,
+        message_at: message.envelope.timestamp,
+        read: message.envelope.read,
+        requires_ack: !matches!(ack_requirement, AckRequirementState::NotRequired),
+        pending_ack: matches!(ack_requirement, AckRequirementState::RequiredPending),
+        acknowledged_at: message.envelope.acknowledged_at,
+        expires_at: message.envelope.expires_at,
+        task_id: message.envelope.task_id,
     }
 }
 

--- a/crates/atm-storage/src/schema/inbox_message.rs
+++ b/crates/atm-storage/src/schema/inbox_message.rs
@@ -241,31 +241,6 @@ struct RawMessageEnvelope {
     extra: Map<String, Value>,
 }
 
-impl From<MessageEnvelope> for RawMessageEnvelope {
-    fn from(value: MessageEnvelope) -> Self {
-        Self {
-            from: value.from,
-            source_chat_id: value.source_chat_id,
-            text: value.text,
-            timestamp: value.timestamp,
-            read: value.read,
-            source_team: value.source_team,
-            destination_chat_id: value.destination_chat_id,
-            summary: value.summary,
-            message_id: value.message_id,
-            requires_ack: Some(value.requires_ack),
-            pending_ack_at: value.pending_ack_at,
-            acknowledged_at: value.acknowledged_at,
-            acknowledges_message_id: value.acknowledges_message_id,
-            parent_message_id: value.parent_message_id,
-            thread_mode: value.thread_mode,
-            expires_at: value.expires_at,
-            task_id: value.task_id,
-            extra: value.extra,
-        }
-    }
-}
-
 impl From<RawMessageEnvelope> for MessageEnvelope {
     fn from(value: RawMessageEnvelope) -> Self {
         let requires_ack = value

--- a/crates/atm-template-sc-compose/src/lib.rs
+++ b/crates/atm-template-sc-compose/src/lib.rs
@@ -38,19 +38,6 @@ pub struct ScComposeTemplateComposer {
 }
 
 impl ScComposeTemplateComposer {
-    const fn to_sc_output_format(format: TemplateOutputFormat) -> OutputFormat {
-        match format {
-            TemplateOutputFormat::Text => OutputFormat::Text,
-            TemplateOutputFormat::Json => OutputFormat::Json,
-        }
-    }
-
-    const fn from_sc_output_format(format: OutputFormat) -> TemplateOutputFormat {
-        match format {
-            OutputFormat::Text => TemplateOutputFormat::Text,
-            OutputFormat::Json => TemplateOutputFormat::Json,
-        }
-    }
     /// Builds the production adapter.
     #[must_use]
     pub fn new() -> Self {
@@ -61,171 +48,184 @@ impl ScComposeTemplateComposer {
     pub fn root_render_calls(&self) -> usize {
         self.root_render_calls.load(Ordering::Relaxed)
     }
+}
 
-    fn source_text(source: &TemplateSource) -> Result<&str, AtmError> {
-        std::str::from_utf8(&source.raw_file_bytes)
-            .map_err(|_| AtmError::template_content_not_utf8())
+const fn to_sc_output_format(format: TemplateOutputFormat) -> OutputFormat {
+    match format {
+        TemplateOutputFormat::Text => OutputFormat::Text,
+        TemplateOutputFormat::Json => OutputFormat::Json,
     }
+}
 
-    fn template_load_error(cause: impl std::fmt::Display) -> AtmError {
-        AtmError::new(
-            atm_storage::AtmErrorCode::TemplateLoadFailed,
-            "template source could not be read",
-        )
-        .with_cause(cause)
+const fn from_sc_output_format(format: OutputFormat) -> TemplateOutputFormat {
+    match format {
+        OutputFormat::Text => TemplateOutputFormat::Text,
+        OutputFormat::Json => TemplateOutputFormat::Json,
     }
+}
 
-    fn composition_error(error: ComposeError) -> AtmError {
-        match error {
-            ComposeError::Include(error) => AtmError::template_include_unresolved(error),
-            ComposeError::Resolve(error) => AtmError::template_include_unresolved(error),
-            ComposeError::Validation(error) => AtmError::template_render_verification_failed(error),
-            ComposeError::Render(error) => AtmError::template_render_verification_failed(error),
-            ComposeError::Config(error) => Self::inspection_parse_error(error),
-        }
+fn source_text(source: &TemplateSource) -> Result<&str, AtmError> {
+    std::str::from_utf8(&source.raw_file_bytes).map_err(|_| AtmError::template_content_not_utf8())
+}
+
+fn template_load_error(cause: impl std::fmt::Display) -> AtmError {
+    AtmError::new(
+        atm_storage::AtmErrorCode::TemplateLoadFailed,
+        "template source could not be read",
+    )
+    .with_cause(cause)
+}
+
+fn composition_error(error: ComposeError) -> AtmError {
+    match error {
+        ComposeError::Include(error) => AtmError::template_include_unresolved(error),
+        ComposeError::Resolve(error) => AtmError::template_include_unresolved(error),
+        ComposeError::Validation(error) => AtmError::template_render_verification_failed(error),
+        ComposeError::Render(error) => AtmError::template_render_verification_failed(error),
+        ComposeError::Config(error) => inspection_parse_error(error),
     }
+}
 
-    fn inspection_parse_error(cause: impl std::fmt::Display) -> AtmError {
-        AtmError::new(
-            atm_storage::AtmErrorCode::TemplateInspectionParseFailed,
-            "template inspection parser rejected frontmatter or body/directive syntax",
-        )
-        .with_cause(cause)
+fn inspection_parse_error(cause: impl std::fmt::Display) -> AtmError {
+    AtmError::new(
+        atm_storage::AtmErrorCode::TemplateInspectionParseFailed,
+        "template inspection parser rejected frontmatter or body/directive syntax",
+    )
+    .with_cause(cause)
+}
+
+fn inspection_error(error: ComposeError) -> AtmError {
+    match error {
+        ComposeError::Include(error) => AtmError::template_include_unresolved(error),
+        ComposeError::Resolve(error) => AtmError::template_include_unresolved(error),
+        ComposeError::Validation(error) => AtmError::template_render_verification_failed(error),
+        ComposeError::Render(error) => AtmError::template_render_verification_failed(error),
+        ComposeError::Config(error) => inspection_parse_error(error),
     }
+}
 
-    fn inspection_error(error: ComposeError) -> AtmError {
-        match error {
-            ComposeError::Include(error) => AtmError::template_include_unresolved(error),
-            ComposeError::Resolve(error) => AtmError::template_include_unresolved(error),
-            ComposeError::Validation(error) => AtmError::template_render_verification_failed(error),
-            ComposeError::Render(error) => AtmError::template_render_verification_failed(error),
-            ComposeError::Config(error) => Self::inspection_parse_error(error),
-        }
-    }
+fn hash_api_error(cause: impl std::fmt::Display) -> AtmError {
+    AtmError::new(
+        atm_storage::AtmErrorCode::TemplateHashApiFailed,
+        "template SHA/hash identity API failed to produce a valid identity",
+    )
+    .with_cause(cause)
+}
 
-    fn hash_api_error(cause: impl std::fmt::Display) -> AtmError {
-        AtmError::new(
-            atm_storage::AtmErrorCode::TemplateHashApiFailed,
-            "template SHA/hash identity API failed to produce a valid identity",
-        )
-        .with_cause(cause)
-    }
-
-    fn upstream_frontmatter(
-        raw_file_bytes: &[u8],
-    ) -> Result<atm_storage::TemplateFrontmatter, AtmError> {
-        let source = std::str::from_utf8(raw_file_bytes)
-            .map_err(|_| AtmError::template_content_not_utf8())?;
-        let document = parse_template_document(source).map_err(Self::inspection_error)?;
-        let Some(frontmatter) = document.frontmatter() else {
-            return Ok(atm_storage::TemplateFrontmatter::default());
-        };
-        let required_variables = frontmatter
-            .required_variables()
-            .iter()
-            .map(|name| atm_storage::TemplateVariableName::new(name.as_str()))
-            .collect::<Result<Vec<_>, _>>()?;
-        let defaults = frontmatter
-            .defaults()
-            .iter()
-            .map(|(name, value)| (name.as_str().to_owned(), value.clone()))
-            .collect();
-        let metadata = frontmatter
-            .metadata()
-            .iter()
-            .map(|(name, value)| {
-                value
-                    .to_json_value()
-                    .map(|value| (name.clone(), value))
-                    .map_err(Self::inspection_parse_error)
-            })
-            .collect::<Result<_, _>>()?;
-        Ok(atm_storage::TemplateFrontmatter {
-            required_variables,
-            defaults,
-            metadata,
-            ..atm_storage::TemplateFrontmatter::default()
+fn upstream_frontmatter(
+    raw_file_bytes: &[u8],
+) -> Result<atm_storage::TemplateFrontmatter, AtmError> {
+    let source =
+        std::str::from_utf8(raw_file_bytes).map_err(|_| AtmError::template_content_not_utf8())?;
+    let document = parse_template_document(source).map_err(inspection_error)?;
+    let Some(frontmatter) = document.frontmatter() else {
+        return Ok(atm_storage::TemplateFrontmatter::default());
+    };
+    let required_variables = frontmatter
+        .required_variables()
+        .iter()
+        .map(|name| atm_storage::TemplateVariableName::new(name.as_str()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let defaults = frontmatter
+        .defaults()
+        .iter()
+        .map(|(name, value)| (name.as_str().to_owned(), value.clone()))
+        .collect();
+    let metadata = frontmatter
+        .metadata()
+        .iter()
+        .map(|(name, value)| {
+            value
+                .to_json_value()
+                .map(|value| (name.clone(), value))
+                .map_err(inspection_parse_error)
         })
-    }
+        .collect::<Result<_, _>>()?;
+    Ok(atm_storage::TemplateFrontmatter {
+        required_variables,
+        defaults,
+        metadata,
+        ..atm_storage::TemplateFrontmatter::default()
+    })
+}
 
-    fn upstream_references(raw_file_bytes: &[u8]) -> Result<Vec<TemplateReference>, AtmError> {
-        inspect_template_directives(raw_file_bytes)
-            .map_err(Self::inspection_error)?
-            .into_iter()
-            .map(|reference| {
-                let directive = match reference.directive {
-                    TemplateDirectiveKind::Include => TemplateReferenceKind::Include,
-                    TemplateDirectiveKind::Import => TemplateReferenceKind::Import,
-                    TemplateDirectiveKind::FromImport => TemplateReferenceKind::FromImport,
-                };
-                Ok(TemplateReference {
-                    directive,
-                    source_span: SourceSpan {
-                        byte_start: reference.source_span.byte_start,
-                        byte_end: reference.source_span.byte_end,
-                    },
-                })
+fn upstream_references(raw_file_bytes: &[u8]) -> Result<Vec<TemplateReference>, AtmError> {
+    inspect_template_directives(raw_file_bytes)
+        .map_err(inspection_error)?
+        .into_iter()
+        .map(|reference| {
+            let directive = match reference.directive {
+                TemplateDirectiveKind::Include => TemplateReferenceKind::Include,
+                TemplateDirectiveKind::Import => TemplateReferenceKind::Import,
+                TemplateDirectiveKind::FromImport => TemplateReferenceKind::FromImport,
+            };
+            Ok(TemplateReference {
+                directive,
+                source_span: SourceSpan {
+                    byte_start: reference.source_span.byte_start,
+                    byte_end: reference.source_span.byte_end,
+                },
             })
-            .collect()
-    }
-
-    fn inspect_raw_file(
-        raw_file_bytes: &[u8],
-        output_format: TemplateOutputFormat,
-    ) -> Result<TemplateInspection, AtmError> {
-        let sha = calculate_hash(HashInput::TextFileBytes {
-            utf8_file_bytes: raw_file_bytes,
         })
-        .map_err(|_| AtmError::template_content_not_utf8())?
-        .template()
-        .to_hex();
-        Ok(TemplateInspection {
-            sha: atm_storage::TemplateSha::new(sha).map_err(Self::hash_api_error)?,
-            frontmatter: Self::upstream_frontmatter(raw_file_bytes)?,
-            include_references: Self::upstream_references(raw_file_bytes)?,
-            output_format,
+        .collect()
+}
+
+fn inspect_raw_file(
+    raw_file_bytes: &[u8],
+    output_format: TemplateOutputFormat,
+) -> Result<TemplateInspection, AtmError> {
+    let sha = calculate_hash(HashInput::TextFileBytes {
+        utf8_file_bytes: raw_file_bytes,
+    })
+    .map_err(|_| AtmError::template_content_not_utf8())?
+    .template()
+    .to_hex();
+    Ok(TemplateInspection {
+        sha: atm_storage::TemplateSha::new(sha).map_err(hash_api_error)?,
+        frontmatter: upstream_frontmatter(raw_file_bytes)?,
+        include_references: upstream_references(raw_file_bytes)?,
+        output_format,
+    })
+}
+
+/// Reject a source file that changed after ATM captured its immutable
+/// admission bytes. Both confined render entry points share this check.
+fn verify_unchanged(source_path: &Path, expected: &[u8]) -> Result<(), AtmError> {
+    let actual = std::fs::read(source_path).map_err(template_load_error)?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(AtmError::template_render_verification_failed(format!(
+        "template source changed after it was loaded: '{}' no longer matches the verified raw bytes",
+        source_path.display()
+    )))
+}
+
+/// The only ATM production checked-emission seam.  The checker consumes
+/// the complete body, so invalid JSON can never reach a send or read path.
+fn checked_body(
+    text: &str,
+    format: TemplateOutputFormat,
+    template_path: &Path,
+    failing_pass: Option<u8>,
+) -> Result<RenderedBody, AtmError> {
+    let format = to_sc_output_format(format);
+    let meta = RenderCheckMeta::for_template_with_format(template_path, format);
+    check_rendered_output_with_meta(meta, text)
+        .map(|checked| RenderedBody {
+            text: checked.body().to_owned(),
         })
-    }
-
-    /// Reject a source file that changed after ATM captured its immutable
-    /// admission bytes. Both confined render entry points share this check.
-    fn verify_unchanged(source_path: &Path, expected: &[u8]) -> Result<(), AtmError> {
-        let actual = std::fs::read(source_path).map_err(Self::template_load_error)?;
-        if actual == expected {
-            return Ok(());
-        }
-        Err(AtmError::template_render_verification_failed(format!(
-            "template source changed after it was loaded: '{}' no longer matches the verified raw bytes",
-            source_path.display()
-        )))
-    }
-
-    /// The only ATM production checked-emission seam.  The checker consumes
-    /// the complete body, so invalid JSON can never reach a send or read path.
-    fn checked_body(
-        text: &str,
-        format: TemplateOutputFormat,
-        template_path: &Path,
-        failing_pass: Option<u8>,
-    ) -> Result<RenderedBody, AtmError> {
-        let format = Self::to_sc_output_format(format);
-        let meta = RenderCheckMeta::for_template_with_format(template_path, format);
-        check_rendered_output_with_meta(meta, text)
-            .map(|checked| RenderedBody {
-                text: checked.body().to_owned(),
-            })
-            .map_err(|error| {
-                let error = error.with_failing_pass(failing_pass);
-                let cause = failing_pass.map_or_else(
-                    || error.to_string(),
-                    |pass| format!("{error}; final output rejected after render pass {pass}"),
-                );
-                match format {
-                    OutputFormat::Json => AtmError::template_json_escape_migration_required(cause),
-                    OutputFormat::Text => AtmError::template_render_verification_failed(cause),
-                }
-            })
-    }
+        .map_err(|error| {
+            let error = error.with_failing_pass(failing_pass);
+            let cause = failing_pass.map_or_else(
+                || error.to_string(),
+                |pass| format!("{error}; final output rejected after render pass {pass}"),
+            );
+            match format {
+                OutputFormat::Json => AtmError::template_json_escape_migration_required(cause),
+                OutputFormat::Text => AtmError::template_render_verification_failed(cause),
+            }
+        })
 }
 
 impl sealed::Sealed for ScComposeTemplateComposer {}
@@ -240,9 +240,9 @@ impl TemplateComposer for ScComposeTemplateComposer {
         })?;
         // This is the sole format classification site. Core and storage only
         // carry the small ATM-owned enum persisted with the immutable row.
-        Self::inspect_raw_file(
+        inspect_raw_file(
             &source.raw_file_bytes,
-            Self::from_sc_output_format(OutputFormat::from_template_path(canonical_path)),
+            from_sc_output_format(OutputFormat::from_template_path(canonical_path)),
         )
     }
 
@@ -259,16 +259,16 @@ impl TemplateComposer for ScComposeTemplateComposer {
                 "root-constrained rendering requires a canonical source-file path; stored templates must render without includes",
             )
         })?;
-        Self::verify_unchanged(source_path, &template.raw_file_bytes)?;
+        verify_unchanged(source_path, &template.raw_file_bytes)?;
         let confining_root = ConfiningRoot::from_path_buf(root.canonical_path.clone());
         let expanded = expand_includes(source_path, &confining_root, &ComposePolicy::default())
             .map_err(AtmError::template_include_unresolved)?;
         let text = render_template(&expanded.text, vars)
             .map_err(AtmError::template_render_verification_failed)?;
 
-        Self::checked_body(
+        checked_body(
             &text,
-            Self::from_sc_output_format(OutputFormat::from_template_path(source_path)),
+            from_sc_output_format(OutputFormat::from_template_path(source_path)),
             source_path,
             None,
         )
@@ -286,7 +286,7 @@ impl TemplateComposer for ScComposeTemplateComposer {
                 "composition requires a canonical source-file path",
             )
         })?;
-        Self::verify_unchanged(source_path, &template.raw_file_bytes)?;
+        verify_unchanged(source_path, &template.raw_file_bytes)?;
 
         let vars_input = vars
             .iter()
@@ -319,10 +319,10 @@ impl TemplateComposer for ScComposeTemplateComposer {
                 ..sc_composer::ComposePolicy::default()
             },
         };
-        let result = sc_composer::compose(&request).map_err(Self::composition_error)?;
-        Self::checked_body(
+        let result = sc_composer::compose(&request).map_err(composition_error)?;
+        checked_body(
             &result.rendered_text,
-            Self::from_sc_output_format(OutputFormat::from_template_path(source_path)),
+            from_sc_output_format(OutputFormat::from_template_path(source_path)),
             source_path,
             result.failing_pass,
         )
@@ -338,18 +338,18 @@ impl TemplateComposer for ScComposeTemplateComposer {
                 "stored template has legacy/unverified output_format; re-register the source through the current adapter before claiming checked-render compatibility",
             )
         })?;
-        let inspection = Self::inspect_raw_file(&source.raw_file_bytes, output_format)?;
+        let inspection = inspect_raw_file(&source.raw_file_bytes, output_format)?;
         if !inspection.include_references.is_empty() {
             return Err(AtmError::decomposed_template_include_forbidden());
         }
-        let source_text = Self::source_text(source)?;
+        let source_text = source_text(source)?;
         let text = render_template(source_text, vars)
             .map_err(AtmError::template_render_verification_failed)?;
         let path = match output_format {
             TemplateOutputFormat::Text => Path::new("stored-template.txt"),
             TemplateOutputFormat::Json => Path::new("stored-template.json"),
         };
-        Self::checked_body(&text, output_format, path, None)
+        checked_body(&text, output_format, path, None)
     }
 }
 
@@ -1023,7 +1023,7 @@ mod tests {
             ))
             .expect_err("malformed Jinja must fail inspection");
         let hash_error = atm_storage::TemplateSha::new("not-a-sha")
-            .map_err(ScComposeTemplateComposer::hash_api_error)
+            .map_err(super::hash_api_error)
             .expect_err("invalid storage identity must fail the hash adapter seam");
 
         assert_eq!(

--- a/crates/atm/src/commands/search.rs
+++ b/crates/atm/src/commands/search.rs
@@ -181,12 +181,9 @@ impl SearchCommand {
             cursor: self.cursor.clone(),
             per_mailbox: self.per_mailbox,
             aggregate: self.aggregate(),
-        }
-        .into_request();
-        let mut request = atm_core::search::SearchRequest {
-            lifecycle,
-            ..request
         };
+        let mut request = atm_core::search::SearchRequest::from(request);
+        request.lifecycle = lifecycle;
         // Fail before opening a daemon connection while keeping the exact
         // same core compiler authoritative for HTTP ingress.
         let query = request.compile_query()?;

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -195,13 +195,10 @@ impl TeamsCommand {
             Some(TeamsSubcommand::Restore(command)) => command.run(home_dir).await,
         }
     }
+}
 
-    /// Publish a durable roster mutation into the daemon's immutable admission
-    /// view before reporting the command complete. This uses the same
-    /// authenticated control-plane reload as peer-trust mutations.
-    async fn reload_runtime_view() -> Result<()> {
-        Ok(reload_running_runtime_view().await?)
-    }
+async fn reload_runtime_view() -> Result<()> {
+    Ok(reload_running_runtime_view().await?)
 }
 
 impl AddMemberCommand {
@@ -212,7 +209,7 @@ impl AddMemberCommand {
         let outcome = with_retained_roster_store(|roster_store| {
             team_admin::add_member_with_roster_store(roster_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_add_member_result(&outcome, json)
     }
 
@@ -263,7 +260,7 @@ impl SetNudgeTemplateCommand {
         let outcome = with_default_nudge_template_override_store(|override_store| {
             team_admin::set_nudge_template_override_with_store(override_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_set_nudge_template_override_result(&outcome, json)
     }
 
@@ -288,7 +285,7 @@ impl DisableNudgeTemplateCommand {
         let outcome = with_default_nudge_template_override_store(|override_store| {
             team_admin::disable_nudge_template_override_with_store(override_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_disable_nudge_template_override_result(&outcome, json)
     }
 
@@ -308,7 +305,7 @@ impl ClearNudgeTemplateCommand {
         let outcome = with_default_nudge_template_override_store(|override_store| {
             team_admin::clear_nudge_template_override_with_store(override_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_clear_nudge_template_override_result(&outcome, json)
     }
 
@@ -328,7 +325,7 @@ impl UpdateMemberCommand {
         let outcome = with_retained_roster_store(|roster_store| {
             team_admin::update_member_with_roster_store(roster_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_update_member_result(&outcome, json)
     }
 
@@ -356,7 +353,7 @@ impl RemoveMemberCommand {
         let outcome = with_retained_roster_store(|roster_store| {
             team_admin::remove_member_with_roster_store(roster_store, request)
         })?;
-        TeamsCommand::reload_runtime_view().await?;
+        reload_runtime_view().await?;
         output::print_remove_member_result(&outcome, json)
     }
 
@@ -379,7 +376,7 @@ impl RestoreCommand {
             team_admin::restore_team_with_roster_store(roster_store, request)
         })? {
             RestoreResult::Applied(outcome) => {
-                TeamsCommand::reload_runtime_view().await?;
+                reload_runtime_view().await?;
                 output::print_restore_result(&outcome, json)
             }
             RestoreResult::DryRun(plan) => output::print_restore_plan(&plan, json),
@@ -903,6 +900,124 @@ mod tests {
                         team: TEST_TEAM.to_string(),
                         from: Some(backup_dir),
                         dry_run: true,
+                        json: true,
+                    }
+                    .run(fixture.home_dir.clone()),
+                )
+                .expect("restore run");
+        });
+    }
+
+    #[test]
+    #[serial(env)]
+    fn add_member_run_executes_successfully_without_daemon() {
+        let fixture = Fixture::new();
+        let command = AddMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: "new-member".to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            home_dir: Some(fixture.current_dir.clone()),
+            pane_id: Some("21".to_string()),
+            json: true,
+        };
+
+        fixture.with_env_and_cwd(|| {
+            test_runtime()
+                .block_on(command.run(fixture.home_dir.clone()))
+                .expect("add-member run");
+            assert!(
+                fixture
+                    .home_dir
+                    .join(".claude/teams")
+                    .join(TEST_TEAM)
+                    .join("inboxes/new-member.json")
+                    .exists()
+            );
+        });
+    }
+
+    #[test]
+    #[serial(env)]
+    fn update_member_run_executes_successfully_without_daemon() {
+        let fixture = Fixture::new();
+        let command = UpdateMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: TEST_SENDER.to_string(),
+            home_dir: Some(fixture.current_dir.clone()),
+            workspace_root: None,
+            harness: Some("codex-cli".to_string()),
+            agent_type: Some("worker".to_string()),
+            model: Some("gpt-5".to_string()),
+            pane_id: Some("%19".to_string()),
+            json: true,
+        };
+
+        fixture.with_env_and_cwd(|| {
+            test_runtime()
+                .block_on(command.run(
+                    fixture.home_dir.clone(),
+                    CallerContext {
+                        caller_identity: TEST_SENDER.parse().expect("caller"),
+                        caller_chat_id: None,
+                        caller_team: TEST_TEAM.parse().expect("team"),
+                        activity_observation: None,
+                    },
+                ))
+                .expect("update-member run");
+        });
+    }
+
+    #[test]
+    #[serial(env)]
+    fn remove_member_run_executes_successfully_without_daemon() {
+        let fixture = Fixture::new();
+        let command = RemoveMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: TEST_SENDER.to_string(),
+            json: true,
+        };
+
+        fixture.with_env_and_cwd(|| {
+            test_runtime()
+                .block_on(command.run(CallerContext {
+                    caller_identity: TEST_SENDER.parse().expect("caller"),
+                    caller_chat_id: None,
+                    caller_team: TEST_TEAM.parse().expect("team"),
+                    activity_observation: None,
+                }))
+                .expect("remove-member run");
+        });
+    }
+
+    #[test]
+    #[serial(env)]
+    fn restore_run_executes_successfully_without_daemon() {
+        let fixture = Fixture::new();
+
+        fixture.with_env_and_cwd(|| {
+            BackupCommand {
+                team: TEST_TEAM.to_string(),
+                json: true,
+            }
+            .run(fixture.home_dir.clone())
+            .expect("backup run");
+            let backup_root = fixture
+                .home_dir
+                .join(".claude/teams/.backups")
+                .join(TEST_TEAM);
+            let backup_dir = fs::read_dir(backup_root)
+                .expect("backup root")
+                .next()
+                .expect("backup entry")
+                .expect("backup dir")
+                .path();
+            test_runtime()
+                .block_on(
+                    RestoreCommand {
+                        team: TEST_TEAM.to_string(),
+                        from: Some(backup_dir),
+                        dry_run: false,
                         json: true,
                     }
                     .run(fixture.home_dir.clone()),

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -539,20 +539,19 @@ mod tests {
     #[derive(Clone, Default)]
     struct SharedLogBuffer(Arc<Mutex<Vec<u8>>>);
 
-    struct SharedLogWriter(SharedLogBuffer);
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
 
     impl<'a> MakeWriter<'a> for SharedLogBuffer {
         type Writer = SharedLogWriter;
 
         fn make_writer(&'a self) -> Self::Writer {
-            SharedLogWriter(self.clone())
+            SharedLogWriter(Arc::clone(&self.0))
         }
     }
 
     impl Write for SharedLogWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             self.0
-                .0
                 .lock()
                 .expect("log buffer lock")
                 .extend_from_slice(buf);


### PR DESCRIPTION
## Sprint AU.1 — boundary code fixes (easy wave)

Phase AU (sc-boundary debt retirement, GH #1028 / waiver AO2-SCBOUNDARY-DEBT-001). Plan: `docs/plans/phase-au/sprint-AU1-boundary-code-fixes.md` (PR #1032).

**Head**: 99349baf2 · **Assignee**: Cipher-311d · **Target**: integrate/phase-au

### Scope delivered
- Fixed owned sc-boundary findings #2/#3/#4/#5/#6/#7/#17/#19/#20/#22 (optional #12 SendCommand hoist skipped — AU.2 owns it)
- Finding #20 residual: hoisted `atm-runtime` `BoundaryMailStoreView::mailbox_row` to a module-level free fn (routed from AU.2 per plan amendment; file verified NOT a Phase-AM deletion target)
- Added required `teams .run` success tests (incl. applied restore) and four HelperThreadBudget/Permit tests
- Added sc-lint dependency/allowlist entries

### Dev evidence
- `cargo test -p agent-team-mail` 182 pass; `cargo test -p atm-graft` 26 pass
- Full `run_tests` default: 714 Python + workspace Rust/CLI all pass
- `just lint` non-sc-boundary checks pass
- Aggregate sc-boundary now reports only the expected 13 AU.2/AU.3/heuristic findings
- Public API audit: `SearchInput::into_request` has no remaining code references

### Merge gate
- Identity gate: owned finding indices absent from full sc-boundary JSON payload (not count-based)
- quality-mgr sign-off on 100% of findings; CI green at merge time
- Merge with merge commit (never squash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)