### PR TITLE
fix(aq1.9): restart-matrix evidence harness crash guard

### DIFF
--- a/scripts/phase-aq/run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/run_hermes_atm_restart_matrix.py
@@ -19,12 +19,14 @@ import os
 from pathlib import Path
 import queue
 import re
+import shutil
 import signal
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import traceback
 import uuid
 from typing import Any, Callable, Iterator
 
@@ -474,100 +476,172 @@ def doctor(atm: Path, env: dict[str, str]) -> dict[str, Any]:
     return payload
 
 
+def _remove_tree_tolerant(path: Path, *, attempts: int = 6, initial_delay: float = 0.15) -> str | None:
+    """Best-effort recursive removal of one row's scratch directory.
+
+    Mirrors `run_aq4_transfer_evidence.py`'s `_remove_tree_tolerant`. This
+    row previously relied on `tempfile.TemporaryDirectory`'s automatic
+    `__exit__` cleanup, whose exception (observed on Windows: WinError
+    32/5 sharing violations against a directory this row's own `atm` /
+    daemon / receiver-worker subprocesses -- already stopped and fully
+    waited on above -- briefly still held a handle on) unwound straight
+    past this row's own `try`/`except`/`finally` and the `return record`
+    that used to sit inside it, discarding the already-computed row
+    record entirely with no evidence written for that row at all.
+    Retrying with backoff absorbs that transient lag; if the directory
+    still will not budge, this reports a warning string instead of
+    raising, so an OS-level cleanup race can never discard or crash a
+    row's evidence. Returns `None` on success, or a description of the
+    final failure.
+    """
+    delay = initial_delay
+    last_error: OSError | None = None
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(path)
+            return None
+        except FileNotFoundError:
+            return None
+        except OSError as error:
+            last_error = error
+            if attempt == attempts - 1:
+                break
+            time.sleep(delay)
+            delay *= 2
+    return f"could not remove {path} after {attempts} attempts: {last_error}"
+
+
 def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, Any]:
     started_at = time.time_ns()
-    with tempfile.TemporaryDirectory(prefix=f"aq1-9-{row}-") as temporary:
-        root = Path(temporary)
-        env, workspace = fixture_environment(root, args.atm)
-        home = Path(env["HOME"])
-        native_env = {key: env[key] for key in NATIVE_SESSION_ENV_KEYS}
-        daemon = OwnedDaemon(args.daemon, env, args.timeout)
-        receiver: ReceiverWorker | None = None
-        sender_session: Any | None = None
-        roster_members: list[str] = []
-        record: dict[str, Any] = {
-            "id": row,
-            "action": action,
-            "started_at_ns": started_at,
-            "status": "fail",
-            "host": args.host,
-        }
-        with scoped_process_environment(native_env):
-            try:
-                add_roster_member(args.atm, env, home, SENDER)
-                roster_members.append(SENDER)
-                add_roster_member(args.atm, env, home, RECEIVER)
-                roster_members.append(RECEIVER)
-                daemon_start = daemon.start()
-                record["daemon_before"] = daemon_start
-                record["doctor_before"] = doctor(args.atm, env)
-                receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
-                record["receiver_before"] = receiver.start()
-                import atm_graft
+    # A manually-managed `mkdtemp` (not `tempfile.TemporaryDirectory`'s
+    # `with`-block auto-cleanup) deliberately, mirroring
+    # `run_aq4_transfer_evidence.py`'s `run_scenario`: that context
+    # manager's `__exit__` calls `cleanup()`, which can raise while
+    # unwinding past this row's own `return record` below, discarding the
+    # already-computed record entirely. Cleanup now happens explicitly,
+    # below, through `_remove_tree_tolerant`, which can never raise past
+    # this function -- and only runs after the record is fully populated
+    # and every child process this row owns has already been stopped.
+    directory = tempfile.mkdtemp(prefix=f"aq1-9-{row}-")
+    root = Path(directory)
+    env, workspace = fixture_environment(root, args.atm)
+    home = Path(env["HOME"])
+    native_env = {key: env[key] for key in NATIVE_SESSION_ENV_KEYS}
+    daemon = OwnedDaemon(args.daemon, env, args.timeout)
+    receiver: ReceiverWorker | None = None
+    sender_session: Any | None = None
+    roster_members: list[str] = []
+    record: dict[str, Any] = {
+        "id": row,
+        "action": action,
+        "started_at_ns": started_at,
+        "status": "fail",
+        "host": args.host,
+    }
+    with scoped_process_environment(native_env):
+        try:
+            add_roster_member(args.atm, env, home, SENDER)
+            roster_members.append(SENDER)
+            add_roster_member(args.atm, env, home, RECEIVER)
+            roster_members.append(RECEIVER)
+            daemon_start = daemon.start()
+            record["daemon_before"] = daemon_start
+            record["doctor_before"] = doctor(args.atm, env)
+            receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
+            record["receiver_before"] = receiver.start()
+            import atm_graft
 
-                sender_session = atm_graft.PyGraftSession(atm_graft.PyAgentAddress(SENDER, TEAM, None))
-                receiver_address = atm_graft.PyAgentAddress(RECEIVER, TEAM, None)
-                if action == "daemon_restart":
-                    record["restart_at_ns"] = time.time_ns()
-                    record["daemon_stop"] = daemon.stop()
-                    record["daemon_after"] = daemon.start()
-                else:
-                    crash = action == "receiver_crash_within_window"
-                    record["restart_at_ns"] = time.time_ns()
-                    record["receiver_stop"] = receiver.stop(crash=crash)
-                    receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
-                    record["receiver_after"] = receiver.start()
-                marker = f"aq1-9-{row}-{uuid.uuid4()}"
-                send_started = time.time_ns()
-                sent = sender_session.send(receiver_address, marker, False)
-                nudge = receiver.wait_for_nudge(marker, args.timeout)
-                delivered_at = int(nudge["at_ns"])
-                record.update(
-                    {
-                        "marker": marker,
-                        "message_id": str(sent.message_id),
-                        "sent_at_ns": send_started,
-                        "delivered_at_ns": delivered_at,
-                        "delivery_latency_ms": round((delivered_at - send_started) / 1_000_000, 3),
-                        "nudge": nudge,
-                        "receiver_transcript": receiver.output.tail() if receiver.output is not None else [],
-                        "daemon_transcript": daemon.output.tail() if daemon.output is not None else [],
-                        "doctor_after": doctor(args.atm, env),
-                        "status": "pass",
-                    }
-                )
-                if action == "receiver_crash_within_window":
-                    recovery_ms = (delivered_at - int(record["restart_at_ns"])) / 1_000_000
-                    record["crash_recovery_ms"] = round(recovery_ms, 3)
-                    record["within_one_refresh_tick"] = recovery_ms <= CRASH_RECOVERY_LIMIT_SECONDS * 1000
-                    if not record["within_one_refresh_tick"]:
-                        record["status"] = "fail"
-                        record["error"] = "successor delivery exceeded the one-refresh-tick recovery bound"
-            except Exception as error:  # noqa: BLE001 - evidence must retain the row failure
-                record["error"] = f"{type(error).__name__}: {error}"
-            finally:
-                if sender_session is not None:
-                    try:
-                        sender_session.close()
-                    except Exception:
-                        pass
-                if receiver is not None:
-                    receiver.stop()
-                record["daemon_cleanup"] = daemon.stop()
-                if RECEIVER in roster_members:
-                    remove_roster_member(args.atm, env, SENDER)
-                    remove_roster_member(args.atm, env, RECEIVER)
-                elif SENDER in roster_members:
-                    remove_roster_member(args.atm, env, SENDER, caller=SENDER)
-                record["finished_at_ns"] = time.time_ns()
-        return record
+            sender_session = atm_graft.PyGraftSession(atm_graft.PyAgentAddress(SENDER, TEAM, None))
+            receiver_address = atm_graft.PyAgentAddress(RECEIVER, TEAM, None)
+            if action == "daemon_restart":
+                record["restart_at_ns"] = time.time_ns()
+                record["daemon_stop"] = daemon.stop()
+                record["daemon_after"] = daemon.start()
+            else:
+                crash = action == "receiver_crash_within_window"
+                record["restart_at_ns"] = time.time_ns()
+                record["receiver_stop"] = receiver.stop(crash=crash)
+                receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
+                record["receiver_after"] = receiver.start()
+            marker = f"aq1-9-{row}-{uuid.uuid4()}"
+            send_started = time.time_ns()
+            sent = sender_session.send(receiver_address, marker, False)
+            nudge = receiver.wait_for_nudge(marker, args.timeout)
+            delivered_at = int(nudge["at_ns"])
+            record.update(
+                {
+                    "marker": marker,
+                    "message_id": str(sent.message_id),
+                    "sent_at_ns": send_started,
+                    "delivered_at_ns": delivered_at,
+                    "delivery_latency_ms": round((delivered_at - send_started) / 1_000_000, 3),
+                    "nudge": nudge,
+                    "receiver_transcript": receiver.output.tail() if receiver.output is not None else [],
+                    "daemon_transcript": daemon.output.tail() if daemon.output is not None else [],
+                    "doctor_after": doctor(args.atm, env),
+                    "status": "pass",
+                }
+            )
+            if action == "receiver_crash_within_window":
+                recovery_ms = (delivered_at - int(record["restart_at_ns"])) / 1_000_000
+                record["crash_recovery_ms"] = round(recovery_ms, 3)
+                record["within_one_refresh_tick"] = recovery_ms <= CRASH_RECOVERY_LIMIT_SECONDS * 1000
+                if not record["within_one_refresh_tick"]:
+                    record["status"] = "fail"
+                    record["error"] = "successor delivery exceeded the one-refresh-tick recovery bound"
+        except Exception as error:  # noqa: BLE001 - evidence must retain the row failure
+            record["error"] = f"{type(error).__name__}: {error}"
+        finally:
+            if sender_session is not None:
+                try:
+                    sender_session.close()
+                except Exception:
+                    pass
+            if receiver is not None:
+                receiver.stop()
+            record["daemon_cleanup"] = daemon.stop()
+            if RECEIVER in roster_members:
+                remove_roster_member(args.atm, env, SENDER)
+                remove_roster_member(args.atm, env, RECEIVER)
+            elif SENDER in roster_members:
+                remove_roster_member(args.atm, env, SENDER, caller=SENDER)
+            record["finished_at_ns"] = time.time_ns()
+    # Scratch-directory teardown happens last, strictly after the row's
+    # record is fully populated above -- a teardown failure can only ever
+    # attach a `cleanup_warning` to an already-complete record, never
+    # discard it.
+    cleanup_warning = _remove_tree_tolerant(root)
+    if cleanup_warning is not None:
+        record["cleanup_warning"] = cleanup_warning
+    return record
+
+
+def _evidence_output_paths(args: argparse.Namespace) -> tuple[Path, Path]:
+    evidence_dir = args.evidence_dir or ROOT / "docs" / "plans" / "phase-aq" / "evidence" / "AQ1.9"
+    return evidence_dir / f"restart-matrix-{args.host}.json", evidence_dir / f"restart-matrix-{args.host}.md"
+
+
+def _clear_stale_evidence(*paths: Path) -> None:
+    """Deletes any pre-existing evidence file at these exact output paths
+    before the matrix runs. Evidence directories are committed to the
+    repo, so without this a harness that crashes before `write_evidence`
+    ever runs (see `main`'s top-level guard around the three
+    `run_scenario` rows) would otherwise leave the previous, stale run's
+    committed file in place -- and a CI workflow's `if: always()`
+    artifact-upload step would then publish that stale file as if it were
+    fresh for this run. Deleting first means a genuine crash the guard
+    itself cannot recover from (for example the interpreter being killed
+    outright) leaves this run's evidence *missing*, never *stale* -- an
+    honest signal `if-no-files-found: warn` already tolerates. Mirrors
+    `run_aq4_transfer_evidence.py`'s `_clear_stale_evidence`.
+    """
+    for path in paths:
+        path.unlink(missing_ok=True)
 
 
 def write_evidence(args: argparse.Namespace, records: list[dict[str, Any]]) -> tuple[Path, Path]:
-    evidence_dir = args.evidence_dir or ROOT / "docs" / "plans" / "phase-aq" / "evidence" / "AQ1.9"
-    evidence_dir.mkdir(parents=True, exist_ok=True)
-    json_path = evidence_dir / f"restart-matrix-{args.host}.json"
-    markdown_path = evidence_dir / f"restart-matrix-{args.host}.md"
+    json_path, markdown_path = _evidence_output_paths(args)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema_version": 1,
         "sprint": "AQ1.9",
@@ -591,6 +665,27 @@ def write_evidence(args: argparse.Namespace, records: list[dict[str, Any]]) -> t
     for record in records:
         latency = record.get("delivery_latency_ms", "—")
         lines.append(f"| {record['id']} | {record['status'].upper()} | {latency} ms | `{json_path.name}` |")
+    crashed = [record for record in records if record.get("status") == "harness_crashed"]
+    if crashed:
+        lines += [
+            "",
+            "The harness raised an unhandled exception before it could "
+            "finish running every row. This transcript is written by a "
+            "top-level guard in `main` specifically so a crash can never "
+            "leave this run's evidence stale (a previous run's committed "
+            "file, reused unchanged) or missing (no file at all) -- see "
+            "`main`'s top-level `try`/`except` around the three "
+            "`run_scenario` rows.",
+        ]
+        for record in crashed:
+            lines += [
+                "",
+                f"Error: `{record.get('error')}`",
+                "",
+                "```",
+                record.get("traceback", "").rstrip(),
+                "```",
+            ]
     lines.extend(
         [
             "",
@@ -599,6 +694,13 @@ def write_evidence(args: argparse.Namespace, records: list[dict[str, Any]]) -> t
             "The m5 live run must be executed on m5; no remote result is inferred from this local artifact.",
         ]
     )
+    cleanup_warnings = [record["cleanup_warning"] for record in records if record.get("cleanup_warning")]
+    for warning in cleanup_warnings:
+        lines += [
+            "",
+            "**Cleanup warning** (best-effort only; does not affect the "
+            f"row status above): `{warning}`",
+        ]
     markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return json_path, markdown_path
 
@@ -611,16 +713,40 @@ def main() -> int:
         raise SystemExit("--timeout must be positive")
     if args.worker:
         return worker_main(args)
+    # Deleted before any other work (and only for the top-level matrix
+    # invocation -- never a `--worker` subprocess, which never writes
+    # evidence and must not race the parent's own evidence files): a
+    # harness crash the top-level guard below cannot itself recover from
+    # must leave this run's evidence missing, never a stale copy of a
+    # previous run's committed file.
+    _clear_stale_evidence(*_evidence_output_paths(args))
     if not args.daemon.is_file():
         raise SystemExit(f"owned daemon binary does not exist: {args.daemon}")
     if not args.atm.is_file():
         raise SystemExit(f"matched atm binary does not exist: {args.atm}")
     require_clean_host()
-    records = [
-        run_scenario(args, "daemon-restart-live-receiver", "daemon_restart"),
-        run_scenario(args, "receiver-restart-live-daemon", "receiver_restart"),
-        run_scenario(args, "receiver-crash-within-window", "receiver_crash_within_window"),
-    ]
+    try:
+        records = [
+            run_scenario(args, "daemon-restart-live-receiver", "daemon_restart"),
+            run_scenario(args, "receiver-restart-live-daemon", "receiver_restart"),
+            run_scenario(args, "receiver-crash-within-window", "receiver_crash_within_window"),
+        ]
+    except Exception as error:  # noqa: BLE001 - a crash must still produce evidence, not none
+        # Per-row structure: a single crashed row stands in for the whole
+        # matrix here rather than three "fail" rows, since a harness crash
+        # (as opposed to an in-row `run_scenario` failure, already caught
+        # and recorded by that function's own try/except) means no row
+        # ever finished running.
+        records = [
+            {
+                "id": "harness_crashed",
+                "action": "harness_crashed",
+                "host": args.host,
+                "status": "harness_crashed",
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc(),
+            }
+        ]
     json_path, markdown_path = write_evidence(args, records)
     passed = all(record.get("status") == "pass" for record in records)
     print(f"{'PASS' if passed else 'FAIL'} restart matrix evidence: {json_path}")

--- a/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 from pathlib import Path
+import sys
 import tempfile
 import unittest
 from types import SimpleNamespace
+from typing import Any
 
 
 SCRIPT = Path(__file__).with_name("run_hermes_atm_restart_matrix.py")
@@ -82,6 +85,202 @@ class HermesAtmRestartMatrixTests(unittest.TestCase):
                 self.assertEqual(os.environ[absent_key], "during")
                 raise RuntimeError("boom")
         self.assertNotIn(absent_key, os.environ)
+
+    # -- stale-evidence clearing (mirrors run_aq4_transfer_evidence.py) --
+
+    def test_clear_stale_evidence_removes_pre_existing_files_and_tolerates_absence(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary)
+            json_path = evidence_dir / "restart-matrix-m5.json"
+            markdown_path = evidence_dir / "restart-matrix-m5.md"
+            json_path.write_text('{"stale": true}', encoding="utf-8")
+            markdown_path.write_text("stale", encoding="utf-8")
+
+            # Must not raise even when one of the two paths is already gone.
+            module._clear_stale_evidence(json_path, evidence_dir / "does-not-exist.md")
+
+            self.assertFalse(json_path.exists())
+            self.assertTrue(markdown_path.exists(), "only the passed-in paths are cleared")
+
+    def test_evidence_output_paths_match_write_evidences_own_naming(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            args = SimpleNamespace(host="m5", evidence_dir=Path(temporary))
+            json_path, markdown_path = module._evidence_output_paths(args)
+            self.assertEqual(json_path.name, "restart-matrix-m5.json")
+            self.assertEqual(markdown_path.name, "restart-matrix-m5.md")
+
+    # -- harness_crashed top-level guard around the three run_scenario rows --
+
+    def test_main_never_leaves_a_stale_evidence_file_when_a_row_crashes(self) -> None:
+        # Regression coverage for the AQ1.9 sibling of the AQ4 harness
+        # fix: a top-level guard in main() around the three run_scenario
+        # rows must always (a) delete any pre-existing evidence file for
+        # this host before doing any real work, and (b) still write a
+        # fresh, non-stale single "harness_crashed" row -- with a
+        # traceback -- when one of the three run_scenario calls raises, so
+        # a CI `if: always()` artifact-upload step never re-publishes the
+        # previous run's committed file as if it were fresh.
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary)
+            json_path = evidence_dir / "restart-matrix-m5.json"
+            evidence_dir.mkdir(parents=True, exist_ok=True)
+            stale_payload = {"schema_version": 1, "sprint": "AQ1.9", "records": [{"status": "pass", "stale": True}]}
+            json_path.write_text(json.dumps(stale_payload), encoding="utf-8")
+
+            def _boom(_args: SimpleNamespace, _row: str, _action: str) -> dict[str, Any]:
+                raise RuntimeError("owned daemon did not report ready")
+
+            original_run_scenario = module.run_scenario
+            original_require_clean_host = module.require_clean_host
+            original_argv = sys.argv
+            module.run_scenario = _boom
+            module.require_clean_host = lambda: None
+            sys.argv = [
+                "run_hermes_atm_restart_matrix.py",
+                "--host",
+                "m5",
+                "--evidence-dir",
+                str(evidence_dir),
+                "--daemon",
+                str(module.ROOT / "Cargo.toml"),
+                "--atm",
+                str(module.ROOT / "Cargo.toml"),
+            ]
+            try:
+                exit_code = module.main()
+            finally:
+                module.run_scenario = original_run_scenario
+                module.require_clean_host = original_require_clean_host
+                sys.argv = original_argv
+
+            self.assertEqual(exit_code, 1)
+            written = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(len(written["records"]), 1)
+            crashed = written["records"][0]
+            self.assertEqual(crashed["status"], "harness_crashed")
+            self.assertNotIn("stale", crashed)
+            self.assertIn("owned daemon did not report ready", crashed["error"])
+            self.assertIn("Traceback", crashed["traceback"])
+            markdown = (evidence_dir / "restart-matrix-m5.md").read_text(encoding="utf-8")
+            self.assertIn("owned daemon did not report ready", markdown)
+            self.assertIn("Traceback", markdown)
+
+    def test_main_worker_mode_returns_before_clearing_any_evidence(self) -> None:
+        # `--worker` re-invokes this same script as a receiver subprocess
+        # (see ReceiverWorker.start); it must never race the parent
+        # matrix's own evidence files by clearing them too.
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary)
+            json_path = evidence_dir / "restart-matrix-local.json"
+            evidence_dir.mkdir(parents=True, exist_ok=True)
+            json_path.write_text('{"kept": true}', encoding="utf-8")
+
+            original_worker_main = module.worker_main
+            original_argv = sys.argv
+            module.worker_main = lambda _args: 0
+            sys.argv = [
+                "run_hermes_atm_restart_matrix.py",
+                "--worker",
+                "--workspace-root",
+                str(evidence_dir),
+                "--evidence-dir",
+                str(evidence_dir),
+            ]
+            try:
+                exit_code = module.main()
+            finally:
+                module.worker_main = original_worker_main
+                sys.argv = original_argv
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(json_path.exists(), "worker mode must never clear the parent's evidence")
+
+    def test_write_evidence_harness_crashed_row_includes_error_and_traceback(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            args = SimpleNamespace(host="local", evidence_dir=Path(temporary))
+            records = [
+                {
+                    "id": "harness_crashed",
+                    "status": "harness_crashed",
+                    "error": "RuntimeError: boom",
+                    "traceback": "Traceback (most recent call last):\n  ...\nRuntimeError: boom\n",
+                }
+            ]
+            _json_path, markdown_path = module.write_evidence(args, records)
+            markdown = markdown_path.read_text(encoding="utf-8")
+            self.assertIn("HARNESS_CRASHED", markdown)
+            self.assertIn("RuntimeError: boom", markdown)
+            self.assertIn("Traceback (most recent call last):", markdown)
+
+    def test_write_evidence_surfaces_a_cleanup_warning_without_changing_status(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            args = SimpleNamespace(host="local", evidence_dir=Path(temporary))
+            records = [
+                {
+                    "id": "daemon-restart-live-receiver",
+                    "status": "pass",
+                    "delivery_latency_ms": 3.0,
+                    "cleanup_warning": "could not remove /tmp/aq1-9-x after 6 attempts: boom",
+                }
+            ]
+            _json_path, markdown_path = module.write_evidence(args, records)
+            markdown = markdown_path.read_text(encoding="utf-8")
+            self.assertIn("PASS", markdown)
+            self.assertIn("Cleanup warning", markdown)
+            self.assertIn("could not remove /tmp/aq1-9-x", markdown)
+
+    # -- tolerant scratch-directory cleanup (mirrors run_aq4_transfer_evidence.py) --
+
+    def test_remove_tree_tolerant_removes_a_real_directory(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "victim"
+            (target / "nested").mkdir(parents=True)
+            (target / "nested" / "file.txt").write_text("x", encoding="utf-8")
+
+            result = module._remove_tree_tolerant(target)
+
+            self.assertIsNone(result)
+            self.assertFalse(target.exists())
+
+    def test_remove_tree_tolerant_returns_none_for_an_already_missing_path(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            missing = Path(temporary) / "never-created"
+            self.assertIsNone(module._remove_tree_tolerant(missing))
+
+    def test_remove_tree_tolerant_reports_a_warning_instead_of_raising_when_removal_never_succeeds(
+        self,
+    ) -> None:
+        # Simulates the observed Windows failure mode (WinError 32/5
+        # sharing violation that never clears) without needing an actual
+        # locked directory: shutil.rmtree always raises for this path.
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "locked"
+            target.mkdir()
+
+            original_rmtree = module.shutil.rmtree
+
+            def _always_fails(_path: object, *_args: object, **_kwargs: object) -> None:
+                raise PermissionError("[WinError 32] The process cannot access the file")
+
+            module.shutil.rmtree = _always_fails
+            try:
+                result = module._remove_tree_tolerant(target, attempts=2, initial_delay=0.0)
+            finally:
+                module.shutil.rmtree = original_rmtree
+
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertIn("could not remove", result)
+            self.assertIn("WinError 32", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Sibling of the AQ4 harness-integrity fix (`run_aq4_transfer_evidence.py` on `feature/aq-4-send-to-core` @ 7f6774802): `run_hermes_atm_restart_matrix.py` (AQ1.9, row-based evidence writer) now carries the same evidence-integrity guarantees.
- `_clear_stale_evidence` deletes this host's pre-existing evidence JSON/Markdown before any real work, so a hard crash leaves evidence *missing*, never *stale*.
- `main()` wraps the three `run_scenario` rows in a top-level `try`/`except` that writes a single `"harness_crashed"` row (with `error` + full `traceback`) through the harness's normal `write_evidence` writer before exiting non-zero — per-row structure, so one crashed row stands in for the whole matrix.
- Each row's `run_scenario` now uses a manually-managed `tempfile.mkdtemp` instead of `tempfile.TemporaryDirectory`'s `with`-block auto-cleanup (whose `__exit__` could previously raise past the row's own `return record`, discarding an already-computed row entirely). Teardown now happens explicitly, after the row's daemon/receiver/roster cleanup, via a tolerant `_remove_tree_tolerant` (retry-with-backoff, never raises) that attaches a non-fatal `cleanup_warning` to the record instead.

## Why
Every other AQ evidence harness (AQ4, AQ2.5) already has this crash-guard/stale-evidence/tolerant-cleanup shape; AQ1.9's restart matrix was the one row-based harness still missing it, so a Windows-style teardown race or an unhandled exception before `write_evidence` ran could leave a CI `if: always()` artifact-upload step re-publishing a stale committed evidence file as if it were fresh for the run.

## Test plan
- [x] `python3 -m unittest discover -s scripts/phase-aq -p "test_run_hermes_atm_restart_matrix.py"` — 14 tests pass, including new coverage: `test_clear_stale_evidence_removes_pre_existing_files_and_tolerates_absence`, `test_main_never_leaves_a_stale_evidence_file_when_a_row_crashes`, `test_main_worker_mode_returns_before_clearing_any_evidence`, `test_write_evidence_harness_crashed_row_includes_error_and_traceback`, `test_write_evidence_surfaces_a_cleanup_warning_without_changing_status`, `test_remove_tree_tolerant_removes_a_real_directory`, `test_remove_tree_tolerant_returns_none_for_an_already_missing_path`, `test_remove_tree_tolerant_reports_a_warning_instead_of_raising_when_removal_never_succeeds`, `test_evidence_output_paths_match_write_evidences_own_naming`.
- [x] `python3 .just/run_lint.py all` — 32/32 checks pass.
- [x] `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)