### PR TITLE
fix(release): homebrew formula runtime break (pkgshare) + tag-pinned tooling checkouts — v1.4.4 round 4

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -26,9 +26,15 @@ jobs:
       asset_patterns: ${{ steps.config.outputs.asset_patterns }}
       release_version: ${{ steps.meta.outputs.release_version }}
     steps:
+      # Release-branch fix (v1.4.4, upstream sc-publish#76): check out the
+      # dispatch ref, not the immutable tag. This workflow never builds from
+      # source — release assets stay tag-pinned via their download URLs and
+      # verify-published-release validates via the API — so the checkout
+      # exists solely to supply the verify tooling, manifest, and formula
+      # template. Pinning it to the tag freezes any tooling or template
+      # defect into the release forever (the tag is immutable). Same model
+      # as release.yml: immutable tag for artifacts, dispatch ref for tooling.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
       - id: config
         name: Read Homebrew configuration from release manifest
         shell: bash
@@ -69,11 +75,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Bootstrap renderer
         uses: ./.github/actions/setup-renderer
-      - name: Checkout immutable release source
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
-          path: release-source
       - name: Checkout Homebrew tap
         uses: actions/checkout@v4
         with:
@@ -187,7 +188,7 @@ jobs:
                       "--mode",
                       "file",
                       "--root",
-                      "release-source",
+                      ".",
                       "--file",
                       formula["template"],
                       "--var-file",

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -27,9 +27,15 @@ jobs:
       asset_patterns: ${{ steps.config.outputs.asset_patterns }}
       release_version: ${{ steps.meta.outputs.release_version }}
     steps:
+      # Release-branch fix (v1.4.4, upstream sc-publish#76): check out the
+      # dispatch ref, not the immutable tag. This workflow never builds from
+      # source — release assets stay tag-pinned via their download URLs and
+      # verify-published-release validates via the API — so the checkout
+      # exists solely to supply the verify tooling, manifest, and manifest
+      # template. Pinning it to the tag freezes any tooling or template
+      # defect into the release forever (the tag is immutable). Same model
+      # as release.yml: immutable tag for artifacts, dispatch ref for tooling.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
       - id: config
         name: Read Scoop configuration from release manifest
         shell: bash
@@ -70,11 +76,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Bootstrap renderer
         uses: ./.github/actions/setup-renderer
-      - name: Checkout immutable release source
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
-          path: release-source
       - name: Checkout configured Scoop bucket
         uses: actions/checkout@v4
         with:
@@ -133,7 +134,7 @@ jobs:
           set -euo pipefail
           workspace_root="$(pwd)"
           mkdir -p "$(dirname "scoop-bucket/${MANIFEST_PATH}")"
-          "${PUBLISHED_RENDERER}" render --mode file --root release-source \
+          "${PUBLISHED_RENDERER}" render --mode file --root . \
             --file "${MANIFEST_TEMPLATE}" \
             --var-file "${workspace_root}/scoop-vars.json" \
             --output "${workspace_root}/scoop-bucket/${MANIFEST_PATH}"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -25,9 +25,15 @@ jobs:
       channel_config: ${{ steps.config.outputs.channel_config }}
       asset_patterns: ${{ steps.config.outputs.asset_patterns }}
     steps:
+      # Release-branch fix (v1.4.4, upstream sc-publish#76): check out the
+      # dispatch ref, not the immutable tag. This workflow never builds from
+      # source — release assets stay tag-pinned via their download URLs and
+      # verify-published-release validates via the API — so the checkout
+      # exists solely to supply the verify tooling and manifest. Pinning it
+      # to the tag freezes any tooling defect into the release forever (the
+      # tag is immutable). Same model as release.yml: immutable tag for
+      # artifacts, dispatch ref for tooling.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
       - id: config
         name: Read Winget configuration from release manifest
         shell: bash

--- a/release/homebrew/formula.rb.j2
+++ b/release/homebrew/formula.rb.j2
@@ -26,7 +26,7 @@ class {{ formula_class }} < Formula
     bin.install {{ binary_path | tojson }}
 {% endfor %}
 {% for bundle in bundled_paths %}
-    ({% for component in bundle.destination_components %}{{ component | tojson }}{% if not loop.last %}/{% endif %}{% endfor %}).install Dir[{{ bundle.source_glob | tojson }}]
+    ({% for component in bundle.destination_components %}{% if loop.first %}{{ component }}{% else %}/{{ component | tojson }}{% endif %}{% endfor %}).install Dir[{{ bundle.source_glob | tojson }}]
 {% endfor %}
   end
 

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -201,7 +201,7 @@ class = "AgentTeamMail"
 binaries = ["atm", "atm-daemon"]
 test_binary = "atm"
 test_command = "--help"
-test_output = "CLI for local agent team mail workflows"
+test_output = "ATM CLI"
 release_track = "stable"
 [[channels.homebrew.formulas]]
 path = "Formula/atm.rb"
@@ -210,7 +210,7 @@ class = "Atm"
 binaries = ["atm", "atm-daemon"]
 test_binary = "atm"
 test_command = "--help"
-test_output = "CLI for local agent team mail workflows"
+test_output = "ATM CLI"
 release_track = "stable"
 [[channels.homebrew.formulas]]
 path = "Formula/atm-beta.rb"
@@ -219,7 +219,7 @@ class = "AtmBeta"
 binaries = ["atm", "atm-daemon"]
 test_binary = "atm"
 test_command = "--help"
-test_output = "CLI for local agent team mail workflows"
+test_output = "ATM CLI"
 release_track = "prerelease"
 
 [[channels.homebrew.assets]]

--- a/release/sc-publish-qualification-25668ecc.md
+++ b/release/sc-publish-qualification-25668ecc.md
@@ -271,3 +271,52 @@ documented in its comment); the edited composite parses as valid YAML. The
 runner-image race itself is not reproducible on a local macOS host with a
 fully provisioned toolchain, so in-repo CI precedent is the rehearsal
 authority here.
+
+### Round 4 (live homebrew channel run 33220372286 — workflow PASSED, formula runtime-broken)
+
+The homebrew channel run went green and pushed both formulas to the tap, but
+`brew install randlee/tap/atm` fails at runtime for every user
+(reported by publisher's post-push live verification):
+
+14. **`formula.rb.j2` renders Homebrew path-helper methods as string
+    literals**: every `bundled_paths` destination component goes through
+    `| tojson`, so `["pkgshare"]` renders as `("pkgshare").install Dir[...]`
+    — a String, not the `pkgshare` method →
+    `NoMethodError: undefined method 'install' for an instance of String`
+    during `brew install`. `ruby -c` (the workflow's only formula gate)
+    passes on the broken output, which is why both the workflow and the
+    round-3 local rehearsal (render + `ruby -c`) missed it — **syntax
+    validation is not runtime validation**. Fix: the first component
+    renders as the bare path-helper method, subsequent components as
+    quoted segments (the `pkgshare/"subdir"` idiom). Upstream:
+    [sc-publish #77](https://github.com/randlee/sc-publish/issues/77);
+    the missing runtime gate is
+    [sc-publish #78](https://github.com/randlee/sc-publish/issues/78).
+15. **Manifest `test_output` stale against the released binary** (found
+    only by the round-4 runtime rehearsal): all three formula entries
+    asserted `"CLI for local agent team mail workflows"`, but the v1.4.4
+    binary's `--help` prints `ATM CLI` — the formula `test do` block fails
+    for anyone running `brew test`. No gate ever executes the test block
+    (also #78). Fix: `test_output = "ATM CLI"` (the stable first line of
+    the real help output), verified against the released binary.
+
+This round also drops the `ref: ${{ inputs.tag }}` checkout pins from
+`homebrew-publish.yml`, `scoop-publish.yml`, and `winget-publish.yml` (the
+defect-13 / sc-publish #76 class): homebrew's render step read the formula
+template from a tag-pinned `release-source` checkout, so a re-dispatch after
+merging fix 14 would have re-pushed the tag's frozen broken template. All
+three now use the dispatch-ref checkout for tooling/templates; release
+assets stay tag-pinned via their download URLs and
+`verify-published-release` API validation (same model as `release.yml` and
+the fixed `pypi-publish.yml`).
+
+Round-4 runtime rehearsal (the new bar for this channel, per #78):
+`brew install` executed locally from the fixed rendered formula in a
+throwaway local tap against the real v1.4.4 release assets — install block
+runs clean (41 files incl. pkgshare docs in the keg), keg binary reports
+`atm 1.4.4`, and the test-block assertion (`--help` contains `ATM CLI`)
+passes against the real released binary. `ruby -c` both formulas OK; all
+three edited workflows YAML-parse; scoop manifest re-rendered under the new
+`--root .` model and JSON-validates. The scoop/winget artifacts themselves
+were already live-verified by publisher (bucket JSON content; winget-pkgs
+PR #425892) and are declarative — no analogous runtime DSL surface.


### PR DESCRIPTION
## Live break

`brew install randlee/tap/atm` fails at runtime for every user right now (caught by publisher's post-push live verification, after homebrew-publish run 33220372286 went green):

```
NoMethodError: undefined method 'install' for an instance of String
```

**Defect 14** — `release/homebrew/formula.rb.j2` renders `bundled_paths` destination components through `| tojson`, producing `("pkgshare").install Dir[...]` (a String) instead of the `pkgshare` path-helper method. `ruby -c` — the workflow's only formula gate — passes on the broken output, which is also why the round-3 rehearsal (render + syntax check) missed it. Upstream: [sc-publish#77](https://github.com/randlee/sc-publish/issues/77); the missing runtime gate is [sc-publish#78](https://github.com/randlee/sc-publish/issues/78).

## Batched into the same round (per the batch-never-trickle rule)

- **Defect 15** — manifest `test_output` was stale vs the released binary (`--help` prints `ATM CLI`, not "CLI for local agent team mail workflows"), so the formula `test do` block fails for anyone running `brew test`. Found only by the round-4 runtime rehearsal.
- **Defect-13 class in the binary channels** — `homebrew-publish.yml`, `scoop-publish.yml`, `winget-publish.yml` checked out `ref: inputs.tag` for tooling/templates; homebrew's render step read the formula template from the tag-pinned `release-source` checkout, so a re-dispatch after merging this fix would have re-pushed the tag's frozen broken template. All three now use the dispatch-ref checkout ([sc-publish#76](https://github.com/randlee/sc-publish/issues/76) model: immutable tag for artifacts via download URLs + API verification, dispatch ref for tooling).

## Runtime rehearsal (new bar for this channel)

- Real local `brew install` of the fixed rendered formula from a throwaway local tap against the live v1.4.4 release assets: install block clean (41 files, pkgshare docs in keg), keg binary reports `atm 1.4.4`, test-block assertion passes against the real binary.
- `ruby -c` both formulas; all three workflows YAML-parse; scoop manifest re-renders under `--root .` and JSON-validates.
- Receipt updated with round 4 (defects 14–15).

## After merge

Re-dispatch `homebrew-publish.yml` from main for tag v1.4.4 — it re-renders with the fixed template and pushes a new tap commit (forward-only). Scoop/winget need no re-dispatch (their published artifacts are declarative and already live-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)