### PR TITLE
docs: v1.4.4 publish post-mortem — first-attempt success criteria

### DIFF
--- a/.triage/phase-at/findings/ATM-QA-024.ttl
+++ b/.triage/phase-at/findings/ATM-QA-024.ttl
@@ -14,13 +14,17 @@
   triage:category "deliverable-missing" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:POSTMORTEM-1084 ;
   triage:foundAt "2026-08-28T04:45:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-024/POSTMORTEM-1084-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-024/QMGR-CLOSE-1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-024/QMGR-CLOSE-2> ;
+  triage:closedAt "2026-08-29T00:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "3" .
 
 <urn:atm:triage:occurrence/ATM-QA-024/POSTMORTEM-1084-1>
   a triage:Occurrence ;
@@ -37,3 +41,35 @@
   triage:branch "plan/v144-publish-postmortem" ;
   triage:headSha "6689ed3f3" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-024/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file "docs/postmortems/v1.4.4-publish-postmortem.md" ;
+  triage:line 82 ;
+  triage:snippet "round-1 fix (commit 1ae18c516) split the table into Landed (merged) vs In review (open PRs -- not yet in effect), correctly reflecting #1083 as still open at that time; adequate for the state of the world when written, but PR #1083 merged shortly after (5436f69886380f1dcf17fe884141e3040b64742f, 2026-08-28T23:58:54Z), making the In-review placement of the #1083 rows stale -- flagged back to fenix per fenix's own invitation in the re-review request rather than closed" ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "plan/v144-publish-postmortem" ; triage:headSha "1ae18c516" ;
+  triage:occursIn <urn:atm:triage:worktree/POSTMORTEM-1084/1ae18c516> .
+
+<urn:atm:triage:worktree/POSTMORTEM-1084/1ae18c516>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/plan-v144-publish-postmortem" ;
+  triage:branch "plan/v144-publish-postmortem" ;
+  triage:headSha "1ae18c516" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:occurrence/ATM-QA-024/QMGR-CLOSE-2>
+  a triage:Occurrence ;
+  triage:file "docs/postmortems/v1.4.4-publish-postmortem.md" ;
+  triage:line 82 ;
+  triage:snippet "#1083 rows flipped to Landed (merged): 'PR #1083 (merged to main 2026-08-28; homebrew re-dispatched from main, recovery run 33222167237 passed with live consumer verification)'; outcome line now reads '7 merges to main (#1067, #1071, #1072, #1073, #1074, #1077, #1083)' and '7 failed CI publish runs'. Independently confirmed: gh run view 33222167237 shows conclusion success (Publish Homebrew); table counts now match the timeline table's own 7 rows with no residual pending marker." ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "plan/v144-publish-postmortem" ; triage:headSha "48ba07772" ;
+  triage:occursIn <urn:atm:triage:worktree/POSTMORTEM-1084/48ba07772> .
+
+<urn:atm:triage:worktree/POSTMORTEM-1084/48ba07772>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/plan-v144-publish-postmortem" ;
+  triage:branch "plan/v144-publish-postmortem" ;
+  triage:headSha "48ba07772" ;
+  triage:orderIndex 3 .

--- a/.triage/phase-at/findings/ATM-QA-024.ttl
+++ b/.triage/phase-at/findings/ATM-QA-024.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-024>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-024" ;
+  triage:title "Postmortem's 'Already landed (this release)' table claims PR #1083's dispatch-ref checkout fix and test_output correction are landed, but PR #1083 is confirmed still OPEN and main still has the broken code" ;
+  triage:description "docs/postmortems/v1.4.4-publish-postmortem.md's '## 3. Improvements / Already landed (this release)' table (lines 82-83) lists 'Dispatch-ref tooling checkouts in all publish workflows' (pypi/homebrew/scoop/winget-publish.yml, #1077, #1083) and 'Manifest test_output corrected against the real binary' (release/publish-artifacts.toml, #1083) without any pending/in-flight qualifier, under a heading that unconditionally means merged. The document's own timeline table (row 7) marks the same PR '#1083 (pending)'. Independently confirmed via `gh pr view 1083 --json state,mergedAt,baseRefName,headRefName`: state OPEN, mergedAt null, base main, head release/v1.4.4 -- not merged. Direct file inspection of the atm-core-worktrees/main checkout confirms the underlying defects are still present verbatim: pypi-publish.yml and homebrew-publish.yml on main still pin tooling checkout to the immutable tag (ref: ${{ inputs.tag }}), release/homebrew/formula.rb.j2 on main still renders the first bundled_paths component through tojson (the exact defect-14 bug that breaks brew install for every user -- the release's headline defect), and release/publish-artifacts.toml on main still carries the stale test_output value. The postmortem overstates its own remediation status and its own document self-contradicts (timeline says pending, improvements table says landed). Found by req-qa. Independently verified by quality-mgr via gh pr view 1083 and direct read of docs/postmortems/v1.4.4-publish-postmortem.md:65-83 on commit 6689ed3f3." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "deliverable-missing" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:POSTMORTEM-1084 ;
+  triage:foundAt "2026-08-28T04:45:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-024/POSTMORTEM-1084-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-024/POSTMORTEM-1084-1>
+  a triage:Occurrence ;
+  triage:file "docs/postmortems/v1.4.4-publish-postmortem.md" ;
+  triage:line 82 ;
+  triage:snippet "Dispatch-ref tooling checkouts in all publish workflows | pypi/homebrew/scoop/winget-publish.yml (#1077, #1083)" ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "plan/v144-publish-postmortem" ; triage:headSha "6689ed3f3" ;
+  triage:occursIn <urn:atm:triage:worktree/POSTMORTEM-1084/6689ed3f3> .
+
+<urn:atm:triage:worktree/POSTMORTEM-1084/6689ed3f3>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/plan-v144-publish-postmortem" ;
+  triage:branch "plan/v144-publish-postmortem" ;
+  triage:headSha "6689ed3f3" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-at/findings/ATM-QA-025.ttl
+++ b/.triage/phase-at/findings/ATM-QA-025.ttl
@@ -14,13 +14,16 @@
   triage:category "cross-doc-conflict" ;
   triage:severity "important" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:POSTMORTEM-1084 ;
   triage:foundAt "2026-08-28T04:45:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-025/POSTMORTEM-1084-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-025/QMGR-CLOSE-1> ;
+  triage:closedAt "2026-08-29T00:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "3" .
 
 <urn:atm:triage:occurrence/ATM-QA-025/POSTMORTEM-1084-1>
   a triage:Occurrence ;
@@ -37,3 +40,19 @@
   triage:branch "plan/v144-publish-postmortem" ;
   triage:headSha "6689ed3f3" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-025/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file "docs/postmortems/v1.4.4-publish-postmortem.md" ;
+  triage:line 6 ;
+  triage:snippet "final outcome line: 'all seven channels completed on 2026-08-28 -- but it took 15 documented defects, 7 merges to main (#1067, #1071, #1072, #1073, #1074, #1077, #1083), and 7 failed CI publish runs, plus one channel run that passed CI while shipping a live break' -- counters now match the timeline table's own row/run counts exactly (verified at both 1ae18c516 and 48ba07772)" ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "plan/v144-publish-postmortem" ; triage:headSha "48ba07772" ;
+  triage:occursIn <urn:atm:triage:worktree/POSTMORTEM-1084/48ba07772-b> .
+
+<urn:atm:triage:worktree/POSTMORTEM-1084/48ba07772-b>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/plan-v144-publish-postmortem" ;
+  triage:branch "plan/v144-publish-postmortem" ;
+  triage:headSha "48ba07772" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-at/findings/ATM-QA-025.ttl
+++ b/.triage/phase-at/findings/ATM-QA-025.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-025>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-025" ;
+  triage:title "Outcome summary's '7 merges to main' and '8 failed CI publish runs' don't match the postmortem's own timeline table" ;
+  triage:description "docs/postmortems/v1.4.4-publish-postmortem.md's outcome statement (lines 6-9) claims '7 merges to main' and '8 failed CI publish runs, plus one post-success live break'. The timeline table itself (lines 19-27) lists exactly 8 distinct workflow-run IDs across 7 rows (row 5 covers two retry run IDs), of which only 7 are marked failed (an X mark); the 8th (run 33220372286, row 7) is explicitly marked 'CI passed' with only the live install broken afterward -- it is the same event as the cited 'live break', not a distinct 9th failed run. Separately, '7 merges to main' requires counting PR #1083 as a completed merge, but the same table's row 7 marks it '(pending)' -- independently confirmed OPEN via gh pr view 1083. Only 6 merges are confirmed complete by the document's own evidence. Found by req-qa. Independently verified by quality-mgr via direct read of the timeline table and gh pr view 1083 on commit 6689ed3f3." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "cross-doc-conflict" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:POSTMORTEM-1084 ;
+  triage:foundAt "2026-08-28T04:45:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-025/POSTMORTEM-1084-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-025/POSTMORTEM-1084-1>
+  a triage:Occurrence ;
+  triage:file "docs/postmortems/v1.4.4-publish-postmortem.md" ;
+  triage:line 6 ;
+  triage:snippet "it took 15 documented defects, 7 merges to main, and 8 failed CI publish runs, plus one post-success live break" ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "plan/v144-publish-postmortem" ; triage:headSha "6689ed3f3" ;
+  triage:occursIn <urn:atm:triage:worktree/POSTMORTEM-1084/6689ed3f3-b> .
+
+<urn:atm:triage:worktree/POSTMORTEM-1084/6689ed3f3-b>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/plan-v144-publish-postmortem" ;
+  triage:branch "plan/v144-publish-postmortem" ;
+  triage:headSha "6689ed3f3" ;
+  triage:orderIndex 1 .

--- a/docs/postmortems/v1.4.4-publish-postmortem.md
+++ b/docs/postmortems/v1.4.4-publish-postmortem.md
@@ -3,12 +3,13 @@
 - **Release**: atm-core v1.4.4 — the first kit-era release exercising the full
   sc-publish channel surface (GitHub Release, crates.io ×13, TestPyPI,
   production PyPI, Homebrew, winget, Scoop) on pin `25668ecc`.
-- **Outcome**: all seven channels completed CI on 2026-08-28 — but it took
-  **15 documented defects**, **6 merges to `main` plus a 7th fix PR still
-  pending (#1083)**, and **7 failed CI publish runs**, plus one channel run
-  that passed CI while shipping a live break (`brew install` fails at
-  runtime for every user; the homebrew channel stays broken until #1083
-  merges and the channel is re-dispatched).
+- **Outcome**: all seven channels completed on 2026-08-28 — but it took
+  **15 documented defects**, **7 merges to `main`** (#1067, #1071, #1072,
+  #1073, #1074, #1077, #1083), and **7 failed CI publish runs**, plus one
+  channel run that passed CI while shipping a live break (`brew install`
+  failed at runtime for every user until #1083 merged and
+  homebrew-publish.yml was re-dispatched from `main` — recovery run
+  33222167237, live consumer verification passed).
 - **Author**: fenix (atm-dev), 2026-08-28.
 - **Canonical defect ledger**: `release/sc-publish-qualification-25668ecc.md`
   on `release/v1.4.4` (rounds 1–4). This post-mortem analyzes; the receipt is
@@ -26,7 +27,7 @@
 | 4 | 33198964299 | release.yml (main) | ❌ (after tag + 13/13 crates) | 9: kit composite installs Rust toolchain without declared components → rustfmt auto-add race breaks maturin builds intermittently | #1073 |
 | 5 | 33201363132 / 33202161368 | release.yml retries | ❌ | 10: `sync/verify-python-version` can't handle `dynamic = ["version"]` | #1074 |
 | 6 | 33211063257 | pypi-publish.yml (TestPyPI) | ❌ | 11: sdist PKG-INFO matcher rejects valid setuptools sdists. **12–13** found only by local rehearsal (universal-wheel count expectation; pypi-publish.yml checkout pinned to the immutable tag — a re-dispatch would have run the tag's frozen broken tooling and failed identically) | #1077 |
-| 7 | 33220372286 | homebrew-publish.yml | ✅ CI / ❌ **live** | 14: formula renders `("pkgshare").install` — String, not method → `brew install` fails at runtime for every user; `ruby -c` (the only gate) passes. **15** found only by runtime rehearsal (manifest `test_output` stale vs the released binary — `brew test` fails) | #1083 (pending) |
+| 7 | 33220372286 | homebrew-publish.yml | ✅ CI / ❌ **live** | 14: formula renders `("pkgshare").install` — String, not method → `brew install` fails at runtime for every user; `ruby -c` (the only gate) passes. **15** found only by runtime rehearsal (manifest `test_output` stale vs the released binary — `brew test` fails) | #1083 (merged 2026-08-28; recovery run 33222167237 passed with live consumer verification) |
 
 Successes, for contrast: crates.io 13/13 on the first ordered attempt once
 release.yml ran; TestPyPI and production PyPI passed **first try after** the
@@ -35,8 +36,8 @@ binary-channel rehearsal. Every channel that was fully rehearsed first
 published clean; every channel that wasn't, didn't.
 
 Cost: each fix cycle (find → fix → PR → approval → merge → re-dispatch) took
-roughly an hour. Seven cycles (six merged, #1083 still in flight) ≈ a working
-day of wall-clock on defects, most of it serialized.
+roughly an hour. Seven cycles (all seven now merged) ≈ a working day of
+wall-clock on defects, most of it serialized.
 
 ## 2. Root causes — why first attempts failed
 
@@ -77,6 +78,8 @@ day of wall-clock on defects, most of it serialized.
 | Improvement | Where | Closes root cause |
 |---|---|---|
 | **Dispatch-ref tooling checkout in pypi-publish.yml** — immutable tag for artifacts (download URLs + API verification), dispatch ref for tooling | PR #1077 (merged to `main`) | 4 |
+| **Dispatch-ref tooling checkouts in the binary-channel workflows** (homebrew/scoop/winget) + the defect-14 formula-template fix | PR #1083 (merged to `main` 2026-08-28; homebrew re-dispatched from `main`, recovery run 33222167237 passed with live consumer verification) | 3, 4 |
+| Manifest `test_output` corrected against the real binary | `release/publish-artifacts.toml`, PR #1083 (merged) | 6 |
 
 ### In review (open PRs — not yet in effect)
 
@@ -87,8 +90,6 @@ day of wall-clock on defects, most of it serialized.
 | **Runtime-faithful rehearsal** — syntax validation is not runtime validation; artifacts that execute at install time get a real local `brew install` + test-block assertion from a throwaway tap | SKILL.md operating rule, PR #1085 | 3 |
 | **Batch, never trickle** — on any failure, rehearse the entire remaining pipeline, one fix round, one batched fix merge, verify the re-dispatch executes fixed tooling | SKILL.md + `.claude/agents/publisher.md`, PR #1085 | 2 |
 | **Parallel channel dispatch** — fan out every remaining channel the moment the GitHub Release verifies live; failures hold only their own channel | SKILL.md + publisher.md, PR #1085 | 5 |
-| **Dispatch-ref tooling checkouts in the binary-channel workflows** (homebrew/scoop/winget) + the defect-14 formula-template fix | PR #1083 → `main` (**pending approval** — until it merges and homebrew-publish.yml is re-dispatched, `main` still carries the broken template and the live `brew install` break persists) | 3, 4 |
-| Manifest `test_output` corrected against the real binary | `release/publish-artifacts.toml`, PR #1083 (pending) | 6 |
 
 ### Proposed — consumer side (atm-core)
 

--- a/docs/postmortems/v1.4.4-publish-postmortem.md
+++ b/docs/postmortems/v1.4.4-publish-postmortem.md
@@ -3,10 +3,12 @@
 - **Release**: atm-core v1.4.4 — the first kit-era release exercising the full
   sc-publish channel surface (GitHub Release, crates.io ×13, TestPyPI,
   production PyPI, Homebrew, winget, Scoop) on pin `25668ecc`.
-- **Outcome**: all seven channels live on 2026-08-28 — but it took **15
-  documented defects**, **7 merges to `main`**, and **8 failed CI publish
-  runs**, plus one post-"success" live break (`brew install` failed at
-  runtime for every user after the channel run went green).
+- **Outcome**: all seven channels completed CI on 2026-08-28 — but it took
+  **15 documented defects**, **6 merges to `main` plus a 7th fix PR still
+  pending (#1083)**, and **7 failed CI publish runs**, plus one channel run
+  that passed CI while shipping a live break (`brew install` fails at
+  runtime for every user; the homebrew channel stays broken until #1083
+  merges and the channel is re-dispatched).
 - **Author**: fenix (atm-dev), 2026-08-28.
 - **Canonical defect ledger**: `release/sc-publish-qualification-25668ecc.md`
   on `release/v1.4.4` (rounds 1–4). This post-mortem analyzes; the receipt is
@@ -33,8 +35,8 @@ binary-channel rehearsal. Every channel that was fully rehearsed first
 published clean; every channel that wasn't, didn't.
 
 Cost: each fix cycle (find → fix → PR → approval → merge → re-dispatch) took
-roughly an hour. Seven cycles ≈ a working day of wall-clock on defects, most
-of it serialized.
+roughly an hour. Seven cycles (six merged, #1083 still in flight) ≈ a working
+day of wall-clock on defects, most of it serialized.
 
 ## 2. Root causes — why first attempts failed
 
@@ -70,17 +72,23 @@ of it serialized.
 
 ## 3. Improvements
 
-### Already landed (this release)
+### Landed (merged)
 
 | Improvement | Where | Closes root cause |
 |---|---|---|
-| **One skill invocation, one human approval** as the declared goal — everything before the release→main PR is rehearsal; everything after is autonomous and parallel | `.claude/skills/publishing/SKILL.md` preamble (PR from `skill/publishing-rehearsal-parallel`) | 2, 5 |
-| **Full-pipeline rehearsal before the single approval** — every manifest-declared channel, real artifacts, the tooling revision each workflow will actually check out; credentialed ops exempt | SKILL.md operating rule | 1, 2 |
-| **Runtime-faithful rehearsal** — syntax validation is not runtime validation; artifacts that execute at install time get a real local `brew install` + test-block assertion from a throwaway tap | SKILL.md operating rule (round-4 lesson) | 3 |
-| **Batch, never trickle** — on any failure, rehearse the entire remaining pipeline, one fix round, one main merge, verify the re-dispatch executes fixed tooling | SKILL.md + `.claude/agents/publisher.md` | 2 |
-| **Parallel channel dispatch** — fan out every remaining channel the moment the GitHub Release verifies live; failures hold only their own channel | SKILL.md + publisher.md | 5 |
-| **Dispatch-ref tooling checkouts in all publish workflows** — immutable tag for artifacts (download URLs + API verification), dispatch ref for tooling/templates | pypi/homebrew/scoop/winget-publish.yml (#1077, #1083) | 4 |
-| Manifest `test_output` corrected against the real binary | `release/publish-artifacts.toml` (#1083) | 6 |
+| **Dispatch-ref tooling checkout in pypi-publish.yml** — immutable tag for artifacts (download URLs + API verification), dispatch ref for tooling | PR #1077 (merged to `main`) | 4 |
+
+### In review (open PRs — not yet in effect)
+
+| Improvement | Where | Closes root cause |
+|---|---|---|
+| **One skill invocation, one human approval** as the declared goal — everything before the release→main PR is rehearsal; everything after is autonomous and parallel | `.claude/skills/publishing/SKILL.md` preamble, PR #1085 → `develop` | 2, 5 |
+| **Full-pipeline rehearsal before the single approval** — every manifest-declared channel, the tooling revision each workflow will actually check out; credentialed ops exempt | SKILL.md operating rule, PR #1085 | 1, 2 |
+| **Runtime-faithful rehearsal** — syntax validation is not runtime validation; artifacts that execute at install time get a real local `brew install` + test-block assertion from a throwaway tap | SKILL.md operating rule, PR #1085 | 3 |
+| **Batch, never trickle** — on any failure, rehearse the entire remaining pipeline, one fix round, one batched fix merge, verify the re-dispatch executes fixed tooling | SKILL.md + `.claude/agents/publisher.md`, PR #1085 | 2 |
+| **Parallel channel dispatch** — fan out every remaining channel the moment the GitHub Release verifies live; failures hold only their own channel | SKILL.md + publisher.md, PR #1085 | 5 |
+| **Dispatch-ref tooling checkouts in the binary-channel workflows** (homebrew/scoop/winget) + the defect-14 formula-template fix | PR #1083 → `main` (**pending approval** — until it merges and homebrew-publish.yml is re-dispatched, `main` still carries the broken template and the live `brew install` break persists) | 3, 4 |
+| Manifest `test_output` corrected against the real binary | `release/publish-artifacts.toml`, PR #1083 (pending) | 6 |
 
 ### Proposed — consumer side (atm-core)
 

--- a/docs/postmortems/v1.4.4-publish-postmortem.md
+++ b/docs/postmortems/v1.4.4-publish-postmortem.md
@@ -1,0 +1,140 @@
+# v1.4.4 Publish Post-Mortem — Every Failed Attempt, and How Future Releases Publish on the First Try
+
+- **Release**: atm-core v1.4.4 — the first kit-era release exercising the full
+  sc-publish channel surface (GitHub Release, crates.io ×13, TestPyPI,
+  production PyPI, Homebrew, winget, Scoop) on pin `25668ecc`.
+- **Outcome**: all seven channels live on 2026-08-28 — but it took **15
+  documented defects**, **7 merges to `main`**, and **8 failed CI publish
+  runs**, plus one post-"success" live break (`brew install` failed at
+  runtime for every user after the channel run went green).
+- **Author**: fenix (atm-dev), 2026-08-28.
+- **Canonical defect ledger**: `release/sc-publish-qualification-25668ecc.md`
+  on `release/v1.4.4` (rounds 1–4). This post-mortem analyzes; the receipt is
+  the evidence of record.
+
+---
+
+## 1. Timeline of failed attempts
+
+| # | Run / event | Workflow | Result | Defects surfaced | Fix merge to `main` |
+|---|------------|----------|--------|------------------|--------------------|
+| 1 | 33135181716 | release-candidate.yml (develop) | ❌ | broken pin 42e0fce: git-identity failure — no candidate tag could be cut | #1067 (re-pin, first v1.4.4 PR) |
+| 2 | 33150049684 | release-preflight.yml (main) | ❌ | 1–3: sc-lint version skew gate; missing crates.io liveness arm; evidence steps skipped on failure | (fixed on release branch, forwarded via #1071/#1072) |
+| 3 | 33154250124 | release-preflight.yml (release branch) | ❌ | 4–7: unsound liveness probe; preflight tests missing `just bootstrap`; publish-plan emitted unpublishable crates / ignored order; per-crate `cargo package` chicken-and-egg. **8** found only by local rehearsal (dev-dep `version =` on a never-published crate — would have hard-failed mid-publish) | #1072 (Release v1.4.4) |
+| 4 | 33198964299 | release.yml (main) | ❌ (after tag + 13/13 crates) | 9: kit composite installs Rust toolchain without declared components → rustfmt auto-add race breaks maturin builds intermittently | #1073 |
+| 5 | 33201363132 / 33202161368 | release.yml retries | ❌ | 10: `sync/verify-python-version` can't handle `dynamic = ["version"]` | #1074 |
+| 6 | 33211063257 | pypi-publish.yml (TestPyPI) | ❌ | 11: sdist PKG-INFO matcher rejects valid setuptools sdists. **12–13** found only by local rehearsal (universal-wheel count expectation; pypi-publish.yml checkout pinned to the immutable tag — a re-dispatch would have run the tag's frozen broken tooling and failed identically) | #1077 |
+| 7 | 33220372286 | homebrew-publish.yml | ✅ CI / ❌ **live** | 14: formula renders `("pkgshare").install` — String, not method → `brew install` fails at runtime for every user; `ruby -c` (the only gate) passes. **15** found only by runtime rehearsal (manifest `test_output` stale vs the released binary — `brew test` fails) | #1083 (pending) |
+
+Successes, for contrast: crates.io 13/13 on the first ordered attempt once
+release.yml ran; TestPyPI and production PyPI passed **first try after** the
+round-3 full-pipeline rehearsal; winget and scoop passed first try after the
+binary-channel rehearsal. Every channel that was fully rehearsed first
+published clean; every channel that wasn't, didn't.
+
+Cost: each fix cycle (find → fix → PR → approval → merge → re-dispatch) took
+roughly an hour. Seven cycles ≈ a working day of wall-clock on defects, most
+of it serialized.
+
+## 2. Root causes — why first attempts failed
+
+1. **First-execution risk concentrated in production.** v1.4.4 was the first
+   real execution of most kit publish paths on a crates-publishing consumer.
+   The kit's pytest suite passed (101/109) while 15 execution-path defects
+   waited in the workflows, composites, helper scripts, and templates. Unit
+   tests validated functions; nothing had ever executed the *pipelines*.
+2. **One-defect-per-cycle discovery.** Until round 3, CI was the discovery
+   mechanism: each dispatch found exactly one defect, each defect cost a full
+   merge cycle. The fix — rehearse every remaining step locally and batch all
+   defects into one merge — was adopted mid-release (Rand's ruling) and
+   immediately paid off: rounds 3–4 rehearsals caught defects 8, 12, 13, and
+   15 *before* any CI dispatch could fail on them.
+3. **Syntax gates masquerading as validation.** `ruby -c` passed a formula
+   that failed every user's `brew install` (defect 14). `validate-manifest`
+   passed a `test_output` the released binary never prints (defect 15). A
+   gate that cannot fail on the defect class it guards is decorative.
+4. **Tag-pinned tooling checkouts (the #76 class).** Four of five publish
+   workflows checked out `ref: <tag>` for their *tooling* — verify scripts,
+   manifest, templates. The tag is immutable, so any tooling defect is frozen
+   into the release permanently: fixes merged to `main` are invisible to a
+   re-dispatch. This turned recoverable defects into channel-bricking ones
+   (13 for PyPI, and homebrew's render step would have re-pushed the broken
+   template even after the #1083 fix).
+5. **Serial channel dispatch.** Homebrew/winget/scoop depend only on the live
+   GitHub Release, yet sat undispatched for hours while the PyPI chain ran —
+   pure wall-clock loss, plus the defect-14 discovery was delayed by the same
+   amount.
+6. **Stale manifest facts vs the released binary.** `test_output` was written
+   once and never re-verified against what the binary actually prints. No
+   preflight leg compares manifest assertions against real artifact behavior.
+
+## 3. Improvements
+
+### Already landed (this release)
+
+| Improvement | Where | Closes root cause |
+|---|---|---|
+| **One skill invocation, one human approval** as the declared goal — everything before the release→main PR is rehearsal; everything after is autonomous and parallel | `.claude/skills/publishing/SKILL.md` preamble (PR from `skill/publishing-rehearsal-parallel`) | 2, 5 |
+| **Full-pipeline rehearsal before the single approval** — every manifest-declared channel, real artifacts, the tooling revision each workflow will actually check out; credentialed ops exempt | SKILL.md operating rule | 1, 2 |
+| **Runtime-faithful rehearsal** — syntax validation is not runtime validation; artifacts that execute at install time get a real local `brew install` + test-block assertion from a throwaway tap | SKILL.md operating rule (round-4 lesson) | 3 |
+| **Batch, never trickle** — on any failure, rehearse the entire remaining pipeline, one fix round, one main merge, verify the re-dispatch executes fixed tooling | SKILL.md + `.claude/agents/publisher.md` | 2 |
+| **Parallel channel dispatch** — fan out every remaining channel the moment the GitHub Release verifies live; failures hold only their own channel | SKILL.md + publisher.md | 5 |
+| **Dispatch-ref tooling checkouts in all publish workflows** — immutable tag for artifacts (download URLs + API verification), dispatch ref for tooling/templates | pypi/homebrew/scoop/winget-publish.yml (#1077, #1083) | 4 |
+| Manifest `test_output` corrected against the real binary | `release/publish-artifacts.toml` (#1083) | 6 |
+
+### Proposed — consumer side (atm-core)
+
+1. **Preflight leg: manifest assertions vs real artifacts.** After binaries
+   build, execute `<bin> <test_command>` and assert `test_output` matches —
+   the same check the formula test block performs, run where it can still
+   fail cheaply. Prevents the defect-15 class for every channel that embeds
+   assertions.
+2. **Codify the rehearsal as a script, not a memory.** The round-3/4
+   rehearsals were assembled by hand (extract tag tooling, download assets,
+   render, install). A `release_artifacts.py rehearse --channel <name>`
+   subcommand (or `just rehearse-publish`) makes "full rehearsal ran clean"
+   a checkable preflight fact instead of an agent behavior. Candidate for
+   the next skill/kit iteration; keep scope small (wraps existing commands).
+3. **Publisher completion requires per-channel *consumer-visible* proof, not
+   CI green.** Round 4 proved a channel run can pass while users are broken.
+   The publisher's live verification (actually reading the tap/bucket,
+   attempting the install) caught defect 14 — make that the standard
+   channel-final criterion in the channel contracts: homebrew = `brew
+   install` succeeds from the real tap; scoop = manifest fetch + hash match;
+   pypi = install-verification matrix (already done); winget = PR opened
+   (external review outside our gate).
+
+### Proposed — kit side (sc-publish, filed upstream)
+
+| Issue | Class it closes |
+|---|---|
+| #76 | tag-pinned tooling checkouts (all publish workflows) |
+| #77 | formula template renders path-helper methods as strings |
+| #78 | homebrew channel has no runtime gate — add render → local-tap `brew install` + `brew test` before the tap push |
+| #65–#75 | rounds 1–3 defects (see receipt) |
+
+The structural kit ask beyond individual fixes: **exercise the publish
+workflows end-to-end in sc-publish's own CI against a synthetic release**
+(fake repo, real workflow files, throwaway registries/taps where possible)
+so a consumer's production release is never again the first execution of a
+publish path. Fold #65–#78 into the next qualified pin; atm-core `develop`
+re-converges byte-clean on that pin and the release-branch drift retires.
+
+### The first-attempt success test
+
+A future release publishes first-try when all of these hold before the single
+PR approval:
+
+1. Every remaining pipeline step of every manifest-declared channel rehearsed
+   locally against real (or release-candidate) artifacts, with the tooling
+   revision the workflow will actually check out — runtime-faithful, not
+   syntax-only.
+2. Manifest assertions verified against real binary behavior.
+3. No publish workflow reads tooling from an immutable ref.
+4. All independent channels dispatch in parallel on GitHub-Release-live.
+5. Any failure triggers a full remaining-pipeline rehearsal and exactly one
+   batched fix merge.
+
+v1.4.4 evidence this works: every channel published **after** its full
+rehearsal succeeded on the first attempt; every channel published **before**
+one failed.


### PR DESCRIPTION
Post-mortem of every failed v1.4.4 publish attempt, per Rand's request (2026-08-28): dedicated worktree off develop, all failed attempts analyzed, improvements to ensure high likelihood of first-attempt publish success.

Contents:
- Timeline: 8 failed CI runs + 1 post-success live break (homebrew runtime), 15 defects, 7 main merges
- Six root causes (first-execution risk, one-defect-per-cycle discovery, syntax-only gates, tag-pinned tooling checkouts, serial channel dispatch, stale manifest assertions)
- Improvements: landed (skill/publisher rules, dispatch-ref checkouts), proposed consumer-side (rehearsal script, assertion preflight, consumer-visible channel proof), proposed kit-side (sc-publish #65–#78 + synthetic-release CI)
- The first-attempt success test (5 conditions)

Companion PRs: #1083 (round-4 fixes → main, pending approval), skill hardening PR from skill/publishing-rehearsal-parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)