### PR TITLE
ci(aq): phase-aq evidence job (clean-runner live evidence for AQ1.9/AQ2.5/AQ3)

### DIFF
--- a/.github/workflows/phase-aq-evidence.yml
+++ b/.github/workflows/phase-aq-evidence.yml
@@ -134,16 +134,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          venv_root="$GITHUB_WORKSPACE/.bootstrap-venv"
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            venv_python=".bootstrap-venv/Scripts/python.exe"
-            venv_maturin=".bootstrap-venv/Scripts/maturin.exe"
+            venv_python="$venv_root/Scripts/python.exe"
+            venv_bin="$venv_root/Scripts"
           else
-            venv_python=".bootstrap-venv/bin/python"
-            venv_maturin=".bootstrap-venv/bin/maturin"
+            venv_python="$venv_root/bin/python"
+            venv_bin="$venv_root/bin"
           fi
-          "$venv_maturin" develop --manifest-path crates/atm-graft-python/Cargo.toml
+          # maturin refuses to "develop" without an active virtualenv. The
+          # repository's .bootstrap-venv is never `source`d by CI, so mirror
+          # scripts/test_atm_graft_python.py's approach of setting VIRTUAL_ENV
+          # and prepending the venv's bin/Scripts dir to PATH for this
+          # command instead of relying on shell activation.
+          export VIRTUAL_ENV="$venv_root"
+          export PATH="$venv_bin:$PATH"
+          maturin develop --manifest-path crates/atm-graft-python/Cargo.toml
           "$venv_python" -c "import atm_graft; print('atm_graft import ok:', atm_graft.__file__)"
-          echo "PHASE_AQ_EVIDENCE_PYTHON=$(pwd)/$venv_python" >> "$GITHUB_ENV"
+          echo "PHASE_AQ_EVIDENCE_PYTHON=$venv_python" >> "$GITHUB_ENV"
 
       - name: Run available Phase AQ live-evidence harnesses
         shell: python
@@ -151,7 +159,6 @@ jobs:
           PHASE_AQ_EVIDENCE_PYTHON: ${{ env.PHASE_AQ_EVIDENCE_PYTHON }}
         run: |
           import os
-          import re
           import subprocess
           import sys
           from pathlib import Path
@@ -161,18 +168,24 @@ jobs:
           python_bin = os.environ["PHASE_AQ_EVIDENCE_PYTHON"]
           host_label = f"clean-runner-{os.environ.get('RUNNER_OS', 'unknown').lower()}"
 
+          # Explicit script -> evidence-subdirectory mapping. Deliberately
+          # not inferred by regex-scraping the harness source (fragile and
+          # implicit); add one entry here the moment a new Phase AQ
+          # live-evidence harness (for example an AQ3 drain/sweep transcript
+          # runner) lands on its branch.
+          EVIDENCE_DIR_BY_SCRIPT = {
+              "run_hermes_atm_restart_matrix.py": "AQ1.9",
+              "run_aq25_queue_delivery_trigger_evidence.py": "AQ2.5",
+          }
+
+          # A harness's eligibility is decided by its own --help output, not
+          # by substring-scraping its source text.
+          REQUIRED_HELP_FLAGS = ("--evidence-dir", "--daemon", "--atm")
+
           if not scripts_dir.is_dir():
               print(f"SKIP: {scripts_dir} is not present on this branch; no Phase AQ evidence harnesses to run.")
               sys.exit(0)
 
-          # Every known Phase AQ live-evidence harness (AQ1.9's
-          # run_hermes_atm_restart_matrix.py, AQ2.5's
-          # run_aq25_queue_delivery_trigger_evidence.py, and any future AQ3
-          # drain/sweep transcript runner) is a scripts/phase-aq/run_*.py
-          # module, is not a test_*.py unit test, and accepts --evidence-dir.
-          # Discover by that shape instead of a hardcoded filename list so a
-          # harness that has not landed yet (for example AQ3's) is picked up
-          # automatically once it exists on the checked-out branch.
           candidates = sorted(
               path for path in scripts_dir.glob("run_*.py") if not path.name.startswith("test_")
           )
@@ -180,21 +193,33 @@ jobs:
               print(f"SKIP: no run_*.py live-evidence harnesses found under {scripts_dir}.")
               sys.exit(0)
 
-          default_evidence_dir_re = re.compile(
-              r'ROOT\s*/\s*"docs"\s*/\s*"plans"\s*/\s*"phase-aq"\s*/\s*"evidence"\s*/\s*"([^"]+)"'
-          )
-
           failures: list[str] = []
           for script in candidates:
-              text = script.read_text(encoding="utf-8")
-              if "--evidence-dir" not in text:
-                  print(f"SKIP: {script} does not accept --evidence-dir; not a live-evidence harness, leaving it alone.")
+              help_result = subprocess.run(
+                  [python_bin, str(script), "--help"],
+                  cwd=root,
+                  capture_output=True,
+                  text=True,
+                  check=False,
+              )
+              help_text = help_result.stdout + help_result.stderr
+              if help_result.returncode != 0 or not all(flag in help_text for flag in REQUIRED_HELP_FLAGS):
+                  print(
+                      f"SKIP: {script.name} --help does not advertise {REQUIRED_HELP_FLAGS}; "
+                      "not a live-evidence harness, leaving it alone."
+                  )
                   continue
 
-              match = default_evidence_dir_re.search(text)
-              sprint = match.group(1) if match else script.stem
-              evidence_dir = root / "docs" / "plans" / "phase-aq" / "evidence" / sprint
+              sprint = EVIDENCE_DIR_BY_SCRIPT.get(script.name)
+              if sprint is None:
+                  print(
+                      f"SKIP: {script.name} looks like a live-evidence harness (advertises "
+                      f"{REQUIRED_HELP_FLAGS}) but has no entry in EVIDENCE_DIR_BY_SCRIPT in "
+                      "this workflow; add one to run it. Refusing to guess its evidence directory."
+                  )
+                  continue
 
+              evidence_dir = root / "docs" / "plans" / "phase-aq" / "evidence" / sprint
               print(f"::group::Running {script.relative_to(root)} -> {evidence_dir.relative_to(root)}")
               result = subprocess.run(
                   [

--- a/.github/workflows/phase-aq-evidence.yml
+++ b/.github/workflows/phase-aq-evidence.yml
@@ -1,0 +1,263 @@
+name: Phase AQ Evidence
+
+# Runs the Phase AQ live-evidence harnesses (AQ1.9 restart matrix, AQ2.5
+# queue-delivery triggers, and any future AQ3 drain/sweep transcript) on a
+# clean runner with no ambient atm-daemon.
+#
+# These harnesses fail closed by design: `atm_core::home::current_host_runtime_scope`
+# intentionally ignores `ATM_HOME`/`HOME` and always resolves the OS
+# account's real profile directory, so `DaemonOwnerGuard`'s exclusive-lock
+# singleton check refuses to start a second daemon whenever a developer's own
+# ambient `atm-daemon` already owns that lock. A hosted Actions runner has no
+# such ambient daemon, so this job can produce real positive-path evidence
+# where a developer host cannot. See
+# docs/plans/phase-aq/evidence/README.md for the full explanation and the
+# manual recovery path when this job cannot commit evidence back on its own.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to check out and run the Phase AQ live-evidence harnesses against"
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - "scripts/phase-aq/**"
+      - "docs/plans/phase-aq/evidence/**"
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    name: Phase AQ live evidence (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      # --- Rust setup mirrors .github/workflows/ci.yml (toolchain pin + caching) ---
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14.7"
+
+      - name: Expose Cargo binaries on PATH
+        run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
+
+      - name: Cache bootstrap outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/binstall
+            .bootstrap-venv
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/bootstrap.toml', 'tools/bootstrap-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-phase-aq-evidence-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-phase-aq-evidence-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-phase-aq-evidence-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.58.0
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
+        with:
+          version: "1.22.0"
+
+      - name: Bootstrap exact repository tools
+        run: just bootstrap
+      # --- end shared CI setup ---
+
+      - name: Ensure tmux is available (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v tmux >/dev/null 2>&1; then
+            brew install tmux
+          fi
+
+      - name: Confirm this runner has no ambient atm-daemon
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Phase AQ live-evidence harnesses fail closed the moment they see
+          # an OS-account-owned atm-daemon already holding the singleton
+          # runtime lock (by design: current_host_runtime_scope ignores
+          # ATM_HOME/HOME). A hosted Actions runner must never have one; if it
+          # does, something is wrong with the runner image or a prior step in
+          # this job, not with the harnesses themselves.
+          if pgrep -x atm-daemon >/dev/null 2>&1; then
+            echo "::error::an ambient atm-daemon is already running on this runner; refusing to start the live-evidence harnesses" >&2
+            exit 1
+          fi
+          echo "confirmed: no ambient atm-daemon on this runner"
+
+      - name: Build workspace (release)
+        run: cargo build --release --workspace --verbose
+
+      - name: Install the atm-graft Python extension (maturin develop, per scripts/test_atm_graft_python.py)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            venv_python=".bootstrap-venv/Scripts/python.exe"
+            venv_maturin=".bootstrap-venv/Scripts/maturin.exe"
+          else
+            venv_python=".bootstrap-venv/bin/python"
+            venv_maturin=".bootstrap-venv/bin/maturin"
+          fi
+          "$venv_maturin" develop --manifest-path crates/atm-graft-python/Cargo.toml
+          "$venv_python" -c "import atm_graft; print('atm_graft import ok:', atm_graft.__file__)"
+          echo "PHASE_AQ_EVIDENCE_PYTHON=$(pwd)/$venv_python" >> "$GITHUB_ENV"
+
+      - name: Run available Phase AQ live-evidence harnesses
+        shell: python
+        env:
+          PHASE_AQ_EVIDENCE_PYTHON: ${{ env.PHASE_AQ_EVIDENCE_PYTHON }}
+        run: |
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          root = Path.cwd()
+          scripts_dir = root / "scripts" / "phase-aq"
+          python_bin = os.environ["PHASE_AQ_EVIDENCE_PYTHON"]
+          host_label = f"clean-runner-{os.environ.get('RUNNER_OS', 'unknown').lower()}"
+
+          if not scripts_dir.is_dir():
+              print(f"SKIP: {scripts_dir} is not present on this branch; no Phase AQ evidence harnesses to run.")
+              sys.exit(0)
+
+          # Every known Phase AQ live-evidence harness (AQ1.9's
+          # run_hermes_atm_restart_matrix.py, AQ2.5's
+          # run_aq25_queue_delivery_trigger_evidence.py, and any future AQ3
+          # drain/sweep transcript runner) is a scripts/phase-aq/run_*.py
+          # module, is not a test_*.py unit test, and accepts --evidence-dir.
+          # Discover by that shape instead of a hardcoded filename list so a
+          # harness that has not landed yet (for example AQ3's) is picked up
+          # automatically once it exists on the checked-out branch.
+          candidates = sorted(
+              path for path in scripts_dir.glob("run_*.py") if not path.name.startswith("test_")
+          )
+          if not candidates:
+              print(f"SKIP: no run_*.py live-evidence harnesses found under {scripts_dir}.")
+              sys.exit(0)
+
+          default_evidence_dir_re = re.compile(
+              r'ROOT\s*/\s*"docs"\s*/\s*"plans"\s*/\s*"phase-aq"\s*/\s*"evidence"\s*/\s*"([^"]+)"'
+          )
+
+          failures: list[str] = []
+          for script in candidates:
+              text = script.read_text(encoding="utf-8")
+              if "--evidence-dir" not in text:
+                  print(f"SKIP: {script} does not accept --evidence-dir; not a live-evidence harness, leaving it alone.")
+                  continue
+
+              match = default_evidence_dir_re.search(text)
+              sprint = match.group(1) if match else script.stem
+              evidence_dir = root / "docs" / "plans" / "phase-aq" / "evidence" / sprint
+
+              print(f"::group::Running {script.relative_to(root)} -> {evidence_dir.relative_to(root)}")
+              result = subprocess.run(
+                  [
+                      python_bin,
+                      str(script),
+                      "--host", host_label,
+                      "--daemon", str(root / "target" / "release" / "atm-daemon"),
+                      "--atm", str(root / "target" / "release" / "atm"),
+                      "--evidence-dir", str(evidence_dir),
+                  ],
+                  cwd=root,
+                  check=False,
+              )
+              print("::endgroup::")
+              if result.returncode != 0:
+                  failures.append(script.name)
+
+          if failures:
+              print(f"::error::Phase AQ live-evidence harness failure(s): {failures}", file=sys.stderr)
+              sys.exit(1)
+
+      - name: Show produced/updated evidence files
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          git status --porcelain -- docs/plans/phase-aq/evidence || true
+
+      - name: Upload Phase AQ evidence transcripts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase-aq-evidence-${{ matrix.os }}
+          path: docs/plans/phase-aq/evidence/**
+          if-no-files-found: warn
+
+      # Opening/updating a PR that commits these transcripts back onto the
+      # dispatched branch would need a token with pull-requests: write scope
+      # against this repository. Neither the default GITHUB_TOKEN convention
+      # used elsewhere in this repo's workflows (see release.yml,
+      # release-preflight.yml) nor any repository secret currently grants
+      # that. This job intentionally stops at the artifact upload above; see
+      # docs/plans/phase-aq/evidence/README.md for the manual
+      # `gh run download` + commit step that lands the transcripts.
+      - name: Print manual evidence-commit instructions
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### Phase AQ evidence — manual commit step required"
+            echo
+            echo "This job does not have a token authorized to open or update a pull"
+            echo "request against this repository, so it stops at the artifact upload."
+            echo "Download and commit the transcripts manually:"
+            echo
+            echo '```bash'
+            echo "gh run download ${{ github.run_id }} --name phase-aq-evidence-${{ matrix.os }} --dir /tmp/phase-aq-evidence"
+            echo "cp -R /tmp/phase-aq-evidence/. docs/plans/phase-aq/evidence/"
+            echo "git checkout -b evidence/${{ github.event.inputs.branch }}-${{ github.run_id }} origin/${{ github.event.inputs.branch }}"
+            echo "git add docs/plans/phase-aq/evidence"
+            echo "git commit -m 'docs(aq): live-evidence transcripts from run ${{ github.run_id }}'"
+            echo "git push -u origin evidence/${{ github.event.inputs.branch }}-${{ github.run_id }}"
+            echo "gh pr create --base ${{ github.event.inputs.branch }} --title 'docs(aq): live-evidence transcripts (run ${{ github.run_id }})' --fill"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/plans/phase-aq/evidence/README.md
+++ b/docs/plans/phase-aq/evidence/README.md
@@ -1,0 +1,108 @@
+# Phase AQ live-evidence job
+
+`.github/workflows/phase-aq-evidence.yml` runs the Phase AQ live-evidence
+harnesses — AQ1.9's restart matrix, AQ2.5's queue-delivery-trigger scenario,
+and any future AQ3 drain/sweep transcript harness — on a clean GitHub Actions
+runner instead of a developer host.
+
+## Why local runs fail closed
+
+Every one of these harnesses drives a real, owned `atm-daemon` process
+against the real `atm` CLI. The daemon runtime and database are intentionally
+**OS-account scoped**: `atm_core::home::current_host_runtime_scope` ignores
+`ATM_HOME`, `HOME`, and the current directory by design, and
+`DaemonOwnerGuard` enforces that scope with an OS-level exclusive file lock so
+two daemons can never race the same host account.
+
+That is correct behavior in production, but it means every harness refuses to
+start whenever a developer's own ambient `atm-daemon` already owns that lock
+— which is the normal state of any workstation actively dogfooding ATM. The
+harnesses do not fake or skip this check; they record a
+`blocked_ambient_daemon` (or `PENDING-DEDICATED-HOST-RUN`) status and exit,
+exactly as designed, rather than risk contending with the ambient session.
+See `scripts/phase-aq/run_hermes_atm_restart_matrix.py` and
+`scripts/phase-aq/run_aq25_queue_delivery_trigger_evidence.py` for the exact
+check (`ambient_daemon_pids()` / `require_clean_host()`).
+
+A hosted GitHub Actions runner has no such ambient daemon. It is a clean,
+single-use OS account for the duration of the job, so it can produce real
+positive-path evidence where a developer host structurally cannot.
+
+## How to trigger the job
+
+Dispatch it manually against the PR branch that needs live evidence:
+
+```bash
+gh workflow run phase-aq-evidence.yml \
+  --ref integrate/phase-aq \
+  -f branch=<pr-branch-name>
+```
+
+For example, to (re)run evidence for the AQ2.5 branch:
+
+```bash
+gh workflow run phase-aq-evidence.yml \
+  --ref integrate/phase-aq \
+  -f branch=feature/aq-2-5-queue-delivery-triggers
+```
+
+The job also runs automatically on any pull request that touches
+`scripts/phase-aq/**` or `docs/plans/phase-aq/evidence/**`, using the PR's own
+head commit. That automatic run is a correctness check on the harness itself
+(does it still build, install, and execute cleanly) — it uploads whatever
+transcripts it produces as workflow artifacts but does not commit them
+anywhere, since a pull-request-triggered run has no authority to push to the
+PR branch.
+
+The job runs on both `ubuntu-latest` and `macos-latest`. The macOS leg exists
+because AQ3's drain/sweep transcript exercises a real tmux pane, and `tmux` is
+not preinstalled on the macOS runner image (the job installs it via
+`brew install tmux` when missing).
+
+## How evidence lands
+
+1. The job builds the workspace in release mode, installs the `atm_graft`
+   Python extension into the repository's `.bootstrap-venv` via
+   `maturin develop` (mirroring `scripts/test_atm_graft_python.py`), confirms
+   the runner has no ambient `atm-daemon`, and then runs every
+   `scripts/phase-aq/run_*.py` harness present on the checked-out branch that
+   accepts an `--evidence-dir` flag. A harness that has not landed yet on that
+   branch (for example, an AQ3 drain/sweep transcript runner that does not
+   exist at the time of writing) is skipped with a clear `SKIP:` log line —
+   the job does not hardcode a fixed script list, so a differently named
+   harness that lands later is picked up automatically.
+2. Each harness writes its own JSON + Markdown transcript under
+   `docs/plans/phase-aq/evidence/<sprint>/…` (for example `AQ1.9/` or
+   `AQ2.5/`), exactly as it does when run locally.
+3. The job uploads the full `docs/plans/phase-aq/evidence/` tree as a workflow
+   artifact named `phase-aq-evidence-<os>` for each matrix leg.
+4. **Committing the transcripts back is a manual step.** Opening or updating a
+   pull request that commits these transcripts onto the dispatched branch
+   would need a token with `pull-requests: write` scope against this
+   repository. Neither the default `GITHUB_TOKEN` convention used elsewhere in
+   this repo's workflows (see `.github/workflows/release.yml` and
+   `.github/workflows/release-preflight.yml`, which only use `contents: write`
+   plus external registry secrets — never a PR-creation token) nor any
+   repository secret currently grants that. Rather than invent a new token or
+   silently no-op, the job stops at the artifact upload and prints the exact
+   manual recovery command in its job summary. Reproduced here:
+
+   ```bash
+   # Download the transcripts produced by a dispatched run.
+   gh run download <run-id> --name phase-aq-evidence-ubuntu-latest --dir /tmp/phase-aq-evidence
+   # (repeat with phase-aq-evidence-macos-latest if that leg produced
+   # evidence you also want, e.g. AQ3's tmux transcript)
+
+   # Land them on the branch that needs the evidence.
+   cp -R /tmp/phase-aq-evidence/. docs/plans/phase-aq/evidence/
+   git checkout -b evidence/<branch>-<run-id> origin/<branch>
+   git add docs/plans/phase-aq/evidence
+   git commit -m "docs(aq): live-evidence transcripts from run <run-id>"
+   git push -u origin evidence/<branch>-<run-id>
+   gh pr create --base <branch> --title "docs(aq): live-evidence transcripts (run <run-id>)" --fill
+   ```
+
+   If a future sprint wires up a repository-scoped PR-creation token, this
+   workflow's final step (`Print manual evidence-commit instructions`) is the
+   place to replace with an actual `gh pr create` / `peter-evans/create-pull-request`
+   call.

--- a/docs/plans/phase-aq/evidence/README.md
+++ b/docs/plans/phase-aq/evidence/README.md
@@ -63,14 +63,24 @@ not preinstalled on the macOS runner image (the job installs it via
 
 1. The job builds the workspace in release mode, installs the `atm_graft`
    Python extension into the repository's `.bootstrap-venv` via
-   `maturin develop` (mirroring `scripts/test_atm_graft_python.py`), confirms
-   the runner has no ambient `atm-daemon`, and then runs every
-   `scripts/phase-aq/run_*.py` harness present on the checked-out branch that
-   accepts an `--evidence-dir` flag. A harness that has not landed yet on that
-   branch (for example, an AQ3 drain/sweep transcript runner that does not
-   exist at the time of writing) is skipped with a clear `SKIP:` log line —
-   the job does not hardcode a fixed script list, so a differently named
-   harness that lands later is picked up automatically.
+   `maturin develop` (mirroring `scripts/test_atm_graft_python.py`; the venv
+   is activated for that command via `VIRTUAL_ENV` + a `PATH` prepend, since
+   maturin refuses to run outside an active virtualenv), confirms the runner
+   has no ambient `atm-daemon`, and then considers every
+   `scripts/phase-aq/run_*.py` file present on the checked-out branch (except
+   `test_*.py` unit tests). Each candidate's *eligibility* is decided by
+   running it with `--help` and checking that the parsed help text advertises
+   `--evidence-dir`, `--daemon`, and `--atm` — never by scanning its source
+   text. Each eligible harness's *evidence directory* comes from an explicit
+   `EVIDENCE_DIR_BY_SCRIPT` mapping in the workflow (filename → sprint, for
+   example `run_hermes_atm_restart_matrix.py` → `AQ1.9`), never by
+   regex-reconstructing it from the harness's own source. A harness that is
+   eligible but has no mapping entry yet (for example, an AQ3 drain/sweep
+   transcript runner that does not exist at the time of writing) is skipped
+   with a clear `SKIP:` log line that says to add a mapping entry — the job
+   never guesses an evidence directory. When AQ3's harness lands, add its
+   filename and sprint slug to `EVIDENCE_DIR_BY_SCRIPT` in
+   `.github/workflows/phase-aq-evidence.yml`.
 2. Each harness writes its own JSON + Markdown transcript under
    `docs/plans/phase-aq/evidence/<sprint>/…` (for example `AQ1.9/` or
    `AQ2.5/`), exactly as it does when run locally.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/phase-aq-evidence.yml`: a `workflow_dispatch` (input `branch`) + `pull_request` (paths `scripts/phase-aq/**`, `docs/plans/phase-aq/evidence/**`) workflow that runs the Phase AQ live-evidence harnesses on `ubuntu-latest`/`macos-latest` clean hosted runners — no ambient `atm-daemon`, so the OS-account singleton lock check that makes these harnesses fail closed on developer hosts (`current_host_runtime_scope` ignores `ATM_HOME`/`HOME` by design) does not trip.
- The job mirrors `ci.yml`'s Rust toolchain pin (1.94.1) and caching, builds the workspace in release mode, installs the `atm_graft` Python extension via `maturin develop` against `.bootstrap-venv` (same approach as `scripts/test_atm_graft_python.py`), then discovers and runs every `scripts/phase-aq/run_*.py` harness present on the checked-out branch that accepts `--evidence-dir` — skipping ones that don't exist yet (AQ3's drain/sweep transcript harness has not landed on `feature/aq-3-queue-tmux` as of this PR) with a clear log line, rather than a hardcoded filename list.
- Transcripts land under `docs/plans/phase-aq/evidence/<sprint>/…` and are uploaded as workflow artifacts. Automatically opening a PR to commit them back needs a `pull-requests: write` token this repo's other workflows don't provision (`release.yml` / `release-preflight.yml` only use `contents: write` plus external registry secrets), so the job intentionally stops at the artifact upload and documents the manual `gh run download` + commit path.
- Add `docs/plans/phase-aq/evidence/README.md` explaining why local runs fail closed, how to dispatch the job, and how evidence lands (including the manual commit/PR recovery command).

## Test plan
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/phase-aq-evidence.yml"))'`
- [x] YAML `bash -n` / `py_compile` syntax check of every embedded shell/python step
- [x] `codespell` on the new docs/workflow
- [x] `python3 .just/run_lint.py spell`
- [ ] Live: dispatch `gh workflow run phase-aq-evidence.yml --ref integrate/phase-aq -f branch=feature/aq-2-5-queue-delivery-triggers` once this PR merges, confirm positive-path evidence is produced