### PR TITLE
fix(release): round-3 kit fixes — sdist matcher, universal wheels, tag-pinned checkout (v1.4.4)

### DIFF
--- a/.github/scripts/release_artifacts.py
+++ b/.github/scripts/release_artifacts.py
@@ -641,11 +641,20 @@ def _python_distribution_name_from_wheel(path: Path, expected: set[str]) -> str:
 
 def _python_distribution_name_from_sdist(path: Path, expected: set[str]) -> str | None:
     with tarfile.open(path, "r:gz") as archive:
-        metadata = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+        # Release-branch fix (v1.4.4, upstream sc-publish#74): match only the
+        # sdist's canonical root metadata file (`<rootdir>/PKG-INFO`). A
+        # standard setuptools sdist also legitimately contains the package's
+        # `*.egg-info/PKG-INFO` deeper in the tree, so matching every
+        # `*/PKG-INFO` member rejects well-formed sdists.
+        metadata = [
+            member
+            for member in archive.getmembers()
+            if member.name.endswith("/PKG-INFO") and member.name.count("/") == 1
+        ]
         if not metadata:
             return None
         if len(metadata) != 1:
-            raise SystemExit(f"{path}: expected exactly one sdist PKG-INFO file")
+            raise SystemExit(f"{path}: expected exactly one root-level sdist PKG-INFO file")
         extracted = archive.extractfile(metadata[0])
         if extracted is None:
             raise SystemExit(f"{path}: unable to read sdist PKG-INFO")
@@ -662,6 +671,7 @@ def cmd_verify_python_release_assets(args: argparse.Namespace) -> int:
         raise SystemExit(f"Python asset directory does not exist: {asset_dir}")
     expected = _python_distribution_expectations(manifest)
     found = {name: {"wheel": 0, "sdist": 0} for name in expected}
+    universal_wheel = {name: False for name in expected}
     destination = Path(args.copy_to) if args.copy_to else None
     if destination:
         destination.mkdir(parents=True, exist_ok=True)
@@ -672,6 +682,8 @@ def cmd_verify_python_release_assets(args: argparse.Namespace) -> int:
         if asset.suffix == ".whl":
             name = _python_distribution_name_from_wheel(asset, set(expected))
             found[name]["wheel"] += 1
+            if asset.name.endswith("-none-any.whl"):
+                universal_wheel[name] = True
         elif asset.name.endswith(".tar.gz"):
             name = _python_distribution_name_from_sdist(asset, set(expected))
             if name is None:
@@ -681,6 +693,15 @@ def cmd_verify_python_release_assets(args: argparse.Namespace) -> int:
             continue
         if destination:
             shutil.copy2(asset, destination / asset.name)
+
+    # Release-branch fix (v1.4.4, upstream sc-publish#75): the manifest's
+    # `wheels` list drives the per-OS build matrix, but a pure-Python build
+    # produces one platform-independent wheel (`*-none-any.whl`) whose
+    # identical filename deduplicates across matrix legs in the GitHub
+    # Release. Expect exactly one wheel for such distributions.
+    for name, entry in expected.items():
+        if universal_wheel[name] and found[name]["wheel"] == 1 and entry["wheel"] > 1:
+            entry["wheel"] = 1
 
     if found != expected:
         raise SystemExit(

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -35,9 +35,15 @@ jobs:
       pypi_config: ${{ steps.config.outputs.config }}
       python_upload_tool: ${{ steps.config.outputs.python_upload_tool }}
     steps:
+      # Release-branch fix (v1.4.4, upstream sc-publish#76): check out the
+      # dispatch ref, not the immutable tag. This workflow never builds from
+      # source — it only downloads already-published release assets — so the
+      # checkout exists solely to supply the verify tooling and manifest.
+      # Pinning it to the tag freezes any tooling defect into the release
+      # forever (the tag is immutable), making PyPI publication unrecoverable.
+      # Same model as release.yml: immutable tag for artifacts, current main
+      # for tooling.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
       - uses: ./.github/actions/verify-published-release
         with:
           release_tag: ${{ inputs.tag }}
@@ -57,9 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.target == 'production' && 'pypi' || 'testpypi' }}
     steps:
+      # Release-branch fix (v1.4.4, upstream sc-publish#76): dispatch ref, not
+      # the immutable tag — see verify-release above.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
       - name: Download Python assets from the published GitHub Release
         shell: bash
         env:

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -220,6 +220,42 @@ artifact builds:
     a removed platform wheel and a duplicate universal wheel both still
     fail). Upstream:
     [sc-publish #75](https://github.com/randlee/sc-publish/issues/75).
+13. **`pypi-publish.yml` pins its checkout to the immutable release tag**
+    (found while verifying that fixes 11–12 would actually take effect on
+    re-dispatch): both jobs check out `ref: ${{ inputs.tag }}`, but the
+    workflow never builds from source — the checkout exists only to supply
+    the verify tooling and manifest. Tag `v1.4.4` (e8a5b1c1b) predates
+    every round-3 script fix, so a re-dispatch after merging fixes 11–12 to
+    `main` would have run the tag's frozen `release_artifacts.py` and
+    failed identically — the immutable tag permanently bricks PyPI
+    publication on any verify-tooling defect. Fix: drop the `ref:` pins so
+    both jobs check out the dispatch ref (main), mirroring `release.yml`'s
+    model (immutable tag for artifacts — `gh release download` stays pinned
+    to the tag and `verify-published-release` validates via the API — with
+    tooling from current main). Upstream:
+    [sc-publish #76](https://github.com/randlee/sc-publish/issues/76).
+
+Round-3 full-pipeline rehearsal (every remaining pypi-publish.yml step,
+per the standing "no surprises" rule — collect all defects in one pass
+rather than one merge cycle per CI discovery):
+
+- `channel-config --channel pypi` → valid JSON; `test_repository=testpypi`,
+  `production_repository=pypi`.
+- `build-plan` → `python_upload_tool=maturin` (correct: maturin
+  distributions present).
+- The "Select configured Python repository" inline snippet run verbatim
+  with the real channel JSON → `PYPI_REPOSITORY=testpypi` (target=testpypi)
+  and `PYPI_REPOSITORY=pypi` (target=production).
+- `twine check` (twine 6.1.0, the kit-pinned uploader version) over all 10
+  release dist files → 10/10 PASSED. The maturin wheels/sdists warn about a
+  missing `long_description` (empty PyPI description page — cosmetic, not
+  an upload blocker; candidate future polish, not a v1.4.4 gate).
+- maturin 1.9.4 upload semantics verified in its pinned source
+  (`src/upload.rs` at tag v1.9.4): `testpypi` and `pypi` repository names
+  are built in (no `.pypirc` needed), token read from `MATURIN_PYPI_TOKEN`,
+  and `--skip-existing` is supported. Upload itself is deliberately NOT
+  rehearsed locally (tokens are CI secrets; maturin falls back to keyring
+  credentials, so a local invocation risks an accidental real publish).
 
 Round-3 rehearsal evidence (fixes 11–12): the exact failing CI step was
 rehearsed verbatim against the real v1.4.4 GitHub Release assets

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -195,6 +195,39 @@ artifact builds:
     `--version` still fails closed, and `maturin sdist` builds
     `atm_graft-1.4.4.tar.gz` with the correctly derived dynamic version.
 
+11. **sdist metadata matcher rejects well-formed setuptools sdists** (found
+    on TestPyPI rehearsal run 33211063257, pypi-publish.yml "Select and
+    verify Python distributions"): `_python_distribution_name_from_sdist`
+    matched every `*/PKG-INFO` tar member and hard-failed on more than one.
+    A standard setuptools sdist legitimately contains both the root
+    `<pkg>-<ver>/PKG-INFO` and the package's `*.egg-info/PKG-INFO`
+    (hermes_atm-1.4.4.tar.gz carries `src/hermes_atm.egg-info/PKG-INFO`),
+    so the well-formed hermes-atm sdist was rejected before any upload
+    began. The sdist itself is NOT defective. Fix: match only the canonical
+    root-level `<rootdir>/PKG-INFO`; still fail closed on zero or multiple
+    root matches. Upstream:
+    [sc-publish #74](https://github.com/randlee/sc-publish/issues/74).
+12. **Asset-count expectation wrong for pure-Python wheels** (found only by
+    local rehearsal of fix 11 against the real v1.4.4 release assets —
+    would have failed the next CI dispatch): `verify-python-release-assets`
+    expects `len(wheels)` wheel files per distribution, but the manifest's
+    `wheels` list drives the per-OS *build matrix*, and a pure-Python
+    setuptools build produces one platform-independent `*-none-any.whl`
+    whose identical filename deduplicates across the three matrix legs in
+    the GitHub Release (hermes-atm: expected 3, release correctly holds 1).
+    Fix: when a distribution's found wheel is a single universal wheel,
+    expect exactly one; every other mismatch still fails closed (verified:
+    a removed platform wheel and a duplicate universal wheel both still
+    fail). Upstream:
+    [sc-publish #75](https://github.com/randlee/sc-publish/issues/75).
+
+Round-3 rehearsal evidence (fixes 11–12): the exact failing CI step was
+rehearsed verbatim against the real v1.4.4 GitHub Release assets
+(`verify-python-release-assets --manifest release/publish-artifacts.toml`
+over the downloaded `*.whl`/`*.tar.gz` set) — passes and selects all 10
+distributions (3+1 atm-graft, 3+1 atm-query, 1+1 hermes-atm); both
+negative paths above still exit nonzero.
+
 Round-3 rehearsal evidence (fix 9): the fix is byte-for-byte the component list and
 rationale already running green on every sprint CI maturin job (`ci.yml`
 "Install Rust toolchain": `components: clippy, rustfmt` with the same race


### PR DESCRIPTION
## What

Two release-branch kit fixes in `.github/scripts/release_artifacts.py` for the v1.4.4 TestPyPI publish failure (pypi-publish.yml run 33211063257, "Select and verify Python distributions" step), plus the qualification-receipt round-3 drift accounting. Same delivery pattern as #1073/#1074.

- **Defect 11** — `_python_distribution_name_from_sdist` counted every `PKG-INFO` member and required exactly one, rejecting the well-formed setuptools sdist `hermes_atm-1.4.4.tar.gz` (root `PKG-INFO` + `src/hermes_atm.egg-info/PKG-INFO` is the standard setuptools layout). Now matches only the canonical root-level `<pkg>-<ver>/PKG-INFO`. Upstream: randlee/sc-publish#74.
- **Defect 12** — `verify-python-release-assets` expected one wheel per manifest matrix leg, but hermes-atm's pure-Python build produces one universal `py3-none-any` wheel that deduplicates across the 3 OS legs in the GitHub Release. Accept 1-found-where->1-expected only for a universal wheel. Upstream: randlee/sc-publish#75. (Found only by locally rehearsing fix 11 — the CI run died on defect 11 before reaching it.)

## Rehearsal evidence

The exact failing CI command was run verbatim against the real v1.4.4 GitHub Release assets:

```
python3 .github/scripts/release_artifacts.py verify-python-release-assets \
  --manifest release/publish-artifacts.toml --asset-dir <release assets> --copy-to <dist>
```

Result: `verified Python release assets: {'atm-graft': {'wheel': 3, 'sdist': 1}, 'atm-query': {'wheel': 3, 'sdist': 1}, 'hermes-atm': {'wheel': 1, 'sdist': 1}}` — all 10 distributions selected. Negative tests fail closed: sdist with no root PKG-INFO, missing platform wheel for a maturin package, duplicate universal wheel.

## Kit drift accounting

- develop stays byte-clean on sc-publish pin 25668ecc164261be676c9414c4f603b18ab74c91; these are release-branch-only fixes.
- Recorded in `release/sc-publish-qualification-25668ecc.md` round 3 (defects 11–12) with rehearsal evidence.
- Filed upstream as sc-publish #74 and #75 for the next qualified pin.

## Re-dispatch mechanics

After merge, publisher re-dispatches `pypi-publish.yml` with `target=testpypi`. Tag v1.4.4 is untouched; the release gate builds from origin/main tip, and the already-published GitHub Release + crates.io channels are covered by `already_published_channels=crates_io,github_release` where the gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)