### PR TITLE
ci: authenticate cargo-binstall bootstrap (fix macOS 403 bootstrap failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run just lint
         run: just lint
@@ -245,6 +247,8 @@ jobs:
       - name: Bootstrap exact repository tools
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build workspace
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/phase-aq-evidence.yml
+++ b/.github/workflows/phase-aq-evidence.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # --- end shared CI setup ---
 
       - name: Ensure tmux is available (macOS)

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Bootstrap exact repository tools
         run: just bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Normalize version input
         id: meta


### PR DESCRIPTION
## Root cause

macOS (and occasionally other) CI jobs fail during \`just bootstrap\` because \`cargo-binstall\` resolves \`cargo-deny\` (and other pinned tools) via unauthenticated requests to \`api.github.com\`. GitHub rate-limits unauthenticated API requests aggressively per-IP, and shared GitHub-hosted runner IP ranges hit that limit routinely. When the API lookup returns \`403 Forbidden\`, \`cargo-binstall\` cannot resolve the release asset, and since this repo's bootstrap explicitly disables the compile fallback (\`tools/bootstrap.py\`'s \`cargo_binstall_command\` passes \`--disable-strategies quick-install,compile\` to prevent a silent from-source rebuild), bootstrap aborts with "Fallback to cargo-install is disabled" → "bootstrap refused".

Evidence (macOS job runs hitting this exact failure mode):
- 33046749264
- 33045503107
- 33094566377

## Fix

\`cargo-binstall\` authenticates \`api.github.com\` requests automatically when a \`GITHUB_TOKEN\` environment variable is present, which raises the rate limit from the unauthenticated per-IP limit to the much higher per-token limit. This PR adds

\`\`\`yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
\`\`\`

to the \`Bootstrap exact repository tools\` step (\`run: just bootstrap\`) in every workflow that invokes it:

- \`.github/workflows/ci.yml\` — \`just-lint\` job and \`test\` job (2 steps)
- \`.github/workflows/phase-aq-evidence.yml\` — \`evidence\` job (1 step)
- \`.github/workflows/release-preflight.yml\` — \`preflight\` job (1 step)

\`tools/bootstrap.py\` invokes \`cargo binstall\` via \`subprocess.run\` without overriding \`env\`, so it inherits the step's environment automatically — no changes to \`tools/bootstrap.py\` or \`tools/bootstrap.toml\` were needed, and the \`--disable-strategies\` compile-fallback guard is untouched. This is additive-only: no other step, job, or workflow behavior changes.

## Verification

\`python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"\` passes (all workflow YAML still parses). \`python3 .just/run_lint.py all\` passes 30/32 checks; the 2 failures (\`fmt\`, \`clippy\`) are pre-existing local-environment gaps in this fresh worktree (\`.bootstrap-venv\` doesn't exist because \`just bootstrap\` hasn't been run locally yet) and are unrelated to this change.

This PR's own CI run on the \`macos\` job is the real verification — a green \`just bootstrap\` step there (rather than a repeat 403) confirms the fix.