### PR TITLE
docs(at2): retarget deletion gates to first kit-era release (forward-only publishing)

### DIFF
--- a/docs/plans/phase-at/AT.1-install-parity-and-publish.md
+++ b/docs/plans/phase-at/AT.1-install-parity-and-publish.md
@@ -382,6 +382,18 @@ PR may merge with the TestPyPI receipt and an explicit
 a follow-up commit/PR on the same receipt file
 (`docs/plans/phase-at/receipts/AT.1-receipt.md`) without reopening this sprint.
 
+**Amendment (2026-08-27, owner decision — forward-only publishing).** The
+authorized v1.4.3 TestPyPI attempt (run 33040465059) failed pre-upload:
+`pypi-publish.yml` checks out the release tag's tree, and at `v1.4.3` the kit
+action is absent and the legacy manifest fails the kit schema — v1.4.3 is
+unpublishable via the kit on two independent grounds. Rand ruled
+re-publishing pre-kit tags out of scope ("I don't see a reason to try to
+re-publish anything before the first kit install"). This checkpoint is
+therefore retargeted to the **first kit-era tag (workspace version `1.4.4`)**,
+cut after phase AT merges to `develop`; the TestPyPI authorization carries
+over, and production remains `pending-contemporaneous-authorization`. Full
+evidence: the AT.1 receipt's TestPyPI amendment.
+
 ## Publication Non-Goals
 
 - No product-source changes (sprint artifacts on the feature branch are

--- a/docs/plans/phase-at/AT.2-legacy-deletion.md
+++ b/docs/plans/phase-at/AT.2-legacy-deletion.md
@@ -118,21 +118,28 @@ schema are absent/incompatible at that tag; see the AT.1 receipt's TestPyPI
 amendment). All publication evidence for this sprint's gates therefore comes
 from the **first kit-era release (workspace version `1.4.4`)**, cut from a
 kit-installed tree after phase AT merges to `develop`. This sprint executes
-as a post-release deletion pass once that release's receipts exist.
+now, within phase AT: rows whose gate receipt does not yet exist are RETAINED
+as `deferred-until-<gate>` per the Deletion Candidates deferral rule above,
+and the follow-up deletion pass after the first kit-era release resolves
+them. The sprint does not wait for that release.
 
-- At minimum, the first kit-era release's TestPyPI receipt proving the kit
-  built and published every declared distribution — including the setuptools
-  `hermes-atm` — end-to-end. The hermes rows (the
+- Gate evidence for **deleting** a publish-path row is the first kit-era
+  release's TestPyPI receipt proving the kit built and published every
+  declared distribution — including the setuptools `hermes-atm` —
+  end-to-end. The hermes rows (the
   `.github/workflows/hermes-atm-pypi-publish.yml` workflow, its feeder
   script, and their tests) additionally require the production PyPI receipt
   (the receipt's production section complete, not
-  `production: pending-authorization`), per the `Gate` column.
+  `production: pending-authorization`), per the `Gate` column. Rows whose
+  gate receipt does not yet exist when the sprint runs are deferred, not
+  deleted.
 - A channel-scoped credential-unavailable (fail-closed) result in AT.1 is
   valid evidence the workflow fails closed, and per the phase README
   Non-Blocking Outcomes table it is never an emergency — but it does NOT
-  constitute publication and does not satisfy this coverage-evidence
-  prerequisite. AT.2 proceeds only on receipts showing the public indexes
-  actually contain the first kit-era (1.4.4) distributions.
+  constitute publication and does not satisfy a row's gate. A row is deleted
+  only on receipts showing the public indexes actually contain the first
+  kit-era (1.4.4) distributions; otherwise it is retained as
+  `deferred-until-<gate>`.
 - `install.py --dry-run` (run from the pinned checkout, per the phase README
   installer contract) clean on the sprint branch before starting.
 

--- a/docs/plans/phase-at/AT.2-legacy-deletion.md
+++ b/docs/plans/phase-at/AT.2-legacy-deletion.md
@@ -60,8 +60,8 @@ replace by name.
 The `Gate` column names the specific receipt that must exist before that
 row may be deleted:
 
-- **AT.1 production receipt** = `docs/plans/phase-at/receipts/AT.1-receipt.md`
-  with its production PyPI section complete (not
+- **Production PyPI receipt** = the first kit-driven release's receipt with
+  its production PyPI section complete (not
   `production: pending-authorization`).
 - **First kit-release receipt** = the receipt of the first kit-driven
   release proving the crates.io + GitHub Release legs end-to-end.
@@ -70,10 +70,10 @@ row may be deleted:
 
 | Path | Observed state | Expected coverage | Gate |
 | --- | --- | --- | --- |
-| `.github/workflows/hermes-atm-pypi-publish.yml` | Legacy bespoke PyPI workflow for `hermes-atm` | Kit `pypi-publish.yml` building the declared setuptools distribution (upstream #39) | AT.1 production receipt |
-| `scripts/prepare_hermes_atm_publish_artifacts.py` | Feeds the legacy hermes workflow | Same kit leg; manifest-declared distribution | AT.1 production receipt (deleted with the workflow it feeds) |
-| `.just/tests/test_hermes_atm_pypi_publish_workflow.py` | Tests the legacy hermes workflow | Kit upstream tests at the pinned revision | AT.1 production receipt (same gate as its subject) |
-| `.just/tests/test_prepare_hermes_atm_publish_artifacts.py` | Tests the legacy prepare script | Same | AT.1 production receipt (same gate as its subject) |
+| `.github/workflows/hermes-atm-pypi-publish.yml` | Legacy bespoke PyPI workflow for `hermes-atm` | Kit `pypi-publish.yml` building the declared setuptools distribution (upstream #39) | Production PyPI receipt |
+| `scripts/prepare_hermes_atm_publish_artifacts.py` | Feeds the legacy hermes workflow | Same kit leg; manifest-declared distribution | Production PyPI receipt (deleted with the workflow it feeds) |
+| `.just/tests/test_hermes_atm_pypi_publish_workflow.py` | Tests the legacy hermes workflow | Kit upstream tests at the pinned revision | Production PyPI receipt (same gate as its subject) |
+| `.just/tests/test_prepare_hermes_atm_publish_artifacts.py` | Tests the legacy prepare script | Same | Production PyPI receipt (same gate as its subject) |
 | `scripts/release_artifacts.py` | Legacy copy at root; kit installs `.github/scripts/release_artifacts.py` | Kit script | First kit-release receipt |
 | `scripts/release_gate.sh` | Legacy copy at root | Kit `.github/scripts/release_gate.sh` via `release.yml` | First kit-release receipt |
 | `scripts/verify_release_archive.py` | Legacy archive verifier | Kit `verify-published-release` action + `verify-*-release-assets` subcommands; retain only if it checks ATM-owned data the kit does not | First kit-release receipt |
@@ -110,9 +110,18 @@ retained test records that rationale in its module docstring.
 
 ## Prerequisites
 
-- At minimum, the AT.1 TestPyPI receipt
-  (`docs/plans/phase-at/receipts/AT.1-receipt.md`) proving the kit built and
-  published every declared distribution — including the setuptools
+**Amendment (2026-08-27, owner decision — forward-only publishing).** Rand
+ruled that re-publishing tags predating the kit installation is out of scope
+("I don't see a reason to try to re-publish anything before the first kit
+install"). `v1.4.3` is unpublishable via the kit (the kit action and manifest
+schema are absent/incompatible at that tag; see the AT.1 receipt's TestPyPI
+amendment). All publication evidence for this sprint's gates therefore comes
+from the **first kit-era release (workspace version `1.4.4`)**, cut from a
+kit-installed tree after phase AT merges to `develop`. This sprint executes
+as a post-release deletion pass once that release's receipts exist.
+
+- At minimum, the first kit-era release's TestPyPI receipt proving the kit
+  built and published every declared distribution — including the setuptools
   `hermes-atm` — end-to-end. The hermes rows (the
   `.github/workflows/hermes-atm-pypi-publish.yml` workflow, its feeder
   script, and their tests) additionally require the production PyPI receipt
@@ -123,7 +132,7 @@ retained test records that rationale in its module docstring.
   Non-Blocking Outcomes table it is never an emergency — but it does NOT
   constitute publication and does not satisfy this coverage-evidence
   prerequisite. AT.2 proceeds only on receipts showing the public indexes
-  actually contain the 1.4.3 distributions.
+  actually contain the first kit-era (1.4.4) distributions.
 - `install.py --dry-run` (run from the pinned checkout, per the phase README
   installer contract) clean on the sprint branch before starting.
 
@@ -176,7 +185,7 @@ python3 -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathli
 - `scripts/validate_release.py` drives a live Justfile recipe; deleting it
   without replacing the recipe breaks `just` targets. Resolve the decision
   first, then delete.
-- The hermes-atm legacy workflow must not be deleted before AT.1's production
+- The hermes-atm legacy workflow must not be deleted before the production
   PyPI receipt proves the kit publishes the setuptools distribution — the
   TestPyPI receipt alone does not clear that row, and the proof depends on
   the upstream #39 fix being in the pinned revision.

--- a/docs/plans/phase-at/README.md
+++ b/docs/plans/phase-at/README.md
@@ -14,9 +14,20 @@ upstream_revision: 42e0fcea23f730fae0ef3d08b060cd4df6a2602e
 
 Replace no product code and add no ATM-specific publishing framework. Install
 the shared `sc-publish` package from one immutable upstream revision using
-ATM's complete JSON input, prove a retryable 1.4.3 Python release from
-immutable `main` reaches TestPyPI and PyPI (AT.1), then delete the deprecated
-legacy publish surface the shared kit demonstrably covers (AT.2).
+ATM's complete JSON input and prove install parity (AT.1), then delete the
+deprecated legacy publish surface the shared kit demonstrably covers (AT.2).
+
+**Amendment (2026-08-27, owner decision — forward-only publishing).** The
+original goal also included proving a retryable 1.4.3 Python release from
+immutable `main` reaches TestPyPI and PyPI. Rand ruled re-publishing tags
+that predate the kit installation out of scope ("I don't see a reason to try
+to re-publish anything before the first kit install"). `v1.4.3` is
+unpublishable via the kit — the kit action is absent at that tag and the
+legacy manifest fails the kit schema (see the AT.1 receipt's TestPyPI
+amendment). The publish-proof leg is retargeted to the **first kit-era tag
+(workspace version `1.4.4`)**, cut after phase AT merges to `develop`;
+TestPyPI authorization carries over, production remains
+`pending-contemporaneous-authorization`.
 
 ## Baseline
 
@@ -101,15 +112,20 @@ The new release-candidate provenance gate (sc-publish PR #48) runs in
 `release-candidate.yml`/`release.yml` before release creation. The
 `pypi-publish.yml` dispatch accepts only `tag` and `target`, and then requires
 the named GitHub Release to be published, non-draft, and to have all required
-assets. An immutable v1.4.3 retry therefore uses the post-release path without
-re-running provenance or rebuilding assets; this is recorded in the AT.1
-receipt and the recovered re-pin verification receipt.
+assets. An immutable v1.4.3 retry would therefore have used the post-release
+path without re-running provenance or rebuilding assets — but per the
+2026-08-27 forward-only ruling (see Goal amendment) the v1.4.3 retry is
+withdrawn: `pypi-publish.yml` checks out the release tag's tree for its
+action and manifest, so only tags cut from kit-installed trees are
+publishable. The publish proof runs against the first kit-era tag (1.4.4);
+this is recorded in the AT.1 receipt and the recovered re-pin verification
+receipt.
 
 ## Sprint Sequence
 
 | Sprint | Purpose | Dependency |
 | --- | --- | --- |
-| [AT.1](AT.1-install-parity-and-publish.md) | Install the pinned shared package, prove parity, and perform authorized TestPyPI/PyPI 1.4.3 publication. | Start point |
+| [AT.1](AT.1-install-parity-and-publish.md) | Install the pinned shared package and prove parity. The 1.4.3 publish leg was retargeted to the first kit-era tag (1.4.4) per the forward-only ruling (see Goal amendment). | Start point |
 | [AT.2](AT.2-legacy-deletion.md) | Verify coverage, then delete the deprecated legacy publish surface. | must_follow AT.1 |
 
 Each sprint doc's frontmatter `status:` flips to `in-progress` when its

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1448,25 +1448,32 @@ forward no AS work, files, acceptance criteria, or release receipts. The AS
 artifacts remain only on `origin/integrate/phase-as` as historical
 reference; do not build on them.
 
-## 52. Phase AT — Manifest-Driven Publishing Recovery [PROPOSED — PLAN ON BRANCH, AT.1 REHEARSED]
+## 52. Phase AT — Manifest-Driven Publishing Recovery [IN PROGRESS — AT.1 MERGED, AT.2 PENDING]
 
 Phase AT restarts the publish-kit adoption from the post-AS-revert baseline
 (commit `d610b4c07`) under the ADR-050 ownership split: `sc-publish` owns
 generic publish mechanics; atm-core owns its own manifest, validation, and
-publish-order correctness. Three sprints: `AT.1` install one immutable,
+publish-order correctness. Two sprints: `AT.1` install one immutable,
 pinned `sc-publish` revision (never patched locally) driven by ATM's
-complete consumer JSON input and prove preflight/release parity; `AT.2`
-authorized TestPyPI→PyPI retry of the previously-unpublished 1.4.3 Python
-release from immutable `main` (must_follow AT.1); `AT.3` verify coverage,
-then delete the legacy publish surface — `release.yml`,
-`release-preflight.yml`, `hermes-atm-pypi-publish.yml`, root `scripts/` —
-that the kit now covers (must_follow AT.2). Integration branch:
-`integrate/phase-at`.
+complete consumer JSON input, prove preflight/release parity, and perform
+the authorized publish proof; `AT.2` verify coverage, then delete the
+legacy publish surface — `release.yml`, `release-preflight.yml`,
+`hermes-atm-pypi-publish.yml`, root `scripts/` — that the kit now covers
+(must_follow AT.1), retaining rows whose gate receipt does not yet exist as
+`deferred-until-<gate>`. Integration branch: `integrate/phase-at`.
 
-The plan lives on branch `plan/phase-at-publish-recovery`
-(`docs/plans/phase-at/`, status proposed, hardened 2026-08-20 per
-critical/traceability review); an AT.1 dry-run rehearsal receipt exists on
-`smoke/phase-at-at1-rehearsal`. Not yet merged to `develop`.
+**Amendment (2026-08-27, owner decision — forward-only publishing).** The
+originally planned TestPyPI→PyPI retry of the pre-kit 1.4.3 release is
+withdrawn: v1.4.3 is unpublishable via the kit (kit action absent at the
+tag; legacy manifest fails the kit schema), and Rand ruled pre-kit-tag
+republishing out of scope. The publish-proof leg is retargeted to the first
+kit-era tag (workspace version 1.4.4), cut after phase AT merges to
+`develop`; TestPyPI authorization carries over, production remains
+pending contemporaneous authorization. See
+`docs/plans/phase-at/receipts/AT.1-receipt.md`.
+
+AT.1 merged via PR #1044 (plus receipt amendments #1052/#1062); an AT.1
+dry-run rehearsal receipt exists on `smoke/phase-at-at1-rehearsal`.
 
 ## 53. Phase AU — Boundary Debt Retirement [PLANNING ACTIVE]
 


### PR DESCRIPTION
Records the owner's forward-only decision in the AT.2 plan: v1.4.3 is unpublishable via the kit, so all deletion-gate receipts (TestPyPI, production PyPI, first kit-release, channel receipts) come from the first kit-era release (1.4.4) after phase AT merges to develop. AT.2 becomes the post-release deletion pass. Companion to the AT.1 receipt amendment (PR #1062) and sc-publish #57 closure / #58 docs note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)