### PR TITLE
feat(atm-dev): 5-agent team, 3-window layout (cipher + fenix + publisher)

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -30,30 +30,72 @@ all = ["read .claude/agents/quality-mgr.md for directive",
        "Use native atm send or atm ack for messages to team-lead or arch-ctm",
        "Use native atm read to read messages from team-members" ]
 
+[startup.cipher]
+all = ["HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see AGENTS.md hard rule)",
+       "Use native atm send or atm ack for messages to team-lead, arch-ctm, or quality-mgr",
+       "Use native atm read to read messages from team-members" ]
+
+[startup.fenix]
+all = ["HARD RULE: daemon target is Tokio+Axum (atm-http-runtime) for ALL cli+graft+cross-host transport; the synchronous daemon is frozen legacy slated for Phase-AM deletion — immediately reject any finding/fix/task that remodels or patches it; route daemon work to the AL.5-AL.7 atm-http-runtime cutover (see AGENTS.md hard rule)",
+       "Use native atm send or atm ack for messages to team-lead, arch-ctm, or quality-mgr",
+       "Use native atm read to read messages from team-members" ]
+
+[startup.publisher]
+all = ["Use native atm send or atm ack for messages to team-lead or quality-mgr",
+       "Use native atm read to read messages from team-members" ]
+
 # ── rmux: tmux session launcher ──────────────────────────────────────
 [rmux]
 session = "atm-dev"
 
+# Window 1: Core agents (standard 3-agent pattern)
 [[rmux.windows]]
 name = "agents"
 layout = "even-horizontal"
 
 [[rmux.windows.panes]]
 name = "team-lead"
-tmux_pane_id = "%0"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "arch-ctm"
-tmux_pane_id = "%1"
 command = "codex -c features.hooks=true --yolo"
 env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "quality-mgr"
-tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+# Window 2: Support agents (cipher + fenix)
+[[rmux.windows]]
+name = "support"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "cipher"
+command = "codex -c features.hooks=true -c model_reasoning_effort=\"high\" --yolo"
+env = { ATM_IDENTITY = "cipher", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "fenix"
+model = "fable"
+env = { ATM_IDENTITY = "fenix", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+# Window 3: Publishing (publisher + spare)
+[[rmux.windows]]
+name = "publishing"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "publisher"
+model = "sonnet"
+color = "blue"
+env = { ATM_IDENTITY = "publisher", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "spare"
+env = { ATM_TEAM = "atm-dev" }


### PR DESCRIPTION
## Summary

Expands atm-dev  from 3 agents / 1 window to 5 agents across 3 windows.

## Layout

| Window | Name | Panes |
|---|---|---|
| 1 | agents | team-lead (sonnet), arch-ctm (codex), quality-mgr (sonnet) |
| 2 | support | cipher (codex-luna, high reasoning), fenix (fable) |
| 3 | publishing | publisher (sonnet), spare (terminal) |

## Changes

- **New agents**: cipher (codex with `model_reasoning_effort=high`), fenix (Claude fable model)
- **New windows**: support (window 2), publishing (window 3) with spare terminal pane
- **Startup directives**: added cipher, fenix, and publisher blocks with ATM send/read + tokio hard rule
- **Roster cleanup**: removed orphaned arch-ctm-m4 and m5-test from atm-dev
- **No post-send hooks** — team uses cron/poll pattern
- **Roster ↔ config**: verified consistent (6 members = 6 ATM_IDENTITY panes)

## Verification

- `rmux --dry-run` exits 0 with correct 3-window layout
- `atm members --team atm-dev` ↔ `.atm.toml` ATM_IDENTITY grep diff is empty
- All 7 startup blocks (5 agents + no startup needed for spare) present