### PR TITLE
fix(release): v1.4.4 round-3 — maturin toolchain components (sc-publish#72)

### DIFF
--- a/.github/actions/setup-python-release-build/action.yml
+++ b/.github/actions/setup-python-release-build/action.yml
@@ -42,6 +42,13 @@ runs:
       if: ${{ inputs.build_system == 'maturin' }}
       with:
         toolchain: ${{ inputs.rust_toolchain }}
+        # Release-branch fix (v1.4.4, upstream sc-publish#72): install the
+        # components declared by the consumer's rust-toolchain.toml up front.
+        # Without them, maturin's nested `cargo metadata` triggers rustup's
+        # component auto-add, which races the hosted runner's preinstalled
+        # cargo-fmt and fails with rustfmt-preview's `bin/cargo-fmt` conflict
+        # (same workaround as this repo's ci.yml maturin job).
+        components: clippy, rustfmt
     - name: Install maturin
       if: ${{ inputs.build_system == 'maturin' }}
       shell: bash

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -145,3 +145,39 @@ the exact fixed package-checks step verbatim (plan-derived multi-package
 `cargo package --locked --allow-dirty`), and the CLI surface contract test.
 The kit's own pytest expectations for `list-publish-plan` were not updated
 (consumer CI does not run them); flagged in sc-publish #70.
+
+### Round 3 (live release run 33198964299 from main e8a5b1c1b)
+
+The first live `release.yml` dispatch succeeded through gate-and-tag (tag
+`v1.4.4` created), all binary builds, and the full ordered crates.io publish
+(13/13 crates live). One more kit defect surfaced in the maturin Python
+artifact builds:
+
+9. **`setup-python-release-build` installs the Rust toolchain without the
+   consumer's declared components**: the kit composite's
+   `dtolnay/rust-toolchain` step passes no `components`, so maturin's nested
+   `cargo metadata` triggers rustup's auto-add of the components declared in
+   `rust-toolchain.toml` (`clippy`, `rustfmt`). That auto-add races the hosted
+   runner's preinstalled cargo-fmt and fails intermittently with
+   `failed to install component: 'rustfmt-preview-…', detected conflict:
+   'bin/cargo-fmt'` → `cargo metadata` fails → maturin aborts
+   (atm-graft-python and atm-query-python failed on some matrix runners,
+   passed on others — a race, not a deterministic failure; the setuptools
+   distribution was unaffected). This repo's own `ci.yml` maturin job already
+   documents and prevents exactly this race by passing
+   `components: clippy, rustfmt` to the same action — the fix applies that
+   proven pattern to the kit composite. Upstream:
+   [sc-publish #72](https://github.com/randlee/sc-publish/issues/72).
+   Because `release.yml` computes `build_ref` from the verified `origin/main`
+   tip (the immutable tag only needs to be an ancestor), merging this fix to
+   `main` and re-dispatching the same version/target picks it up without
+   touching tag `v1.4.4`; the idempotent crates.io publish job skips all
+   already-live crates.
+
+Round-3 rehearsal evidence: the fix is byte-for-byte the component list and
+rationale already running green on every sprint CI maturin job (`ci.yml`
+"Install Rust toolchain": `components: clippy, rustfmt` with the same race
+documented in its comment); the edited composite parses as valid YAML. The
+runner-image race itself is not reproducible on a local macOS host with a
+fully provisioned toolchain, so in-repo CI precedent is the rehearsal
+authority here.


### PR DESCRIPTION
## Summary

One-line workflow fix for the only failure in live release run 33198964299: the `setup-python-release-build` kit composite installs the Rust toolchain **without** the components declared in `rust-toolchain.toml`, so maturin's nested `cargo metadata` triggers rustup's component auto-add, which races the hosted runner's preinstalled cargo-fmt (`detected conflict: 'bin/cargo-fmt'`). Both maturin distributions (atm-graft-python, atm-query-python) failed on some matrix runners and passed on others; hermes-atm (setuptools) was unaffected.

Fix: pass `components: clippy, rustfmt` to `dtolnay/rust-toolchain` — byte-for-byte the pattern this repo's own `ci.yml` maturin job already uses, with a comment documenting this exact race.

## Run 33198964299 state (for context)

- gate-and-tag ✅ (tag `v1.4.4` created at e8a5b1c1b)
- crates.io publish ✅ **13/13 crates live**
- binary builds ✅ all targets
- build-python-wheels / build-python-sdists ❌ maturin distributions only (this defect)
- GitHub Release + testpypi jobs skipped downstream

## Why this merges to main

`release.yml` computes `build_ref` from the verified `origin/main` tip; the immutable tag `v1.4.4` only needs to remain an ancestor (the gate logs "reusing immutable tag while building from origin/main"). Merging this and re-dispatching the same version/target picks up the fixed composite with no tag changes; the manifest-idempotent crates.io job skips all already-live crates.

## Drift accounting

`setup-python-release-build/action.yml` is an sc-publish kit file at pin 25668ecc — this is documented round-3 drift in `release/sc-publish-qualification-25668ecc.md`, filed upstream as [sc-publish#72](https://github.com/randlee/sc-publish/issues/72) (joins #67–#71 for the next qualified pin).

## Rehearsal

The runner-image race is not locally reproducible on a provisioned macOS host; rehearsal authority is the in-repo precedent — `ci.yml`'s maturin job runs this exact component list green on every sprint. Edited composite validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)