### PR TITLE
ci(release): register pypi-publish.yml on default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run just lint
         run: just lint
@@ -245,6 +247,8 @@ jobs:
       - name: Bootstrap exact repository tools
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build workspace
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,131 @@
+name: Publish PyPI
+
+# Production publication is intentionally separate from release.yml. It uploads
+# only the already-attached artifacts from a published, immutable GitHub Release
+# so an upload failure can be retried without creating another tag, rerunning
+# crates.io publication, or rebuilding any artifact.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published GitHub Release tag to publish (e.g. v1.4.1)'
+        required: true
+        type: string
+      target:
+        description: 'Python package repository'
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-pypi-${{ inputs.target }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  verify-release:
+    runs-on: ubuntu-latest
+    outputs:
+      pypi_config: ${{ steps.config.outputs.config }}
+      python_upload_tool: ${{ steps.config.outputs.python_upload_tool }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: ./.github/actions/verify-published-release
+        with:
+          release_tag: ${{ inputs.tag }}
+      - id: config
+        name: Read PyPI channel configuration from release manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "config=$(python3 .github/scripts/release_artifacts.py channel-config --manifest release/publish-artifacts.toml --channel pypi)" >> "$GITHUB_OUTPUT"
+          # The manifest's declared build systems select the uploader:
+          # maturin when any distribution is maturin-built, twine otherwise.
+          plan="$(python3 .github/scripts/release_artifacts.py build-plan --manifest release/publish-artifacts.toml)"
+          echo "python_upload_tool=$(jq -r '.python_upload_tool' <<<"${plan}")" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: verify-release
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target == 'production' && 'pypi' || 'testpypi' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Download Python assets from the published GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets dist
+          gh release download "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+            --pattern '*.whl' --pattern '*.tar.gz' --dir release-assets
+      - name: Select and verify Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_artifacts.py verify-python-release-assets \
+            --manifest release/publish-artifacts.toml \
+            --asset-dir release-assets \
+            --copy-to dist
+      - name: Select configured Python repository
+        shell: bash
+        env:
+          CHANNEL_CONFIG: ${{ needs.verify-release.outputs.pypi_config }}
+          PUBLISH_TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import json
+          import os
+
+          config = json.loads(os.environ["CHANNEL_CONFIG"])["channel"]
+          key = "test_repository" if os.environ["PUBLISH_TARGET"] == "testpypi" else "production_repository"
+          print(f"PYPI_REPOSITORY={config[key]}")
+          PY
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install maturin
+        if: ${{ needs.verify-release.outputs.python_upload_tool == 'maturin' }}
+        run: python -m pip install maturin==1.9.4
+      - name: Install twine
+        if: ${{ needs.verify-release.outputs.python_upload_tool == 'twine' }}
+        run: python -m pip install twine==6.1.0
+      - name: Publish manifest-declared wheels and sdists to TestPyPI
+        if: ${{ inputs.target == 'testpypi' && needs.verify-release.outputs.python_upload_tool == 'maturin' }}
+        env:
+          MATURIN_NON_INTERACTIVE: '1'
+          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: maturin upload --repository "${PYPI_REPOSITORY}" --non-interactive --skip-existing dist/*.whl dist/*.tar.gz
+      - name: Publish manifest-declared wheels and sdists to PyPI
+        if: ${{ inputs.target == 'production' && needs.verify-release.outputs.python_upload_tool == 'maturin' }}
+        env:
+          MATURIN_NON_INTERACTIVE: '1'
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: maturin upload --repository "${PYPI_REPOSITORY}" --non-interactive --skip-existing dist/*.whl dist/*.tar.gz
+      - name: Publish manifest-declared wheels and sdists to TestPyPI with twine
+        if: ${{ inputs.target == 'testpypi' && needs.verify-release.outputs.python_upload_tool == 'twine' }}
+        env:
+          TWINE_NON_INTERACTIVE: '1'
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: python -m twine upload --repository "${PYPI_REPOSITORY}" --skip-existing dist/*.whl dist/*.tar.gz
+      - name: Publish manifest-declared wheels and sdists to PyPI with twine
+        if: ${{ inputs.target == 'production' && needs.verify-release.outputs.python_upload_tool == 'twine' }}
+        env:
+          TWINE_NON_INTERACTIVE: '1'
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --repository "${PYPI_REPOSITORY}" --skip-existing dist/*.whl dist/*.tar.gz

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Normalize version input
         id: meta


### PR DESCRIPTION
GitHub Actions only registers `workflow_dispatch` workflows that exist on the default branch (now `develop`). This adds the byte-identical kit copy of `.github/workflows/pypi-publish.yml` from `integrate/phase-at` (sc-publish pin `42e0fcea`) — registration only; dispatches run with `--ref integrate/phase-at` and execute that ref's copy.

Unblocks the Rand-authorized AT.1 TestPyPI publish leg (PR #1044 / AT.1 receipt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)