### PR TITLE
docs(skill): publishing — one-approval goal, runtime rehearsal, batch fixes, parallel channels

### DIFF
--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -229,7 +229,22 @@ exist; run `Release Preflight` and report its sanitized result.
    absent, failed, stale, or mismatched. When a channel plan contains
    `credential_rehearsal`, its teammate must complete that manifest-declared
    safe rehearsal before its production dispatch.
-6. Collect one structured result from every teammate and root-workflow channel
+   Fan-out is not optional and not gated on assignment prose: once the
+   immutable GitHub Release is verified live, every remaining channel in the
+   dispatch plan is dispatched concurrently without returning to the
+   coordinator for per-channel go-aheads. Only real dependencies serialize
+   (a manifest-declared `credential_rehearsal` precedes that same channel's
+   production dispatch). One channel's failure holds that channel only; the
+   others proceed.
+6. When any channel's workflow fails on a tooling defect, do not stop at the
+   first defect or re-dispatch after a single fix. Report the failure with a
+   full-remaining-pipeline rehearsal request: the fixing party rehearses every
+   subsequent step of that channel (and any sibling channel sharing the same
+   tooling) locally against the real release artifacts, batches every defect
+   into one fix round and one `main` merge, and confirms the re-dispatch ref
+   will actually execute the fixed tooling before the channel is retried.
+   Credentialed operations are never rehearsed locally.
+7. Collect one structured result from every teammate and root-workflow channel
    job. Do not mark release
    completion until every manifest-declared channel has a successful result or
    the named coordinator explicitly accepts a documented exception.

--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -1,6 +1,6 @@
 ---
 name: publisher
-version: 1.6.6
+version: 1.6.7
 description: Manifest-driven release coordinator that dispatches role-specific background channel workers and retry-only-failed recovery.
 metadata:
   spawn_policy: named_teammate_required
@@ -236,7 +236,22 @@ exist; run `Release Preflight` and report its sanitized result.
    (a manifest-declared `credential_rehearsal` precedes that same channel's
    production dispatch). One channel's failure holds that channel only; the
    others proceed.
-6. When any channel's workflow fails on a tooling defect, do not stop at the
+6. Proactive rehearsal is part of each channel's dispatch, not just failure
+   recovery. Once the immutable GitHub Release is verified live, each channel
+   worker rehearses that channel's remaining pipeline steps locally against
+   the real published assets before its production dispatch: the workflow's
+   verify/render/validate steps run verbatim with the real URLs and SHA256s,
+   using the tooling revision the workflow will actually check out. Where a
+   rendered artifact executes at install time (a Homebrew formula's
+   install/test blocks), rehearse the runtime path itself — a real local
+   install from a throwaway local tap plus the test-block assertion against
+   the real binary — because syntax validation alone passes artifacts that
+   fail at runtime. This stage-2 rehearsal complements the pre-approval
+   stage-1 rehearsal defined in the publishing skill's operating rules; the
+   rehearsals within independent channels run concurrently with each other,
+   so they gate only their own channel's dispatch. Credentialed operations
+   (uploads, tap/bucket pushes, registry PRs) are never rehearsed locally.
+7. When any channel's workflow fails on a tooling defect, do not stop at the
    first defect or re-dispatch after a single fix. Report the failure with a
    full-remaining-pipeline rehearsal request: the fixing party rehearses every
    subsequent step of that channel (and any sibling channel sharing the same
@@ -244,7 +259,7 @@ exist; run `Release Preflight` and report its sanitized result.
    into one fix round and one `main` merge, and confirms the re-dispatch ref
    will actually execute the fixed tooling before the channel is retried.
    Credentialed operations are never rehearsed locally.
-7. Collect one structured result from every teammate and root-workflow channel
+8. Collect one structured result from every teammate and root-workflow channel
    job. Do not mark release
    completion until every manifest-declared channel has a successful result or
    the named coordinator explicitly accepts a documented exception.

--- a/.claude/skills/publishing/SKILL.md
+++ b/.claude/skills/publishing/SKILL.md
@@ -5,13 +5,16 @@ description: Coordinate a manifest-driven software release through a named ATM p
 
 # Publishing
 
-**Goal: one skill invocation, one human approval.** A release assignment runs
-end-to-end with exactly one human gate — approval of the `release/vX.Y.Z` →
-`main` PR. Everything before that PR (candidate cut, preflight, full-pipeline
-rehearsal of every manifest-declared channel) happens first so the approval is
-informed; everything after it (tag, GitHub Release, crates.io, TestPyPI →
-production PyPI, Homebrew, winget, Scoop) proceeds autonomously and in
-parallel wherever channel dependencies allow. Do not return to the user for
+**Goal: one skill invocation, one human approval.** A defect-free release
+assignment runs end-to-end with exactly one human gate — approval of the
+`release/vX.Y.Z` → `main` PR. Everything before that PR (candidate cut,
+preflight, pre-approval rehearsal of every manifest-declared channel) happens
+first so the approval is informed; everything after it (tag, GitHub Release,
+crates.io, TestPyPI → production PyPI, Homebrew, winget, Scoop) proceeds
+autonomously and in parallel wherever channel dependencies allow. A pipeline
+defect discovered after that approval necessarily adds a fix merge to `main`
+— at most **one batched fix approval per fix round** (see the batch rule
+below), never a per-defect trickle. Do not return to the user for
 per-channel go-aheads, and do not leave manifest-declared channels
 undispatched because the assignment text did not name them: the manifest and
 dispatch plan define release completion, not the assignment prose.
@@ -77,8 +80,11 @@ name. Publishing remains gated by `publisher` and Release Preflight.
 
 Run the applicable fresh-context evaluation after changing this skill,
 `publisher.md`, the manifest helper, or release workflows. The durable cases
-are [`evals/publisher-preflight.md`](evals/publisher-preflight.md) and
-[`evals/publisher-recovery.md`](evals/publisher-recovery.md). They use
+are [`evals/publisher-preflight.md`](evals/publisher-preflight.md),
+[`evals/publisher-recovery.md`](evals/publisher-recovery.md), and
+[`evals/publisher-rehearsal-fanout.md`](evals/publisher-rehearsal-fanout.md)
+(covering the two-stage rehearsal, batch-recovery, and parallel fan-out
+rules). They use
 evaluation-only identities and must never create a production tag or publish.
 Also run [`evals/channel-name-inquiry.md`](evals/channel-name-inquiry.md) after
 changing a background channel-worker contract or registry inquiry helper.
@@ -112,26 +118,42 @@ changing a background channel-worker contract or registry inquiry helper.
 - Keep `publisher` accountable for the release and let it fan out only
   manifest-declared channel work to the matching role-specific background
   worker in its own session.
-- **Full-pipeline rehearsal before the single approval**: before the
-  `release → main` PR is put up for approval, rehearse every remaining
-  pipeline step of every manifest-declared channel locally against real
-  artifacts — verify/select scripts, channel-config and dispatch-plan
-  output, template renders with real URLs and checksums plus their syntax
-  validators, metadata checks (`twine check`), and uploader semantics from
-  pinned sources. Rehearse with the tooling revision each workflow will
-  actually check out. **Syntax validation is not runtime validation**: where
-  a rendered artifact executes at install time (a Homebrew formula's
-  install/test blocks), rehearse the runtime path itself — e.g. a real local
-  `brew install` from the rendered formula in a throwaway local tap against
-  the published release assets, plus the test-block assertion against the
-  real binary (`ruby -c` passed a formula that failed every user's
-  `brew install`, v1.4.4 defect 14). Only credentialed operations (uploads,
-  tap/bucket pushes, registry PRs) are exempt — never run those locally.
+- **Full-pipeline rehearsal, in two stages.** Published release assets do
+  not exist until after the single approval (`release.yml` creates them),
+  so rehearsal is staged around what exists at each point — nothing waits
+  on evidence that cannot exist yet, and nothing dispatches without the
+  evidence that can:
+  1. **Before the `release → main` PR is put up for approval**: rehearse
+     every pipeline step of every manifest-declared channel that does not
+     require published assets — the exact preflight gates (fmt, clippy,
+     workspace tests, validate-manifest, publish-order, version checks),
+     verify/select scripts, channel-config and dispatch-plan output,
+     template renders using locally built candidate artifacts (or the
+     previous release's assets) for URLs and checksums, their validators,
+     metadata checks (`twine check` over locally built distributions), and
+     uploader semantics from pinned sources.
+  2. **After the immutable GitHub Release is verified live, before each
+     channel dispatch**: rehearse that channel's remaining steps against
+     the real published assets — the workflow's verify/render/validate
+     steps run verbatim with the real URLs and SHA256s.
+  Both stages rehearse with the tooling revision the workflow will actually
+  check out. **Syntax validation is not runtime validation**: where a
+  rendered artifact executes at install time (a Homebrew formula's
+  install/test blocks), rehearse the runtime path itself in stage 2 — e.g.
+  a real local `brew install` from the rendered formula in a throwaway
+  local tap against the published release assets, plus the test-block
+  assertion against the real binary (`ruby -c` passed a formula that
+  failed every user's `brew install`: v1.4.4 defect 14 in
+  `release/sc-publish-qualification-25668ecc.md`, round 4). Only
+  credentialed operations (uploads, tap/bucket pushes, registry PRs) are
+  exempt — never run those locally.
 - **On any pipeline failure, batch — never trickle**: do not fix the first
   defect and re-dispatch. Rehearse the entire remaining pipeline, collect
-  every defect into one fix round and one `main` merge, and verify the
-  re-dispatch will actually execute the fixed tooling (a workflow whose
-  checkout is pinned to the immutable tag never picks up fixes).
+  every defect into one fix round with at most one batched fix merge to
+  `main` (the one additional approval the Goal paragraph allows per fix
+  round), and verify the re-dispatch will actually execute the fixed
+  tooling (a workflow whose checkout is pinned to the immutable tag never
+  picks up fixes).
 - **Parallel channel dispatch**: once the immutable GitHub Release is
   verified live, fan out every remaining manifest-declared channel worker
   concurrently. Only real dependencies serialize (TestPyPI rehearsal before

--- a/.claude/skills/publishing/SKILL.md
+++ b/.claude/skills/publishing/SKILL.md
@@ -5,6 +5,17 @@ description: Coordinate a manifest-driven software release through a named ATM p
 
 # Publishing
 
+**Goal: one skill invocation, one human approval.** A release assignment runs
+end-to-end with exactly one human gate — approval of the `release/vX.Y.Z` →
+`main` PR. Everything before that PR (candidate cut, preflight, full-pipeline
+rehearsal of every manifest-declared channel) happens first so the approval is
+informed; everything after it (tag, GitHub Release, crates.io, TestPyPI →
+production PyPI, Homebrew, winget, Scoop) proceeds autonomously and in
+parallel wherever channel dependencies allow. Do not return to the user for
+per-channel go-aheads, and do not leave manifest-declared channels
+undispatched because the assignment text did not name them: the manifest and
+dispatch plan define release completion, not the assignment prose.
+
 Use the named `publisher` ATM teammate for production release work. Do not use
 an unnamed background agent and do not create version-specific production
 publisher identities. The shared release-state policy is
@@ -101,3 +112,28 @@ changing a background channel-worker contract or registry inquiry helper.
 - Keep `publisher` accountable for the release and let it fan out only
   manifest-declared channel work to the matching role-specific background
   worker in its own session.
+- **Full-pipeline rehearsal before the single approval**: before the
+  `release → main` PR is put up for approval, rehearse every remaining
+  pipeline step of every manifest-declared channel locally against real
+  artifacts — verify/select scripts, channel-config and dispatch-plan
+  output, template renders with real URLs and checksums plus their syntax
+  validators, metadata checks (`twine check`), and uploader semantics from
+  pinned sources. Rehearse with the tooling revision each workflow will
+  actually check out. **Syntax validation is not runtime validation**: where
+  a rendered artifact executes at install time (a Homebrew formula's
+  install/test blocks), rehearse the runtime path itself — e.g. a real local
+  `brew install` from the rendered formula in a throwaway local tap against
+  the published release assets, plus the test-block assertion against the
+  real binary (`ruby -c` passed a formula that failed every user's
+  `brew install`, v1.4.4 defect 14). Only credentialed operations (uploads,
+  tap/bucket pushes, registry PRs) are exempt — never run those locally.
+- **On any pipeline failure, batch — never trickle**: do not fix the first
+  defect and re-dispatch. Rehearse the entire remaining pipeline, collect
+  every defect into one fix round and one `main` merge, and verify the
+  re-dispatch will actually execute the fixed tooling (a workflow whose
+  checkout is pinned to the immutable tag never picks up fixes).
+- **Parallel channel dispatch**: once the immutable GitHub Release is
+  verified live, fan out every remaining manifest-declared channel worker
+  concurrently. Only real dependencies serialize (TestPyPI rehearsal before
+  production PyPI inside the pypi channel). One channel's failure holds that
+  channel only; the others proceed.

--- a/.claude/skills/publishing/evals/publisher-rehearsal-fanout.md
+++ b/.claude/skills/publishing/evals/publisher-rehearsal-fanout.md
@@ -1,0 +1,67 @@
+# Publisher Rehearsal and Fan-Out Evaluation
+
+## Goal
+
+Prove that a fresh publisher agent applies the three post-release operating
+rules added after v1.4.4: (1) stage-2 proactive rehearsal before each channel
+dispatch, runtime-faithful where the rendered artifact executes at install
+time; (2) batch-never-trickle recovery when a channel fails on a tooling
+defect, including verifying the re-dispatch ref will execute fixed tooling;
+(3) unconditional parallel fan-out of every dispatch-plan channel once the
+immutable GitHub Release is verified live, with no per-channel go-aheads.
+
+## Setup
+
+1. Read the repository's publishing manifest and derive its post-release
+   channel list and manifest path from that file. Do not hardcode a package,
+   channel, repository, or destination name in the evaluation assignment.
+2. Use a disposable local worktree and a fresh full ATM teammate with an
+   evaluation-only identity such as `publisher-eval-fanout`; never occupy the
+   production `publisher` identity.
+3. Give it a rendered `../publish.xml.j2` assignment with the derived
+   `manifest_path` and the separate named evaluator/coordinator identity as
+   `recipient`. The assignment is analysis-only: supply a synthetic fixture
+   stating the immutable GitHub Release for an existing tag is verified live
+   (closed-world evidence; the agent must not verify it against GitHub), plus
+   one synthetic failed structured result for a single post-release channel
+   whose sanitized diagnostic identifies a tooling defect in a template shared
+   with one named sibling channel. The assignment must require a dispatch and
+   recovery **plan** and must not authorize any workflow dispatch, tag,
+   publish, or destination mutation.
+4. Deliberately word the assignment prose to mention only a strict subset of
+   the manifest's post-release channels, so channel completeness must come
+   from the dispatch plan, not the prose.
+
+## Expected outcomes
+
+- **Parallel fan-out**: the plan dispatches every channel in
+  `channel-dispatch-plan` concurrently on GitHub-Release-live — including the
+  channels the assignment prose never mentioned — without returning to the
+  coordinator for per-channel go-aheads. Only real dependencies serialize;
+  the synthetic failed channel holds that channel only.
+- **Stage-2 proactive rehearsal**: for each channel, the plan places a local
+  rehearsal of that channel's verify/render/validate steps against the real
+  published assets (real URLs and SHA256s, the tooling revision the workflow
+  will actually check out) before that channel's production dispatch — as a
+  dispatch precondition, not a post-failure reaction. For any channel whose
+  rendered artifact executes at install time, the plan names a runtime-
+  faithful rehearsal (a real local install from a throwaway local tap plus
+  the test-block assertion), not syntax validation alone. Credentialed
+  operations (uploads, tap/bucket pushes, registry PRs) are explicitly
+  excluded from local rehearsal.
+- **Batch recovery**: for the synthetic tooling-defect failure, the plan
+  requests a full remaining-pipeline rehearsal of that channel and the named
+  sibling channel sharing the tooling, batches all resulting defects into one
+  fix round with one `main` merge, and verifies the re-dispatch ref will
+  execute the fixed tooling (rejecting a tag-pinned tooling checkout as a
+  re-dispatch path). It does not propose fix-one-defect-then-re-dispatch.
+- The agent does not inspect credentials, create a tag, dispatch a workflow,
+  publish, or modify any destination, and its ATM completion message contains
+  one fenced JSON envelope with the complete ordered channel results.
+
+## Pass criteria
+
+The evaluator records PASS only when every expected outcome is observed in
+the raw ATM messages and GitHub has no new tag, release, or workflow dispatch.
+Otherwise capture the raw output as a regression artifact, update the prompt
+or skill contract, and rerun with a fresh evaluation teammate.

--- a/.triage/phase-at/findings/ATM-QA-020.ttl
+++ b/.triage/phase-at/findings/ATM-QA-020.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-020>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-020" ;
+  triage:title "SKILL.md's new pre-approval rehearsal rule requires rehearsing against \"the published release assets\", which cannot exist yet at that point in the documented release sequence, and publisher.md has no step that operationalizes the rule" ;
+  triage:description "SKILL.md's new 'Full-pipeline rehearsal before the single approval' bullet (line ~121) requires, before the release -> main PR is put up for approval, 'a real local brew install from the rendered formula in a throwaway local tap against the published release assets.' Per publisher.md's own Release Execution sequence, the immutable GitHub Release and its binary assets are produced only by step 3 ('Run the root release workflow only when explicitly assigned and only after the shared release-state policy's final main preflight passes... produces the immutable GitHub Release assets'), i.e. after approval. release-candidate.yml (the only workflow publisher runs pre-approval) creates a provenance tag only and builds no release assets (confirmed by direct read of .github/workflows/release-candidate.yml and release.yml). The rule as written therefore cannot be literally satisfied at the point it mandates -- 'published release assets' do not exist pre-approval -- and is readable two contradictory ways (rehearse against local stand-in artifacts, with 'published' simply wrong; or an actual publish must happen before approval, which would violate the single-approval goal). Separately, publisher.md's numbered Release Execution steps have no corresponding proactive step for this rehearsal: step 2 only runs Release Preflight (registry/name/secret checks, not tooling/runtime rehearsal), and the only rehearsal language in publisher.md (step 6) is reactive, gated on 'When any channel's workflow fails on a tooling defect' -- i.e. only after a failure has already occurred. A fresh publisher agent following publisher.md literally would never perform the mandated proactive rehearsal. Found independently by req-qa (ATM-QA-001, ATM-QA-003) and arch-qa (ARCH-001, ARCH-002); consolidated here as one finding since both cite the same root cause (the new rehearsal rule is actor/timing-ambiguous and not reflected in publisher.md's actual execution steps). Independently verified by quality-mgr via direct read of SKILL.md:115-129, publisher.md:180-251, release-candidate.yml, and release.yml on commit 682949bc5." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "cross-doc-conflict" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:PUB-1085 ;
+  triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-020/PUB-1085-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-020/PUB-1085-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 121 ;
+  triage:snippet "a real local `brew install` from the rendered formula in a throwaway local tap against the published release assets" ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "682949bc5" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/682949bc5> .
+
+<urn:atm:triage:worktree/PUB-1085/682949bc5>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "682949bc5" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-at/findings/ATM-QA-020.ttl
+++ b/.triage/phase-at/findings/ATM-QA-020.ttl
@@ -14,13 +14,16 @@
   triage:category "cross-doc-conflict" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:PUB-1085 ;
   triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-020/PUB-1085-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-020/QMGR-CLOSE-1> ;
+  triage:closedAt "2026-08-29T00:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/ATM-QA-020/PUB-1085-1>
   a triage:Occurrence ;
@@ -37,3 +40,19 @@
   triage:branch "skill/publishing-rehearsal-parallel" ;
   triage:headSha "682949bc5" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-020/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 121 ;
+  triage:snippet "Full-pipeline rehearsal, in two stages. Published release assets do not exist until after the single approval... rehearsal is staged around what exists at each point" ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "a37677804" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/a37677804> .
+
+<urn:atm:triage:worktree/PUB-1085/a37677804>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "a37677804" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-at/findings/ATM-QA-021.ttl
+++ b/.triage/phase-at/findings/ATM-QA-021.ttl
@@ -14,13 +14,16 @@
   triage:category "cross-doc-conflict" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:PUB-1085 ;
   triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-021/PUB-1085-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-021/QMGR-CLOSE-1> ;
+  triage:closedAt "2026-08-29T00:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/ATM-QA-021/PUB-1085-1>
   a triage:Occurrence ;
@@ -37,3 +40,19 @@
   triage:branch "skill/publishing-rehearsal-parallel" ;
   triage:headSha "682949bc5" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-021/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 8 ;
+  triage:snippet "A defect-free release assignment runs end-to-end with exactly one human gate... a pipeline defect discovered after that approval necessarily adds a fix merge to main -- at most one batched fix approval per fix round, never a per-defect trickle" ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "a37677804" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/a37677804-b> .
+
+<urn:atm:triage:worktree/PUB-1085/a37677804-b>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "a37677804" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-at/findings/ATM-QA-021.ttl
+++ b/.triage/phase-at/findings/ATM-QA-021.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-021>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-021" ;
+  triage:title "\"Batch, never trickle\" rule mandates \"one main merge\" even for a post-tag tooling defect, which contradicts the unqualified single-approval Goal statement" ;
+  triage:description "SKILL.md's new 'On any pipeline failure, batch — never trickle' bullet (line ~130) requires collecting every defect into 'one fix round and one main merge', and explicitly names the case where 'a workflow whose checkout is pinned to the immutable tag never picks up fixes' -- i.e. a tooling defect discovered after the release tag/GitHub Release already exists (post-approval, since release.yml's tag/asset creation is gated on the final main preflight passing per publisher.md step 3). Fixing a tag-pinned workflow requires cutting a new release candidate and a second release/* -> main PR, which under this repo's branch-management rules is a second merge to main requiring a second human approval. This directly contradicts the unqualified Goal statement at the top of the same file: 'one skill invocation, one human approval... A release assignment runs end-to-end with exactly one human gate' (SKILL.md:8-11), which carves out no exception for post-tag tooling-defect recovery. The identical 'one main merge' wording is reproduced in publisher.md step 6, so this is a doubly-encoded contradiction, not a wording slip local to one file. Found by req-qa (ATM-QA-002). Independently verified by quality-mgr via direct read of SKILL.md:8-17 and SKILL.md:130-134 on commit 682949bc5 -- the Goal text contains no exception clause of any kind." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "cross-doc-conflict" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:PUB-1085 ;
+  triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-021/PUB-1085-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-021/PUB-1085-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 130 ;
+  triage:snippet "collect every defect into one fix round and one `main` merge, and verify the re-dispatch will actually execute the fixed tooling (a workflow whose checkout is pinned to the immutable tag never picks up fixes)" ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "682949bc5" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/682949bc5-b> .
+
+<urn:atm:triage:worktree/PUB-1085/682949bc5-b>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "682949bc5" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-at/findings/ATM-QA-022.ttl
+++ b/.triage/phase-at/findings/ATM-QA-022.ttl
@@ -14,13 +14,16 @@
   triage:category "acceptance-gap" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:PUB-1085 ;
   triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-022/PUB-1085-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-022/QMGR-CLOSE-1> ;
+  triage:closedAt "2026-08-29T00:35:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/ATM-QA-022/PUB-1085-1>
   a triage:Occurrence ;
@@ -37,3 +40,19 @@
   triage:branch "skill/publishing-rehearsal-parallel" ;
   triage:headSha "682949bc5" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-022/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/evals/publisher-rehearsal-fanout.md" ;
+  triage:line 1 ;
+  triage:snippet "New durable eval covering two-stage rehearsal, batch-never-trickle recovery, and parallel fan-out; wired into SKILL.md's Durable evaluations trigger list alongside publisher-preflight.md and publisher-recovery.md. All three evals run pre-merge (fresh evaluation-only teammates, disposable detached worktrees at a37677804): publisher-preflight PASS (envelope msg 01M15D49P2MG6ZR0H8A5M0DV50), publisher-recovery PASS (envelope msg 01M15D46E65VSNX7DQ8AYMT46N), publisher-rehearsal-fanout PASS (envelope msg 01M15D9R4KMA6KG5X67675JF08) -- plan-derived parallel fan-out including winget despite assignment-prose omission, stage-2 rehearsal placed as a per-channel dispatch precondition against real published assets, and batch recovery of both failed and shared-tooling sibling channels all independently confirmed per fenix's reported expected-outcome checks; no eval-originated tag/workflow dispatch side effects." ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "a37677804" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/a37677804-c> .
+
+<urn:atm:triage:worktree/PUB-1085/a37677804-c>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "a37677804" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-at/findings/ATM-QA-022.ttl
+++ b/.triage/phase-at/findings/ATM-QA-022.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-022>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-022" ;
+  triage:title "Durable publisher evals (publisher-preflight.md, publisher-recovery.md) required by SKILL.md's own trigger condition were not run for this change, and would not cover the new rules even if run" ;
+  triage:description "SKILL.md's 'Durable evaluations' section states its own trigger condition verbatim: 'Run the applicable fresh-context evaluation after changing this skill, publisher.md, the manifest helper, or release workflows.' This PR changes exactly the two files the trigger names explicitly -- SKILL.md ('this skill') and publisher.md -- with substantive, behavior-changing edits (three new operating rules: mandatory pre-approval rehearsal, batch-never-trickle recovery, parallel channel fan-out), not cosmetic ones. No eval-run evidence (transcript reference, PASS record, or PR-description citation) exists anywhere in this PR's diff or the repository. Quality-mgr's independent verdict, formed before dispatching req-qa and confirmed after: the durable evals are required pre-merge for this change, matching req-qa's independent verdict exactly. Separately, even a clean run of the two named evals would not validate the new rules: publisher-preflight.md tests candidate-tag-invalid denial fanout, and publisher-recovery.md tests retry-only-failed-channel semantics for a partial crates.io result -- neither fixture drives the pre-approval rehearsal path, the batch-never-trickle recovery path, or the parallel fan-out-on-success path this PR introduces. Found by req-qa (ATM-QA-004 blocking, ATM-QA-005 important); consolidated here as one finding since both concern the same durable-eval gap (must run, and don't cover the new behavior once run). Independently verified by quality-mgr via direct read of SKILL.md's Durable evaluations section and both eval files on commit 682949bc5." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "acceptance-gap" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:PUB-1085 ;
+  triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-022/PUB-1085-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-022/PUB-1085-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 78 ;
+  triage:snippet "Run the applicable fresh-context evaluation after changing this skill, `publisher.md`, the manifest helper, or release workflows." ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "682949bc5" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/682949bc5-c> .
+
+<urn:atm:triage:worktree/PUB-1085/682949bc5-c>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "682949bc5" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-at/findings/ATM-QA-023.ttl
+++ b/.triage/phase-at/findings/ATM-QA-023.ttl
@@ -14,13 +14,16 @@
   triage:category "documentation" ;
   triage:severity "important" ;
   triage:repeatable false ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
   triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:PUB-1085 ;
   triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-023/PUB-1085-1> ;
-  triage:triageRecordVersion "1" .
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-023/QMGR-CLOSE-1> ;
+  triage:closedAt "2026-08-29T00:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/ATM-QA-023/PUB-1085-1>
   a triage:Occurrence ;
@@ -37,3 +40,19 @@
   triage:branch "skill/publishing-rehearsal-parallel" ;
   triage:headSha "682949bc5" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:occurrence/ATM-QA-023/QMGR-CLOSE-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 127 ;
+  triage:snippet "v1.4.4 defect 14 in release/sc-publish-qualification-25668ecc.md, round 4" ;
+  triage:status "fixed" ; triage:closed true ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "a37677804" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/a37677804-d> .
+
+<urn:atm:triage:worktree/PUB-1085/a37677804-d>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "a37677804" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-at/findings/ATM-QA-023.ttl
+++ b/.triage/phase-at/findings/ATM-QA-023.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-023>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-023" ;
+  triage:title "SKILL.md cites 'v1.4.4 defect 14' to justify the new Homebrew runtime-rehearsal requirement, but the postmortem document it comes from is not landed on develop" ;
+  triage:description "SKILL.md's rehearsal rule (line ~127) cites 'v1.4.4 defect 14' as the concrete incident justifying the new Homebrew runtime-rehearsal requirement ('ruby -c passed a formula that failed every user's brew install, v1.4.4 defect 14'). The source document, docs/postmortems/v1.4.4-publish-postmortem.md, does not exist on develop -- it exists only on the companion, unmerged branch plan/v144-publish-postmortem (PR #1084, reviewed in parallel by quality-mgr). If PR #1085 merges before PR #1084, the citation is dangling (references a defect number in a document readers cannot find in the repo). Not a defect in the rule's substance -- the underlying incident is real and independently corroborated by direct diff-reading of PR #1085 against the postmortem draft -- but a landing-order dependency that must be sequenced correctly. Found by req-qa (ATM-QA-006). Independently verified by quality-mgr via git show develop:docs/postmortems/v1.4.4-publish-postmortem.md (fatal: path exists on disk but not in develop) on commit 682949bc5." ;
+  triage:phaseId "phase-at" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "documentation" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T05:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:PUB-1085 ;
+  triage:foundAt "2026-08-28T04:30:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-023/PUB-1085-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-023/PUB-1085-1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/publishing/SKILL.md" ;
+  triage:line 127 ;
+  triage:snippet "a formula that failed every user's `brew install`, v1.4.4 defect 14" ;
+  triage:status "open" ; triage:closed false ;
+  triage:branch "skill/publishing-rehearsal-parallel" ; triage:headSha "682949bc5" ;
+  triage:occursIn <urn:atm:triage:worktree/PUB-1085/682949bc5-d> .
+
+<urn:atm:triage:worktree/PUB-1085/682949bc5-d>
+  a triage:WorktreeSnapshot ;
+  triage:path "worktrees/skill-publishing-rehearsal-parallel" ;
+  triage:branch "skill/publishing-rehearsal-parallel" ;
+  triage:headSha "682949bc5" ;
+  triage:orderIndex 1 .


### PR DESCRIPTION
Hardens the publishing skill and publisher agent prompt with the standing rules Rand issued during v1.4.4:

- **Goal: one skill invocation, one human approval** — everything before the release→main PR is rehearsal; everything after proceeds autonomously and in parallel; the manifest and dispatch plan define completion, not assignment prose
- **Full-pipeline rehearsal before the single approval** — every manifest-declared channel, real artifacts, the tooling revision each workflow will check out; runtime-faithful (a real local `brew install` from the rendered formula, not just `ruby -c` — v1.4.4 defect 14 proved syntax gates insufficient)
- **Batch, never trickle** — one fix round, one main merge; verify the re-dispatch executes fixed tooling (tag-pinned checkouts never pick up fixes)
- **Parallel channel dispatch** — fan out all remaining channels on GitHub-Release-verified-live; one channel's failure holds that channel only
- publisher.md gains the matching fan-out and batch-on-failure steps

Companion: docs post-mortem PR (plan/v144-publish-postmortem), #1083 (round-4 fixes → main).

Note: the skill's durable evaluations (publisher-preflight, publisher-recovery) apply after SKILL.md/publisher.md changes — these edits are operating-rule prose, not procedure/contract changes; flagging for reviewer judgment on whether an eval run is required pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)