### PR TITLE
fix(release): v1.4.4 round-3b — dynamic [project].version support (sc-publish#73)

### DIFF
--- a/.github/scripts/release_artifacts.py
+++ b/.github/scripts/release_artifacts.py
@@ -744,11 +744,36 @@ def cmd_verify_version_lockstep(args: argparse.Namespace) -> int:
     return 0
 
 
+def _python_project_declares_dynamic_version(pyproject: Path) -> bool:
+    project = tomllib.loads(pyproject.read_text(encoding="utf-8")).get("project", {})
+    return project.get("version") is None and "version" in project.get("dynamic", [])
+
+
 def cmd_verify_python_version(args: argparse.Namespace) -> int:
     version = workspace_version(Path(args.workspace_toml))
     if version != args.version:
         raise SystemExit(f"workspace version mismatch: expected {args.version}, got {version}")
-    actual = _python_project_version(Path(args.pyproject))
+    pyproject = Path(args.pyproject)
+    if _python_project_declares_dynamic_version(pyproject):
+        # Release-branch fix (v1.4.4, upstream sc-publish#73): maturin derives
+        # a dynamic [project].version from the adjacent Cargo manifest, so
+        # verify that source instead (same semantics as the lockstep check's
+        # _assert_python_package_version, which compares against the workspace
+        # base version).
+        cargo_toml = pyproject.parent / "Cargo.toml"
+        if not cargo_toml.is_file():
+            raise SystemExit(f"{pyproject}: dynamic version requires an adjacent Cargo.toml")
+        cargo_version = tomllib.loads(cargo_toml.read_text(encoding="utf-8")).get("package", {}).get("version")
+        if isinstance(cargo_version, dict) and cargo_version.get("workspace") is True:
+            cargo_version = version
+        expected = version.split("-", 1)[0]
+        if cargo_version != expected:
+            raise SystemExit(
+                f"python package version mismatch: expected {expected}, got {cargo_version!r} from {cargo_toml}"
+            )
+        print("python version verification passed (dynamic version from Cargo manifest)")
+        return 0
+    actual = _python_project_version(pyproject)
     if actual != version:
         raise SystemExit(f"python package version mismatch: expected {version}, got {actual}")
     print("python version verification passed")
@@ -758,6 +783,13 @@ def cmd_verify_python_version(args: argparse.Namespace) -> int:
 def cmd_sync_python_version(args: argparse.Namespace) -> int:
     version = workspace_version(Path(args.workspace_toml))
     pyproject = Path(args.pyproject)
+    if _python_project_declares_dynamic_version(pyproject):
+        # Release-branch fix (v1.4.4, upstream sc-publish#73): a dynamic
+        # [project].version has no static line to rewrite — maturin reads the
+        # version from the adjacent Cargo manifest at build time, which the
+        # lockstep check has already verified. Nothing to sync.
+        print("python package declares dynamic [project].version; nothing to sync")
+        return 0
     lines = pyproject.read_text(encoding="utf-8").splitlines()
     output: list[str] = []
     in_project = False

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -174,7 +174,28 @@ artifact builds:
    touching tag `v1.4.4`; the idempotent crates.io publish job skips all
    already-live crates.
 
-Round-3 rehearsal evidence: the fix is byte-for-byte the component list and
+10. **`sync-python-version`/`verify-python-version` cannot handle
+    `dynamic = ["version"]`** (found on retry run 33202161368, after fix 9
+    unblocked atm-query-python and hermes-atm): `cmd_sync_python_version`
+    hard-fails with "could not find [project].version to rewrite" when a
+    pyproject deliberately declares `dynamic = ["version"]`
+    (atm-graft-python does, by design — maturin derives the wheel version
+    from the adjacent Cargo manifest), and `cmd_verify_python_version`
+    would likewise mismatch on the empty dynamic version. The manifest
+    layer's `_assert_python_package_version` (used by the lockstep gate)
+    already supports dynamic versions by falling back to the Cargo
+    manifest; the two composite-invoked commands never got that handling.
+    Fix: `sync-python-version` treats a dynamic version as a no-op success,
+    and `verify-python-version` verifies the adjacent Cargo manifest's
+    version against the workspace base (same semantics as the lockstep
+    check). Upstream:
+    [sc-publish #73](https://github.com/randlee/sc-publish/issues/73).
+    Rehearsed locally: sync+verify green on both the dynamic
+    (atm-graft-python) and static (atm-query-python) distributions, a wrong
+    `--version` still fails closed, and `maturin sdist` builds
+    `atm_graft-1.4.4.tar.gz` with the correctly derived dynamic version.
+
+Round-3 rehearsal evidence (fix 9): the fix is byte-for-byte the component list and
 rationale already running green on every sprint CI maturin job (`ci.yml`
 "Install Rust toolchain": `components: clippy, rustfmt` with the same race
 documented in its comment); the edited composite parses as valid YAML. The


### PR DESCRIPTION
## Summary

Fixes the one remaining failure on retry run 33202161368: every atm-graft-python wheel/sdist leg dies at the composite's **Sync Python package version** step because `cmd_sync_python_version` hard-fails when a pyproject declares `dynamic = ["version"]` — which `crates/atm-graft-python/pyproject.toml` does by design (maturin derives the wheel version from the adjacent Cargo manifest). `cmd_verify_python_version` had the same gap.

The kit's own lockstep gate (`_assert_python_package_version`) already supports dynamic versions via Cargo-manifest fallback — which is why preflight passed and only the live build failed. This PR gives the two composite-invoked commands the same semantics:

- `sync-python-version`: dynamic version → no-op success (nothing to rewrite; the lockstep gate already verified the Cargo source)
- `verify-python-version`: dynamic version → verify the adjacent `Cargo.toml` version (resolving workspace inheritance) against the workspace base

## Run 33202161368 state

- gate-and-tag ✅ (with `already_published_channels=crates_io`), all binary builds ✅
- atm-query-python + hermes-atm wheels/sdists ✅ (fix 9 / PR #1073 worked)
- atm-graft-python ❌ all legs at sync-version (this defect) → GitHub Release + testpypi skipped

## Rehearsal (all green locally)

- `sync-python-version` + `verify-python-version` on both the dynamic (atm-graft-python) and static (atm-query-python) distributions
- wrong `--version` input still fails closed
- `maturin sdist --manifest-path crates/atm-graft-python/Cargo.toml` builds `atm_graft-1.4.4.tar.gz` with the correctly derived version

## Drift accounting

`release_artifacts.py` is an sc-publish kit file at pin 25668ecc — documented as round-3 defect 10 in `release/sc-publish-qualification-25668ecc.md`, filed upstream as [sc-publish#73](https://github.com/randlee/sc-publish/issues/73) (joins #67–#72).

Same re-dispatch mechanics as #1073: merge to main, publisher re-runs release.yml v1.4.4 same target with `already_published_channels=crates_io`; tag stays put, crates.io skips idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)