### PR TITLE
feat(aq1.5): graft receiver registration API + durable SQLite store (ADR-056)

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -123,7 +123,7 @@ allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstr
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "getrandom", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-error/Cargo.toml"
@@ -161,7 +161,7 @@ allowed_dependencies = ["atm-core", "atm-storage", "serde_json", "tokio", "traci
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "chrono", "rustls", "serde", "serde_json", "sha2", "toml", "ulid", "x509-parser", "zeroize"]
+allowed_dependencies = ["async-trait", "atm-error", "base64", "chrono", "getrandom", "rustls", "serde", "serde_json", "sha2", "toml", "ulid", "x509-parser", "zeroize"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-storage-rusqlite/Cargo.toml"

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -11,6 +11,7 @@ import sys
 from lint_common import build_report
 from lint_common import discover_repo_root
 from lint_common import is_comment_line
+from lint_common import is_rust_test_cfg_attribute
 from lint_common import load_lint_config
 from lint_common import monotonic_now
 from lint_common import print_report
@@ -65,6 +66,8 @@ FORBIDDEN_EDGE_RE = re.compile(
 PUBLIC_TYPE_TEMPLATE = r"^\s*pub(?:\([^)]*\))?\s+(?:struct|enum|type)\s+{name}\b"
 PUBLIC_REEXPORT_TEMPLATE = r"^\s*pub(?:\([^)]*\))?\s+use\b.*\b{name}\b"
 PUBLIC_FUNCTION_RE = re.compile(r"^\s*pub(?:\([^)]*\))?\s+fn\s+[A-Za-z_][A-Za-z0-9_]*\b")
+MOD_BLOCK_OPEN_RE = re.compile(r"^(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{")
+MOD_FILE_DECL_RE = re.compile(r"^(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;$")
 
 # ``ownership.io_forbidden`` is a source-level policy, not merely metadata.
 # Keep the vocabulary explicit so adding a new tag cannot silently create an
@@ -2154,6 +2157,57 @@ def is_inside_string_literal(line: str, match_start: int) -> bool:
     return quote_count % 2 == 1
 
 
+def _trait_impl_pattern(public_trait: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"\bimpl(?:<[^>]+>)?\s+(?:[A-Za-z_][A-Za-z0-9_:]*::)?"
+        rf"{re.escape(public_trait)}(?:<[^>]+>)?\s+for\s+([A-Za-z_][A-Za-z0-9_]*)"
+    )
+
+
+def _scan_lines_for_trait_impl_violations(
+    *,
+    record: BoundaryRecord,
+    trait_pattern: re.Pattern[str],
+    module_path: str,
+    rel_source: str,
+    lines: list[str],
+    line_offset: int = 0,
+) -> list[BoundaryViolation]:
+    """Scan `lines` (already sliced to the region under consideration) for
+    unapproved implementations of `record.public_trait`.
+
+    `line_offset` is the 0-based index of `lines[0]` within the original
+    file, so reported line numbers stay accurate when scanning a slice
+    (e.g. an inline `#[cfg(test)] mod { .. }` block) rather than a whole file.
+    """
+
+    allowed_paths = set(record.allowed_test_double_paths)
+    violations: list[BoundaryViolation] = []
+    for offset, line in enumerate(lines):
+        if is_comment_line(line):
+            continue
+        match = trait_pattern.search(line)
+        if match is None:
+            continue
+        if is_inside_string_literal(line, match.start()):
+            # Architecture/boundary tests commonly assert against source text
+            # via string literals, e.g.
+            # `source.contains("impl Foo for Bar")`. That inert literal is not
+            # a real implementation and must not be mistaken for one.
+            continue
+        implementation_path = f"{module_path}::{match.group(1)}"
+        if implementation_path in allowed_paths:
+            continue
+        violations.append(
+            BoundaryViolation(
+                f"{rel_source}:{line_offset + offset + 1}",
+                f"{record.boundary_id} trait-only implementation {implementation_path!r} "
+                "is not listed in testing.allowed_test_double_paths",
+            )
+        )
+    return violations
+
+
 def find_trait_only_test_double_violations(
     record: BoundaryRecord,
     module_path: str,
@@ -2174,35 +2228,185 @@ def find_trait_only_test_double_violations(
 
     if record.public_trait is None:
         return []
-    trait_pattern = re.compile(
-        rf"\bimpl(?:<[^>]+>)?\s+(?:[A-Za-z_][A-Za-z0-9_:]*::)?"
-        rf"{re.escape(record.public_trait)}(?:<[^>]+>)?\s+for\s+([A-Za-z_][A-Za-z0-9_]*)"
+    rel_source = source_path.relative_to(repo_root).as_posix()
+    lines = source_path.read_text(encoding="utf-8").splitlines()
+    return _scan_lines_for_trait_impl_violations(
+        record=record,
+        trait_pattern=_trait_impl_pattern(record.public_trait),
+        module_path=module_path,
+        rel_source=rel_source,
+        lines=lines,
     )
-    allowed_paths = set(record.allowed_test_double_paths)
+
+
+def crate_qualified_module_path(info: ManifestInfo, source_path: Path) -> str:
+    """Return the module path a `src/` file is addressed by from *outside* its crate.
+
+    Mirrors `source_module_path`'s directory-derived path but replaces the
+    intra-crate `crate::` prefix with the crate's own path name (e.g.
+    `atm_core::…`), matching the `<crate>::<module path>` convention
+    `testing.allowed_test_double_paths` manifest entries use to name a
+    `#[cfg(test)]` test double declared in another workspace crate's `src/`
+    (e.g. `atm_core::ack::admission_tests::EmptyGraftReceiverStore`).
+    """
+
+    module_path = source_module_path(info, source_path)
+    suffix = module_path[len("crate") :]
+    return f"{info.crate_path_name}{suffix}"
+
+
+def find_inline_cfg_test_mod_blocks(lines: list[str]) -> list[tuple[str, int, int]]:
+    """Return `(mod_name, start_index, end_index)` for each outermost inline
+    ``#[cfg(test)] mod NAME { .. }`` block in `lines` (0-based, `end_index`
+    exclusive; the mod-declaration and closing-brace lines are excluded from
+    the range).
+
+    Only tracks the `#[cfg(test)]` attribute immediately preceding the `mod`
+    item (stacked attribute lines in between are tolerated) and relies on
+    `cargo fmt`'s convention of opening a block's brace on the same line as
+    its declaration, which this repository enforces as a CI gate.
+    """
+
+    blocks: list[tuple[str, int, int]] = []
+    pending_test_attr = False
+    index = 0
+    total = len(lines)
+    while index < total:
+        stripped = lines[index].strip()
+        if stripped.startswith("#[") and not stripped.startswith("#!["):
+            if is_rust_test_cfg_attribute(stripped):
+                pending_test_attr = True
+            index += 1
+            continue
+        match = MOD_BLOCK_OPEN_RE.match(stripped)
+        if match is not None and pending_test_attr:
+            name = match.group(1)
+            depth = lines[index].count("{") - lines[index].count("}")
+            end_index = index + 1
+            while end_index < total and depth > 0:
+                depth += lines[end_index].count("{") - lines[end_index].count("}")
+                end_index += 1
+            # `end_index - 1` is the block's closing-brace line; exclude it
+            # (and the opening `mod NAME {` line at `index`) from the range
+            # handed back to callers, which only care about the block body.
+            blocks.append((name, index + 1, end_index - 1))
+            pending_test_attr = False
+            index = end_index
+            continue
+        if stripped:
+            pending_test_attr = False
+        index += 1
+    return blocks
+
+
+def find_cfg_test_file_mod_declarations(lines: list[str]) -> list[str]:
+    """Return the names declared by top-level ``#[cfg(test)] mod NAME;`` file
+    modules in `lines`.
+
+    Declarations nested inside an inline `mod { .. }` block are intentionally
+    skipped here; `find_inline_cfg_test_mod_blocks` already accounts for
+    everything inside such a block, and Rust's file-module resolution for a
+    `mod NAME;` nested inside an inline module is an unusual (`#[path]`-only)
+    pattern this scanner does not need to resolve.
+    """
+
+    names: list[str] = []
+    pending_test_attr = False
+    depth = 0
+    for line in lines:
+        stripped = line.strip()
+        if depth == 0 and stripped.startswith("#[") and not stripped.startswith("#!["):
+            if is_rust_test_cfg_attribute(stripped):
+                pending_test_attr = True
+            depth += line.count("{") - line.count("}")
+            continue
+        if depth == 0:
+            match = MOD_FILE_DECL_RE.match(stripped)
+            if match is not None and pending_test_attr:
+                names.append(match.group(1))
+        if depth == 0 and stripped:
+            pending_test_attr = False
+        depth += line.count("{") - line.count("}")
+        depth = max(depth, 0)
+    return names
+
+
+def resolve_file_module_child(source_path: Path, name: str) -> Path | None:
+    """Resolve the file backing a ``mod NAME;`` declared inside `source_path`.
+
+    Follows Rust's module-file resolution: a directory-index file (`mod.rs`,
+    `lib.rs`, `main.rs`) declares children as siblings in its own directory;
+    any other file (`foo.rs`) declares children under a `foo/` sibling
+    directory. Both the 2018-edition sibling-directory form (`NAME.rs`) and
+    the legacy form (`NAME/mod.rs`) are accepted for the child itself.
+    """
+
+    if source_path.stem in {"mod", "lib", "main"}:
+        base_dir = source_path.parent
+    else:
+        base_dir = source_path.parent / source_path.stem
+
+    direct = base_dir / f"{name}.rs"
+    if direct.exists():
+        return direct
+    nested = base_dir / name / "mod.rs"
+    if nested.exists():
+        return nested
+    return None
+
+
+def find_cfg_test_src_module_test_double_violations(
+    record: BoundaryRecord,
+    info: ManifestInfo,
+    source_path: Path,
+    repo_root: Path,
+) -> list[BoundaryViolation]:
+    """Find sealed-trait test doubles hidden inside a `src/` file's
+    `#[cfg(test)]` modules — both inline `mod NAME { .. }` blocks and
+    `mod NAME;` file modules — in a workspace crate other than the boundary's
+    owner.
+
+    `collect_active_implementation_violations` already scans the owner
+    crate's entire `src/` (test-gated or not) and every crate's `tests/`
+    directory unconditionally. Neither pass visits a *consumer* crate's
+    `#[cfg(test)]` module inside `src/`, so a sealed-trait test double
+    declared that way (e.g. `atm_core::ack::admission_tests::EmptyGraftReceiverStore`)
+    was invisible to allowlist enforcement even though the manifest can name
+    it with the same `<crate>::<module path>` convention used for `tests/`
+    directory doubles.
+    """
+
+    if record.public_trait is None:
+        return []
+
     violations: list[BoundaryViolation] = []
     rel_source = source_path.relative_to(repo_root).as_posix()
-    for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
-        if is_comment_line(line):
-            continue
-        match = trait_pattern.search(line)
-        if match is None:
-            continue
-        if is_inside_string_literal(line, match.start()):
-            # Architecture/boundary tests commonly assert against source text
-            # via string literals, e.g.
-            # `source.contains("impl Foo for Bar")`. That inert literal is not
-            # a real implementation and must not be mistaken for one.
-            continue
-        implementation_path = f"{module_path}::{match.group(1)}"
-        if implementation_path in allowed_paths:
-            continue
-        violations.append(
-            BoundaryViolation(
-                f"{rel_source}:{line_number}",
-                f"{record.boundary_id} trait-only implementation {implementation_path!r} "
-                "is not listed in testing.allowed_test_double_paths",
+    lines = source_path.read_text(encoding="utf-8").splitlines()
+    base_module_path = crate_qualified_module_path(info, source_path)
+    trait_pattern = _trait_impl_pattern(record.public_trait)
+
+    for mod_name, start_index, end_index in find_inline_cfg_test_mod_blocks(lines):
+        module_path = f"{base_module_path}::{mod_name}"
+        violations.extend(
+            _scan_lines_for_trait_impl_violations(
+                record=record,
+                trait_pattern=trait_pattern,
+                module_path=module_path,
+                rel_source=rel_source,
+                lines=lines[start_index:end_index],
+                line_offset=start_index,
             )
         )
+
+    for mod_name in find_cfg_test_file_mod_declarations(lines):
+        child_path = resolve_file_module_child(source_path, mod_name)
+        if child_path is None:
+            continue
+        child_module_path = crate_qualified_module_path(info, child_path)
+        violations.extend(
+            find_trait_only_test_double_violations(record, child_module_path, child_path, repo_root)
+        )
+
     return violations
 
 
@@ -2244,6 +2448,22 @@ def collect_active_implementation_violations(repo_root: Path, records: list[Boun
                     violations.extend(
                         find_trait_only_test_double_violations(
                             record, test_module_path(test_info, test_path), test_path, repo_root
+                        )
+                    )
+            # Nor are they confined to `tests/`: a consumer crate can just as
+            # easily hide a `impl Trait for Double` inside a `#[cfg(test)]`
+            # module of its own `src/` (an inline `mod x { .. }` block or a
+            # `mod x;` file module). The owner crate's own `src/` is already
+            # fully scanned above regardless of test-gating, so skip it here
+            # to avoid re-flagging an already-approved `crate::…`-qualified
+            # double under a second, `<crate>::…`-qualified identity.
+            for consumer_info in all_infos:
+                if consumer_info.path == owner_info.path:
+                    continue
+                for consumer_src_path in source_files_for_crate(consumer_info):
+                    violations.extend(
+                        find_cfg_test_src_module_test_double_violations(
+                            record, consumer_info, consumer_src_path, repo_root
                         )
                     )
     return violations

--- a/.just/tests/test_lint_boundaries.py
+++ b/.just/tests/test_lint_boundaries.py
@@ -1308,6 +1308,96 @@ atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.1.2" }
                 rendered,
             )
 
+    def test_collect_boundary_violations_scans_consumer_crate_cfg_test_src_module_for_trait_only_doubles(
+        self,
+    ) -> None:
+        """AQ1.5 QA-2: a `#[cfg(test)]` module inside a *consumer* crate's
+        `src/` must not be invisible either.
+
+        Covers both shapes the finding calls out: an inline
+        `#[cfg(test)] mod NAME { .. }` block and a `#[cfg(test)] mod NAME;`
+        file module -- the latter is the exact shape of the real
+        `atm_core::ack::admission_tests::EmptyGraftReceiverStore` double this
+        regression guards.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            trait_only_record = (
+                BASE_BOUNDARY_TOML.replace('trait = "MailStore"', 'trait = "TestEmitter"')
+                .replace('owner_package = "atm-storage-rusqlite"', 'owner_package = "atm-core"')
+                .replace('owner_crate_path = "atm_storage_rusqlite"', 'owner_crate_path = "atm_core"')
+                .replace(
+                    'allowed_dependents = ["atm-daemon"]',
+                    'allowed_dependents = ["agent-team-mail", "atm-daemon", "atm-storage-rusqlite"]',
+                )
+                .replace('type = "SqliteMailStore"\nmodule = "atm_storage_rusqlite::mail_store"\n', "")
+                .replace('visibility = "private"\nconstructor = "private"', 'visibility = "trait_only"\nconstructor = "none"')
+                .replace('state = "planned"', 'state = "active"')
+                .replace(
+                    'allowed_test_double_paths = ["atm_core::test_support::InMemoryMailStore"]',
+                    'allowed_test_double_paths = ['
+                    '"atm_daemon::tests::ApprovedInlineEmitter", '
+                    '"atm_daemon::emitter_double::ApprovedFileEmitter"]',
+                )
+            )
+            self.write_toml_record(repo_root, "atm-core", text=trait_only_record)
+            (repo_root / "crates/atm-daemon/src/lib.rs").write_text(
+                "impl TestEmitter for ProductionOutsideCfgTestEmitter {}\n"
+                "\n"
+                "#[cfg(test)]\n"
+                "mod tests {\n"
+                "    impl TestEmitter for ApprovedInlineEmitter {}\n"
+                "    impl TestEmitter for UnapprovedInlineEmitter {}\n"
+                "}\n"
+                "\n"
+                "#[cfg(test)]\n"
+                "mod emitter_double;\n",
+                encoding="utf-8",
+            )
+            (repo_root / "crates/atm-daemon/src/emitter_double.rs").write_text(
+                "impl TestEmitter for ApprovedFileEmitter {}\n"
+                "impl TestEmitter for UnapprovedFileEmitter {}\n"
+                '// impl TestEmitter for CommentedOutFileEmitter {}\n'
+                '    source.contains("impl TestEmitter for StringLiteralFileEmitter");\n',
+                encoding="utf-8",
+            )
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+
+            self.assertFalse(
+                any("atm_daemon::tests::ApprovedInlineEmitter" in item for item in rendered), rendered
+            )
+            self.assertFalse(
+                any("atm_daemon::emitter_double::ApprovedFileEmitter" in item for item in rendered), rendered
+            )
+            self.assertFalse(any("CommentedOutFileEmitter" in item for item in rendered), rendered)
+            self.assertFalse(any("StringLiteralFileEmitter" in item for item in rendered), rendered)
+            # A production impl sitting outside any #[cfg(test)] scope in a
+            # consumer crate is out of this pass's remit (that is a different
+            # policy question than test-double allowlisting); confirm the new
+            # cfg(test)-module scan did not silently widen scope to it.
+            self.assertFalse(
+                any("ProductionOutsideCfgTestEmitter" in item for item in rendered), rendered
+            )
+            self.assertTrue(
+                any(
+                    "trait-only implementation 'atm_daemon::tests::UnapprovedInlineEmitter'" in item
+                    and "allowed_test_double_paths" in item
+                    for item in rendered
+                ),
+                rendered,
+            )
+            self.assertTrue(
+                any(
+                    "trait-only implementation 'atm_daemon::emitter_double::UnapprovedFileEmitter'" in item
+                    and "allowed_test_double_paths" in item
+                    for item in rendered
+                ),
+                rendered,
+            )
+
     def test_every_declared_io_forbidden_tag_has_source_pattern_mapping(self) -> None:
         declared: set[str] = set()
         for path in Path(__file__).resolve().parents[2].glob("boundaries/*/*.toml"):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "base64",
  "chrono",
  "fs4",
- "getrandom 0.3.4",
  "interprocess",
  "libc",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,9 @@ version = "1.4.4"
 dependencies = [
  "async-trait",
  "atm-error",
+ "base64",
  "chrono",
+ "getrandom 0.3.4",
  "rustls",
  "serde",
  "serde_json",

--- a/boundaries/atm-storage/graft-receiver-endpoint-store.toml
+++ b/boundaries/atm-storage/graft-receiver-endpoint-store.toml
@@ -34,7 +34,10 @@ error_types = ["GraftEndpointStoreError"]
 notes = ["register unconditionally displaces a different owner generation because its sole in-tree caller has already acquired the same-host receiver flock", "lookup liveness is derived by consumers from last_seen_at and unreachable_at; no status boolean is stored", "the lease table uses a natural (team, agent) join key and declares no roster foreign key"]
 
 [testing]
-allowed_test_double_paths = []
+allowed_test_double_paths = [
+  "crate::contract::DummyGraftReceiverEndpointStore",
+  "atm_core::ack::admission_tests::EmptyGraftReceiverStore",
+]
 forbidden_test_bypasses = ["rusqlite::Connection"]
 
 [enforcement]

--- a/boundaries/atm-storage/graft-receiver-endpoint-store.toml
+++ b/boundaries/atm-storage/graft-receiver-endpoint-store.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-GraftReceiverEndpointStore"
+owner_package = "atm-storage"
+owner_crate_path = "atm_storage"
+name = "GraftReceiverEndpointStore"
+
+[public]
+trait = "GraftReceiverEndpointStore"
+notes = "sealed storage-neutral durable registry for loopback graft receiver leases; the natural (team, agent) key is intentionally not a SQL foreign key to the replace-on-save roster"
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["graft_receiver_lease_registration", "graft_receiver_lease_refresh", "graft_receiver_lease_unregistration", "graft_receiver_liveness_feedback"]
+io_forbidden = ["direct_sqlite_io", "message_delivery", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-core", "atm-daemon-bootstrap", "atm-runtime", "atm-storage-rusqlite"]
+allowed_dependencies = []
+forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite", "atm-storage -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["rusqlite::Connection"]
+
+[contracts]
+request_types = ["GraftReceiverRegistration", "TeamName", "AgentName", "SocketAddr", "LocalCapability", "DateTime<Utc>"]
+response_types = ["GraftReceiverLease", "Option<GraftReceiverLease>"]
+error_types = ["GraftEndpointStoreError"]
+notes = ["register unconditionally displaces a different owner generation because its sole in-tree caller has already acquired the same-host receiver flock", "lookup liveness is derived by consumers from last_seen_at and unreachable_at; no status boolean is stored", "the lease table uses a natural (team, agent) join key and declares no roster foreign key"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["rusqlite::Connection"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-GRAFT-RECEIVER-ENDPOINT-STORE-REFERENCES"]
+review_gates = ["local_ingress_only", "loopback_endpoint_only", "no_backend_to_core_edge_for_graft_receiver_endpoint_store"]
+
+[status]
+state = "concrete_landed"
+notes = ["AQ1.5 owns the sealed contract, SQLite implementation, schema migration, and replacement-router registration routes; receiver-side announce and production bootstrap wiring belong to AQ1.6 and AQ1.7"]

--- a/boundaries/atm-storage/graft-receiver-endpoint-store.toml
+++ b/boundaries/atm-storage/graft-receiver-endpoint-store.toml
@@ -20,7 +20,7 @@ io_forbidden = ["direct_sqlite_io", "message_delivery", "process_spawn"]
 
 [dependencies]
 allowed_dependents = ["atm-core", "atm-daemon-bootstrap", "atm-runtime", "atm-storage-rusqlite"]
-allowed_dependencies = []
+allowed_dependencies = ["atm-error", "base64", "chrono", "getrandom", "serde"]
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite", "atm-storage -> atm-daemon"]
 
 [references]

--- a/boundaries/atm-storage/pending-nudge-store.toml
+++ b/boundaries/atm-storage/pending-nudge-store.toml
@@ -19,7 +19,7 @@ io_owns = ["deferred_nudge_marker_lifecycle", "deferred_nudge_claim_at_most_once
 io_forbidden = ["direct_sqlite_io", "message_delivery", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm-core", "atm-daemon-bootstrap", "atm-storage-rusqlite"]
+allowed_dependents = ["atm-core", "atm-daemon-bootstrap", "atm-runtime", "atm-storage-rusqlite"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite", "atm-storage -> atm-daemon"]
 

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -32,7 +32,6 @@ toml = "0.8"
 parking_lot = "0.12"
 ulid.workspace = true
 base64.workspace = true
-getrandom.workspace = true
 semver.workspace = true
 fs4 = "0.13"
 async-trait.workspace = true

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -22,6 +22,7 @@ use crate::send::{SendMessageSource, SendRequest};
 use crate::service_runtime::LocalServiceRuntime;
 use crate::test_support::{TEST_SENDER, TEST_TEAM};
 use crate::types::{AgentName, IsoTimestamp, TeamName};
+use atm_storage::OwnerGeneration;
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource,
     GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
@@ -445,7 +446,7 @@ impl GraftReceiverEndpointStore for EmptyGraftReceiverStore {
         &self,
         _team: &TeamName,
         _agent: &AgentName,
-        _owner_generation: &str,
+        _owner_generation: &OwnerGeneration,
         _now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError> {
         Ok(())
@@ -455,7 +456,7 @@ impl GraftReceiverEndpointStore for EmptyGraftReceiverStore {
         &self,
         _team: &TeamName,
         _agent: &AgentName,
-        _owner_generation: &str,
+        _owner_generation: &OwnerGeneration,
     ) -> Result<(), GraftEndpointStoreError> {
         Ok(())
     }
@@ -472,7 +473,7 @@ impl GraftReceiverEndpointStore for EmptyGraftReceiverStore {
         &self,
         _team: &TeamName,
         _agent: &AgentName,
-        _owner_generation: &str,
+        _owner_generation: &OwnerGeneration,
         _now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError> {
         Ok(())
@@ -501,7 +502,7 @@ fn graft_receiver_runtime_wiring_and_unconfigured_defaults_are_explicit() {
         .mark_graft_receiver_unreachable(
             &TeamName::from_validated(TEST_TEAM),
             &AgentName::from_validated(CALLER),
-            "generation-1",
+            &OwnerGeneration::new("01J00000000000000000000001").expect("owner generation"),
             Utc::now(),
         )
         .expect("unconfigured unreachable default");

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use chrono::{DateTime, Utc};
 use serde_json::Map;
 
 use super::{admit_acknowledgement_write, admit_acknowledgement_write_async};
@@ -23,6 +24,8 @@ use crate::test_support::{TEST_SENDER, TEST_TEAM};
 use crate::types::{AgentName, IsoTimestamp, TeamName};
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource,
+    GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
+    GraftReceiverRegistration,
 };
 
 /// The acknowledging agent: the pending source sits in this agent's mailbox
@@ -423,6 +426,103 @@ fn local_runtime(store: Arc<InMemoryAsyncStore>, attach_async_store: bool) -> Lo
     } else {
         runtime
     }
+}
+
+struct EmptyGraftReceiverStore;
+
+impl atm_storage::contract::sealed::Sealed for EmptyGraftReceiverStore {}
+
+impl GraftReceiverEndpointStore for EmptyGraftReceiverStore {
+    fn register(
+        &self,
+        _registration: &GraftReceiverRegistration,
+        _now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        Ok(())
+    }
+
+    fn refresh(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+        _owner_generation: &str,
+        _now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        Ok(())
+    }
+
+    fn unregister(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+        _owner_generation: &str,
+    ) -> Result<(), GraftEndpointStoreError> {
+        Ok(())
+    }
+
+    fn lookup(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+    ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError> {
+        Ok(None)
+    }
+
+    fn mark_unreachable(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+        _owner_generation: &str,
+        _now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn graft_receiver_runtime_wiring_and_unconfigured_defaults_are_explicit() {
+    use crate::service_runtime::RetainedServiceRuntime;
+
+    let store = Arc::new(InMemoryAsyncStore {
+        records: Mutex::new(Vec::new()),
+    });
+    let runtime = local_runtime(store, false);
+    assert!(runtime.graft_receiver_endpoint_store().is_err());
+    assert_eq!(
+        runtime
+            .graft_receiver_lease(
+                &TeamName::from_validated(TEST_TEAM),
+                &AgentName::from_validated(CALLER)
+            )
+            .expect("unconfigured lease default"),
+        None
+    );
+    runtime
+        .mark_graft_receiver_unreachable(
+            &TeamName::from_validated(TEST_TEAM),
+            &AgentName::from_validated(CALLER),
+            "generation-1",
+            Utc::now(),
+        )
+        .expect("unconfigured unreachable default");
+
+    let runtime = local_runtime(
+        Arc::new(InMemoryAsyncStore {
+            records: Mutex::new(Vec::new()),
+        }),
+        false,
+    )
+    .with_graft_receiver_endpoint_store(Arc::new(EmptyGraftReceiverStore));
+    assert!(runtime.graft_receiver_endpoint_store().is_ok());
+    assert_eq!(
+        runtime
+            .graft_receiver_lease(
+                &TeamName::from_validated(TEST_TEAM),
+                &AgentName::from_validated(CALLER)
+            )
+            .expect("configured lease lookup"),
+        None
+    );
 }
 
 /// Minimal executor: with in-memory stores the admission future never pends,

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -34,6 +34,9 @@ const READ_PATH: &str = "/v1/atm/messages/read";
 const DOCTOR_PATH: &str = "/v1/atm/doctor";
 const COMPATIBILITY_PATH: &str = "/v1/atm/compatibility";
 const HEARTBEAT_PATH: &str = "/v1/atm/heartbeat";
+const GRAFT_RECEIVER_REGISTER_PATH: &str = "/v1/atm/graft/receiver/register";
+const GRAFT_RECEIVER_UNREGISTER_PATH: &str = "/v1/atm/graft/receiver/unregister";
+const GRAFT_RECEIVER_LOOKUP_PATH: &str = "/v1/atm/graft/receiver/lookup";
 const RUNTIME_RELOAD_PATH: &str = "/v1/atm/runtime/reload";
 const SEARCH_PATH: &str = "/v1/atm/messages/search";
 
@@ -55,6 +58,9 @@ pub enum HttpRouteKind {
     RuntimeReload,
     Compatibility,
     Heartbeat,
+    GraftReceiverRegister,
+    GraftReceiverUnregister,
+    GraftReceiverLookup,
     Search,
 }
 
@@ -137,6 +143,27 @@ const HTTP_ROUTE_SPECS: &[HttpRouteSpec] = &[
             path_template: HEARTBEAT_PATH,
         },
     },
+    HttpRouteSpec {
+        kind: HttpRouteKind::GraftReceiverRegister,
+        route: HttpRoute {
+            method: "POST",
+            path_template: GRAFT_RECEIVER_REGISTER_PATH,
+        },
+    },
+    HttpRouteSpec {
+        kind: HttpRouteKind::GraftReceiverUnregister,
+        route: HttpRoute {
+            method: "POST",
+            path_template: GRAFT_RECEIVER_UNREGISTER_PATH,
+        },
+    },
+    HttpRouteSpec {
+        kind: HttpRouteKind::GraftReceiverLookup,
+        route: HttpRoute {
+            method: "POST",
+            path_template: GRAFT_RECEIVER_LOOKUP_PATH,
+        },
+    },
 ];
 
 /// Registered HTTP route inventory for documentation conformance tests.
@@ -158,6 +185,9 @@ fn route_spec(kind: HttpRouteKind) -> &'static HttpRouteSpec {
         HttpRouteKind::RuntimeReload => &HTTP_ROUTE_SPECS[7],
         HttpRouteKind::Compatibility => &HTTP_ROUTE_SPECS[8],
         HttpRouteKind::Heartbeat => &HTTP_ROUTE_SPECS[9],
+        HttpRouteKind::GraftReceiverRegister => &HTTP_ROUTE_SPECS[10],
+        HttpRouteKind::GraftReceiverUnregister => &HTTP_ROUTE_SPECS[11],
+        HttpRouteKind::GraftReceiverLookup => &HTTP_ROUTE_SPECS[12],
     }
 }
 
@@ -173,6 +203,9 @@ fn route_kind_for_request(request: &RequestEnvelope) -> HttpRouteKind {
         RequestEnvelope::ReloadRuntimeView => HttpRouteKind::RuntimeReload,
         RequestEnvelope::CompatibilityPreflight(_) => HttpRouteKind::Compatibility,
         RequestEnvelope::Heartbeat(_) => HttpRouteKind::Heartbeat,
+        RequestEnvelope::GraftReceiverRegister(_) => HttpRouteKind::GraftReceiverRegister,
+        RequestEnvelope::GraftReceiverUnregister(_) => HttpRouteKind::GraftReceiverUnregister,
+        RequestEnvelope::GraftReceiverLookup { .. } => HttpRouteKind::GraftReceiverLookup,
     }
 }
 
@@ -299,6 +332,14 @@ fn encode_request_body(request: &RequestEnvelope) -> Result<Vec<u8>, AtmError> {
         RequestEnvelope::Write(value) => serde_json::to_vec(value),
         RequestEnvelope::CompatibilityPreflight(value) => serde_json::to_vec(value),
         RequestEnvelope::Heartbeat(value) => serde_json::to_vec(value),
+        RequestEnvelope::GraftReceiverRegister(value) => serde_json::to_vec(value),
+        RequestEnvelope::GraftReceiverUnregister(value) => serde_json::to_vec(value),
+        RequestEnvelope::GraftReceiverLookup { team, agent } => {
+            serde_json::to_vec(&crate::protocol::GraftReceiverLookupRequest {
+                team: team.clone(),
+                agent: agent.clone(),
+            })
+        }
         RequestEnvelope::List(value) => serde_json::to_vec(value),
         RequestEnvelope::Peek(value) => serde_json::to_vec(value),
         RequestEnvelope::Receive(value) => serde_json::to_vec(value),
@@ -343,6 +384,18 @@ fn decode_success_response(
         RequestEnvelope::Heartbeat(_) => {
             decode_response_body(body, "heartbeat").map(ResponseEnvelope::Heartbeat)
         }
+        RequestEnvelope::GraftReceiverRegister(_) => {
+            decode_response_body::<()>(body, "graft receiver register")
+                .map(|()| ResponseEnvelope::GraftReceiverRegister)
+        }
+        RequestEnvelope::GraftReceiverUnregister(_) => {
+            decode_response_body::<()>(body, "graft receiver unregister")
+                .map(|()| ResponseEnvelope::GraftReceiverUnregister)
+        }
+        RequestEnvelope::GraftReceiverLookup { .. } => {
+            decode_response_body(body, "graft receiver lookup")
+                .map(ResponseEnvelope::GraftReceiverLookup)
+        }
         RequestEnvelope::List(_) => decode_response_body(body, "list").map(ResponseEnvelope::List),
         RequestEnvelope::Peek(_) => {
             decode_response_body(body, "peek").map(|value| ResponseEnvelope::Peek(Box::new(value)))
@@ -379,6 +432,12 @@ pub enum ApiRequest {
     Search(Box<SearchRequest>),
     CompatibilityPreflight(CompatibilityPreflight),
     Heartbeat(TeamMemberHeartbeatRequest),
+    GraftReceiverRegister(atm_storage::GraftReceiverRegistration),
+    GraftReceiverUnregister(crate::protocol::GraftReceiverUnregistration),
+    GraftReceiverLookup {
+        team: crate::types::TeamName,
+        agent: crate::types::AgentName,
+    },
     ReloadRuntimeView,
 }
 
@@ -409,6 +468,13 @@ impl ApiRequest {
                 RequestEnvelope::CompatibilityPreflight(preflight)
             }
             Self::Heartbeat(request) => RequestEnvelope::Heartbeat(request),
+            Self::GraftReceiverRegister(request) => RequestEnvelope::GraftReceiverRegister(request),
+            Self::GraftReceiverUnregister(request) => {
+                RequestEnvelope::GraftReceiverUnregister(request)
+            }
+            Self::GraftReceiverLookup { team, agent } => {
+                RequestEnvelope::GraftReceiverLookup { team, agent }
+            }
             Self::ReloadRuntimeView => RequestEnvelope::ReloadRuntimeView,
         }
     }
@@ -434,6 +500,13 @@ impl From<RequestEnvelope> for ApiRequest {
                 Self::CompatibilityPreflight(preflight)
             }
             RequestEnvelope::Heartbeat(request) => Self::Heartbeat(request),
+            RequestEnvelope::GraftReceiverRegister(request) => Self::GraftReceiverRegister(request),
+            RequestEnvelope::GraftReceiverUnregister(request) => {
+                Self::GraftReceiverUnregister(request)
+            }
+            RequestEnvelope::GraftReceiverLookup { team, agent } => {
+                Self::GraftReceiverLookup { team, agent }
+            }
             RequestEnvelope::ReloadRuntimeView => Self::ReloadRuntimeView,
         }
     }
@@ -457,10 +530,12 @@ impl ApiResponse {
 #[cfg(test)]
 mod tests {
     use base64::Engine as _;
+    use std::net::SocketAddr;
 
     use super::{HttpRouteKind, encode_http_request, http_route_kind};
-    use crate::protocol::RequestEnvelope;
+    use crate::protocol::{GraftReceiverLookupRequest, GraftReceiverRegistration, RequestEnvelope};
     use crate::search::SearchRequest;
+    use crate::types::{AgentName, TeamName};
 
     #[test]
     fn search_is_encoded_as_one_bodyless_get_query_parameter() {
@@ -490,6 +565,55 @@ mod tests {
                 lifecycle: None,
             }
         );
+    }
+
+    #[test]
+    fn graft_receiver_routes_round_trip_through_the_shared_codec() {
+        let registration = GraftReceiverRegistration {
+            team: TeamName::from_validated("test-team"),
+            agent: AgentName::from_validated("test-agent"),
+            endpoint: "127.0.0.1:43101".parse::<SocketAddr>().expect("endpoint"),
+            capability: crate::local_http::LocalCapability::generate().expect("capability"),
+            owner_generation: "01J00000000000000000000000".to_owned(),
+        };
+        let requests = [
+            RequestEnvelope::GraftReceiverRegister(registration),
+            RequestEnvelope::GraftReceiverUnregister(
+                crate::protocol::GraftReceiverUnregistration {
+                    team: TeamName::from_validated("test-team"),
+                    agent: AgentName::from_validated("test-agent"),
+                    owner_generation: "01J00000000000000000000000".to_owned(),
+                },
+            ),
+            RequestEnvelope::GraftReceiverLookup {
+                team: TeamName::from_validated("test-team"),
+                agent: AgentName::from_validated("test-agent"),
+            },
+        ];
+        for request in requests {
+            let encoded = encode_http_request(&request, &[]).expect("HTTP request");
+            assert_eq!(
+                http_route_kind(&encoded.method, &encoded.path),
+                Some(match request {
+                    RequestEnvelope::GraftReceiverRegister(_) => {
+                        HttpRouteKind::GraftReceiverRegister
+                    }
+                    RequestEnvelope::GraftReceiverUnregister(_) => {
+                        HttpRouteKind::GraftReceiverUnregister
+                    }
+                    RequestEnvelope::GraftReceiverLookup { .. } => {
+                        HttpRouteKind::GraftReceiverLookup
+                    }
+                    _ => unreachable!(),
+                })
+            );
+            if matches!(request, RequestEnvelope::GraftReceiverLookup { .. }) {
+                let decoded: GraftReceiverLookupRequest =
+                    serde_json::from_slice(&encoded.body).expect("lookup body");
+                assert_eq!(decoded.team.as_str(), "test-team");
+                assert_eq!(decoded.agent.as_str(), "test-agent");
+            }
+        }
     }
 }
 

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -533,7 +533,9 @@ mod tests {
     use std::net::SocketAddr;
 
     use super::{HttpRouteKind, encode_http_request, http_route_kind};
-    use crate::protocol::{GraftReceiverLookupRequest, GraftReceiverRegistration, RequestEnvelope};
+    use crate::protocol::{
+        GraftReceiverLookupRequest, GraftReceiverRegistration, OwnerGeneration, RequestEnvelope,
+    };
     use crate::search::SearchRequest;
     use crate::types::{AgentName, TeamName};
 
@@ -569,12 +571,14 @@ mod tests {
 
     #[test]
     fn graft_receiver_routes_round_trip_through_the_shared_codec() {
+        let owner_generation =
+            OwnerGeneration::new("01J00000000000000000000000").expect("owner generation");
         let registration = GraftReceiverRegistration {
             team: TeamName::from_validated("test-team"),
             agent: AgentName::from_validated("test-agent"),
             endpoint: "127.0.0.1:43101".parse::<SocketAddr>().expect("endpoint"),
             capability: crate::local_http::LocalCapability::generate().expect("capability"),
-            owner_generation: "01J00000000000000000000000".to_owned(),
+            owner_generation: owner_generation.clone(),
         };
         let requests = [
             RequestEnvelope::GraftReceiverRegister(registration),
@@ -582,7 +586,7 @@ mod tests {
                 crate::protocol::GraftReceiverUnregistration {
                     team: TeamName::from_validated("test-team"),
                     agent: AgentName::from_validated("test-agent"),
-                    owner_generation: "01J00000000000000000000000".to_owned(),
+                    owner_generation,
                 },
             ),
             RequestEnvelope::GraftReceiverLookup {

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -143,6 +143,11 @@ pub use delivery_channel::{
 pub use graft::AtmGraftClient;
 pub use protocol::{RequestEnvelope, ResponseEnvelope};
 pub use search::{SearchAggregateInput, SearchHit, SearchInput, SearchRequest, SearchResponse};
+// The canonical `GraftEndpointStoreError` -> `AtmError` mapping. Every
+// dispatch path (HTTP handlers, the retained-runtime bridge) must produce the
+// same `AtmError` — and therefore the same HTTP status — for a given store
+// error; see the doc comment on `service_runtime::graft_store_error`.
+pub use service_runtime::graft_store_error;
 pub use service_runtime::{
     LocalFileNonClaudeOutbound, LocalServiceRuntime, with_default_local_service_runtime,
 };

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -112,6 +112,7 @@ pub use api::{
     MAX_HTTP_REQUEST_BODY_BYTES, RequestDeadline,
 };
 pub use atm_storage::derive_ack_requirement;
+pub use atm_storage::{GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease};
 pub use atm_storage::{TemplateFrontmatter, TemplateSha};
 #[allow(deprecated)]
 pub use boundary::{

--- a/crates/atm-core/src/local_http.rs
+++ b/crates/atm-core/src/local_http.rs
@@ -7,7 +7,6 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -16,50 +15,7 @@ use crate::types::IsoTimestamp;
 
 pub const LOCAL_HTTP_RECORD_FILENAME: &str = "local-http.json";
 pub const LOCAL_CAPABILITY_HEADER: &str = "X-ATM-Local-Capability";
-pub const LOCAL_CAPABILITY_BYTES: usize = 32;
-
-/// Capability presented by local loopback HTTP clients.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LocalCapability([u8; LOCAL_CAPABILITY_BYTES]);
-
-impl LocalCapability {
-    /// Generates a fresh capability using the operating system RNG.
-    pub fn generate() -> Result<Self, AtmError> {
-        let mut bytes = [0; LOCAL_CAPABILITY_BYTES];
-        getrandom::fill(&mut bytes).map_err(|source| {
-            AtmError::daemon_unavailable(format!(
-                "failed to generate local HTTP capability: {source}"
-            ))
-        })?;
-        Ok(Self(bytes))
-    }
-
-    pub fn to_base64url(&self) -> String {
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(self.0)
-    }
-
-    pub fn parse_base64url(value: &str) -> Result<Self, AtmError> {
-        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(value)
-            .map_err(|source| {
-                AtmError::local_http_capability_invalid("local HTTP capability is not base64url")
-                    .with_cause(source)
-            })?;
-        let bytes: [u8; LOCAL_CAPABILITY_BYTES] = bytes.try_into().map_err(|_| {
-            AtmError::local_http_capability_invalid(
-                "local HTTP capability must decode to exactly 32 bytes",
-            )
-        })?;
-        Ok(Self(bytes))
-    }
-
-    pub fn matches_header(&self, value: &str) -> bool {
-        match Self::parse_base64url(value) {
-            Ok(candidate) => constant_time_eq(&self.0, &candidate.0),
-            Err(_) => false,
-        }
-    }
-}
+pub use atm_storage::{LOCAL_CAPABILITY_BYTES, LocalCapability};
 
 /// Owner-readable local endpoint publication next to the singleton lock.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -206,20 +162,9 @@ fn read_owner_shadow_record(_lock_path: &Path) -> Result<String, AtmError> {
     ))
 }
 
-fn constant_time_eq(
-    left: &[u8; LOCAL_CAPABILITY_BYTES],
-    right: &[u8; LOCAL_CAPABILITY_BYTES],
-) -> bool {
-    let mut difference = 0_u8;
-    for (left, right) in left.iter().zip(right) {
-        difference |= left ^ right;
-    }
-    difference == 0
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{LOCAL_CAPABILITY_BYTES, LocalCapability, LocalHttpEndpointRecord};
+    use super::{LocalCapability, LocalHttpEndpointRecord};
     use crate::error::AtmErrorCode;
     use std::net::SocketAddr;
     use ulid::Ulid;
@@ -234,10 +179,10 @@ mod tests {
         assert_eq!(
             LocalCapability::parse_base64url(&encoded)
                 .expect("decode")
-                .0
-                .len(),
-            LOCAL_CAPABILITY_BYTES
+                .to_base64url(),
+            encoded
         );
+        assert_eq!(encoded.len(), 43, "32 bytes in unpadded base64url");
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -25,6 +25,15 @@ use crate::search::{SearchRequest, SearchResponse};
 use crate::send::{SendOutcome, WriteRequest};
 use crate::types::{AgentName, IsoTimestamp, SessionId, TeamName, deserialize_optional_session_id};
 
+pub use atm_storage::{GraftReceiverLease, GraftReceiverRegistration, LocalCapability};
+
+/// Body representation for the local graft receiver lookup route.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraftReceiverLookupRequest {
+    pub team: TeamName,
+    pub agent: AgentName,
+}
+
 const DAEMON_SOCKET_FILENAME: &str = "atm-daemon.sock";
 const MAX_VERSION_LENGTH: usize = 256;
 
@@ -41,6 +50,12 @@ pub enum RequestEnvelope {
     Write(Box<WriteRequest>),
     CompatibilityPreflight(CompatibilityPreflight),
     Heartbeat(TeamMemberHeartbeatRequest),
+    GraftReceiverRegister(GraftReceiverRegistration),
+    GraftReceiverUnregister(GraftReceiverUnregistration),
+    GraftReceiverLookup {
+        team: TeamName,
+        agent: AgentName,
+    },
     List(ListQuery),
     Peek(PeekQuery),
     Receive(ReadQuery),
@@ -57,6 +72,9 @@ pub enum ResponseEnvelope {
     Send(SendResponseEnvelope),
     CompatibilityVerdict(CompatibilityVerdict),
     Heartbeat(TeamMemberHeartbeatResponse),
+    GraftReceiverRegister,
+    GraftReceiverUnregister,
+    GraftReceiverLookup(Option<GraftReceiverLease>),
     List(ListOutcome),
     Peek(Box<ReadOutcome>),
     Receive(Box<ReadOutcome>),
@@ -358,6 +376,14 @@ pub struct TeamMemberHeartbeatResponse {
         deserialize_with = "deserialize_optional_session_id"
     )]
     pub session_id: Option<SessionId>,
+}
+
+/// Owner-checked removal request for one durable graft receiver lease.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraftReceiverUnregistration {
+    pub team: TeamName,
+    pub agent: AgentName,
+    pub owner_generation: String,
 }
 
 /// Runtime-owned live-state projection for one known team member.

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -25,7 +25,9 @@ use crate::search::{SearchRequest, SearchResponse};
 use crate::send::{SendOutcome, WriteRequest};
 use crate::types::{AgentName, IsoTimestamp, SessionId, TeamName, deserialize_optional_session_id};
 
-pub use atm_storage::{GraftReceiverLease, GraftReceiverRegistration, LocalCapability};
+pub use atm_storage::{
+    GraftReceiverLease, GraftReceiverRegistration, LocalCapability, OwnerGeneration,
+};
 
 /// Body representation for the local graft receiver lookup route.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -383,7 +385,7 @@ pub struct TeamMemberHeartbeatResponse {
 pub struct GraftReceiverUnregistration {
     pub team: TeamName,
     pub agent: AgentName,
-    pub owner_generation: String,
+    pub owner_generation: OwnerGeneration,
 }
 
 /// Runtime-owned live-state projection for one known team member.

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 use atm_storage::{
     AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore, GraftEndpointStoreError,
     GraftReceiverEndpointStore, GraftReceiverLease, MessageStore as SharedMessageStore,
-    PendingNudgeStore, RosterStore as SharedRosterStore, TemplateCatalogStore,
+    OwnerGeneration, PendingNudgeStore, RosterStore as SharedRosterStore, TemplateCatalogStore,
 };
 
 use crate::boundary::TemplateComposer;
@@ -109,7 +109,7 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
         &self,
         _team: &TeamName,
         _agent: &AgentName,
-        _owner_generation: &str,
+        _owner_generation: &OwnerGeneration,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), AtmError> {
         Ok(())
@@ -598,7 +598,7 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
         now: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), AtmError> {
         let Some(store) = &self.graft_receiver_endpoint_store else {
@@ -668,14 +668,26 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
     }
 }
 
-#[allow(dead_code)]
-fn graft_store_error(error: GraftEndpointStoreError) -> AtmError {
+/// Canonical `GraftEndpointStoreError` -> `AtmError` mapping.
+///
+/// This is the single source of truth for how graft-receiver store errors
+/// surface as `AtmError`s (and therefore as HTTP statuses, via the shared
+/// `error_response` translation in `atm-http-runtime`). QA-1 finding: this
+/// mapping used to be duplicated here and in
+/// `atm-http-runtime::storage_and_nudge_router`, with different outcomes
+/// (`NotOwner` mapped to `daemon_unavailable`/503 here but to
+/// `validation`/400 there) depending on which call path produced the error.
+/// A generation mismatch is a caller-input problem, not a backend outage, so
+/// the unified mapping treats it (and the reserved `AlreadyActive` variant)
+/// as a validation error; only genuine backend I/O failures map to
+/// `daemon_unavailable`.
+pub fn graft_store_error(error: GraftEndpointStoreError) -> AtmError {
     match error {
         GraftEndpointStoreError::NotOwner => {
-            AtmError::daemon_unavailable("graft receiver lease is owned by another generation")
+            AtmError::validation("graft receiver lease is owned by another generation")
         }
         GraftEndpointStoreError::AlreadyActive => {
-            AtmError::daemon_unavailable("graft receiver lease is already active")
+            AtmError::validation("graft receiver lease is already active")
         }
         GraftEndpointStoreError::Storage(message) => AtmError::daemon_unavailable(message),
     }

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -9,9 +9,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use atm_storage::{
-    AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore,
-    MessageStore as SharedMessageStore, PendingNudgeStore, RosterStore as SharedRosterStore,
-    TemplateCatalogStore,
+    AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore, GraftEndpointStoreError,
+    GraftReceiverEndpointStore, GraftReceiverLease, MessageStore as SharedMessageStore,
+    PendingNudgeStore, RosterStore as SharedRosterStore, TemplateCatalogStore,
 };
 
 use crate::boundary::TemplateComposer;
@@ -96,6 +96,24 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
     ) -> Result<Option<crate::boundary::TeamNudgeTemplateOverrideRow>, AtmError> {
         Ok(None)
     }
+    #[allow(dead_code)]
+    fn graft_receiver_lease(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+    ) -> Result<Option<GraftReceiverLease>, AtmError> {
+        Ok(None)
+    }
+    #[allow(dead_code)]
+    fn mark_graft_receiver_unreachable(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+        _owner_generation: &str,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), AtmError> {
+        Ok(())
+    }
     fn inbox_path(
         &self,
         home_dir: &Path,
@@ -145,6 +163,8 @@ pub struct LocalServiceRuntime {
     /// (`atm queue`) nudges. Unset in runtimes that never enqueue a deferred
     /// nudge, e.g. plain-text mailbox tests.
     pending_nudge_store: Option<std::sync::Arc<dyn PendingNudgeStore + Send + Sync>>,
+    graft_receiver_endpoint_store:
+        Option<std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>>,
     /// Optional renderer selected by the bootstrap composition root. Core send
     /// policy sees only this port; it never depends on `sc-composer` itself.
     pub(crate) template_composer: Option<std::sync::Arc<dyn TemplateComposer>>,
@@ -179,6 +199,7 @@ impl LocalServiceRuntime {
             nudge_template_override_store,
             non_claude_outbound,
             pending_nudge_store: None,
+            graft_receiver_endpoint_store: None,
             template_composer: None,
             template_catalog_store: None,
             roster_cache: Arc::new(RosterSnapshotCache::default()),
@@ -258,6 +279,27 @@ impl LocalServiceRuntime {
         self.pending_nudge_store.clone().ok_or_else(|| {
             AtmError::daemon_unavailable(
                 "the deferred-nudge pending store was not installed in this runtime",
+            )
+        })
+    }
+
+    /// Attaches the durable graft receiver endpoint registry for local-only
+    /// registration, refresh, unregistration, and lookup requests.
+    #[must_use]
+    pub fn with_graft_receiver_endpoint_store(
+        mut self,
+        store: std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
+    ) -> Self {
+        self.graft_receiver_endpoint_store = Some(store);
+        self
+    }
+
+    pub fn graft_receiver_endpoint_store(
+        &self,
+    ) -> Result<std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>, AtmError> {
+        self.graft_receiver_endpoint_store.clone().ok_or_else(|| {
+            AtmError::daemon_unavailable(
+                "the graft receiver endpoint store was not installed in this runtime",
             )
         })
     }
@@ -425,6 +467,10 @@ impl fmt::Debug for LocalServiceRuntime {
                 &std::sync::Arc::as_ptr(&self.non_claude_outbound),
             )
             .field("pending_nudge_store", &self.pending_nudge_store.is_some())
+            .field(
+                "graft_receiver_endpoint_store",
+                &self.graft_receiver_endpoint_store.is_some(),
+            )
             .finish()
     }
 }
@@ -537,6 +583,32 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
             .load_template_override(team, kind)
     }
 
+    fn graft_receiver_lease(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Result<Option<GraftReceiverLease>, AtmError> {
+        let Some(store) = &self.graft_receiver_endpoint_store else {
+            return Ok(None);
+        };
+        store.lookup(team, agent).map_err(graft_store_error)
+    }
+
+    fn mark_graft_receiver_unreachable(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), AtmError> {
+        let Some(store) = &self.graft_receiver_endpoint_store else {
+            return Ok(());
+        };
+        store
+            .mark_unreachable(team, agent, owner_generation, now)
+            .map_err(graft_store_error)
+    }
+
     fn inbox_path(
         &self,
         home_dir: &Path,
@@ -593,6 +665,19 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
                 messages: messages.to_vec(),
             })
             .map(|_| ())
+    }
+}
+
+#[allow(dead_code)]
+fn graft_store_error(error: GraftEndpointStoreError) -> AtmError {
+    match error {
+        GraftEndpointStoreError::NotOwner => {
+            AtmError::daemon_unavailable("graft receiver lease is owned by another generation")
+        }
+        GraftEndpointStoreError::AlreadyActive => {
+            AtmError::daemon_unavailable("graft receiver lease is already active")
+        }
+        GraftEndpointStoreError::Storage(message) => AtmError::daemon_unavailable(message),
     }
 }
 

--- a/crates/atm-core/src/transport/testing.rs
+++ b/crates/atm-core/src/transport/testing.rs
@@ -100,6 +100,11 @@ impl LoopbackClientTransport {
             RequestEnvelope::Heartbeat(_) => Err(AtmError::daemon_unavailable(
                 "loopback heartbeat transport is not wired outside the daemon runtime",
             )),
+            RequestEnvelope::GraftReceiverRegister(_)
+            | RequestEnvelope::GraftReceiverUnregister(_)
+            | RequestEnvelope::GraftReceiverLookup { .. } => Err(AtmError::daemon_unavailable(
+                "loopback graft receiver transport is not wired outside the daemon runtime",
+            )),
             RequestEnvelope::List(query) => {
                 list::list_mail(query, self.observability.as_ref()).map(ResponseEnvelope::List)
             }

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -17,7 +17,8 @@ use atm_core::clear::ClearQuery;
 use atm_core::doctor::DoctorQuery;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::protocol::{
-    CompatibilityPreflight, RequestId, ResponseEnvelope, SendResponseEnvelope,
+    CompatibilityPreflight, GraftReceiverLookupRequest, GraftReceiverRegistration,
+    GraftReceiverUnregistration, RequestId, ResponseEnvelope, SendResponseEnvelope,
     TeamMemberHeartbeatRequest, next_request_id,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
@@ -482,6 +483,24 @@ fn decode_framework_request(
                 .map(ApiRequest::Heartbeat)
                 .map_err(|source| invalid("heartbeat", source))
         }
+        Some(HttpRouteKind::GraftReceiverRegister) => {
+            serde_json::from_slice::<GraftReceiverRegistration>(body)
+                .map(ApiRequest::GraftReceiverRegister)
+                .map_err(|source| invalid("graft receiver register", source))
+        }
+        Some(HttpRouteKind::GraftReceiverUnregister) => {
+            serde_json::from_slice::<GraftReceiverUnregistration>(body)
+                .map(ApiRequest::GraftReceiverUnregister)
+                .map_err(|source| invalid("graft receiver unregister", source))
+        }
+        Some(HttpRouteKind::GraftReceiverLookup) => {
+            serde_json::from_slice::<GraftReceiverLookupRequest>(body)
+                .map(|value| ApiRequest::GraftReceiverLookup {
+                    team: value.team,
+                    agent: value.agent,
+                })
+                .map_err(|source| invalid("graft receiver lookup", source))
+        }
         Some(HttpRouteKind::RuntimeReload) => serde_json::from_slice::<()>(body)
             .map(|()| ApiRequest::ReloadRuntimeView)
             .map_err(|source| invalid("runtime reload", source)),
@@ -629,6 +648,9 @@ fn map_api_response(response: ApiResponse) -> Result<Response, AtmError> {
             json_response(StatusCode::OK, &value, None)
         }
         ResponseEnvelope::Heartbeat(value) => json_response(StatusCode::OK, &value, None),
+        ResponseEnvelope::GraftReceiverRegister => json_response(StatusCode::OK, &(), None),
+        ResponseEnvelope::GraftReceiverUnregister => json_response(StatusCode::OK, &(), None),
+        ResponseEnvelope::GraftReceiverLookup(value) => json_response(StatusCode::OK, &value, None),
         ResponseEnvelope::List(value) => json_response(StatusCode::OK, &value, None),
         ResponseEnvelope::Peek(value) => json_response(StatusCode::OK, &value, None),
         ResponseEnvelope::Receive(value) => json_response(StatusCode::OK, &value, None),

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use atm_core::GraftEndpointStoreError;
 use atm_core::LocalServiceRuntime;
 use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
 use atm_core::boundary::MessageReceivedHookSelector;
@@ -20,8 +21,8 @@ use atm_core::error::AtmError;
 use atm_core::list::ListQuery;
 use atm_core::observability::ObservabilityPort;
 use atm_core::protocol::{
-    CompatibilityVerdict, ReleaseVersion, RequestEnvelope, RequestId, ResponseEnvelope,
-    SendResponseEnvelope,
+    CompatibilityVerdict, GraftReceiverRegistration, GraftReceiverUnregistration, ReleaseVersion,
+    RequestEnvelope, RequestId, ResponseEnvelope, SendResponseEnvelope,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::send::{NudgeMode, WarningEntry, WriteOutcome, prepare_write_with_async_runtime};
@@ -366,6 +367,18 @@ impl StorageAndNudgeRouter {
                 ResponseEnvelope::CompatibilityVerdict(compatibility_verdict(preflight)),
             )),
             ApiRequest::Heartbeat(request) => self.heartbeat(request, ingress, deadline).await,
+            ApiRequest::GraftReceiverRegister(request) => {
+                self.graft_receiver_register(request, ingress, deadline)
+                    .await
+            }
+            ApiRequest::GraftReceiverUnregister(request) => {
+                self.graft_receiver_unregister(request, ingress, deadline)
+                    .await
+            }
+            ApiRequest::GraftReceiverLookup { team, agent } => {
+                self.graft_receiver_lookup(team, agent, ingress, deadline)
+                    .await
+            }
             ApiRequest::ReloadRuntimeView => self.reload_runtime_view(ingress),
         }
     }
@@ -530,6 +543,72 @@ impl StorageAndNudgeRouter {
             })
     }
 
+    async fn graft_receiver_register(
+        &self,
+        request: GraftReceiverRegistration,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        require_local_graft_ingress(ingress)?;
+        let runtime = self.service_runtime.clone();
+        let store = runtime.graft_receiver_endpoint_store()?;
+        self.blocking_core_bridge
+            .run(deadline, move || {
+                validate_graft_receiver_member(&runtime, &request.team, &request.agent)?;
+                if !request.endpoint.ip().is_loopback() {
+                    return Err(AtmError::local_http_endpoint_non_loopback(
+                        "graft receiver endpoint must be loopback",
+                    ));
+                }
+                store
+                    .register(&request, atm_core::types::IsoTimestamp::now().into_inner())
+                    .map_err(graft_store_error)?;
+                Ok(ApiResponse::new(ResponseEnvelope::GraftReceiverRegister))
+            })
+            .await
+    }
+
+    async fn graft_receiver_unregister(
+        &self,
+        request: GraftReceiverUnregistration,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        require_local_graft_ingress(ingress)?;
+        let runtime = self.service_runtime.clone();
+        let store = runtime.graft_receiver_endpoint_store()?;
+        self.blocking_core_bridge
+            .run(deadline, move || {
+                validate_graft_receiver_member(&runtime, &request.team, &request.agent)?;
+                store
+                    .unregister(&request.team, &request.agent, &request.owner_generation)
+                    .map_err(graft_store_error)?;
+                Ok(ApiResponse::new(ResponseEnvelope::GraftReceiverUnregister))
+            })
+            .await
+    }
+
+    async fn graft_receiver_lookup(
+        &self,
+        team: atm_core::types::TeamName,
+        agent: atm_core::types::AgentName,
+        ingress: AuthenticatedIngress,
+        deadline: RequestDeadline,
+    ) -> Result<ApiResponse, AtmError> {
+        require_local_graft_ingress(ingress)?;
+        let runtime = self.service_runtime.clone();
+        let store = runtime.graft_receiver_endpoint_store()?;
+        self.blocking_core_bridge
+            .run(deadline, move || {
+                validate_graft_receiver_member(&runtime, &team, &agent)?;
+                let lease = store.lookup(&team, &agent).map_err(graft_store_error)?;
+                Ok(ApiResponse::new(ResponseEnvelope::GraftReceiverLookup(
+                    lease,
+                )))
+            })
+            .await
+    }
+
     fn reload_runtime_view(&self, ingress: AuthenticatedIngress) -> Result<ApiResponse, AtmError> {
         if ingress != AuthenticatedIngress::Local {
             return Err(AtmError::validation(
@@ -691,6 +770,38 @@ fn validate_heartbeat_member(
     Ok(())
 }
 
+fn require_local_graft_ingress(ingress: AuthenticatedIngress) -> Result<(), AtmError> {
+    if ingress != AuthenticatedIngress::Local {
+        return Err(AtmError::validation(
+            "graft receiver registration is available only through authenticated local HTTP adapters",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_graft_receiver_member(
+    runtime: &LocalServiceRuntime,
+    team: &atm_core::types::TeamName,
+    agent: &atm_core::types::AgentName,
+) -> Result<(), AtmError> {
+    if runtime.load_roster_member(team, agent)?.is_none() {
+        return Err(AtmError::agent_not_found(agent.as_str(), team.as_str()));
+    }
+    Ok(())
+}
+
+fn graft_store_error(error: GraftEndpointStoreError) -> AtmError {
+    match error {
+        GraftEndpointStoreError::NotOwner => {
+            AtmError::validation("graft receiver lease is owned by another generation")
+        }
+        GraftEndpointStoreError::AlreadyActive => {
+            AtmError::validation("graft receiver lease is already active")
+        }
+        GraftEndpointStoreError::Storage(message) => AtmError::daemon_unavailable(message),
+    }
+}
+
 fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
     match outcome {
         WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
@@ -735,8 +846,8 @@ mod tests {
     };
     use atm_core::observability::NullObservability;
     use atm_core::protocol::{
-        HeartbeatActivity, RequestEnvelope, ResponseEnvelope, RuntimeReadinessState,
-        SendResponseEnvelope, TeamMemberHeartbeatRequest,
+        GraftReceiverRegistration, HeartbeatActivity, RequestEnvelope, ResponseEnvelope,
+        RuntimeReadinessState, SendResponseEnvelope, TeamMemberHeartbeatRequest,
     };
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{
@@ -746,7 +857,7 @@ mod tests {
     use atm_core::{AuthenticatedIngress, RequestDeadline, api::ApiRequest, error::AtmError};
     use atm_runtime_test_support::{
         inspect_template_admission_for_test, install_sqlite_message_write_failure,
-        open_sqlite_boundary,
+        open_graft_receiver_endpoint_store, open_sqlite_boundary,
     };
     use atm_storage::{
         MessageKey, MessageQuery, MessageStore, RosterSnapshot, TemplateFrontmatter, TemplateSha,
@@ -1069,7 +1180,11 @@ mod tests {
         let service_runtime = match template_composer {
             Some(composer) => assembly.service_runtime.with_template_composer(composer),
             None => assembly.service_runtime,
-        };
+        }
+        .with_graft_receiver_endpoint_store(
+            open_graft_receiver_endpoint_store(&database_path)
+                .expect("sqlite graft receiver endpoint store"),
+        );
         let router = StorageAndNudgeRouter::new(
             service_runtime,
             Arc::new(NullObservability),
@@ -1472,6 +1587,96 @@ mod tests {
         )
         .await
         .expect("infallible Axum service")
+    }
+
+    #[tokio::test]
+    async fn graft_receiver_handlers_enforce_local_roster_and_loopback_contracts() {
+        let fixture = fixture(true, None, None);
+        let registration = GraftReceiverRegistration {
+            team: "test-team".parse().expect("team"),
+            agent: "recipient".parse().expect("agent"),
+            endpoint: "127.0.0.1:43101".parse().expect("endpoint"),
+            capability: atm_core::local_http::LocalCapability::generate().expect("capability"),
+            owner_generation: "01J00000000000000000000000".to_owned(),
+        };
+        let response = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(registration.clone())),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("register response");
+        assert!(matches!(
+            response.into_inner(),
+            ResponseEnvelope::GraftReceiverRegister
+        ));
+
+        let lookup = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverLookup {
+                    team: registration.team.clone(),
+                    agent: registration.agent.clone(),
+                }),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("lookup response")
+            .into_inner();
+        assert!(matches!(
+            lookup,
+            ResponseEnvelope::GraftReceiverLookup(Some(lease))
+                if lease.endpoint == registration.endpoint
+                    && lease.owner_generation == registration.owner_generation
+        ));
+
+        let non_local = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(registration.clone())),
+                AuthenticatedIngress::Peer,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            non_local.is_err(),
+            "peer ingress must not register receivers"
+        );
+
+        let unknown = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverLookup {
+                    team: registration.team.clone(),
+                    agent: "unknown".parse().expect("agent"),
+                }),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(unknown.is_err(), "unknown roster members must be rejected");
+
+        let mut non_loopback = registration;
+        non_loopback.endpoint = "192.0.2.1:43101".parse().expect("endpoint");
+        let rejected_endpoint = fixture
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(non_loopback)),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            rejected_endpoint.is_err(),
+            "non-loopback endpoint must be rejected"
+        );
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -5,6 +5,7 @@
 //! hook. The enclosing HTTP route remains async and awaits both operations.
 
 use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::num::NonZeroU16;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -555,7 +556,11 @@ impl StorageAndNudgeRouter {
         self.blocking_core_bridge
             .run(deadline, move || {
                 validate_graft_receiver_member(&runtime, &request.team, &request.agent)?;
-                if !request.endpoint.ip().is_loopback() {
+                let local_endpoint = match request.endpoint.ip() {
+                    IpAddr::V4(address) => address == Ipv4Addr::LOCALHOST,
+                    IpAddr::V6(address) => address == Ipv6Addr::LOCALHOST,
+                };
+                if !local_endpoint {
                     return Err(AtmError::local_http_endpoint_non_loopback(
                         "graft receiver endpoint must be loopback",
                     ));
@@ -831,7 +836,7 @@ mod tests {
     use std::fs;
     use std::future::Future;
     use std::num::{NonZeroU16, NonZeroUsize};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -854,6 +859,7 @@ mod tests {
         MessageClassification, NudgeMode, SendMessageSource, TemplateSendSource, WriteRequest,
     };
     use atm_core::types::{AgentName, ModelName, PaneId, TeamName};
+    use atm_core::LocalServiceRuntime;
     use atm_core::{AuthenticatedIngress, RequestDeadline, api::ApiRequest, error::AtmError};
     use atm_runtime_test_support::{
         inspect_template_admission_for_test, install_sqlite_message_write_failure,
@@ -1180,11 +1186,8 @@ mod tests {
         let service_runtime = match template_composer {
             Some(composer) => assembly.service_runtime.with_template_composer(composer),
             None => assembly.service_runtime,
-        }
-        .with_graft_receiver_endpoint_store(
-            open_graft_receiver_endpoint_store(&database_path)
-                .expect("sqlite graft receiver endpoint store"),
-        );
+        };
+        let service_runtime = attach_graft_receiver_store(service_runtime, &database_path);
         let router = StorageAndNudgeRouter::new(
             service_runtime,
             Arc::new(NullObservability),
@@ -1202,6 +1205,16 @@ mod tests {
             home_dir,
             current_dir,
         }
+    }
+
+    fn attach_graft_receiver_store(
+        service_runtime: LocalServiceRuntime,
+        database_path: &Path,
+    ) -> LocalServiceRuntime {
+        service_runtime.with_graft_receiver_endpoint_store(
+            open_graft_receiver_endpoint_store(database_path)
+                .expect("sqlite graft receiver endpoint store"),
+        )
     }
 
     fn write_request(home_dir: PathBuf, current_dir: PathBuf) -> WriteRequest {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -12,13 +12,13 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use atm_core::GraftEndpointStoreError;
 use atm_core::LocalServiceRuntime;
 use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
 use atm_core::boundary::MessageReceivedHookSelector;
 use atm_core::clear::ClearQuery;
 use atm_core::doctor::DoctorQuery;
 use atm_core::error::AtmError;
+use atm_core::graft_store_error;
 use atm_core::list::ListQuery;
 use atm_core::observability::ObservabilityPort;
 use atm_core::protocol::{
@@ -795,18 +795,6 @@ fn validate_graft_receiver_member(
     Ok(())
 }
 
-fn graft_store_error(error: GraftEndpointStoreError) -> AtmError {
-    match error {
-        GraftEndpointStoreError::NotOwner => {
-            AtmError::validation("graft receiver lease is owned by another generation")
-        }
-        GraftEndpointStoreError::AlreadyActive => {
-            AtmError::validation("graft receiver lease is already active")
-        }
-        GraftEndpointStoreError::Storage(message) => AtmError::daemon_unavailable(message),
-    }
-}
-
 fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
     match outcome {
         WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
@@ -843,6 +831,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use atm_core::LocalServiceRuntime;
     use atm_core::boundary::{
         AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, GraftNudgeTarget,
         LocalTmuxNudgeTarget, MemberKey, MessageReceivedHookSelector, NudgeKind, PendingNudgeStore,
@@ -851,15 +840,15 @@ mod tests {
     };
     use atm_core::observability::NullObservability;
     use atm_core::protocol::{
-        GraftReceiverRegistration, HeartbeatActivity, RequestEnvelope, ResponseEnvelope,
-        RuntimeReadinessState, SendResponseEnvelope, TeamMemberHeartbeatRequest,
+        GraftReceiverRegistration, GraftReceiverUnregistration, HeartbeatActivity, OwnerGeneration,
+        RequestEnvelope, ResponseEnvelope, RuntimeReadinessState, SendResponseEnvelope,
+        TeamMemberHeartbeatRequest,
     };
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{
         MessageClassification, NudgeMode, SendMessageSource, TemplateSendSource, WriteRequest,
     };
     use atm_core::types::{AgentName, ModelName, PaneId, TeamName};
-    use atm_core::LocalServiceRuntime;
     use atm_core::{AuthenticatedIngress, RequestDeadline, api::ApiRequest, error::AtmError};
     use atm_runtime_test_support::{
         inspect_template_admission_for_test, install_sqlite_message_write_failure,
@@ -1610,7 +1599,8 @@ mod tests {
             agent: "recipient".parse().expect("agent"),
             endpoint: "127.0.0.1:43101".parse().expect("endpoint"),
             capability: atm_core::local_http::LocalCapability::generate().expect("capability"),
-            owner_generation: "01J00000000000000000000000".to_owned(),
+            owner_generation: OwnerGeneration::new("01J00000000000000000000000")
+                .expect("owner generation"),
         };
         let response = fixture
             .router
@@ -1690,6 +1680,181 @@ mod tests {
             rejected_endpoint.is_err(),
             "non-loopback endpoint must be rejected"
         );
+    }
+
+    // AC 4: register and unregister must both reject non-local ingress and an
+    // unknown roster member, independent of the register/lookup coverage
+    // above.
+    #[tokio::test]
+    async fn graft_receiver_register_and_unregister_reject_non_local_ingress_and_unknown_members() {
+        let fixture = fixture(true, None, None);
+        let team: TeamName = "test-team".parse().expect("team");
+        let known_agent: AgentName = "recipient".parse().expect("agent");
+        let unknown_agent: AgentName = "unknown".parse().expect("agent");
+        let generation = OwnerGeneration::new("01J00000000000000000000010").expect("generation");
+        let registration = GraftReceiverRegistration {
+            team: team.clone(),
+            agent: known_agent.clone(),
+            endpoint: "127.0.0.1:43105".parse().expect("endpoint"),
+            capability: atm_core::local_http::LocalCapability::generate().expect("capability"),
+            owner_generation: generation.clone(),
+        };
+        let unregistration = GraftReceiverUnregistration {
+            team: team.clone(),
+            agent: known_agent.clone(),
+            owner_generation: generation.clone(),
+        };
+
+        let non_local_register = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(registration.clone())),
+                AuthenticatedIngress::Peer,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            non_local_register.is_err(),
+            "peer ingress must not register receivers"
+        );
+
+        let non_local_unregister = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverUnregister(
+                    unregistration.clone(),
+                )),
+                AuthenticatedIngress::Peer,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            non_local_unregister.is_err(),
+            "peer ingress must not unregister receivers"
+        );
+
+        let mut unknown_registration = registration.clone();
+        unknown_registration.agent = unknown_agent.clone();
+        let unknown_member_register = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(unknown_registration)),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            unknown_member_register.is_err(),
+            "an unknown roster member must not be registered"
+        );
+
+        let unknown_unregistration = GraftReceiverUnregistration {
+            team: team.clone(),
+            agent: unknown_agent,
+            owner_generation: generation,
+        };
+        let unknown_member_unregister = fixture
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverUnregister(
+                    unknown_unregistration,
+                )),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(
+            unknown_member_unregister.is_err(),
+            "an unknown roster member must not be unregistered"
+        );
+    }
+
+    // AC 6: `GraftReceiverLookup` round-trips: hit, miss (`Ok(None)`, not an
+    // error), and non-local ingress rejected.
+    #[tokio::test]
+    async fn graft_receiver_lookup_round_trips_hit_miss_and_rejects_non_local_ingress() {
+        let fixture = fixture(true, None, None);
+        let team: TeamName = "test-team".parse().expect("team");
+        let registered_agent: AgentName = "recipient".parse().expect("agent");
+        let unleased_agent: AgentName = "sender".parse().expect("agent");
+        let registration = GraftReceiverRegistration {
+            team: team.clone(),
+            agent: registered_agent.clone(),
+            endpoint: "127.0.0.1:43106".parse().expect("endpoint"),
+            capability: atm_core::local_http::LocalCapability::generate().expect("capability"),
+            owner_generation: OwnerGeneration::new("01J00000000000000000000011")
+                .expect("generation"),
+        };
+        fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverRegister(registration.clone())),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("register response");
+
+        // Hit: a registered member returns its lease.
+        let hit = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverLookup {
+                    team: team.clone(),
+                    agent: registered_agent,
+                }),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("lookup response")
+            .into_inner();
+        assert!(matches!(
+            hit,
+            ResponseEnvelope::GraftReceiverLookup(Some(lease))
+                if lease.endpoint == registration.endpoint
+        ));
+
+        // Miss: a known roster member with no registered lease is `Ok(None)`,
+        // not an error.
+        let miss = fixture
+            .router
+            .clone()
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverLookup {
+                    team: team.clone(),
+                    agent: unleased_agent,
+                }),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+            .expect("lookup response for a member with no lease")
+            .into_inner();
+        assert!(
+            matches!(miss, ResponseEnvelope::GraftReceiverLookup(None)),
+            "a known member with no registered lease must be Ok(None), not an error"
+        );
+
+        // Non-local ingress is rejected with the same gating as
+        // register/unregister.
+        let non_local = fixture
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::GraftReceiverLookup {
+                    team,
+                    agent: "recipient".parse().expect("agent"),
+                }),
+                AuthenticatedIngress::Peer,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await;
+        assert!(non_local.is_err(), "peer ingress must not look up leases");
     }
 
     #[tokio::test]

--- a/crates/atm-runtime-test-support/src/lib.rs
+++ b/crates/atm-runtime-test-support/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 
 use atm_core::error::AtmError;
@@ -74,6 +75,15 @@ pub fn open_sqlite_boundary(path: impl AsRef<Path>) -> Result<RuntimeAssembly, A
         template_composer: None,
         workflow_telemetry: None,
     })
+}
+
+/// Open the graft endpoint registry for replacement-router tests without
+/// exposing a concrete SQLite handle to the HTTP runtime.
+pub fn open_graft_receiver_endpoint_store(
+    path: impl AsRef<Path>,
+) -> Result<Arc<dyn atm_core::GraftReceiverEndpointStore + Send + Sync>, AtmError> {
+    let backend = atm_storage_rusqlite::SqliteStorageBackend::new(path)?;
+    Ok(backend.graft_receiver_endpoint_store())
 }
 
 /// Build an isolated SQLite runtime from a test-owned directory.

--- a/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_schema.rs
+++ b/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_schema.rs
@@ -1,0 +1,130 @@
+//! SQLite-owned schema and column migrations for durable graft receiver
+//! endpoint leases.
+//!
+//! Keeping this beside the graft-receiver store adapter prevents the generic
+//! shared-database root from accumulating feature-specific DDL (RULE-003:
+//! `shared_db.rs` stays under the file-length threshold as new storage
+//! features land their own schema modules, mirroring
+//! `template_catalog_schema` and `search_schema`).
+
+use crate::shared_db::{SharedDbTarget, SqliteConnection, ensure_column, sqlite_error};
+use atm_storage::error::AtmError;
+
+const GRAFT_RECEIVER_ENDPOINTS_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS graft_receiver_endpoints (
+    team TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    capability TEXT NOT NULL,
+    owner_generation TEXT NOT NULL,
+    registered_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    unreachable_at TEXT NULL,
+    PRIMARY KEY (team, agent)
+);
+"#;
+
+pub(crate) fn ensure_schema(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    connection
+        .execute_batch(GRAFT_RECEIVER_ENDPOINTS_DDL)
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to initialize graft receiver endpoint schema",
+                error,
+            )
+        })?;
+    ensure_graft_receiver_endpoint_columns(connection, target)
+}
+
+pub(crate) fn ensure_graft_receiver_endpoint_columns(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "endpoint",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN endpoint TEXT NOT NULL DEFAULT '127.0.0.1:0';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "capability",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN capability TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "owner_generation",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN owner_generation TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "registered_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN registered_at TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "last_seen_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN last_seen_at TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "unreachable_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN unreachable_at TEXT NULL;",
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn ensure_graft_receiver_endpoint_columns_is_idempotent() {
+        let connection = Connection::open_in_memory().expect("open sqlite database");
+        let target = SharedDbTarget::InMemory {
+            uri: "file:atm-storage-rusqlite-graft-endpoint-schema-module?mode=memory&cache=shared"
+                .to_owned(),
+        };
+        ensure_schema(&connection, &target).expect("initialise graft endpoint schema");
+        ensure_graft_receiver_endpoint_columns(&connection, &target)
+            .expect("re-run graft endpoint migration idempotently");
+        let columns: Vec<String> = connection
+            .prepare("PRAGMA table_info(graft_receiver_endpoints);")
+            .expect("prepare columns")
+            .query_map([], |row| row.get(1))
+            .expect("query columns")
+            .collect::<Result<_, _>>()
+            .expect("decode columns");
+        for expected in [
+            "team",
+            "agent",
+            "endpoint",
+            "capability",
+            "owner_generation",
+            "registered_at",
+            "last_seen_at",
+            "unreachable_at",
+        ] {
+            assert!(
+                columns.iter().any(|column| column == expected),
+                "missing {expected}"
+            );
+        }
+    }
+}

--- a/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
+++ b/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
@@ -1,0 +1,353 @@
+use std::sync::Arc;
+
+use atm_storage::contract::{
+    GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
+    GraftReceiverRegistration, sealed,
+};
+use atm_storage::types::{AgentName, LocalCapability, TeamName};
+use chrono::{DateTime, Utc};
+use rusqlite::{OptionalExtension, params};
+
+use crate::shared_db::SharedDb;
+
+pub(crate) struct SqliteGraftReceiverEndpointStore {
+    pub(crate) db: Arc<SharedDb>,
+}
+
+impl SqliteGraftReceiverEndpointStore {
+    pub(crate) fn new(db: Arc<SharedDb>) -> Self {
+        Self { db }
+    }
+
+    fn storage_error(error: atm_storage::AtmError) -> GraftEndpointStoreError {
+        GraftEndpointStoreError::Storage(error.to_string())
+    }
+}
+
+impl sealed::Sealed for SqliteGraftReceiverEndpointStore {}
+
+impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
+    fn register(
+        &self,
+        registration: &GraftReceiverRegistration,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        let capability = registration.capability.to_base64url();
+        self.db
+            .with_transaction(|transaction| {
+                transaction
+                    .execute(
+                        "INSERT INTO graft_receiver_endpoints
+                            (team, agent, endpoint, capability, owner_generation,
+                             registered_at, last_seen_at, unreachable_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, NULL)
+                         ON CONFLICT(team, agent) DO UPDATE SET
+                            endpoint = excluded.endpoint,
+                            capability = excluded.capability,
+                            owner_generation = excluded.owner_generation,
+                            registered_at = excluded.registered_at,
+                            last_seen_at = excluded.last_seen_at,
+                            unreachable_at = NULL;",
+                        params![
+                            registration.team.as_str(),
+                            registration.agent.as_str(),
+                            registration.endpoint.to_string(),
+                            capability,
+                            registration.owner_generation,
+                            now.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| {
+                        self.db
+                            .error("failed to register graft receiver endpoint", error)
+                    })?;
+                Ok(())
+            })
+            .map_err(Self::storage_error)
+    }
+
+    fn refresh(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        let changed = self
+            .db
+            .with_transaction(|transaction| {
+                transaction
+                    .execute(
+                        "UPDATE graft_receiver_endpoints
+                         SET last_seen_at = ?1, unreachable_at = NULL
+                         WHERE team = ?2 AND agent = ?3 AND owner_generation = ?4;",
+                        params![
+                            now.to_rfc3339(),
+                            team.as_str(),
+                            agent.as_str(),
+                            owner_generation
+                        ],
+                    )
+                    .map_err(|error| {
+                        self.db
+                            .error("failed to refresh graft receiver endpoint", error)
+                    })
+            })
+            .map_err(Self::storage_error)?;
+        if changed == 0 {
+            return Err(GraftEndpointStoreError::NotOwner);
+        }
+        Ok(())
+    }
+
+    fn unregister(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+    ) -> Result<(), GraftEndpointStoreError> {
+        self.db
+            .with_transaction(|transaction| {
+                transaction
+                    .execute(
+                        "DELETE FROM graft_receiver_endpoints
+                         WHERE team = ?1 AND agent = ?2 AND owner_generation = ?3;",
+                        params![team.as_str(), agent.as_str(), owner_generation],
+                    )
+                    .map_err(|error| {
+                        self.db
+                            .error("failed to unregister graft receiver endpoint", error)
+                    })?;
+                Ok(())
+            })
+            .map_err(Self::storage_error)
+    }
+
+    fn lookup(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError> {
+        self.db
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT endpoint, capability, owner_generation,
+                                registered_at, last_seen_at, unreachable_at
+                         FROM graft_receiver_endpoints
+                         WHERE team = ?1 AND agent = ?2;",
+                        params![team.as_str(), agent.as_str()],
+                        |row| {
+                            let endpoint = row.get::<_, String>(0)?.parse().map_err(|error| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    0,
+                                    rusqlite::types::Type::Text,
+                                    Box::new(error),
+                                )
+                            })?;
+                            let capability =
+                                LocalCapability::parse_base64url(&row.get::<_, String>(1)?)
+                                    .map_err(|error| {
+                                        rusqlite::Error::FromSqlConversionFailure(
+                                            1,
+                                            rusqlite::types::Type::Text,
+                                            Box::new(std::io::Error::other(error.to_string())),
+                                        )
+                                    })?;
+                            Ok(GraftReceiverLease {
+                                endpoint,
+                                capability,
+                                owner_generation: row.get(2)?,
+                                registered_at: parse_timestamp(row.get::<_, String>(3)?)?,
+                                last_seen_at: parse_timestamp(row.get::<_, String>(4)?)?,
+                                unreachable_since: row
+                                    .get::<_, Option<String>>(5)?
+                                    .map(parse_timestamp)
+                                    .transpose()?,
+                            })
+                        },
+                    )
+                    .optional()
+                    .map_err(|error| {
+                        self.db
+                            .error("failed to look up graft receiver endpoint", error)
+                    })
+            })
+            .map_err(Self::storage_error)
+    }
+
+    fn mark_unreachable(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError> {
+        let changed = self
+            .db
+            .with_transaction(|transaction| {
+                transaction
+                    .execute(
+                        "UPDATE graft_receiver_endpoints
+                         SET unreachable_at = COALESCE(unreachable_at, ?1)
+                         WHERE team = ?2 AND agent = ?3 AND owner_generation = ?4;",
+                        params![
+                            now.to_rfc3339(),
+                            team.as_str(),
+                            agent.as_str(),
+                            owner_generation
+                        ],
+                    )
+                    .map_err(|error| {
+                        self.db
+                            .error("failed to mark graft receiver endpoint unreachable", error)
+                    })
+            })
+            .map_err(Self::storage_error)?;
+        if changed == 0 {
+            return Err(GraftEndpointStoreError::NotOwner);
+        }
+        Ok(())
+    }
+}
+
+fn parse_timestamp(value: String) -> Result<DateTime<Utc>, rusqlite::Error> {
+    DateTime::parse_from_rfc3339(&value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atm_storage::types::{AgentName, TeamName};
+    use chrono::TimeZone;
+
+    fn names() -> (TeamName, AgentName) {
+        (
+            TeamName::from_validated("test-team"),
+            AgentName::from_validated("test-agent"),
+        )
+    }
+
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(seconds, 0).single().expect("timestamp")
+    }
+
+    fn registration(generation: &str, endpoint: &str) -> GraftReceiverRegistration {
+        let (team, agent) = names();
+        GraftReceiverRegistration {
+            team,
+            agent,
+            endpoint: endpoint.parse().expect("endpoint"),
+            capability: LocalCapability::generate().expect("capability"),
+            owner_generation: generation.to_owned(),
+        }
+    }
+
+    fn store() -> SqliteGraftReceiverEndpointStore {
+        SqliteGraftReceiverEndpointStore::new(Arc::new(
+            SharedDb::open_in_memory_for_test().expect("sqlite database"),
+        ))
+    }
+
+    #[test]
+    fn register_lookup_refresh_unreachable_and_unregister_round_trip() {
+        let store = store();
+        let (team, agent) = names();
+        let registration = registration("generation-1", "127.0.0.1:43101");
+        let registered_at = timestamp(10);
+        let refreshed_at = timestamp(20);
+        let unreachable_at = timestamp(30);
+
+        store
+            .register(&registration, registered_at)
+            .expect("register");
+        let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
+        assert_eq!(lease.endpoint, registration.endpoint);
+        assert_eq!(lease.capability, registration.capability);
+        assert_eq!(lease.owner_generation, "generation-1");
+        assert_eq!(lease.registered_at, registered_at);
+        assert_eq!(lease.last_seen_at, registered_at);
+        assert_eq!(lease.unreachable_since, None);
+
+        store
+            .mark_unreachable(&team, &agent, "generation-1", unreachable_at)
+            .expect("mark unreachable");
+        assert_eq!(
+            store
+                .lookup(&team, &agent)
+                .expect("lookup")
+                .expect("lease")
+                .unreachable_since,
+            Some(unreachable_at)
+        );
+        store
+            .refresh(&team, &agent, "generation-1", refreshed_at)
+            .expect("refresh");
+        let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
+        assert_eq!(lease.last_seen_at, refreshed_at);
+        assert_eq!(lease.unreachable_since, None);
+
+        store
+            .unregister(&team, &agent, "generation-1")
+            .expect("unregister");
+        assert_eq!(store.lookup(&team, &agent).expect("lookup"), None);
+    }
+
+    #[test]
+    fn register_refreshes_matching_generation_and_displaces_other_generations() {
+        let store = store();
+        let (team, agent) = names();
+        let first = registration("generation-1", "127.0.0.1:43101");
+        store.register(&first, timestamp(10)).expect("register");
+
+        let mut refreshed = first.clone();
+        refreshed.endpoint = "127.0.0.1:43102".parse().expect("endpoint");
+        store
+            .register(&refreshed, timestamp(20))
+            .expect("refresh register");
+        let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
+        assert_eq!(lease.endpoint, refreshed.endpoint);
+        assert_eq!(lease.registered_at, timestamp(20));
+
+        let displaced = registration("generation-2", "127.0.0.1:43103");
+        store.register(&displaced, timestamp(30)).expect("displace");
+        let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
+        assert_eq!(lease.endpoint, displaced.endpoint);
+        assert_eq!(lease.owner_generation, "generation-2");
+        assert_eq!(
+            store.refresh(&team, &agent, "generation-1", timestamp(40)),
+            Err(GraftEndpointStoreError::NotOwner)
+        );
+    }
+
+    #[test]
+    fn lease_survives_backend_reopen() {
+        let directory = tempfile::tempdir().expect("temporary state root");
+        let path = directory.path().join("mail.db");
+        let registration = registration("generation-1", "127.0.0.1:43101");
+        let (team, agent) = names();
+        {
+            let backend = crate::SqliteStorageBackend::new(&path).expect("backend");
+            backend
+                .graft_receiver_endpoint_store()
+                .register(&registration, timestamp(10))
+                .expect("register");
+        }
+        let backend = crate::SqliteStorageBackend::new(&path).expect("reopened backend");
+        let lease = backend
+            .graft_receiver_endpoint_store()
+            .lookup(&team, &agent)
+            .expect("lookup")
+            .expect("persisted lease");
+        assert_eq!(lease.owner_generation, "generation-1");
+        assert_eq!(lease.registered_at, timestamp(10));
+    }
+}

--- a/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
+++ b/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use atm_storage::OwnerGeneration;
 use atm_storage::contract::{
     GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
     GraftReceiverRegistration, sealed,
@@ -53,7 +54,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
                             registration.agent.as_str(),
                             registration.endpoint.to_string(),
                             capability,
-                            registration.owner_generation,
+                            registration.owner_generation.as_str(),
                             now.to_rfc3339(),
                         ],
                     )
@@ -70,7 +71,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
         now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError> {
         let changed = self
@@ -85,7 +86,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
                             now.to_rfc3339(),
                             team.as_str(),
                             agent.as_str(),
-                            owner_generation
+                            owner_generation.as_str()
                         ],
                     )
                     .map_err(|error| {
@@ -104,23 +105,46 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
     ) -> Result<(), GraftEndpointStoreError> {
         self.db
             .with_transaction(|transaction| {
-                transaction
-                    .execute(
-                        "DELETE FROM graft_receiver_endpoints
-                         WHERE team = ?1 AND agent = ?2 AND owner_generation = ?3;",
-                        params![team.as_str(), agent.as_str(), owner_generation],
+                let existing: Option<String> = transaction
+                    .query_row(
+                        "SELECT owner_generation FROM graft_receiver_endpoints
+                         WHERE team = ?1 AND agent = ?2;",
+                        params![team.as_str(), agent.as_str()],
+                        |row| row.get(0),
                     )
+                    .optional()
                     .map_err(|error| {
                         self.db
-                            .error("failed to unregister graft receiver endpoint", error)
+                            .error("failed to inspect graft receiver endpoint lease", error)
                     })?;
-                Ok(())
+                match existing {
+                    // Absent row: unregister is idempotent, per the sprint's
+                    // durable-lease semantics. Nothing to remove, no error.
+                    None => Ok(Ok(())),
+                    Some(stored) if stored == owner_generation.as_str() => {
+                        transaction
+                            .execute(
+                                "DELETE FROM graft_receiver_endpoints
+                                 WHERE team = ?1 AND agent = ?2 AND owner_generation = ?3;",
+                                params![team.as_str(), agent.as_str(), owner_generation.as_str()],
+                            )
+                            .map_err(|error| {
+                                self.db
+                                    .error("failed to unregister graft receiver endpoint", error)
+                            })?;
+                        Ok(Ok(()))
+                    }
+                    // A foreign generation owns the lease: leave the row
+                    // untouched and report the mismatch distinctly from an
+                    // absent row.
+                    Some(_) => Ok(Err(GraftEndpointStoreError::NotOwner)),
+                }
             })
-            .map_err(Self::storage_error)
+            .map_err(Self::storage_error)?
     }
 
     fn lookup(
@@ -157,7 +181,14 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
                             Ok(GraftReceiverLease {
                                 endpoint,
                                 capability,
-                                owner_generation: row.get(2)?,
+                                owner_generation: OwnerGeneration::new(row.get::<_, String>(2)?)
+                                    .map_err(|error| {
+                                        rusqlite::Error::FromSqlConversionFailure(
+                                            2,
+                                            rusqlite::types::Type::Text,
+                                            Box::new(std::io::Error::other(error.to_string())),
+                                        )
+                                    })?,
                                 registered_at: parse_timestamp(row.get::<_, String>(3)?)?,
                                 last_seen_at: parse_timestamp(row.get::<_, String>(4)?)?,
                                 unreachable_since: row
@@ -180,7 +211,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
         now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError> {
         let changed = self
@@ -195,7 +226,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
                             now.to_rfc3339(),
                             team.as_str(),
                             agent.as_str(),
-                            owner_generation
+                            owner_generation.as_str()
                         ],
                     )
                     .map_err(|error| {
@@ -240,14 +271,21 @@ mod tests {
         Utc.timestamp_opt(seconds, 0).single().expect("timestamp")
     }
 
-    fn registration(generation: &str, endpoint: &str) -> GraftReceiverRegistration {
+    fn generation(value: &str) -> OwnerGeneration {
+        OwnerGeneration::new(value).expect("owner generation")
+    }
+
+    const GENERATION_ONE: &str = "01J00000000000000000000001";
+    const GENERATION_TWO: &str = "01J00000000000000000000002";
+
+    fn registration(generation_value: &str, endpoint: &str) -> GraftReceiverRegistration {
         let (team, agent) = names();
         GraftReceiverRegistration {
             team,
             agent,
             endpoint: endpoint.parse().expect("endpoint"),
             capability: LocalCapability::generate().expect("capability"),
-            owner_generation: generation.to_owned(),
+            owner_generation: generation(generation_value),
         }
     }
 
@@ -261,7 +299,7 @@ mod tests {
     fn register_lookup_refresh_unreachable_and_unregister_round_trip() {
         let store = store();
         let (team, agent) = names();
-        let registration = registration("generation-1", "127.0.0.1:43101");
+        let registration = registration(GENERATION_ONE, "127.0.0.1:43101");
         let registered_at = timestamp(10);
         let refreshed_at = timestamp(20);
         let unreachable_at = timestamp(30);
@@ -272,13 +310,13 @@ mod tests {
         let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
         assert_eq!(lease.endpoint, registration.endpoint);
         assert_eq!(lease.capability, registration.capability);
-        assert_eq!(lease.owner_generation, "generation-1");
+        assert_eq!(lease.owner_generation, generation(GENERATION_ONE));
         assert_eq!(lease.registered_at, registered_at);
         assert_eq!(lease.last_seen_at, registered_at);
         assert_eq!(lease.unreachable_since, None);
 
         store
-            .mark_unreachable(&team, &agent, "generation-1", unreachable_at)
+            .mark_unreachable(&team, &agent, &generation(GENERATION_ONE), unreachable_at)
             .expect("mark unreachable");
         assert_eq!(
             store
@@ -289,14 +327,14 @@ mod tests {
             Some(unreachable_at)
         );
         store
-            .refresh(&team, &agent, "generation-1", refreshed_at)
+            .refresh(&team, &agent, &generation(GENERATION_ONE), refreshed_at)
             .expect("refresh");
         let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
         assert_eq!(lease.last_seen_at, refreshed_at);
         assert_eq!(lease.unreachable_since, None);
 
         store
-            .unregister(&team, &agent, "generation-1")
+            .unregister(&team, &agent, &generation(GENERATION_ONE))
             .expect("unregister");
         assert_eq!(store.lookup(&team, &agent).expect("lookup"), None);
     }
@@ -305,7 +343,7 @@ mod tests {
     fn register_refreshes_matching_generation_and_displaces_other_generations() {
         let store = store();
         let (team, agent) = names();
-        let first = registration("generation-1", "127.0.0.1:43101");
+        let first = registration(GENERATION_ONE, "127.0.0.1:43101");
         store.register(&first, timestamp(10)).expect("register");
 
         let mut refreshed = first.clone();
@@ -317,22 +355,81 @@ mod tests {
         assert_eq!(lease.endpoint, refreshed.endpoint);
         assert_eq!(lease.registered_at, timestamp(20));
 
-        let displaced = registration("generation-2", "127.0.0.1:43103");
+        let displaced = registration(GENERATION_TWO, "127.0.0.1:43103");
         store.register(&displaced, timestamp(30)).expect("displace");
         let lease = store.lookup(&team, &agent).expect("lookup").expect("lease");
         assert_eq!(lease.endpoint, displaced.endpoint);
-        assert_eq!(lease.owner_generation, "generation-2");
+        assert_eq!(lease.owner_generation, generation(GENERATION_TWO));
         assert_eq!(
-            store.refresh(&team, &agent, "generation-1", timestamp(40)),
+            store.refresh(&team, &agent, &generation(GENERATION_ONE), timestamp(40)),
             Err(GraftEndpointStoreError::NotOwner)
         );
+    }
+
+    // Truth table for `unregister` (QA-1 finding #1): the caller's
+    // owner_generation is checked against the stored lease before any row is
+    // touched. Matching generation removes the row; a foreign generation
+    // errors and leaves the row intact; an absent row is idempotent (no
+    // error), per the sprint's durable-lease semantics.
+    #[test]
+    fn unregister_with_matching_generation_removes_the_lease() {
+        let store = store();
+        let (team, agent) = names();
+        let registration = registration(GENERATION_ONE, "127.0.0.1:43101");
+        store
+            .register(&registration, timestamp(10))
+            .expect("register");
+
+        store
+            .unregister(&team, &agent, &generation(GENERATION_ONE))
+            .expect("matching generation unregisters");
+        assert_eq!(
+            store.lookup(&team, &agent).expect("lookup"),
+            None,
+            "the lease row must be removed"
+        );
+    }
+
+    #[test]
+    fn unregister_with_foreign_generation_errors_and_leaves_the_row_intact() {
+        let store = store();
+        let (team, agent) = names();
+        let registration = registration(GENERATION_ONE, "127.0.0.1:43101");
+        store
+            .register(&registration, timestamp(10))
+            .expect("register");
+
+        let outcome = store.unregister(&team, &agent, &generation(GENERATION_TWO));
+        assert_eq!(
+            outcome,
+            Err(GraftEndpointStoreError::NotOwner),
+            "a foreign generation must be rejected distinctly, not silently ignored"
+        );
+        let lease = store
+            .lookup(&team, &agent)
+            .expect("lookup")
+            .expect("the row must remain after a rejected unregister");
+        assert_eq!(lease.owner_generation, generation(GENERATION_ONE));
+        assert_eq!(lease.endpoint, registration.endpoint);
+    }
+
+    #[test]
+    fn unregister_of_an_absent_lease_is_idempotent() {
+        let store = store();
+        let (team, agent) = names();
+        assert_eq!(store.lookup(&team, &agent).expect("lookup"), None);
+
+        store
+            .unregister(&team, &agent, &generation(GENERATION_ONE))
+            .expect("unregistering an absent lease must succeed idempotently");
+        assert_eq!(store.lookup(&team, &agent).expect("lookup"), None);
     }
 
     #[test]
     fn lease_survives_backend_reopen() {
         let directory = tempfile::tempdir().expect("temporary state root");
         let path = directory.path().join("mail.db");
-        let registration = registration("generation-1", "127.0.0.1:43101");
+        let registration = registration(GENERATION_ONE, "127.0.0.1:43101");
         let (team, agent) = names();
         {
             let backend = crate::SqliteStorageBackend::new(&path).expect("backend");
@@ -347,7 +444,7 @@ mod tests {
             .lookup(&team, &agent)
             .expect("lookup")
             .expect("persisted lease");
-        assert_eq!(lease.owner_generation, "generation-1");
+        assert_eq!(lease.owner_generation, generation(GENERATION_ONE));
         assert_eq!(lease.registered_at, timestamp(10));
     }
 }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -8,6 +8,7 @@
 //! message and roster contracts.
 
 mod analyst_query;
+mod graft_receiver_endpoint_schema;
 mod graft_receiver_endpoint_store;
 #[cfg(test)]
 mod mailbox_metadata;

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -8,6 +8,7 @@
 //! message and roster contracts.
 
 mod analyst_query;
+mod graft_receiver_endpoint_store;
 #[cfg(test)]
 mod mailbox_metadata;
 mod nudge_template_override_store;
@@ -37,8 +38,8 @@ pub use crate::observability::{
 };
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, AsyncMessageStore,
-    MailboxBucketCounts, Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore,
-    RosterStore,
+    GraftReceiverEndpointStore, MailboxBucketCounts, Message, MessageKey, MessageQuery,
+    MessageStore, PeerConfigStore, RosterStore,
 };
 use atm_storage::schema::MessageEnvelope;
 #[cfg(test)]
@@ -46,6 +47,7 @@ use atm_storage::schema::{AtmMessageId, ThreadMode};
 use atm_storage::types::{AgentName, TeamName};
 use atm_storage::{AsyncMessageSearchStore, MessageSearchStore, TemplateCatalogStore};
 use atm_storage::{AtmError, IsoTimestamp, StorageFactory, StorageHandleParts, StorageHandles};
+use graft_receiver_endpoint_store::SqliteGraftReceiverEndpointStore;
 use rusqlite::{Connection, OptionalExtension, params};
 use search_schema::delete_message_projection;
 use search_store::{async_search_store, search_store};
@@ -642,6 +644,7 @@ pub struct SqliteStorageBackend {
     roster_store: Arc<SqliteRosterStore>,
     nudge_template_override_store: Arc<SqliteNudgeTemplateOverrideStore>,
     pending_nudge_store: Arc<SqlitePendingNudgeStore>,
+    graft_receiver_endpoint_store: Arc<SqliteGraftReceiverEndpointStore>,
     peer_config_store: Arc<SqlitePeerConfigStore>,
     template_catalog_store: Arc<dyn TemplateCatalogStore>,
     message_search_store: Arc<dyn MessageSearchStore>,
@@ -716,6 +719,9 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             pending_nudge_store: Arc::new(SqlitePendingNudgeStore::new(Arc::clone(&db))),
+            graft_receiver_endpoint_store: Arc::new(SqliteGraftReceiverEndpointStore::new(
+                Arc::clone(&db),
+            )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
             template_catalog_store: template_catalog_store(Arc::clone(&db)),
             message_search_store: search_store(Arc::clone(&db)),
@@ -733,6 +739,9 @@ impl SqliteStorageBackend {
                 Arc::clone(&db),
             )),
             pending_nudge_store: Arc::new(SqlitePendingNudgeStore::new(Arc::clone(&db))),
+            graft_receiver_endpoint_store: Arc::new(SqliteGraftReceiverEndpointStore::new(
+                Arc::clone(&db),
+            )),
             peer_config_store: Arc::new(SqlitePeerConfigStore::new(Arc::clone(&db))),
             template_catalog_store: template_catalog_store(Arc::clone(&db)),
             message_search_store: search_store(Arc::clone(&db)),
@@ -775,6 +784,12 @@ impl SqliteStorageBackend {
 
     pub fn pending_nudge_store(&self) -> Arc<dyn atm_storage::PendingNudgeStore + Send + Sync> {
         self.pending_nudge_store.clone()
+    }
+
+    pub fn graft_receiver_endpoint_store(
+        &self,
+    ) -> Arc<dyn GraftReceiverEndpointStore + Send + Sync> {
+        self.graft_receiver_endpoint_store.clone()
     }
 
     pub fn peer_config_store(&self) -> Arc<dyn PeerConfigStore + Send + Sync> {

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -123,6 +123,18 @@ CREATE TABLE IF NOT EXISTS peer_trusted_peers (
     https_port INTEGER NOT NULL DEFAULT 43101 CHECK(https_port BETWEEN 1 AND 65535)
 );
 
+CREATE TABLE IF NOT EXISTS graft_receiver_endpoints (
+    team TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    capability TEXT NOT NULL,
+    owner_generation TEXT NOT NULL,
+    registered_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    unreachable_at TEXT NULL,
+    PRIMARY KEY (team, agent)
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_messages_single_successor
     ON mail_messages(team, agent, parent_message_id)
     WHERE parent_message_id IS NOT NULL;
@@ -664,12 +676,62 @@ pub(crate) fn ensure_schema(
     ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
     ensure_mail_message_states_nudge_columns(connection, target)?;
+    ensure_graft_receiver_endpoint_columns(connection, target)?;
     ensure_column(
         connection,
         target,
         "peer_trusted_peers",
         "https_port",
         "ALTER TABLE peer_trusted_peers ADD COLUMN https_port INTEGER NOT NULL DEFAULT 43101 CHECK(https_port BETWEEN 1 AND 65535);",
+    )?;
+    Ok(())
+}
+
+pub(crate) fn ensure_graft_receiver_endpoint_columns(
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "endpoint",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN endpoint TEXT NOT NULL DEFAULT '127.0.0.1:0';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "capability",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN capability TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "owner_generation",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN owner_generation TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "registered_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN registered_at TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "last_seen_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN last_seen_at TEXT NOT NULL DEFAULT '';",
+    )?;
+    ensure_column(
+        connection,
+        target,
+        "graft_receiver_endpoints",
+        "unreachable_at",
+        "ALTER TABLE graft_receiver_endpoints ADD COLUMN unreachable_at TEXT NULL;",
     )?;
     Ok(())
 }
@@ -1396,5 +1458,41 @@ mod tests {
         // database must not error.
         ensure_mail_message_states_nudge_columns(&connection, &target)
             .expect("re-run migration idempotently");
+    }
+
+    #[test]
+    fn ensure_graft_receiver_endpoint_columns_is_idempotent() {
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:atm-storage-rusqlite-graft-endpoint-schema-{}?mode=memory&cache=shared",
+                NEXT_IN_MEMORY_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_connection_for_target(&target).expect("open connection");
+        ensure_schema(&mut connection, &target).expect("initialise graft endpoint schema");
+        ensure_graft_receiver_endpoint_columns(&connection, &target)
+            .expect("re-run graft endpoint migration idempotently");
+        let columns: Vec<String> = connection
+            .prepare("PRAGMA table_info(graft_receiver_endpoints);")
+            .expect("prepare columns")
+            .query_map([], |row| row.get(1))
+            .expect("query columns")
+            .collect::<Result<_, _>>()
+            .expect("decode columns");
+        for expected in [
+            "team",
+            "agent",
+            "endpoint",
+            "capability",
+            "owner_generation",
+            "registered_at",
+            "last_seen_at",
+            "unreachable_at",
+        ] {
+            assert!(
+                columns.iter().any(|column| column == expected),
+                "missing {expected}"
+            );
+        }
     }
 }

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -123,18 +123,6 @@ CREATE TABLE IF NOT EXISTS peer_trusted_peers (
     https_port INTEGER NOT NULL DEFAULT 43101 CHECK(https_port BETWEEN 1 AND 65535)
 );
 
-CREATE TABLE IF NOT EXISTS graft_receiver_endpoints (
-    team TEXT NOT NULL,
-    agent TEXT NOT NULL,
-    endpoint TEXT NOT NULL,
-    capability TEXT NOT NULL,
-    owner_generation TEXT NOT NULL,
-    registered_at TEXT NOT NULL,
-    last_seen_at TEXT NOT NULL,
-    unreachable_at TEXT NULL,
-    PRIMARY KEY (team, agent)
-);
-
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_messages_single_successor
     ON mail_messages(team, agent, parent_message_id)
     WHERE parent_message_id IS NOT NULL;
@@ -676,62 +664,13 @@ pub(crate) fn ensure_schema(
     ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
     ensure_mail_message_states_nudge_columns(connection, target)?;
-    ensure_graft_receiver_endpoint_columns(connection, target)?;
+    crate::graft_receiver_endpoint_schema::ensure_schema(connection, target)?;
     ensure_column(
         connection,
         target,
         "peer_trusted_peers",
         "https_port",
         "ALTER TABLE peer_trusted_peers ADD COLUMN https_port INTEGER NOT NULL DEFAULT 43101 CHECK(https_port BETWEEN 1 AND 65535);",
-    )?;
-    Ok(())
-}
-
-pub(crate) fn ensure_graft_receiver_endpoint_columns(
-    connection: &Connection,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "endpoint",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN endpoint TEXT NOT NULL DEFAULT '127.0.0.1:0';",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "capability",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN capability TEXT NOT NULL DEFAULT '';",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "owner_generation",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN owner_generation TEXT NOT NULL DEFAULT '';",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "registered_at",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN registered_at TEXT NOT NULL DEFAULT '';",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "last_seen_at",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN last_seen_at TEXT NOT NULL DEFAULT '';",
-    )?;
-    ensure_column(
-        connection,
-        target,
-        "graft_receiver_endpoints",
-        "unreachable_at",
-        "ALTER TABLE graft_receiver_endpoints ADD COLUMN unreachable_at TEXT NULL;",
     )?;
     Ok(())
 }
@@ -1458,41 +1397,5 @@ mod tests {
         // database must not error.
         ensure_mail_message_states_nudge_columns(&connection, &target)
             .expect("re-run migration idempotently");
-    }
-
-    #[test]
-    fn ensure_graft_receiver_endpoint_columns_is_idempotent() {
-        let target = SharedDbTarget::InMemory {
-            uri: format!(
-                "file:atm-storage-rusqlite-graft-endpoint-schema-{}?mode=memory&cache=shared",
-                NEXT_IN_MEMORY_DB_ID.fetch_add(1, Ordering::Relaxed)
-            ),
-        };
-        let mut connection = open_connection_for_target(&target).expect("open connection");
-        ensure_schema(&mut connection, &target).expect("initialise graft endpoint schema");
-        ensure_graft_receiver_endpoint_columns(&connection, &target)
-            .expect("re-run graft endpoint migration idempotently");
-        let columns: Vec<String> = connection
-            .prepare("PRAGMA table_info(graft_receiver_endpoints);")
-            .expect("prepare columns")
-            .query_map([], |row| row.get(1))
-            .expect("query columns")
-            .collect::<Result<_, _>>()
-            .expect("decode columns");
-        for expected in [
-            "team",
-            "agent",
-            "endpoint",
-            "capability",
-            "owner_generation",
-            "registered_at",
-            "last_seen_at",
-            "unreachable_at",
-        ] {
-            assert!(
-                columns.iter().any(|column| column == expected),
-                "missing {expected}"
-            );
-        }
     }
 }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -13,6 +13,8 @@ description = "Shared audited storage contract and canonical domain types for AT
 atm-error = { path = "../atm-error", version = "1.4.4" }
 serde.workspace = true
 serde_json.workspace = true
+base64.workspace = true
+getrandom.workspace = true
 rustls.workspace = true
 x509-parser.workspace = true
 zeroize.workspace = true

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use crate::error::AtmError;
 use crate::schema::{AtmMessageId, InboxMessage, MessageEnvelope};
 use crate::types::{
-    AgentName, HostName, IsoTimestamp, LocalCapability, MemberKey, ModelName, PaneId, TaskId,
-    TeamName,
+    AgentName, HostName, IsoTimestamp, LocalCapability, MemberKey, ModelName, OwnerGeneration,
+    PaneId, TaskId, TeamName,
 };
 
 #[doc(hidden)]
@@ -627,7 +627,7 @@ pub struct GraftReceiverRegistration {
     pub agent: AgentName,
     pub endpoint: SocketAddr,
     pub capability: LocalCapability,
-    pub owner_generation: String,
+    pub owner_generation: OwnerGeneration,
 }
 
 /// Durable graft receiver endpoint and its liveness observations.
@@ -635,7 +635,7 @@ pub struct GraftReceiverRegistration {
 pub struct GraftReceiverLease {
     pub endpoint: SocketAddr,
     pub capability: LocalCapability,
-    pub owner_generation: String,
+    pub owner_generation: OwnerGeneration,
     pub registered_at: DateTime<Utc>,
     pub last_seen_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -682,7 +682,7 @@ pub trait GraftReceiverEndpointStore: sealed::Sealed + Send + Sync {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
         now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError>;
 
@@ -690,7 +690,7 @@ pub trait GraftReceiverEndpointStore: sealed::Sealed + Send + Sync {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
     ) -> Result<(), GraftEndpointStoreError>;
 
     fn lookup(
@@ -703,7 +703,7 @@ pub trait GraftReceiverEndpointStore: sealed::Sealed + Send + Sync {
         &self,
         team: &TeamName,
         agent: &AgentName,
-        owner_generation: &str,
+        owner_generation: &OwnerGeneration,
         now: DateTime<Utc>,
     ) -> Result<(), GraftEndpointStoreError>;
 }
@@ -963,24 +963,80 @@ pub trait PendingNudgeStore: sealed::Sealed + Send + Sync {
 mod tests {
     use super::{
         AckRequirementState, AtmMessageId, BuiltInNudgeTemplateKind, CertificateFingerprint,
-        Message, MessageKey, MessageQuery, MessageReceivedEvent, MessageStore, NudgeClaim,
-        NudgeTemplateOverrideStore, PendingNudgeStore, PrivateKeyRef, RosterChangedEvent,
-        RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot, RosterStore,
-        StorageNotifier, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
+        GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
+        GraftReceiverRegistration, Message, MessageKey, MessageQuery, MessageReceivedEvent,
+        MessageStore, NudgeClaim, NudgeTemplateOverrideStore, PendingNudgeStore, PrivateKeyRef,
+        RosterChangedEvent, RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot,
+        RosterStore, StorageNotifier, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
         derive_ack_requirement, sealed,
     };
     use crate::ROLE_WORKER;
     use crate::error::AtmError;
     use crate::schema::MessageEnvelope;
-    use crate::types::{AgentName, IsoTimestamp, MemberKey, ModelName, TeamName};
-    use chrono::Utc;
+    use crate::types::{
+        AgentName, IsoTimestamp, LocalCapability, MemberKey, ModelName, OwnerGeneration, TeamName,
+    };
+    use chrono::{DateTime, Utc};
     use serde_json::Map;
+    use std::net::SocketAddr;
 
     #[derive(Default)]
     struct DummyStore;
 
     #[derive(Default)]
     struct DummyNudgeTemplateOverrideStore;
+
+    #[derive(Default)]
+    struct DummyGraftReceiverEndpointStore;
+
+    impl sealed::Sealed for DummyGraftReceiverEndpointStore {}
+
+    impl GraftReceiverEndpointStore for DummyGraftReceiverEndpointStore {
+        fn register(
+            &self,
+            _registration: &GraftReceiverRegistration,
+            _now: DateTime<Utc>,
+        ) -> Result<(), GraftEndpointStoreError> {
+            Ok(())
+        }
+
+        fn refresh(
+            &self,
+            _team: &TeamName,
+            _agent: &AgentName,
+            _owner_generation: &OwnerGeneration,
+            _now: DateTime<Utc>,
+        ) -> Result<(), GraftEndpointStoreError> {
+            Ok(())
+        }
+
+        fn unregister(
+            &self,
+            _team: &TeamName,
+            _agent: &AgentName,
+            _owner_generation: &OwnerGeneration,
+        ) -> Result<(), GraftEndpointStoreError> {
+            Ok(())
+        }
+
+        fn lookup(
+            &self,
+            _team: &TeamName,
+            _agent: &AgentName,
+        ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError> {
+            Ok(None)
+        }
+
+        fn mark_unreachable(
+            &self,
+            _team: &TeamName,
+            _agent: &AgentName,
+            _owner_generation: &OwnerGeneration,
+            _now: DateTime<Utc>,
+        ) -> Result<(), GraftEndpointStoreError> {
+            Ok(())
+        }
+    }
 
     impl sealed::Sealed for DummyStore {}
 
@@ -1147,6 +1203,8 @@ mod tests {
         let notifier: &dyn StorageNotifier = &store;
         let pending_nudge_store: &dyn PendingNudgeStore = &DummyPendingNudgeStore;
         let override_store: &dyn NudgeTemplateOverrideStore = &DummyNudgeTemplateOverrideStore;
+        let graft_receiver_endpoint_store: &dyn GraftReceiverEndpointStore =
+            &DummyGraftReceiverEndpointStore;
 
         let team: TeamName = "test-team".parse().expect("team");
         let agent: AgentName = ROLE_WORKER.parse().expect("agent");
@@ -1275,6 +1333,45 @@ mod tests {
                 .expect("list pending members")
                 .is_empty()
         );
+
+        let generation =
+            OwnerGeneration::new("01J00000000000000000000001").expect("owner generation");
+        let registration = GraftReceiverRegistration {
+            team: "test-team".parse().expect("team"),
+            agent: ROLE_WORKER.parse().expect("agent"),
+            endpoint: "127.0.0.1:43101".parse::<SocketAddr>().expect("endpoint"),
+            capability: LocalCapability::generate().expect("capability"),
+            owner_generation: generation.clone(),
+        };
+        graft_receiver_endpoint_store
+            .register(&registration, Utc::now())
+            .expect("register");
+        assert!(
+            graft_receiver_endpoint_store
+                .lookup(&registration.team, &registration.agent)
+                .expect("lookup")
+                .is_none(),
+            "the dummy store never persists a lease"
+        );
+        graft_receiver_endpoint_store
+            .refresh(
+                &registration.team,
+                &registration.agent,
+                &generation,
+                Utc::now(),
+            )
+            .expect("refresh");
+        graft_receiver_endpoint_store
+            .mark_unreachable(
+                &registration.team,
+                &registration.agent,
+                &generation,
+                Utc::now(),
+            )
+            .expect("mark unreachable");
+        graft_receiver_endpoint_store
+            .unregister(&registration.team, &registration.agent, &generation)
+            .expect("unregister");
     }
 
     #[test]

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -1,6 +1,8 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fmt;
+use std::net::SocketAddr;
 use std::num::NonZeroU16;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -9,7 +11,8 @@ use std::sync::Arc;
 use crate::error::AtmError;
 use crate::schema::{AtmMessageId, InboxMessage, MessageEnvelope};
 use crate::types::{
-    AgentName, HostName, IsoTimestamp, MemberKey, ModelName, PaneId, TaskId, TeamName,
+    AgentName, HostName, IsoTimestamp, LocalCapability, MemberKey, ModelName, PaneId, TaskId,
+    TeamName,
 };
 
 #[doc(hidden)]
@@ -615,6 +618,94 @@ pub trait RosterStore: sealed::Sealed + Send + Sync {
     fn load_roster(&self, team: &TeamName) -> Result<RosterSnapshot, AtmError>;
     fn save_roster(&self, roster: &RosterSnapshot) -> Result<(), AtmError>;
     fn list_teams(&self) -> Result<Vec<TeamName>, AtmError>;
+}
+
+/// Registration payload for one loopback graft receiver lease.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraftReceiverRegistration {
+    pub team: TeamName,
+    pub agent: AgentName,
+    pub endpoint: SocketAddr,
+    pub capability: LocalCapability,
+    pub owner_generation: String,
+}
+
+/// Durable graft receiver endpoint and its liveness observations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraftReceiverLease {
+    pub endpoint: SocketAddr,
+    pub capability: LocalCapability,
+    pub owner_generation: String,
+    pub registered_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unreachable_since: Option<DateTime<Utc>>,
+}
+
+/// Errors returned by the durable graft receiver endpoint store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraftEndpointStoreError {
+    /// Reserved for a future caller that cannot prove same-host exclusivity.
+    AlreadyActive,
+    /// The supplied owner generation does not own the stored lease.
+    NotOwner,
+    /// The backend could not complete the requested operation.
+    Storage(String),
+}
+
+impl fmt::Display for GraftEndpointStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyActive => formatter.write_str("graft receiver lease is already active"),
+            Self::NotOwner => {
+                formatter.write_str("graft receiver lease is owned by another generation")
+            }
+            Self::Storage(message) => {
+                write!(
+                    formatter,
+                    "graft receiver endpoint storage failed: {message}"
+                )
+            }
+        }
+    }
+}
+
+/// Durable registry for same-host graft receiver endpoints.
+pub trait GraftReceiverEndpointStore: sealed::Sealed + Send + Sync {
+    fn register(
+        &self,
+        registration: &GraftReceiverRegistration,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError>;
+
+    fn refresh(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError>;
+
+    fn unregister(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+    ) -> Result<(), GraftEndpointStoreError>;
+
+    fn lookup(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError>;
+
+    fn mark_unreachable(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        owner_generation: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), GraftEndpointStoreError>;
 }
 
 /// A non-empty, opaque certificate fingerprint. It cannot be confused with a

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -67,7 +67,7 @@ pub use tls::{
 };
 pub use types::{
     AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, LOCAL_CAPABILITY_BYTES,
-    LocalCapability, MemberKey, ModelName, PaneId, TaskId, TeamName, TemplateFrontmatter,
-    TemplateSha,
+    LocalCapability, MemberKey, ModelName, OwnerGeneration, PaneId, TaskId, TeamName,
+    TemplateFrontmatter, TemplateSha,
 };
 pub use validation::{validate_agent_at_team, validate_path_segment};

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -27,13 +27,14 @@ pub use analyst_query::{AnalystQueryRow, AnalystQueryStore, AnalystQueryValue};
 pub use contract::{
     AckRequirementState, AckTransition, AcknowledgementCommit, AcknowledgementReplyBuilder,
     AcknowledgementSource, AgentType, AsyncMessageStore, BuiltInNudgeTemplateKind,
-    CertificateFingerprint, HttpsInterface, LocalCertificate, MAX_NUDGE_ATTEMPTS, MailMessageState,
-    MailboxBucketCounts, Message, MessageFingerprint, MessageKey, MessageQuery,
-    MessageReceivedEvent, MessageStore, NudgeClaim, NudgeTemplateOverrideStore, PeerConfigStore,
-    PendingNudgeStore, PrivateKeyRef, RosterChangedEvent, RosterHarness, RosterMember,
-    RosterMemberKind, RosterSnapshot, RosterStore, StorageNotifier, TaskState,
-    TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow, TrustedPeer,
-    derive_ack_requirement,
+    CertificateFingerprint, GraftEndpointStoreError, GraftReceiverEndpointStore,
+    GraftReceiverLease, GraftReceiverRegistration, HttpsInterface, LocalCertificate,
+    MAX_NUDGE_ATTEMPTS, MailMessageState, MailboxBucketCounts, Message, MessageFingerprint,
+    MessageKey, MessageQuery, MessageReceivedEvent, MessageStore, NudgeClaim,
+    NudgeTemplateOverrideStore, PeerConfigStore, PendingNudgeStore, PrivateKeyRef,
+    RosterChangedEvent, RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot, RosterStore,
+    StorageNotifier, TaskState, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
+    TrustedPeer, derive_ack_requirement,
 };
 pub use error::AtmError;
 pub use error_codes::AtmErrorCode;
@@ -65,7 +66,8 @@ pub use tls::{
     install_tls_provider, normalize_fingerprint,
 };
 pub use types::{
-    AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, MemberKey, ModelName,
-    PaneId, TaskId, TeamName, TemplateFrontmatter, TemplateSha,
+    AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, LOCAL_CAPABILITY_BYTES,
+    LocalCapability, MemberKey, ModelName, PaneId, TaskId, TeamName, TemplateFrontmatter,
+    TemplateSha,
 };
 pub use validation::{validate_agent_at_team, validate_path_segment};

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -16,8 +16,14 @@ pub const LOCAL_CAPABILITY_BYTES: usize = 32;
 ///
 /// The storage contract owns this value because durable graft registrations
 /// must be implementable without a dependency on `atm-core`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LocalCapability([u8; LOCAL_CAPABILITY_BYTES]);
+
+impl fmt::Debug for LocalCapability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LocalCapability([REDACTED])")
+    }
+}
 
 impl LocalCapability {
     pub fn generate() -> Result<Self, AtmError> {
@@ -79,6 +85,50 @@ impl<'de> Deserialize<'de> for LocalCapability {
     {
         let value = String::deserialize(deserializer)?;
         Self::parse_base64url(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validated ULID identifying the owner generation of a local lease.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct OwnerGeneration(String);
+
+impl OwnerGeneration {
+    pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
+        let value = value.into();
+        value.parse::<ulid::Ulid>().map_err(|_| {
+            AtmError::validation("graft receiver owner generation must be a valid ULID")
+        })?;
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OwnerGeneration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("OwnerGeneration")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for OwnerGeneration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for OwnerGeneration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
     }
 }
 
@@ -589,8 +639,42 @@ impl fmt::Display for TeamName {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, TemplateSha};
+    use super::{
+        AgentId, AgentIdentity, AgentName, ChatId, HostName, IsoTimestamp, LocalCapability,
+        OwnerGeneration, TemplateSha,
+    };
     use std::str::FromStr;
+
+    #[test]
+    fn local_capability_debug_never_prints_the_token() {
+        let capability = LocalCapability::generate().expect("capability");
+        let rendered = format!("{capability:?}");
+        assert_eq!(rendered, "LocalCapability([REDACTED])");
+        assert!(
+            !rendered.contains(&capability.to_base64url()),
+            "debug output must never leak the encoded capability token"
+        );
+    }
+
+    #[test]
+    fn owner_generation_accepts_valid_ulid_and_rejects_garbage() {
+        let generation =
+            OwnerGeneration::new("01J00000000000000000000001").expect("valid ULID generation");
+        assert_eq!(generation.as_str(), "01J00000000000000000000001");
+        assert_eq!(generation.to_string(), "01J00000000000000000000001");
+
+        for invalid in [
+            "",
+            "generation-1",
+            "not-a-ulid",
+            "01J0000000000000000000000",
+        ] {
+            assert!(
+                OwnerGeneration::new(invalid).is_err(),
+                "{invalid} must not parse as a valid owner generation"
+            );
+        }
+    }
 
     #[test]
     fn agent_identity_owns_chat_id_parsing_and_rendering() {

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -2,12 +2,85 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use base64::Engine as _;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::error::AtmError;
 use crate::template_workflow::TemplateVariableName;
 use crate::validation::{validate_agent_at_team, validate_path_segment};
+
+pub const LOCAL_CAPABILITY_BYTES: usize = 32;
+
+/// Per-bind secret used to authenticate same-host local HTTP and graft calls.
+///
+/// The storage contract owns this value because durable graft registrations
+/// must be implementable without a dependency on `atm-core`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalCapability([u8; LOCAL_CAPABILITY_BYTES]);
+
+impl LocalCapability {
+    pub fn generate() -> Result<Self, AtmError> {
+        let mut bytes = [0; LOCAL_CAPABILITY_BYTES];
+        getrandom::fill(&mut bytes).map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to generate local HTTP capability: {source}"
+            ))
+        })?;
+        Ok(Self(bytes))
+    }
+
+    pub fn to_base64url(&self) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(self.0)
+    }
+
+    pub fn parse_base64url(value: &str) -> Result<Self, AtmError> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|source| {
+                AtmError::local_http_capability_invalid("local HTTP capability is not base64url")
+                    .with_cause(source)
+            })?;
+        let bytes: [u8; LOCAL_CAPABILITY_BYTES] = bytes.try_into().map_err(|_| {
+            AtmError::local_http_capability_invalid(
+                "local HTTP capability must decode to exactly 32 bytes",
+            )
+        })?;
+        Ok(Self(bytes))
+    }
+
+    pub fn matches_header(&self, value: &str) -> bool {
+        match Self::parse_base64url(value) {
+            Ok(candidate) => {
+                let mut difference = 0_u8;
+                for (left, right) in self.0.iter().zip(candidate.0.iter()) {
+                    difference |= left ^ right;
+                }
+                difference == 0
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+impl Serialize for LocalCapability {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_base64url())
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalCapability {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse_base64url(&value).map_err(serde::de::Error::custom)
+    }
+}
 
 /// Lowercase SHA-256 identity for an immutable raw template file.
 ///

--- a/crates/atm/openapi.yaml
+++ b/crates/atm/openapi.yaml
@@ -80,6 +80,30 @@ paths:
       responses:
         '200': { description: Heartbeat result, content: { application/json: { schema: { $ref: '#/components/schemas/HeartbeatResponse' } } } }
         default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/register:
+    post:
+      operationId: registerGraftReceiver
+      description: Local-ingress-only registration of the current agent's graft receiver endpoint.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverRegistration' } } } }
+      responses:
+        '200': { description: Receiver registration accepted, content: { application/json: { schema: { type: 'null' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/unregister:
+    post:
+      operationId: unregisterGraftReceiver
+      description: Local-ingress-only removal of the current agent's graft receiver registration.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverUnregistration' } } } }
+      responses:
+        '200': { description: Receiver registration removed, content: { application/json: { schema: { type: 'null' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/lookup:
+    post:
+      operationId: lookupGraftReceiver
+      description: Local-ingress-only lookup of a registered graft receiver lease.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverLookupRequest' } } } }
+      responses:
+        '200': { description: Receiver lease when registered, content: { application/json: { schema: { nullable: true, $ref: '#/components/schemas/GraftReceiverLease' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
   /runtime/reload:
     post:
       operationId: reloadRuntimeView
@@ -190,6 +214,38 @@ components:
     HeartbeatResponse:
       type: object
       description: Team-member heartbeat result.
+    GraftReceiverRegistration:
+      type: object
+      required: [team, agent, endpoint, capability, owner_generation]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+        endpoint: { type: string, format: uri }
+        capability: { type: string, format: byte }
+        owner_generation: { type: string }
+    GraftReceiverUnregistration:
+      type: object
+      required: [team, agent, owner_generation]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+        owner_generation: { type: string }
+    GraftReceiverLookupRequest:
+      type: object
+      required: [team, agent]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+    GraftReceiverLease:
+      type: object
+      required: [endpoint, capability, owner_generation, registered_at, last_seen_at]
+      properties:
+        endpoint: { type: string, format: uri }
+        capability: { type: string, format: byte }
+        owner_generation: { type: string }
+        registered_at: { type: string, format: date-time }
+        last_seen_at: { type: string, format: date-time }
+        unreachable_since: { type: string, format: date-time, nullable: true }
     Message:
       type: object
       required: [message_id, from, to, body]

--- a/crates/atm/tests/openapi_surface_baseline.json
+++ b/crates/atm/tests/openapi_surface_baseline.json
@@ -32,6 +32,54 @@
         }
       }
     },
+    "/graft/receiver/lookup": {
+      "post": {
+        "operation_id": "lookupGraftReceiver",
+        "request_required": true,
+        "responses": {
+          "200": {
+            "error": false,
+            "schema": "#/components/schemas/GraftReceiverLease"
+          },
+          "default": {
+            "error": true,
+            "schema": "#/components/responses/AtmError"
+          }
+        }
+      }
+    },
+    "/graft/receiver/register": {
+      "post": {
+        "operation_id": "registerGraftReceiver",
+        "request_required": true,
+        "responses": {
+          "200": {
+            "error": false,
+            "schema": null
+          },
+          "default": {
+            "error": true,
+            "schema": "#/components/responses/AtmError"
+          }
+        }
+      }
+    },
+    "/graft/receiver/unregister": {
+      "post": {
+        "operation_id": "unregisterGraftReceiver",
+        "request_required": true,
+        "responses": {
+          "200": {
+            "error": false,
+            "schema": null
+          },
+          "default": {
+            "error": true,
+            "schema": "#/components/responses/AtmError"
+          }
+        }
+      }
+    },
     "/heartbeat": {
       "post": {
         "operation_id": "teamMemberHeartbeat",
@@ -191,6 +239,61 @@
     "CompatibilityVerdict": {
       "properties": [],
       "required": []
+    },
+    "GraftReceiverLease": {
+      "properties": [
+        "capability",
+        "endpoint",
+        "last_seen_at",
+        "owner_generation",
+        "registered_at",
+        "unreachable_since"
+      ],
+      "required": [
+        "capability",
+        "endpoint",
+        "last_seen_at",
+        "owner_generation",
+        "registered_at"
+      ]
+    },
+    "GraftReceiverLookupRequest": {
+      "properties": [
+        "agent",
+        "team"
+      ],
+      "required": [
+        "agent",
+        "team"
+      ]
+    },
+    "GraftReceiverRegistration": {
+      "properties": [
+        "agent",
+        "capability",
+        "endpoint",
+        "owner_generation",
+        "team"
+      ],
+      "required": [
+        "agent",
+        "capability",
+        "endpoint",
+        "owner_generation",
+        "team"
+      ]
+    },
+    "GraftReceiverUnregistration": {
+      "properties": [
+        "agent",
+        "owner_generation",
+        "team"
+      ],
+      "required": [
+        "agent",
+        "owner_generation",
+        "team"
+      ]
     },
     "HeartbeatRequest": {
       "properties": [],

--- a/docs/adr/ADR-056-graft-receiver-registration-and-lease.md
+++ b/docs/adr/ADR-056-graft-receiver-registration-and-lease.md
@@ -1,0 +1,59 @@
+# ADR-056 — Graft Receiver Registration And Lease Semantics
+
+Status: accepted
+
+Date: 2026-08-26
+
+## Context
+
+Graft receivers bind same-host loopback listeners and historically published
+their endpoint and capability in a JSON record. A truncating-write race in
+that record can make a live receiver unreachable, and the daemon and receiver
+must be able to restart independently without a manual profile reset.
+
+## Decision
+
+The replacement daemon owns a durable SQLite registry of graft receiver
+leases. A receiver registers `(team, agent, endpoint, capability,
+owner_generation)` after acquiring its same-host ownership flock. The registry
+stores registration and refresh timestamps plus advisory `unreachable_at`
+feedback. Capabilities are encoded with `LocalCapability::to_base64url()` on
+the wire and at rest, and decoded with `parse_base64url()`.
+
+The natural key is `(team, agent)`. It is intentionally a join key rather than
+a SQL foreign key to `team_roster`: roster saves replace all rows for a team,
+so a foreign key would either delete live leases during normal roster refresh
+or reject the roster write.
+
+`register` unconditionally upserts and displaces a row whose owner generation
+differs. The flock is the same-host exclusivity mechanism and is acquired
+before registration; the lease table is not a write-time conflict gate.
+Matching generations refresh the lease. `refresh`, `unregister`, and
+`mark_unreachable` require the stored owner generation and return `NotOwner`
+on mismatch. `AlreadyActive` remains reserved for a future caller that cannot
+prove same-host exclusivity. Delivery-time unreachable feedback never deletes
+the row.
+
+Liveness is derived by readers from lease existence, refresh age, and
+`unreachable_at`; no status boolean is persisted. The two writer families are
+the receiver lifecycle and delivery feedback. Lookup is local-ingress-only,
+read-only, and returns `Ok(None)` for a missing row.
+
+## Consequences
+
+- SQLite persistence survives daemon restart and makes receiver/daemon
+  lifecycle independence explicit.
+- The replacement router validates local ingress, roster membership, and
+  loopback endpoint addresses before invoking the storage boundary.
+- AQ1.6 owns receiver-side announce/refresh/unregister calls and AQ1.7 owns
+  production bootstrap wiring and consumer cutover.
+- The JSON record remains dual-written until AQ1.8; this ADR removes its role
+  as the daemon's source of truth but does not change file-record behavior in
+  AQ1.5.
+
+## Supersession
+
+This decision supersedes the endpoint-publication portion of
+`AI3133-HERMES-GRAFT-RECEIVER-SINGLETON-UNSAFE`. Its flock and generation
+checked ownership fixes remain valid; AQ1.8 removes the remaining file-record
+read/write machinery after the registration and consumer sprints land.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -62,8 +62,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-053 — Typed Temporary Daemon-Service Launch Overlay](./ADR-053-typed-temporary-daemon-service-launch-overlay.md)
 - [ADR-054 — Nudge Taxonomy and Queue Mechanism](./ADR-054-nudge-taxonomy-and-queue-mechanism.md)
 - `ADR-055` — reserved — Phase AQ (ATM_TEMP + transfer seam, AQ4)
-- `ADR-056` — reserved — Phase AQ (graft receiver registration + lease
-  semantics, AQ1.5)
+- [ADR-056 — Graft Receiver Registration And Lease Semantics](./ADR-056-graft-receiver-registration-and-lease.md)
 - [ADR-057 — Peer-Write Redial and Delivery-Attempt Invariant](./ADR-057-peer-write-redial-and-delivery-attempt-invariant.md)
 - [ADR-058 — Herdr Local Steer Backend Contract](./ADR-058-herdr-local-steer-backend-contract.md)
 

--- a/docs/atm-http-runtime/openapi.yaml
+++ b/docs/atm-http-runtime/openapi.yaml
@@ -80,6 +80,30 @@ paths:
       responses:
         '200': { description: Heartbeat result, content: { application/json: { schema: { $ref: '#/components/schemas/HeartbeatResponse' } } } }
         default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/register:
+    post:
+      operationId: registerGraftReceiver
+      description: Local-ingress-only registration of the current agent's graft receiver endpoint.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverRegistration' } } } }
+      responses:
+        '200': { description: Receiver registration accepted, content: { application/json: { schema: { type: 'null' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/unregister:
+    post:
+      operationId: unregisterGraftReceiver
+      description: Local-ingress-only removal of the current agent's graft receiver registration.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverUnregistration' } } } }
+      responses:
+        '200': { description: Receiver registration removed, content: { application/json: { schema: { type: 'null' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
+  /graft/receiver/lookup:
+    post:
+      operationId: lookupGraftReceiver
+      description: Local-ingress-only lookup of a registered graft receiver lease.
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/GraftReceiverLookupRequest' } } } }
+      responses:
+        '200': { description: Receiver lease when registered, content: { application/json: { schema: { nullable: true, $ref: '#/components/schemas/GraftReceiverLease' } } } }
+        default: { $ref: '#/components/responses/AtmError' }
   /runtime/reload:
     post:
       operationId: reloadRuntimeView
@@ -190,6 +214,38 @@ components:
     HeartbeatResponse:
       type: object
       description: Team-member heartbeat result.
+    GraftReceiverRegistration:
+      type: object
+      required: [team, agent, endpoint, capability, owner_generation]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+        endpoint: { type: string, format: uri }
+        capability: { type: string, format: byte }
+        owner_generation: { type: string }
+    GraftReceiverUnregistration:
+      type: object
+      required: [team, agent, owner_generation]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+        owner_generation: { type: string }
+    GraftReceiverLookupRequest:
+      type: object
+      required: [team, agent]
+      properties:
+        team: { type: string }
+        agent: { type: string }
+    GraftReceiverLease:
+      type: object
+      required: [endpoint, capability, owner_generation, registered_at, last_seen_at]
+      properties:
+        endpoint: { type: string, format: uri }
+        capability: { type: string, format: byte }
+        owner_generation: { type: string }
+        registered_at: { type: string, format: date-time }
+        last_seen_at: { type: string, format: date-time }
+        unreachable_since: { type: string, format: date-time, nullable: true }
     Message:
       type: object
       required: [message_id, from, to, body]

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -163,3 +163,25 @@ Rules:
 - concrete backend implementations such as `atm-storage-rusqlite` must
   implement the `atm-storage` sealed trait directly and must not depend on
   `atm-core` to satisfy this contract
+
+## GraftReceiverEndpointStore
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-storage/graft-receiver-endpoint-store.toml](../../boundaries/atm-storage/graft-receiver-endpoint-store.toml)
+
+Purpose:
+- own the durable `(team, agent)` registry for loopback graft receiver
+  endpoints, capabilities, owner generations, refresh timestamps, and
+  delivery-time unreachable feedback
+
+Rules:
+- `register` replaces a stored row when the owner generation changes; the
+  caller has already proved same-host exclusivity with the receiver flock
+- `refresh`, `unregister`, and `mark_unreachable` are owner-generation
+  checked; a lookup miss is `Ok(None)`
+- consumers derive liveness from timestamps and `unreachable_at`; no status
+  boolean or roster mirror is stored
+- the registry uses a natural `(team, agent)` join key without a SQL foreign
+  key because roster saves replace a team's rows in bulk
+- concrete SQLite implementations implement the sealed trait directly and
+  do not depend on `atm-core`

--- a/docs/plans/phase-aq/sprint-AQ1-5-graft-registration-api.md
+++ b/docs/plans/phase-aq/sprint-AQ1-5-graft-registration-api.md
@@ -1,6 +1,12 @@
+---
+status: complete
+branch: feature/aq-1-5-graft-registration-api
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/aq-1-5-graft-registration-api
+---
+
 # Sprint AQ1.5 — Graft Receiver Registration: Daemon API + Durable Store
 
-Status: draft · Branch: `feature/aq-1-5-graft-registration-api` off
+Status: complete · Branch: `feature/aq-1-5-graft-registration-api` off
 `integrate/phase-aq` · PR target: `integrate/phase-aq`
 recommended_agent: arch-ctm · recommended_model: deep-reasoning
 


### PR DESCRIPTION
Sprint AQ1.5 — first of the graft connection-model chain (AQ1.5→1.6→1.7→{1.8∥1.9}); parallel_safe with the Herdr sprints. Implemented by cipher.

- Wire contract: GraftReceiverRegister / Unregister / Lookup envelopes + HttpRouteKind, Local ingress only; capability encoded via LocalCapability::to_base64url
- Sealed `GraftReceiverEndpointStore` (atm-storage) + SQLite impl (atm-storage-rusqlite) with generation displacement / lease lifecycle, ensure_* migration, natural-key join
- Router handlers with roster + loopback validation; unconditional displacement on owner_generation mismatch (flock proves same-host exclusivity — approved by Rand 2026-08-26)
- ADR-056 + boundary record + docs/atm-storage/boundaries.md section; OpenAPI contract + baseline
- LocalServiceRuntime::with_graft_receiver_endpoint_store + accessor, test-wired (AQ1.7 does production wiring)

Gates (local): cargo test --workspace --all-targets, clippy -D warnings, fmt, shear, function-length, boundaries, ADR/nudge lints, graft Python — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)