### PR TITLE
Release v1.4.4

### DIFF
--- a/.github/actions/setup-lint-toolchain/action.yml
+++ b/.github/actions/setup-lint-toolchain/action.yml
@@ -1,10 +1,6 @@
 name: Setup lint toolchain
-description: Install sc-lint plus the cargo-deny/cargo-shear/codespell tools required by cargo test --workspace
+description: Install the cargo-deny/cargo-shear/codespell tools required by cargo test --workspace
 inputs:
-  sc-lint-version:
-    description: Released sc-lint version to install
-    required: false
-    default: "0.4.0"
   cargo-deny-version:
     description: Pinned cargo-deny version
     required: false
@@ -20,11 +16,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up sc-lint
-      uses: ./.github/actions/setup-sc-lint
-      with:
-        version: ${{ inputs.sc-lint-version }}
-
+    # Release-branch fix (v1.4.4, upstream sc-publish#67): sc-lint is a lint
+    # tool owned by repo CI; the publish preflight must not install or gate on
+    # it. The setup-sc-lint step is removed here pending upstream deletion.
     - name: Install cargo-deny
       uses: taiki-e/install-action@v2
       with:

--- a/.github/scripts/release_artifacts.py
+++ b/.github/scripts/release_artifacts.py
@@ -417,7 +417,14 @@ def cmd_validate_manifest(args: argparse.Namespace) -> int:
 
 def cmd_list_publish_plan(args: argparse.Namespace) -> int:
     manifest = load_manifest(Path(args.manifest))
-    for crate in manifest["crates"]:
+    # Only crates.io-publishable crates belong in the plan, and consumers
+    # (crates-publish.yml, release-preflight.yml) rely on the emitted order
+    # being the declared publish_order, not manifest file order.
+    crates = sorted(
+        (crate for crate in manifest["crates"] if crate.get("publish", True)),
+        key=lambda crate: crate["publish_order"],
+    )
+    for crate in crates:
         print(f"{crate['package']}|{crate['wait_after_publish_seconds']}")
     return 0
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -166,6 +166,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
           failures=()
@@ -176,6 +177,12 @@ jobs:
             case "${check_kind}" in
               github)
                 command=(curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header "Accept: application/vnd.github+json" https://api.github.com/user)
+                ;;
+              crates_io)
+                # Release-branch fix (v1.4.4, upstream sc-publish#68): read-only
+                # authenticated probe; crates.io expects the raw token in the
+                # Authorization header.
+                command=(curl --fail --silent --show-error --header "Authorization: ${token}" --header "User-Agent: release-preflight (github-actions)" https://crates.io/api/v1/me)
                 ;;
               *)
                 failures+=("Unsupported credential liveness check kind: ${check_kind}")
@@ -252,6 +259,7 @@ jobs:
 
       - id: manifest
         name: Validate manifest completeness
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           python3 .github/scripts/release_artifacts.py validate-manifest \
@@ -260,6 +268,7 @@ jobs:
 
       - id: publish_order
         name: Validate publish_order dependency graph
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           python3 .github/scripts/release_artifacts.py validate-publish-order \
@@ -268,6 +277,7 @@ jobs:
 
       - id: helpers
         name: Verify release helper files exist
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           test -f .github/scripts/release_gate.sh
@@ -284,6 +294,7 @@ jobs:
 
       - id: version_lockstep
         name: Verify release version lockstep
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           python3 .github/scripts/release_artifacts.py verify-version-lockstep \
@@ -384,6 +395,7 @@ jobs:
 
       - id: github_release_permissions
         name: Verify GitHub Release workflow permissions
+        if: ${{ always() }}
         continue-on-error: true
         shell: bash
         run: |

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -179,10 +179,15 @@ jobs:
                 command=(curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header "Accept: application/vnd.github+json" https://api.github.com/user)
                 ;;
               crates_io)
-                # Release-branch fix (v1.4.4, upstream sc-publish#68): read-only
-                # authenticated probe; crates.io expects the raw token in the
-                # Authorization header.
-                command=(curl --fail --silent --show-error --header "Authorization: ${token}" --header "User-Agent: release-preflight (github-actions)" https://crates.io/api/v1/me)
+                # Release-branch fix (v1.4.4, upstream sc-publish#68): crates.io
+                # API tokens are scope-restricted (RFC 2947) and no read-only
+                # endpoint accepts them (GET /api/v1/me is session-only), so an
+                # authenticated probe returns 403 for a correctly scoped publish
+                # token. Presence is already verified by the required-secrets
+                # step; token authorization is proven at publish time.
+                echo "crates.io exposes no read-only token-validation endpoint; recording presence-only liveness for ${secret_name}."
+                channel_outcomes="$(jq -c --arg channel "${channel}" --arg status "${channel_status}" '.[$channel]=$status' <<<"${channel_outcomes}")"
+                continue
                 ;;
               *)
                 failures+=("Unsupported credential liveness check kind: ${check_kind}")
@@ -223,6 +228,33 @@ jobs:
         if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
         uses: ./.github/actions/install-linux-native-deps
 
+      # Release-branch fix (v1.4.4, upstream sc-publish#70): mirror sprint CI's
+      # tool bootstrap so the workspace test surface is identical — the
+      # passthrough tests require the pinned sc-compose CLI that `just
+      # bootstrap` provisions. The publish pipeline must run the SAME
+      # lint/build/test as sprint CI; a preflight-only environment is banned.
+      - name: Expose Cargo binaries on PATH
+        if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
+        run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
+
+      - name: Install just
+        if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.58.0
+
+      - name: Install cargo-binstall
+        if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
+        uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
+        with:
+          version: "1.22.0"
+
+      - id: bootstrap_tools
+        name: Bootstrap exact repository tools
+        if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
+        continue-on-error: true
+        run: just bootstrap
+
       - name: Normalize version input
         id: meta
         continue-on-error: true
@@ -255,7 +287,14 @@ jobs:
         name: Run workspace tests
         if: ${{ always() && steps.build_plan.outputs.has_crates == 'true' }}
         continue-on-error: true
-        run: cargo test --workspace
+        env:
+          ATM_TEST_RECV_TIMEOUT_SECS: "60"
+        # Release-branch fix (v1.4.4, upstream sc-publish#70): run the exact
+        # sprint-CI test surface (legacy atm-daemon excluded, CLI surface
+        # contract included), not a preflight-specific variant.
+        run: |
+          cargo test --workspace --exclude atm-daemon
+          cargo test -p agent-team-mail --features cli-surface-dump --test cli_surface
 
       - id: manifest
         name: Validate manifest completeness
@@ -389,9 +428,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Release-branch fix (v1.4.4, upstream sc-publish#71): one
+          # multi-package invocation lets cargo verify-build against its local
+          # overlay registry, so crates depending on release siblings that are
+          # not yet live on crates.io still package (requires cargo >= 1.90).
+          packages=()
           while IFS='|' read -r package _; do
-            cargo package -p "$package" --locked --allow-dirty
+            packages+=(-p "$package")
           done < <(python3 .github/scripts/release_artifacts.py list-publish-plan --manifest "${RELEASE_ARTIFACT_MANIFEST}")
+          cargo package "${packages[@]}" --locked --allow-dirty
 
       - id: github_release_permissions
         name: Verify GitHub Release workflow permissions

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -33,6 +33,6 @@ ulid.workspace = true
 
 [dev-dependencies]
 atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.4", features = ["test-support"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.4" }
+atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serde_json.workspace = true
 tempfile = "3"

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -57,3 +57,36 @@ suite, so no consumer CI impact. Filed upstream as
 [sc-publish #65](https://github.com/randlee/sc-publish/issues/65) for the next
 qualified revision; no kit change made mid-qualification per the multi-repo
 qualification rule.
+
+## Release-branch fixes (release/v1.4.4 only — documented kit drift)
+
+The v1.4.4 final Release Preflight (run 33150049684, main tip 78913af39)
+surfaced three defects in the kit's own workflows — the first real execution
+of these paths on a crates-publishing consumer. Per Rand's rulings
+(2026-08-28): sc-lint is a lint tool owned by repo CI (`just lint` runs it —
+the vendored workspace analyzer — extensively, every sprint); sc-publish is
+git workflows and agent prompts; the publish pipeline must run the same
+lint/build/test sprint CI runs plus only publish-specific checks, and there
+must be NO surprises at publish time. Fixes applied directly on
+`release/v1.4.4` (commit 9f5bae568), bypassing `develop` per the
+release-state strategy's release-fix path:
+
+1. Removed the sc-lint install/smoke gate from
+   `.github/actions/setup-lint-toolchain` — preflight was downloading
+   published sc-lint 0.4.0 while the repo runs the vendored workspace
+   analyzer (version/schema skew). Upstream deletion:
+   [sc-publish #67](https://github.com/randlee/sc-publish/issues/67).
+2. Implemented the `crates_io` credential-liveness arm in
+   `release-preflight.yml` (read-only probe of `https://crates.io/api/v1/me`).
+   Upstream: [sc-publish #68](https://github.com/randlee/sc-publish/issues/68).
+3. Added `if: always()` to the five evidence steps that skipped on an earlier
+   hard failure, so one run collects complete evidence. Upstream:
+   [sc-publish #69](https://github.com/randlee/sc-publish/issues/69).
+
+These are deliberate, temporary drift from pin 25668ecc, scoped to the
+release branch; `develop` stays byte-clean against the pin and re-converges
+on the next qualified sc-publish revision. All preflight gates were rehearsed
+locally green before any CI dispatch (fmt, clippy, workspace tests,
+validate-manifest, publish-order, verify-version, version-lockstep, helper
+presence; the crates_io liveness probe and registry-state checks execute
+first in CI since publish tokens exist only as Actions secrets).

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -90,3 +90,58 @@ locally green before any CI dispatch (fmt, clippy, workspace tests,
 validate-manifest, publish-order, verify-version, version-lockstep, helper
 presence; the crates_io liveness probe and registry-state checks execute
 first in CI since publish tokens exist only as Actions secrets).
+
+### Round 2 (readiness preflight run 33154250124 on the release branch)
+
+The first readiness preflight on `release/v1.4.4` collected complete evidence
+(the round-1 fixes worked) and surfaced four more defects — three reported by
+the run, one caught only by local rehearsal of the fix:
+
+4. **crates_io liveness probe is unsound by design** (revises fix 2):
+   crates.io API tokens are scope-restricted (RFC 2947) and no read-only
+   endpoint accepts them — `GET /api/v1/me` is session-only — so the probe
+   returns HTTP 403 for a correctly scoped publish token. The 403 in run
+   33154250124 is expected endpoint behavior, **not** a credential problem.
+   The arm now records presence-only liveness (presence is checked by the
+   required-secrets step; authorization is proven at publish time). Upstream:
+   [sc-publish #68](https://github.com/randlee/sc-publish/issues/68) (updated).
+5. **Preflight workspace tests ran in a preflight-only environment**: the
+   step never ran `just bootstrap`, so the pinned sc-compose CLI was missing
+   and the two compose-passthrough parity tests panicked. The workflow now
+   mirrors sprint CI exactly (cargo-bin PATH, just, cargo-binstall,
+   `just bootstrap`) and runs the exact CI test surface
+   (`cargo test --workspace --exclude atm-daemon` plus the CLI surface
+   contract test). Upstream:
+   [sc-publish #70](https://github.com/randlee/sc-publish/issues/70).
+6. **`list-publish-plan` emitted non-publishable crates in manifest order**:
+   `publish = false` crates (the PyPI-only maturin crates) were included and
+   `publish_order` was ignored. This also affected `crates-publish.yml`,
+   which would have aborted the live ordered publish on
+   `cargo publish -p atm-graft-python`. The helper now filters
+   `publish = false` and sorts by `publish_order`. Upstream:
+   [sc-publish #70](https://github.com/randlee/sc-publish/issues/70).
+7. **Per-crate `cargo package` cannot verify a coordinated version bump**:
+   packaging each crate independently resolves rewritten sibling deps against
+   the live index, which fails until siblings are published (chicken-and-egg;
+   `--no-verify` does not avoid it — resolution happens at lockfile
+   generation). The step now issues one multi-package `cargo package`
+   invocation so cargo verify-builds against its local overlay registry
+   (cargo >= 1.90; the manifest pins 1.94.1). Upstream:
+   [sc-publish #71](https://github.com/randlee/sc-publish/issues/71).
+8. **Product fix (release-blocking, found only in local rehearsal)**:
+   `crates/atm-daemon-bootstrap/Cargo.toml` declared its dev-dependency on
+   the never-published `atm-runtime-test-support` with an explicit
+   `version = "1.4.4"`, so cargo retained it in the packaged manifest and
+   required it on crates.io. `cargo publish -p atm-daemon-bootstrap` would
+   have hard-failed mid-release. The version key is removed (path-only
+   dev-deps are stripped at package time — the pattern the three sibling
+   consumers of this crate already use). One line; Cargo.lock unchanged.
+
+Round-2 local rehearsal, all green before CI dispatch: YAML parse of the
+edited workflow, `bash -n` of all three edited run blocks, functional run of
+the crates_io liveness arm (presence-only path, correct `channel_outcomes`),
+fixed `list-publish-plan` output (13 publishable crates in publish order),
+the exact fixed package-checks step verbatim (plan-derived multi-package
+`cargo package --locked --allow-dirty`), and the CLI surface contract test.
+The kit's own pytest expectations for `list-publish-plan` were not updated
+(consumer CI does not run them); flagged in sc-publish #70.


### PR DESCRIPTION
## Release v1.4.4

Release branch cut directly from tag `release-candidate-v1.4.4` (f99c85656, develop tip at candidate cut), carrying only the preflight fixes made under the release-state strategy's release-fix path. **Readiness preflight PASS** on the branch tip 381662c86: [run 33155304791](https://github.com/randlee/atm-core/actions/runs/33155304791) — final gate ledger `failed=[] blocked=[]`, every tracked check success, zero skipped.

### Candidate-to-release diff (5 files)

**Round 1** (commits 9f5bae568, 416efa70a — after blocked final preflight run 33150049684 on main):
- `.github/actions/setup-lint-toolchain/action.yml` — removed the sc-lint install/smoke gate (redundant parallel lint path with version skew; lint is repo CI's concern — upstream [sc-publish#67](https://github.com/randlee/sc-publish/issues/67))
- `.github/workflows/release-preflight.yml` — crates_io credential-liveness arm ([#68](https://github.com/randlee/sc-publish/issues/68)); `if: always()` on evidence steps ([#69](https://github.com/randlee/sc-publish/issues/69))

**Round 2** (commit 381662c86 — after readiness preflight run 33154250124 on the branch):
- `.github/workflows/release-preflight.yml` — crates_io probe made presence-only (RFC 2947 scoped tokens cannot hit any read-only endpoint; the 403 was expected behavior, not a bad token — [#68](https://github.com/randlee/sc-publish/issues/68)); workspace tests now mirror sprint CI exactly (bootstrap + `--exclude atm-daemon` + cli_surface — [#70](https://github.com/randlee/sc-publish/issues/70)); package checks use one multi-package `cargo package` with cargo's overlay registry ([#71](https://github.com/randlee/sc-publish/issues/71))
- `.github/scripts/release_artifacts.py` — `list-publish-plan` now filters `publish = false` and sorts by `publish_order` (also fixes the live publish job in crates-publish.yml, which iterates the same list — [#70](https://github.com/randlee/sc-publish/issues/70))
- `crates/atm-daemon-bootstrap/Cargo.toml` — **one-line product fix, release-blocking**: dev-dep on never-published `atm-runtime-test-support` carried `version = "1.4.4"`; now path-only so cargo strips it at package time (sibling crates' existing pattern). Cargo.lock unchanged.
- `release/sc-publish-qualification-25668ecc.md` — receipt documents both fix rounds as deliberate, temporary kit drift; develop stays byte-clean on pin 25668ecc

### Local rehearsal (all green before any CI dispatch)
fmt, clippy, full `just bootstrap && just lint && just test`, validate-manifest, publish-order, verify-version, version-lockstep, helpers, fixed publish plan output, the exact package-checks step verbatim (13 crates package + verify-build), cli_surface contract test, functional run of the presence-only liveness arm.

### After merge
Final preflight on the exact merged main commit → tag v1.4.4 + GitHub Release → TestPyPI (authorized) → install verify py3.11–3.14 → production PyPI only with fresh authorization.

**Merge with a merge commit (never squash).** Requires Rand's approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)