### PR TITLE
fix(boundary): canonical backendType test fixture + taxonomy hardening (RBQA-F101/F102); pin atm-graft deps (AL.9)

### DIFF
--- a/.just/tests/test_check_nudge_taxonomy.py
+++ b/.just/tests/test_check_nudge_taxonomy.py
@@ -45,6 +45,85 @@ class CheckNudgeTaxonomyTests(unittest.TestCase):
         )
         self.assertIn("production_nudge_identifier", violations[0].line)
 
+    def test_computed_backend_type_literal_outside_owners_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            core_dir = root / "crates/atm-core/src/team_admin"
+            core_dir.mkdir(parents=True)
+            (root / "crates/atm-core/src").mkdir(parents=True, exist_ok=True)
+            (core_dir / "member_mutation.rs").write_text(
+                'extra.insert("backendType".to_string(), json!("tmux"));\n',
+                encoding="utf-8",
+            )
+            (root / "crates/atm-core/src/delivery_channel.rs").write_text(
+                'pub(crate) const BACKEND_TYPE_METADATA_KEY: &str = "backendType";\n',
+                encoding="utf-8",
+            )
+            other_dir = root / "crates/atm-daemon-bootstrap/src"
+            other_dir.mkdir(parents=True)
+            (other_dir / "queue_drain.rs").write_text(
+                "#[cfg(test)]\n"
+                "mod tests {\n"
+                "    fn entry() {\n"
+                '        metadata.insert(["backend", "Type"].concat(), json!("tmux"));\n'
+                "    }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            other_dir2 = root / "crates/atm-http-runtime/src"
+            other_dir2.mkdir(parents=True)
+            (other_dir2 / "herdr_queue_wake.rs").write_text(
+                'metadata.insert("backend" + "Type", json!("herdr"));\n',
+                encoding="utf-8",
+            )
+
+            violations = CHECK.find_violations(root)
+
+        computed_violations = [
+            violation
+            for violation in violations
+            if "backend_type_containment_gate" in violation.label
+        ]
+        self.assertEqual(
+            sorted(v.path.as_posix() for v in computed_violations),
+            [
+                "crates/atm-daemon-bootstrap/src/queue_drain.rs",
+                "crates/atm-http-runtime/src/herdr_queue_wake.rs",
+            ],
+        )
+
+    def test_canonical_owners_with_real_literal_still_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            core_dir = root / "crates/atm-core/src/team_admin"
+            core_dir.mkdir(parents=True)
+            (core_dir / "member_mutation.rs").write_text(
+                'extra.insert("backendType".to_string(), json!("tmux"));\n',
+                encoding="utf-8",
+            )
+            (root / "crates/atm-core/src/delivery_channel.rs").write_text(
+                'pub(crate) const BACKEND_TYPE_METADATA_KEY: &str = "backendType";\n'
+                "pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Value> {\n"
+                "    let mut metadata = serde_json::Map::new();\n"
+                "    metadata.insert(BACKEND_TYPE_METADATA_KEY.to_owned(), Value::String(backend.to_owned()));\n"
+                "    metadata\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            other_dir = root / "crates/atm-daemon-bootstrap/src"
+            other_dir.mkdir(parents=True)
+            (other_dir / "queue_drain.rs").write_text(
+                "fn entry(backend: Option<&str>) {\n"
+                "    let metadata_json = backend.map_or_else("
+                "Default::default, atm_core::delivery_channel::test_backend_type_metadata);\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = CHECK.find_violations(root)
+
+        self.assertEqual(violations, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.triage/phase-aq/findings/RBQA-F101-AQ.ttl
+++ b/.triage/phase-aq/findings/RBQA-F101-AQ.ttl
@@ -32,8 +32,8 @@
   triage:status "fixed" ;
   triage:closed true ;
   triage:branch "fix/aq-phase-review-boundary" ;
-  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
-  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+  triage:headSha "e79dd52a4" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/e79dd52a4> .
 
 <urn:atm:triage:occurrence/RBQA-F101-AQ/AQ-hqw-1>
   a triage:Occurrence ;
@@ -43,12 +43,12 @@
   triage:status "fixed" ;
   triage:closed true ;
   triage:branch "fix/aq-phase-review-boundary" ;
-  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
-  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+  triage:headSha "e79dd52a4" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/e79dd52a4> .
 
-<urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57>
+<urn:atm:triage:worktree/fix-aq-phase-review-boundary/e79dd52a4>
   a triage:WorktreeSnapshot ;
   triage:path "fix/aq-phase-review-boundary" ;
   triage:branch "fix/aq-phase-review-boundary" ;
-  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:headSha "e79dd52a4" ;
   triage:orderIndex 0 .

--- a/.triage/phase-aq/findings/RBQA-F101-AQ.ttl
+++ b/.triage/phase-aq/findings/RBQA-F101-AQ.ttl
@@ -1,0 +1,54 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/RBQA-F101-AQ>
+  a triage:Finding ;
+  triage:findingId "RBQA-F101-AQ" ;
+  triage:title "Test fixtures build the backendType roster metadata key via a computed [\"backend\",\"Type\"].concat() literal, evading the nudge-taxonomy containment lint" ;
+  triage:description "RosterEntry test fixtures in crates/atm-daemon-bootstrap/src/queue_drain.rs (~line 1023) and crates/atm-http-runtime/src/herdr_queue_wake.rs (~line 704) built the \"backendType\" roster metadata key via [\"backend\", \"Type\"].concat(), which evades scripts/check-nudge-taxonomy.py's literal-containment check since it only scans for the contiguous \"backendType\" token. This let test code route around the single-owner gate (member_mutation.rs/delivery_channel.rs) without detection. Fixed by routing both call sites through the new atm_core::delivery_channel::test_backend_type_metadata fixture constructor, which writes the key through the module's own BACKEND_TYPE_METADATA_KEY constant." ;
+  triage:phaseId "phase-aq" ;
+  triage:triageMode "phase_end" ;
+  triage:category "boundary-violation" ;
+  triage:severity "critical" ;
+  triage:repeatable false ;
+  triage:sweepScope "workspace" ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
+  triage:triagedAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AQ ;
+  triage:foundAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AQ/AQ-qd-1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F101-AQ/AQ-hqw-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/RBQA-F101-AQ/AQ-qd-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon-bootstrap/src/queue_drain.rs" ;
+  triage:line 1023 ;
+  triage:snippet "metadata.insert([\"backend\", \"Type\"].concat(), serde_json::json!(backend));" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-boundary" ;
+  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+
+<urn:atm:triage:occurrence/RBQA-F101-AQ/AQ-hqw-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-http-runtime/src/herdr_queue_wake.rs" ;
+  triage:line 704 ;
+  triage:snippet "metadata.insert([\"backend\", \"Type\"].concat(), json!(\"herdr\"));" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-boundary" ;
+  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+
+<urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/aq-phase-review-boundary" ;
+  triage:branch "fix/aq-phase-review-boundary" ;
+  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:orderIndex 0 .

--- a/.triage/phase-aq/findings/RBQA-F102-AQ.ttl
+++ b/.triage/phase-aq/findings/RBQA-F102-AQ.ttl
@@ -31,12 +31,12 @@
   triage:status "fixed" ;
   triage:closed true ;
   triage:branch "fix/aq-phase-review-boundary" ;
-  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
-  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+  triage:headSha "e79dd52a4" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/e79dd52a4> .
 
-<urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57>
+<urn:atm:triage:worktree/fix-aq-phase-review-boundary/e79dd52a4>
   a triage:WorktreeSnapshot ;
   triage:path "fix/aq-phase-review-boundary" ;
   triage:branch "fix/aq-phase-review-boundary" ;
-  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:headSha "e79dd52a4" ;
   triage:orderIndex 0 .

--- a/.triage/phase-aq/findings/RBQA-F102-AQ.ttl
+++ b/.triage/phase-aq/findings/RBQA-F102-AQ.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/RBQA-F102-AQ>
+  a triage:Finding ;
+  triage:findingId "RBQA-F102-AQ" ;
+  triage:title "scripts/check-nudge-taxonomy.py has no detection for computed/concatenated forms of the backendType literal" ;
+  triage:description "The backendType containment gate in scripts/check-nudge-taxonomy.py only matched a contiguous \"backendType\" string token, so a computed equivalent built from string parts (e.g. [\"backend\", \"Type\"].concat(), concat!(\"backend\", \"Type\"), or \"backend\" + \"Type\") outside the two owning modules (member_mutation.rs, delivery_channel.rs) passed the gate undetected -- see RBQA-F101-AQ. Fixed by adding BACKEND_TYPE_COMPUTED_PATTERNS regexes that flag these computed forms (any internal whitespace) on every Rust source line outside the owning files, including test-only sources and inline #[cfg(test)] modules, since evading the gate from test code is exactly the bug class being guarded against. Covered by .just/tests/test_check_nudge_taxonomy.py::test_computed_backend_type_literal_outside_owners_is_flagged and ::test_canonical_owners_with_real_literal_still_pass." ;
+  triage:phaseId "phase-aq" ;
+  triage:triageMode "phase_end" ;
+  triage:category "lint-gap" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
+  triage:triagedAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AQ ;
+  triage:foundAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F102-AQ/AQ-cnt-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/RBQA-F102-AQ/AQ-cnt-1>
+  a triage:Occurrence ;
+  triage:file "scripts/check-nudge-taxonomy.py" ;
+  triage:line 277 ;
+  triage:snippet "backend_type_containment_gate: computed \"backendType\" literal must not bypass the ownership gate (RBQA-F101-AQ/RBQA-F102-AQ)" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-boundary" ;
+  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57> .
+
+<urn:atm:triage:worktree/fix-aq-phase-review-boundary/974f6f89ca2b7cbb03d8eed070eec47198a7bb57>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/aq-phase-review-boundary" ;
+  triage:branch "fix/aq-phase-review-boundary" ;
+  triage:headSha "974f6f89ca2b7cbb03d8eed070eec47198a7bb57" ;
+  triage:orderIndex 0 .

--- a/boundaries/atm-graft/shared-client-consumer.toml
+++ b/boundaries/atm-graft/shared-client-consumer.toml
@@ -28,7 +28,9 @@ io_forbidden = [
 
 [dependencies]
 allowed_dependents = ["atm-graft-python"]
-allowed_dependencies = ["atm-core", "atm-daemon-client"]
+# atm-http-runtime: AL.9 (cc3ae58c4) routes atm-graft write-transport
+# selection through atm_http_runtime::preferred_local_client/selected_write_transport.
+allowed_dependencies = ["atm-core", "atm-daemon-client", "atm-http-runtime"]
 forbidden_edges = [
   "atm-graft -> atm-daemon-bootstrap",
   "atm-graft -> atm-daemon",
@@ -74,4 +76,5 @@ notes = [
   "session runtime and advisory stream ownership are deferred to U.9 and U.10",
   "AI.15/RBQA-F002: the graft post-send notification channel is loopback TCP plus a per-bind capability token; the 'atm-graft -> interprocess' forbidden_edge blocks any reintroduction of interprocess::local_socket / named-pipe backends inside atm-graft",
   "AI11/AI14 shared-client transport: interprocess is reachable transitively only through the approved atm-daemon-client facade; atm-graft must never add a direct interprocess Cargo dependency.",
+  "AL.9 (cc3ae58c4): atm-graft depends on atm-http-runtime for write-transport selection (preferred_local_client/selected_write_transport); this was a pre-existing Cargo.toml edge backfilled into allowed_dependencies during the AQ post-merge review.",
 ]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2502,6 +2502,68 @@ fn al1_http_runtime_is_core_contract_only_and_excludes_retired_transport_shapes(
 }
 
 #[test]
+fn al9_atm_graft_pins_full_dependency_set_including_http_runtime() {
+    // RBQA post-merge review (2026-08): atm-graft/Cargo.toml declared
+    // atm-http-runtime (AL.9, cc3ae58c4 routes atm-graft write-transport
+    // selection through atm_http_runtime::preferred_local_client /
+    // selected_write_transport) without the boundary TOML's
+    // allowed_dependencies listing it, and without a Rust guard pinning
+    // atm-graft's full dependency set the way al1_http_runtime_is_core_
+    // contract_only_and_excludes_retired_transport_shapes does for
+    // atm-http-runtime. This test closes both gaps.
+    let dependencies = direct_normal_workspace_dependencies();
+    let actual = dependencies
+        .get("atm-graft")
+        .expect("atm-graft package must exist");
+    let expected = BTreeSet::from([
+        "agent-team-mail-core".to_string(),
+        "atm-daemon-client".to_string(),
+        "atm-http-runtime".to_string(),
+    ]);
+    assert_eq!(
+        actual, &expected,
+        "atm-graft's normal workspace dependency set drifted; update this guard and the \
+         boundaries/atm-graft/shared-client-consumer.toml allowed_dependencies together"
+    );
+
+    let root = workspace_root();
+    let boundary_path = root.join("boundaries/atm-graft/shared-client-consumer.toml");
+    let boundary: BoundaryToml = toml::from_str(&read_source(&boundary_path))
+        .expect("atm-graft shared-client-consumer boundary must parse");
+    let allowed_dependencies = boundary
+        .dependencies
+        .allowed_dependencies
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let package_to_crate_name = BTreeMap::from([
+        ("agent-team-mail-core".to_string(), "atm-core".to_string()),
+        (
+            "atm-daemon-client".to_string(),
+            "atm-daemon-client".to_string(),
+        ),
+        (
+            "atm-http-runtime".to_string(),
+            "atm-http-runtime".to_string(),
+        ),
+    ]);
+    let missing = actual
+        .iter()
+        .map(|package| {
+            package_to_crate_name.get(package).unwrap_or_else(|| {
+                panic!("no crate-name mapping registered for package `{package}`")
+            })
+        })
+        .filter(|crate_name| !allowed_dependencies.contains(crate_name.as_str()))
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "boundaries/atm-graft/shared-client-consumer.toml allowed_dependencies is missing crates \
+         atm-graft actually depends on: {missing:?}"
+    );
+}
+
+#[test]
 fn al1_compatibility_oracle_retains_negative_inputs_after_ipc_retirement() {
     let root = workspace_root();
     let oracle = read_source(&root.join("docs/plans/phase-al/AL1-runtime-compatibility-oracle.md"));

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -127,6 +127,24 @@ pub fn classify_delivery_channel(
     }
 }
 
+/// Roster metadata selecting `backend` as the classifier for test fixtures.
+///
+/// Test fixtures in dependent crates (e.g. `atm-daemon-bootstrap`,
+/// `atm-http-runtime`) need roster metadata keyed by `backendType` without
+/// duplicating that literal outside its two owning modules
+/// (`scripts/check-nudge-taxonomy.py` enforces the containment). Callers
+/// that also need `herdrSession` should insert it into the returned map.
+#[cfg(any(test, feature = "test-utils"))]
+#[must_use]
+pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Value> {
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        BACKEND_TYPE_METADATA_KEY.to_owned(),
+        Value::String(backend.to_owned()),
+    );
+    metadata
+}
+
 /// Derives the local backend from durable roster data. No schema migration:
 /// `recipient_pane_id` selects `Tmux`;
 /// `metadata_json["backendType"] == "herdr"` selects `Herdr`, reading an

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
 atm-herdr = { path = "../atm-herdr", version = "1.4.5", features = ["test-utils"] }
 atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5", features = ["test-support"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.5" }

--- a/crates/atm-daemon-bootstrap/src/queue_drain.rs
+++ b/crates/atm-daemon-bootstrap/src/queue_drain.rs
@@ -1018,11 +1018,10 @@ mod tests {
         pane: Option<PaneId>,
         backend: Option<&str>,
     ) -> RosterEntry {
-        let metadata_json = backend.map_or_else(Default::default, |backend| {
-            let mut metadata = serde_json::Map::new();
-            metadata.insert(["backend", "Type"].concat(), serde_json::json!(backend));
-            metadata
-        });
+        let metadata_json = backend.map_or_else(
+            Default::default,
+            atm_core::delivery_channel::test_backend_type_metadata,
+        );
         RosterEntry {
             team_name: team.clone(),
             agent_name: agent.clone(),

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -700,8 +700,7 @@ mod tests {
             model: ModelName::default(),
             recipient_pane_id: None,
             metadata_json: {
-                let mut metadata = serde_json::Map::new();
-                metadata.insert(["backend", "Type"].concat(), json!("herdr"));
+                let mut metadata = atm_core::delivery_channel::test_backend_type_metadata("herdr");
                 metadata.insert("herdrSession".to_owned(), json!(session));
                 metadata
             },

--- a/docs/plans/phase-al/readiness.md
+++ b/docs/plans/phase-al/readiness.md
@@ -29,6 +29,16 @@ final physical proof.
 | RBQA-F103-AL | corrected/waived | `9e303af7`: active Tokio bootstrap and CLI use the `atm-core` contract; the frozen legacy daemon occurrence is waived for Phase AM deletion |
 | AL-CLOSURE-004 | pending physical proof | intentionally out of this documentation/source cleanup; final AL.9 physical-proof run is required |
 
+**2026-08-28 (out-of-band, PR #1082, `fix/aq-phase-review-boundary`):** an
+undeclared Cargo dependency edge from `atm-graft` to `atm-http-runtime` was
+backfilled into `boundaries/atm-graft/shared-client-consumer.toml`, guarded by
+the new architecture test
+`al9_atm_graft_pins_full_dependency_set_including_http_runtime`. This is a
+boundary-declaration correction only, made outside the Phase AL sprint
+sequence during Phase AQ review. **AL-CLOSURE-004 remains open and is
+unaffected by this change** — the AL.9 final physical-proof matrix is still
+required before Phase AL can be declared complete.
+
 ## Required physical proof before completion
 
 At a single SHA/version-selected candidate, retain and index the following:

--- a/scripts/check-nudge-taxonomy.py
+++ b/scripts/check-nudge-taxonomy.py
@@ -166,7 +166,7 @@ HERDR_WIRE_PATTERNS = tuple(
 # token, so it cannot catch a computed equivalent (e.g.
 # `["backend", "Type"].concat()`, `concat!("backend", "Type")`, or
 # `"backend" + "Type"`) built outside the two owning modules to route around
-# the ownership gate (RBQA-F101/F102). These patterns catch the computed
+# the ownership gate (RBQA-F101-AQ/RBQA-F102-AQ). These patterns catch the computed
 # forms regardless of internal whitespace; each is matched against every
 # Rust source line, including test-only sources and inline `#[cfg(test)]`
 # modules, since evading the gate from test code is exactly the bug class
@@ -274,7 +274,7 @@ def find_violations(repo_root: Path) -> tuple[Violation, ...]:
                                 line_number,
                                 "backend_type_containment_gate: computed \"backendType\" literal must not "
                                 "bypass the member_mutation.rs/delivery_channel.rs ownership gate "
-                                "(RBQA-F101/F102)",
+                                "(RBQA-F101-AQ/RBQA-F102-AQ)",
                                 line.strip(),
                             )
                         )

--- a/scripts/check-nudge-taxonomy.py
+++ b/scripts/check-nudge-taxonomy.py
@@ -162,6 +162,23 @@ HERDR_WIRE_PATTERNS = tuple(
     )
 )
 
+# The literal-containment check below only sees a contiguous `"backendType"`
+# token, so it cannot catch a computed equivalent (e.g.
+# `["backend", "Type"].concat()`, `concat!("backend", "Type")`, or
+# `"backend" + "Type"`) built outside the two owning modules to route around
+# the ownership gate (RBQA-F101/F102). These patterns catch the computed
+# forms regardless of internal whitespace; each is matched against every
+# Rust source line, including test-only sources and inline `#[cfg(test)]`
+# modules, since evading the gate from test code is exactly the bug class
+# being guarded against.
+BACKEND_TYPE_COMPUTED_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r'"backend"\s*,\s*"Type"',
+        r'"backend"\s*\+\s*"Type"',
+    )
+)
+
 
 def iter_rust_sources(repo_root: Path) -> tuple[Path, ...]:
     crates_dir = repo_root / "crates"
@@ -245,6 +262,19 @@ def find_violations(repo_root: Path) -> tuple[Violation, ...]:
                                 Path(relative_path),
                                 line_number,
                                 "herdr_string_containment_gate: Herdr wire literal must remain inside crates/atm-herdr",
+                                line.strip(),
+                            )
+                        )
+            if relative_path not in backend_type_paths:
+                for pattern in BACKEND_TYPE_COMPUTED_PATTERNS:
+                    if pattern.search(line):
+                        violations.append(
+                            Violation(
+                                Path(relative_path),
+                                line_number,
+                                "backend_type_containment_gate: computed \"backendType\" literal must not "
+                                "bypass the member_mutation.rs/delivery_channel.rs ownership gate "
+                                "(RBQA-F101/F102)",
                                 line.strip(),
                             )
                         )


### PR DESCRIPTION
Fixes from the Phase AQ post-merge critical review (ruthless-boundary-qa + boundary-guard), develop @ a7af7cf5c.

**dfdb3a6d0 — RBQA-F101/F102 (important):** two test modules built the roster metadata key as `["backend", "Type"].concat()`, defeating `scripts/check-nudge-taxonomy.py`'s containment rule that the literal `"backendType"` is owned only by `member_mutation.rs`/`delivery_channel.rs`. Now: one canonical test fixture `delivery_channel::test_backend_type_metadata(backend)` (gated `cfg(any(test, feature = "test-utils"))`, writes the key through `BACKEND_TYPE_METADATA_KEY`); both sites (`queue_drain.rs`, `herdr_queue_wake.rs`) use it; the taxonomy script now also flags computed/concatenated forms outside the owners, with two new tests in `.just/tests/test_check_nudge_taxonomy.py` (evasion caught; canonical owners pass).

**e79dd52a4 — boundary-guard advisory (pre-existing since AL.9 cc3ae58c4):** `atm-graft` depends on `atm-http-runtime` but its boundary TOML didn't list it and no guard pinned atm-graft's dependency set. Now: `boundaries/atm-graft/shared-client-consumer.toml` lists it (AL.9 note) and `al9_atm_graft_pins_full_dependency_set_including_http_runtime` in `boundary_enforcement.rs` fails closed on drift. Nothing relaxed.

Gates: fmt ✓ · clippy -D warnings ✓ · `cargo test --workspace` 1481 passed / 0 failed · `cargo test -p atm-architecture` 79/79 · run_lint 30/32 (fmt/clippy lanes fail only for the fresh-worktree `.bootstrap-venv` gap; raw cargo fmt/clippy pass) incl. `taxonomy` and `sc-boundary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)