### PR TITLE
docs(aq): critical-review fixes — CHANGELOG Unreleased, ADR-054 wording, AQ4 disclosure, audit window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,42 @@
 # Changelog
 
-## 1.4.5
+## Unreleased
+
+- add the `atm queue` CLI verb (mirrors `atm send`'s full surface, including
+  `--attach`, with the recipient nudge deferred rather than fired
+  immediately) plus the nudge taxonomy and `PendingNudgeStore` storage
+  contract that every later Phase AQ sprint builds on (ADR-054: nudge as the
+  umbrella term, steer/queue as the two kinds) (Phase AQ, AQ1)
+- wire `atm-graft` dual-channel queue delivery to an actual delivery
+  trigger: harness idle-signal heartbeats and a bare-CLI Stop-pull path
+  backed by a bounded, per-member in-memory FIFO, so a deferred queue nudge
+  is guaranteed to drain even for a receiver with no persistent daemon
+  session (Phase AQ, AQ2 + AQ2.5)
+- add Herdr as a second, selector-gated local steer backend (`atm-herdr`)
+  alongside retained tmux, with its own health/circuit breaker (ADR-058)
+  (Phase AQ, AQ2.6)
+- add the Herdr poll-gated queue-wake pump: a fixed-cadence, roster-wide
+  Herdr session poll that drains pending queue messages on `RuntimeHealth`
+  idle transitions (Phase AQ, AQ2.7)
+- add tmux idle-drain (one queued nudge per idle transition) plus a
+  kind-agnostic recovery sweep that catches missed or crashed drains
+  (Phase AQ, AQ3)
+- ship ATM Send-To core: `atm send --attach`/`--from-json`, the `ATM_TEMP`
+  scratch-directory contract with a 30-day TTL sweeper, and per-host
+  cross-host transfer scripts (`scripts/transfer/sftp.sh`, `sftp.ps1`)
+  (ADR-055) (Phase AQ, AQ4)
+- ship the ATM Send-To human-visible surface: one-gesture per-OS shell entry
+  points for Finder/Explorer/Nautilus, the reference and native member
+  pickers, and the upstream Wyvern contract-test filing (wyvern#139,
+  wyvern#140) (Phase AQ, AQ5)
+- add the sc-ecosystem dependency release-preflight gate: pin-latest checks
+  for Wyvern/sc-compose/sc-observability plus their integration tests, run
+  before every release (Phase AQ, AQ6)
+- add the hermes-atm wheel verification harness: rebuilt wheel plus an
+  automated restart-matrix crash-guard suite (the live m5 restart-matrix run
+  remains an open follow-up, `AQ1.9-m5`) (Phase AQ, AQ1.9)
+
+## 1.4.5 (graft-registration slice of Phase AQ only; see Unreleased for the remainder)
 
 - complete the Phase AQ graft registration cutover: `atm-graft` now uses the
   daemon registry lease and same-host flock instead of the retired endpoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ orchestration alert or sprint-plan violation or merge-conflict notice:
 - Agent team execution: Scrum Master → Dev(s) + QA(s), Opus Architect on escalation
 - All work on dedicated worktrees via `sc-git-worktree`
 
-**Current Status**: Phase AQ complete on integrate/phase-aq (14/14 sprints) — integrate → develop PR pending
+**Current Status**: Phase AQ merged to develop (PR #1079, 14/14 sprints; 5 follow-ups open incl. R1/R15 Must items)
 
 ---
 

--- a/docs/plans/phase-aq/.audit/qa-evidence-master.json
+++ b/docs/plans/phase-aq/.audit/qa-evidence-master.json
@@ -3,7 +3,7 @@
  "timezone": "UTC (result_time_pst/assignment_time_pst omitted; verdict timestamps are GitHub PR comment times)",
  "audit_window": {
   "start": "2026-08-27T00:09:55Z",
-  "end": "2026-08-28T10:30:00Z"
+  "end": "2026-08-29T04:40:00Z"
  },
  "scope": "phase-aq sprints in landing order (structure.ttl). Runs recorded: AQ1 (3, final PASS, merged), AQ2.6 (2, latest FAIL, fix cycle 2 in progress), AQ1.5 (1, FAIL, fix in progress). AQ1.6 (#1046) QA-1 requested (pending run recorded, verdict null). Non-sprint lanes reviewed by quality-mgr but not sprint rows: lane A ADR-058 #1039 (PASS d6f4dd90f, merged 4805264a2) and lane C AQ4 groundwork #1043 (QA-1 FAIL a911abfd8 \u2192 QA-2 FAIL 23be719f3 \u2192 QA-3 PASS 28422190e, merge requested) \u2014 they roll into AQ2.6/AQ4 evidence at closeout.",
  "count_basis": "headline/reviewer",

--- a/docs/plans/phase-aq/sprint-AQ4-send-to-core.md
+++ b/docs/plans/phase-aq/sprint-AQ4-send-to-core.md
@@ -6,7 +6,8 @@ worktree: ../atm-core-worktrees/feature/aq-4-send-to-core
 
 # Sprint AQ4 — Send-To Core: ATM_TEMP, CLI Surface, Transfer Scripts
 
-Status: complete · Branch: `feature/aq-4-send-to-core` off `integrate/phase-aq`
+Status: complete (follow-ups open: AQ4-windows-loopback, AQ4-tailscale-m5) ·
+Branch: `feature/aq-4-send-to-core` off `integrate/phase-aq`
 · Worktree: `../atm-core-worktrees/feature/aq-4-send-to-core` · PR target: `integrate/phase-aq`
 recommended_agent: arch-ctm · recommended_model: deep-reasoning
 
@@ -523,11 +524,11 @@ paths unchanged.
   covers the harness's pure launch/record-schema logic (argument defaults,
   evidence-writer output, exit-code mapping) without needing a live `sshd`.
 
-| Runner | Status | Run ID | Head | Files |
-|--------|--------|--------|------|-------|
-| ubuntu-latest | PASS | 33144153970 | 9c9f9918a | [transfer-clean-runner-linux.json](evidence/AQ4/transfer-clean-runner-linux.json) · [transfer-clean-runner-linux.md](evidence/AQ4/transfer-clean-runner-linux.md) |
-| macOS | PASS | 33144153970 | 9c9f9918a | [transfer-clean-runner-macos.json](evidence/AQ4/transfer-clean-runner-macos.json) · [transfer-clean-runner-macos.md](evidence/AQ4/transfer-clean-runner-macos.md) |
-| windows | FAIL | 33144153970 | 9c9f9918a | [transfer-clean-runner-windows.json](evidence/AQ4/transfer-clean-runner-windows.json) · [transfer-clean-runner-windows.md](evidence/AQ4/transfer-clean-runner-windows.md) · harness ssh -vvv probe succeeds; residual failure is ssh-under-pwsh-under-atm handshake behavior, not sshd/auth/config — tracked as **FOLLOW-UP `AQ4-windows-loopback`** (see below) |
+| Runner | Status | Run ID | Head | Files | Disposition |
+|--------|--------|--------|------|-------|--------------|
+| ubuntu-latest | PASS | 33144153970 | 9c9f9918a | [transfer-clean-runner-linux.json](evidence/AQ4/transfer-clean-runner-linux.json) · [transfer-clean-runner-linux.md](evidence/AQ4/transfer-clean-runner-linux.md) | Pass |
+| macOS | PASS | 33144153970 | 9c9f9918a | [transfer-clean-runner-macos.json](evidence/AQ4/transfer-clean-runner-macos.json) · [transfer-clean-runner-macos.md](evidence/AQ4/transfer-clean-runner-macos.md) | Deferred — loopback CI substitutes for Mac→second-host by ruling; see AQ4-tailscale-m5 |
+| windows | FAIL | 33144153970 | 9c9f9918a | [transfer-clean-runner-windows.json](evidence/AQ4/transfer-clean-runner-windows.json) · [transfer-clean-runner-windows.md](evidence/AQ4/transfer-clean-runner-windows.md) · harness ssh -vvv probe succeeds; residual failure is ssh-under-pwsh-under-atm handshake behavior, not sshd/auth/config — tracked as **FOLLOW-UP `AQ4-windows-loopback`** (see below) | Deferred — see FOLLOW-UP AQ4-windows-loopback |
 
 The Tailscale leg (`scripts/transfer/tailscale.sh`) cannot run on either
 clean-runner lane (Tailscale enrollment is an operator/IT environment

--- a/docs/plans/phase-aq/validation-evidence.md
+++ b/docs/plans/phase-aq/validation-evidence.md
@@ -10,7 +10,7 @@ passed without a real transcript and screenshot.
 | Sprint | Verdict | Evidence head / artifact |
 | --- | --- | --- |
 | AQ1 trait foundation + queue CLI | PASS for the merged implementation line | [`a36e45faa456fabccbee53fc2787656b346dff30`](https://github.com/randlee/atm-core/commit/a36e45faa456fabccbee53fc2787656b346dff30) |
-| AQ1.5–AQ1.9 graft chain | PASS for automated/local evidence; AQ1.9 m5 restart row OPEN | [`bdeac0a2605df019bc859e3daa00b6273e642de8`](https://github.com/randlee/atm-core/commit/bdeac0a2605df019bc859e3daa00b6273e642de8) *(recorded short head was reconciled locally; live row remains pending)* |
+| AQ1.5–AQ1.9 graft chain | PASS for automated/local evidence; AQ1.9 m5 restart row OPEN | [`bdeac0a2605df019bc859e3daa00b6273e642de8`](https://github.com/randlee/atm-core/commit/bdeac0a2605df019bc859e3daa00b6273e642de8) *(live row remains pending — see AQ1.9-m5)* |
 | AQ2 queue graft | PASS | [`f41bead9e825655bf423acb90fa58f8784ed2538`](https://github.com/randlee/atm-core/commit/f41bead9e825655bf423acb90fa58f8784ed2538) |
 | AQ2.5 delivery triggers | PASS | [`01e69ed967c56c91824e1a44317ee97178c8324a`](https://github.com/randlee/atm-core/commit/01e69ed967c56c91824e1a44317ee97178c8324a) |
 | AQ2.6 Herdr steer | PASS / referenced upstream evidence | [`cfdcafcd49dc330a18dff6bddbcbb8f5145222e0`](https://github.com/randlee/atm-core/commit/cfdcafcd49dc330a18dff6bddbcbb8f5145222e0) |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1342,7 +1342,7 @@ satisfied — AO merged to `develop` via the AO2 integration (PR #966). AP.1's
 physical hardware proof remains the mandatory entry gate; no AP dispatch has
 occurred.
 
-## 48. Phase AQ — ATM Send-To Shell Integration [COMPLETE — integrate/phase-aq → develop PR pending]
+## 48. Phase AQ — ATM Send-To Shell Integration [COMPLETE ON DEVELOP (PR #1079) — 5 open follow-ups, 2 tied to Must PRD requirements (R1 GUI E2E, R15 m5); see qa-evidence-master.json follow_ups]
 
 Phase AQ delivers PRD Phase 1 of ATM "Send To": one gesture from the OS file
 manager (Finder / Explorer / Nautilus) to a delivered message whose text
@@ -1354,8 +1354,11 @@ change, no daemon transfer machinery. ADR-055 defines the system-level
 transfer-script seam; thin per-OS shell glue drives the pipeline
 `atm teams --json --members | <picker> | atm send --attach "$@" --from-json`.
 Phase 1 also delivers `atm queue` — `atm send` with the nudge deferred until
-the recipient harness is ready (nudge taxonomy: steer = immediate, queue =
-deferred; ADR-054) — via a `nudge_pending_at` marker, a `PendingNudgeStore`
+the recipient harness is ready (nudge taxonomy: steer and queue are message
+*kinds*, not delivery timings — the physical mechanism may itself defer a
+steer-kind notification until the next bare-CLI Stop pull, and mechanism
+timing never changes the kind; ADR-054, AQ2.5 addendum) — via a
+`nudge_pending_at` marker, a `PendingNudgeStore`
 storage capability, graft dual-channel wiring (harness owns landing; Hermes
 `/steer`+`/queue` complete), and a tmux idle-drain, under the ADR-054 nudge
 taxonomy (nudge = umbrella; steer/queue = kinds) with its code-rename
@@ -1384,8 +1387,8 @@ plan is [Phase AQ plan](./plans/phase-aq/plan-phase-aq.md); source PRD is
 [prd-atm-send-to](./plans/phase-aq/prd-atm-send-to.md). PRD Phase 2
 (agent-assisted drafting, Wyvern chat sessions) is explicitly deferred.
 
-Phase AQ complete on `integrate/phase-aq` (14/14 sprints) — integrate →
-develop PR pending.
+Phase AQ complete on `develop` (14/14 sprints) — `integrate/phase-aq` →
+`develop` merged via PR #1079 (`1f5666fa5`).
 
 Status 2026-08-28: all 14 of the phase's sprints are merged to
 `integrate/phase-aq`:


### PR DESCRIPTION
Doc-only fixes from the Phase AQ post-merge critical review (critical-plan-reviewer, develop @ a7af7cf5c). Lightweight doc-lint path.

- **PLAN-CRIT-005 (blocking):** `CHANGELOG.md` gains an `## Unreleased` section enumerating the full Phase AQ feature set (queue CLI/ADR-054 taxonomy, queue delivery triggers, Herdr steer backend + queue-wake pump, tmux idle-drain, Send-To core + ATM_TEMP/transfer scripts, Send-To surface + Wyvern contract, ecosystem preflight, hermes-atm wheel harness); the existing `1.4.5` heading is annotated as the graft-registration slice only.
- **PLAN-CRIT-006 (important):** `docs/project-plan.md` phase summary now uses ADR-054's kind-vs-mechanism wording (steer/queue are message kinds; mechanism timing may defer a steer to the next bare-CLI Stop pull).
- **PLAN-CRIT-008 (important):** `sprint-AQ4-send-to-core.md` status line discloses open follow-ups (AQ4-windows-loopback, AQ4-tailscale-m5) like AQ5's; AC rows carry an explicit disposition.
- **PLAN-CRIT-001 (header disclosure part):** §48 header → `[COMPLETE ON DEVELOP (PR #1079) — 5 open follow-ups, 2 tied to Must PRD requirements (R1 GUI E2E, R15 m5)]`; CLAUDE.md Current Status updated to match.
- **M1/M2:** `audit_window.end` → 2026-08-29T04:40:00Z (max result_time_utc); validation-evidence.md:13 footnote made precise (original intent unrecoverable from history; hash verified real).

**Held for Rand's rulings (PLAN-CRIT-001..004):** inline "approved by Rand <date>" markers for the AC-relaxation deferrals (AQ1.9-m5, AQ2→AQ5 live Hermes path, AQ4 AC7/Windows, AQ5 AC4, AQ6 AC5) will be added to this PR before merge.

No files under `docs/plans/phase-aq/evidence/**` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)