### PR TITLE
fix(test): remove env leakage and wall-clock bounds flagged by phase-end flaky-test audit (FTQ-001..003)

### DIFF
--- a/.triage/phase-aq/findings/FTQ-001.ttl
+++ b/.triage/phase-aq/findings/FTQ-001.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/FTQ-001>
+  a triage:Finding ;
+  triage:findingId "FTQ-001" ;
+  triage:title "Transfer-script tests mutate the real process environment via a shared EnvGuard" ;
+  triage:description "Phase AQ phase-end review (ATM-QA-002) found crates/atm/src/commands/send_to.rs's transfer-script tests used atm_core::test_support::EnvGuard::set_many, which mutates the real, process-global environment under an opt-in RwLock that other std::env::var readers elsewhere in the atm crate do not participate in. Under cargo test's parallel harness this risks cross-test interference and flakiness. Fixed by threading an &dyn EnvSource seam through invoke_transfer_script/resolve_and_invoke_transfer_script and injecting a deterministic atm_core::test_support::FakeEnvSource in tests instead, leaving the real environment untouched; the production call site (land_attachments) still passes &ProcessEnvSource." ;
+  triage:phaseId "phase-aq" ;
+  triage:triageMode "phase_end" ;
+  triage:category "flaky-test" ;
+  triage:severity "minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AQ ;
+  triage:foundAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/occ-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/FTQ-001/occ-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm/src/commands/send_to.rs" ;
+  triage:line 399 ;
+  triage:snippet "let _env = atm_core::test_support::EnvGuard::set_many([" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "a8eac8c48" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-flaky/a8eac8c48> .
+
+<urn:atm:triage:worktree/fix-aq-phase-review-flaky/a8eac8c48>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/aq-phase-review-flaky" ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "a8eac8c48" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-aq/findings/FTQ-002.ttl
+++ b/.triage/phase-aq/findings/FTQ-002.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/FTQ-002>
+  a triage:Finding ;
+  triage:findingId "FTQ-002" ;
+  triage:title "ac6 sustained-load test asserts refresh count within a fixed busy-loop window" ;
+  triage:description "Phase AQ phase-end review (ATM-QA-002) found ac6_sustained_connection_load_never_starves_the_lease_refresh_cadence in crates/atm-graft/src/runtime/mod.rs drove a fixed 4s busy loop and then asserted a minimum refresh count observed within that fixed window -- a source of flakiness under CI scheduling contention, where a slower host can starve the refresh cadence without the production guarantee actually being violated. Fixed by replacing the fixed-window assertion with a bounded poll that drives sustained load until the registry observes >= 2 refreshes, backed by a generous 15s hang-detector deadline, matching the wait_until pattern already used by ac2/ac3/ac5/ac7 in this module." ;
+  triage:phaseId "phase-aq" ;
+  triage:triageMode "phase_end" ;
+  triage:category "flaky-test" ;
+  triage:severity "minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AQ ;
+  triage:foundAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-002/occ-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/FTQ-002/occ-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-graft/src/runtime/mod.rs" ;
+  triage:line 1867 ;
+  triage:snippet "fn ac6_sustained_connection_load_never_starves_the_lease_refresh_cadence() {" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "4db81074d" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-flaky/4db81074d> .
+
+<urn:atm:triage:worktree/fix-aq-phase-review-flaky/4db81074d>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/aq-phase-review-flaky" ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "4db81074d" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-aq/findings/FTQ-003.ttl
+++ b/.triage/phase-aq/findings/FTQ-003.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/FTQ-003>
+  a triage:Finding ;
+  triage:findingId "FTQ-003" ;
+  triage:title "herdr deadline test asserts a tight wall-clock upper bound" ;
+  triage:description "Phase AQ phase-end review (ATM-QA-002) found two_second_caller_deadline_preempts_the_five_second_process_cap in crates/atm-herdr/src/lib.rs asserted a tight 5s elapsed-time upper bound after spawning a real, 30s-sleeping child process -- a source of CI flakiness under kill+reap scheduling contention. Fixed by widening the bound to a generous 15s hang-detector-only margin; the semantic assertion, matches!(result, Err(HerdrError::TimedOut)), is unchanged and remains the real pass/fail condition. ATM-QA-001 separately required this test regain deterministic proof that the 2s caller deadline (not the 5s HERDR_PROCESS_CAP) governs, which is now covered by the effective_process_timeout_* unit tests added alongside this fix." ;
+  triage:phaseId "phase-aq" ;
+  triage:triageMode "phase_end" ;
+  triage:category "flaky-test" ;
+  triage:severity "minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AQ ;
+  triage:foundAt "2026-08-28T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-003/occ-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/FTQ-003/occ-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-herdr/src/lib.rs" ;
+  triage:line 1183 ;
+  triage:snippet "async fn two_second_caller_deadline_preempts_the_five_second_process_cap() {" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "a9cb5aec7" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-aq-phase-review-flaky/a9cb5aec7> .
+
+<urn:atm:triage:worktree/fix-aq-phase-review-flaky/a9cb5aec7>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/aq-phase-review-flaky" ;
+  triage:branch "fix/aq-phase-review-flaky" ;
+  triage:headSha "a9cb5aec7" ;
+  triage:orderIndex 1 .

--- a/crates/atm-core/src/atm_temp.rs
+++ b/crates/atm-core/src/atm_temp.rs
@@ -418,30 +418,9 @@ fn default_scratch_root() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::FakeEnvSource;
     #[cfg(unix)]
     use crate::test_support::capture_tracing;
-    use std::collections::HashMap;
-
-    #[derive(Default)]
-    struct FakeEnvSource(HashMap<String, String>);
-
-    impl FakeEnvSource {
-        fn unset() -> Self {
-            Self::default()
-        }
-
-        fn with(key: &str, value: impl Into<String>) -> Self {
-            let mut map = HashMap::new();
-            map.insert(key.to_string(), value.into());
-            Self(map)
-        }
-    }
-
-    impl EnvSource for FakeEnvSource {
-        fn var(&self, key: &str) -> Option<String> {
-            self.0.get(key).cloned()
-        }
-    }
 
     #[test]
     fn unix_default_scratch_root_has_uid_suffix() {
@@ -457,16 +436,16 @@ mod tests {
 
     #[test]
     fn is_atm_temp_unset_reports_true_only_when_unset() {
-        assert!(is_atm_temp_unset(&FakeEnvSource::unset()));
-        assert!(!is_atm_temp_unset(&FakeEnvSource::with(
+        assert!(is_atm_temp_unset(&FakeEnvSource::empty()));
+        assert!(!is_atm_temp_unset(&FakeEnvSource::new([(
             "ATM_TEMP",
-            "/anywhere"
-        )));
+            Some("/anywhere")
+        )])));
     }
 
     #[test]
     fn explicit_relative_path_is_rejected() {
-        let env = FakeEnvSource::with("ATM_TEMP", "relative/path");
+        let env = FakeEnvSource::new([("ATM_TEMP", Some("relative/path"))]);
         assert_eq!(resolve_atm_temp(&env), Err(AtmTempError::NotAbsolute));
     }
 
@@ -474,7 +453,7 @@ mod tests {
     fn explicit_path_with_missing_parent_is_unresolvable() {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("does-not-exist").join("atm-temp");
-        let env = FakeEnvSource::with("ATM_TEMP", missing.to_str().expect("utf8 path"));
+        let env = FakeEnvSource::new([("ATM_TEMP", Some(missing.to_str().expect("utf8 path")))]);
         assert_eq!(resolve_atm_temp(&env), Err(AtmTempError::Unresolvable));
     }
 
@@ -499,7 +478,7 @@ mod tests {
         fn explicit_new_path_is_created_with_mode_0700() {
             let dir = tempfile::tempdir().expect("tempdir");
             let target = dir.path().join("atm-temp");
-            let env = FakeEnvSource::with("ATM_TEMP", target.to_str().expect("utf8 path"));
+            let env = FakeEnvSource::new([("ATM_TEMP", Some(target.to_str().expect("utf8 path")))]);
             let resolved = resolve_atm_temp(&env).expect("resolves");
             assert_eq!(resolved.path(), target);
             let mode = std::fs::metadata(&target)
@@ -516,7 +495,7 @@ mod tests {
             std::fs::create_dir(&target).expect("create dir");
             std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
                 .expect("chmod");
-            let env = FakeEnvSource::with("ATM_TEMP", target.to_str().expect("utf8 path"));
+            let env = FakeEnvSource::new([("ATM_TEMP", Some(target.to_str().expect("utf8 path")))]);
             let error = resolve_atm_temp(&env).expect_err("insecure directory must be refused");
             assert!(
                 matches!(error, AtmTempError::AtmTempInsecure { .. }),
@@ -531,7 +510,7 @@ mod tests {
             std::fs::create_dir(&target).expect("create dir");
             std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700))
                 .expect("chmod");
-            let env = FakeEnvSource::with("ATM_TEMP", target.to_str().expect("utf8 path"));
+            let env = FakeEnvSource::new([("ATM_TEMP", Some(target.to_str().expect("utf8 path")))]);
             let resolved = resolve_atm_temp(&env).expect("own-uid 0700 directory is accepted");
             assert_eq!(resolved.path(), target);
         }
@@ -586,7 +565,7 @@ mod tests {
             std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o500))
                 .expect("chmod parent read-only");
             let target = parent.join("atm-temp");
-            let env = FakeEnvSource::with("ATM_TEMP", target.to_str().expect("utf8 path"));
+            let env = FakeEnvSource::new([("ATM_TEMP", Some(target.to_str().expect("utf8 path")))]);
             let error = resolve_atm_temp(&env).expect_err("locked parent must refuse creation");
             assert_eq!(error, AtmTempError::NotWritable);
             // Restore permissions so tempfile can clean up the directory.
@@ -605,7 +584,7 @@ mod tests {
             std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o500))
                 .expect("chmod parent read-only");
             let target = parent.join("atm-temp");
-            let env = FakeEnvSource::with("ATM_TEMP", target.to_str().expect("utf8 path"));
+            let env = FakeEnvSource::new([("ATM_TEMP", Some(target.to_str().expect("utf8 path")))]);
 
             let (result, logs) = capture_tracing(|| resolve_atm_temp(&env));
             let error = result.expect_err("locked parent must refuse creation");

--- a/crates/atm-core/src/send_to.rs
+++ b/crates/atm-core/src/send_to.rs
@@ -478,17 +478,10 @@ pub fn format_attachment_note(landed_dir: &Path, source_files: &[PathBuf]) -> St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::atm_temp::{EnvSource, resolve_atm_temp};
+    use crate::atm_temp::resolve_atm_temp;
     use crate::boundary::{RosterHarness, RosterMemberKind};
+    use crate::test_support::FakeEnvSource;
     use serde_json::json;
-
-    struct FixedEnvSource(std::collections::HashMap<&'static str, String>);
-
-    impl EnvSource for FixedEnvSource {
-        fn var(&self, key: &str) -> Option<String> {
-            self.0.get(key).cloned()
-        }
-    }
 
     /// Builds a real, security-checked [`AtmTemp`] rooted at an already
     /// `0700`-permissioned throwaway directory, exercising the same
@@ -498,9 +491,8 @@ mod tests {
     /// -- the same pattern `atm_temp.rs`'s own tests use.
     fn atm_temp_for_tests(root: &Path) -> AtmTemp {
         secure_dir_for_tests(root);
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("ATM_TEMP", root.to_str().expect("utf8 path").to_string());
-        resolve_atm_temp(&FixedEnvSource(vars)).expect("throwaway root resolves")
+        let env = FakeEnvSource::new([("ATM_TEMP", Some(root.to_str().expect("utf8 path")))]);
+        resolve_atm_temp(&env).expect("throwaway root resolves")
     }
 
     #[cfg(unix)]

--- a/crates/atm-core/src/test_support.rs
+++ b/crates/atm-core/src/test_support.rs
@@ -1,12 +1,17 @@
 #![cfg(any(test, feature = "test-utils"))]
 
 #[cfg(any(test, feature = "test-utils"))]
+use std::collections::HashMap;
+#[cfg(any(test, feature = "test-utils"))]
 use std::ffi::{OsStr, OsString};
 #[cfg(any(test, feature = "test-utils"))]
 use std::sync::OnceLock;
 
 #[cfg(any(test, feature = "test-utils"))]
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
+
+#[cfg(any(test, feature = "test-utils"))]
+use crate::atm_temp::EnvSource;
 
 pub const TEST_TEAM: &str = "test-team";
 pub const TEST_SENDER: &str = "sender-a";
@@ -105,6 +110,49 @@ pub fn remove_env_var<K: AsRef<OsStr>>(key: K) {
     // SAFETY: test callers acquire the shared test env lock before mutating
     // the process environment.
     unsafe { std::env::remove_var(key) }
+}
+
+/// A deterministic, in-memory [`EnvSource`] for tests that need to inject
+/// environment values into production code that reads through the
+/// `EnvSource` seam, without mutating the real (process-global) process
+/// environment via [`EnvGuard`].
+///
+/// Prefer this over `EnvGuard` whenever the code under test accepts an
+/// `&dyn EnvSource` parameter: it needs no shared lock, has no cross-test
+/// interference risk, and does not require `std::env::var` callers
+/// elsewhere in the process to cooperate with a guard.
+#[cfg(any(test, feature = "test-utils"))]
+#[derive(Debug, Default, Clone)]
+pub struct FakeEnvSource(HashMap<String, String>);
+
+#[cfg(any(test, feature = "test-utils"))]
+impl FakeEnvSource {
+    /// An env source that reports every key as unset.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Builds a fake env source from `(key, value)` pairs. A `None` value
+    /// leaves that key unset, matching [`EnvGuard::set_many`]'s shape so
+    /// call sites can switch between the two with a minimal diff.
+    #[must_use]
+    pub fn new<'a, const N: usize>(vars: [(&'a str, Option<&'a str>); N]) -> Self {
+        let mut map = HashMap::new();
+        for (key, value) in vars {
+            if let Some(value) = value {
+                map.insert(key.to_string(), value.to_string());
+            }
+        }
+        Self(map)
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl EnvSource for FakeEnvSource {
+    fn var(&self, key: &str) -> Option<String> {
+        self.0.get(key).cloned()
+    }
 }
 
 /// Captures `tracing` events emitted by `f` **on the calling thread**, into

--- a/crates/atm-core/src/test_support.rs
+++ b/crates/atm-core/src/test_support.rs
@@ -146,6 +146,27 @@ impl FakeEnvSource {
         }
         Self(map)
     }
+
+    /// Builds a fake env source from an iterator of `(key, value)` pairs,
+    /// every one of which is treated as set.
+    ///
+    /// Complements [`FakeEnvSource::new`] for callers that assemble pairs
+    /// dynamically (e.g. from a loop over a key list with computed values)
+    /// rather than from a fixed-size array literal, where `new`'s
+    /// const-generic array shape does not fit.
+    #[must_use]
+    pub fn from_pairs<K, V>(pairs: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self(
+            pairs
+                .into_iter()
+                .map(|(key, value)| (key.into(), value.into()))
+                .collect(),
+        )
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/atm-core/src/transfer_script.rs
+++ b/crates/atm-core/src/transfer_script.rs
@@ -798,6 +798,7 @@ fn is_owner_executable(mode: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::FakeEnvSource;
 
     fn host(value: &str) -> HostName {
         value.parse().expect("valid host")
@@ -1306,20 +1307,12 @@ mod tests {
         }
     }
 
-    struct FakeEnvSource(std::collections::HashMap<&'static str, String>);
-
-    impl EnvSource for FakeEnvSource {
-        fn var(&self, key: &str) -> Option<String> {
-            self.0.get(key).cloned()
-        }
-    }
-
     /// A home-directory resolution failure must surface as its own error,
     /// distinct from `AtmTempError::Unresolvable` (which names an
     /// `ATM_TEMP`-resolution failure, not a home-directory one) (QM43-B2).
     #[test]
     fn missing_home_env_vars_report_home_dir_unavailable() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         let error = home_dir_from_env(&env).expect_err("no HOME/USERPROFILE must fail closed");
         assert_eq!(error, AtmTempError::HomeDirUnavailable);
     }
@@ -1330,18 +1323,14 @@ mod tests {
         // raw value flows through unchanged, not that it looks like a real
         // Unix home directory (`home_dir_from_env` does not validate path
         // shape at all).
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("HOME", "test-home-value".to_string());
-        let env = FakeEnvSource(vars);
+        let env = FakeEnvSource::new([("HOME", Some("test-home-value"))]);
         let home = home_dir_from_env(&env).expect("HOME is set");
         assert_eq!(home, PathBuf::from("test-home-value"));
     }
 
     #[test]
     fn userprofile_is_used_when_home_is_unset() {
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("USERPROFILE", r"C:\Users\rand".to_string());
-        let env = FakeEnvSource(vars);
+        let env = FakeEnvSource::new([("USERPROFILE", Some(r"C:\Users\rand"))]);
         let home = home_dir_from_env(&env).expect("USERPROFILE is set");
         assert_eq!(home, PathBuf::from(r"C:\Users\rand"));
     }
@@ -1361,7 +1350,7 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn unix_synthesized_env_is_exactly_the_fixed_minimal_path() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         let entries = synthesized_transfer_script_env(&env);
         assert_eq!(
             entries,
@@ -1372,7 +1361,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_synthesized_env_is_exactly_the_fixed_minimal_path() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         let entries = synthesized_transfer_script_env(&env);
         assert_eq!(
             entries,
@@ -1390,12 +1379,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn unix_synthesized_env_never_forwards_the_callers_path() {
-        let mut vars = std::collections::HashMap::new();
-        vars.insert(
+        let env = FakeEnvSource::new([(
             "PATH",
-            "/definitely-not-a-real-dir/atm-caller-path-marker".to_string(),
-        );
-        let env = FakeEnvSource(vars);
+            Some("/definitely-not-a-real-dir/atm-caller-path-marker"),
+        )]);
         let entries = synthesized_transfer_script_env(&env);
         let path = path_entry(&entries, "PATH").expect("PATH is always present");
         assert!(
@@ -1411,7 +1398,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn unix_synthesized_env_forwards_home_only_when_the_caller_has_one() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         assert_eq!(
             path_entry(&synthesized_transfer_script_env(&env), "HOME"),
             None
@@ -1421,9 +1408,7 @@ mod tests {
         // when_present` above): this test only proves `HOME`'s raw value
         // flows through unchanged, not that it looks like a real Unix home
         // directory.
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("HOME", "test-home-value".to_string());
-        let env = FakeEnvSource(vars);
+        let env = FakeEnvSource::new([("HOME", Some("test-home-value"))]);
         assert_eq!(
             path_entry(&synthesized_transfer_script_env(&env), "HOME"),
             Some(OsString::from("test-home-value"))
@@ -1433,7 +1418,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_synthesized_env_defaults_system_root_when_unset() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         let entries = synthesized_transfer_script_env(&env);
         let path = path_entry(&entries, "PATH").expect("PATH is always present");
         let path = path.to_string_lossy();
@@ -1452,13 +1437,13 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_synthesized_env_uses_an_explicit_system_root_and_never_forwards_the_callers_path() {
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("SystemRoot", r"D:\CustomWindows".to_string());
-        vars.insert(
-            "PATH",
-            r"C:\definitely-not-a-real-dir\atm-caller-path-marker".to_string(),
-        );
-        let env = FakeEnvSource(vars);
+        let env = FakeEnvSource::new([
+            ("SystemRoot", Some(r"D:\CustomWindows")),
+            (
+                "PATH",
+                Some(r"C:\definitely-not-a-real-dir\atm-caller-path-marker"),
+            ),
+        ]);
         let entries = synthesized_transfer_script_env(&env);
         let path = path_entry(&entries, "PATH").expect("PATH is always present");
         let path = path.to_string_lossy();
@@ -1477,12 +1462,10 @@ mod tests {
     fn windows_synthesized_env_includes_pwshs_own_directory_when_locatable() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("pwsh.exe"), b"").expect("write fake pwsh.exe");
-        let mut vars = std::collections::HashMap::new();
-        vars.insert(
+        let env = FakeEnvSource::new([(
             "PATH",
-            dir.path().to_str().expect("utf8 tempdir path").to_string(),
-        );
-        let env = FakeEnvSource(vars);
+            Some(dir.path().to_str().expect("utf8 tempdir path")),
+        )]);
         let entries = synthesized_transfer_script_env(&env);
         let path = path_entry(&entries, "PATH").expect("PATH is always present");
         assert!(
@@ -1495,15 +1478,13 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_synthesized_env_forwards_temp_only_when_the_caller_has_one() {
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         assert_eq!(
             path_entry(&synthesized_transfer_script_env(&env), "TEMP"),
             None
         );
 
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("TEMP", r"C:\Users\rand\AppData\Local\Temp".to_string());
-        let env = FakeEnvSource(vars);
+        let env = FakeEnvSource::new([("TEMP", Some(r"C:\Users\rand\AppData\Local\Temp"))]);
         assert_eq!(
             path_entry(&synthesized_transfer_script_env(&env), "TEMP"),
             Some(OsString::from(r"C:\Users\rand\AppData\Local\Temp"))
@@ -1530,7 +1511,7 @@ mod tests {
             "COMSPEC",
         ];
 
-        let env = FakeEnvSource(std::collections::HashMap::new());
+        let env = FakeEnvSource::empty();
         let entries = synthesized_transfer_script_env(&env);
         for key in keys {
             assert_eq!(
@@ -1540,11 +1521,8 @@ mod tests {
             );
         }
 
-        let mut vars = std::collections::HashMap::new();
-        for key in keys {
-            vars.insert(key, format!("value-for-{key}"));
-        }
-        let env = FakeEnvSource(vars);
+        let env =
+            FakeEnvSource::from_pairs(keys.iter().map(|key| (*key, format!("value-for-{key}"))));
         let entries = synthesized_transfer_script_env(&env);
         for key in keys {
             assert_eq!(

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
 atm-herdr = { path = "../atm-herdr", version = "1.4.5", features = ["test-utils"] }
 atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5", features = ["test-support"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.5" }

--- a/crates/atm-daemon-bootstrap/src/atm_temp_config.rs
+++ b/crates/atm-daemon-bootstrap/src/atm_temp_config.rs
@@ -25,15 +25,7 @@ pub(crate) fn daemon_atm_config(env: &dyn EnvSource) -> Option<AtmConfig> {
 #[cfg(test)]
 mod tests {
     use super::daemon_atm_config;
-    use std::collections::HashMap;
-
-    struct FixedEnvSource(HashMap<&'static str, String>);
-
-    impl atm_core::atm_temp::EnvSource for FixedEnvSource {
-        fn var(&self, key: &str) -> Option<String> {
-            self.0.get(key).cloned()
-        }
-    }
+    use atm_core::test_support::FakeEnvSource;
 
     /// QM43-I5: sweep-interval/TTL threading reads `$HOME/.atm.toml`, not a
     /// workspace-relative config -- `assemble_daemon_runtime`'s doc comment
@@ -47,9 +39,8 @@ mod tests {
             "[atm]\nsweep_interval_seconds = 120\nsweep_ttl_days = 7\n",
         )
         .expect("write .atm.toml");
-        let mut vars = HashMap::new();
-        vars.insert("HOME", home.path().to_str().expect("utf8 path").to_string());
-        let config = daemon_atm_config(&FixedEnvSource(vars)).expect("config resolves");
+        let env = FakeEnvSource::new([("HOME", Some(home.path().to_str().expect("utf8 path")))]);
+        let config = daemon_atm_config(&env).expect("config resolves");
         assert_eq!(config.sweep_interval_seconds, 120);
         assert_eq!(config.sweep_ttl_days, 7);
     }
@@ -57,13 +48,12 @@ mod tests {
     #[test]
     fn daemon_atm_config_is_none_without_a_home_atm_toml() {
         let home = tempfile::tempdir().expect("tempdir");
-        let mut vars = HashMap::new();
-        vars.insert("HOME", home.path().to_str().expect("utf8 path").to_string());
-        assert_eq!(daemon_atm_config(&FixedEnvSource(vars)), None);
+        let env = FakeEnvSource::new([("HOME", Some(home.path().to_str().expect("utf8 path")))]);
+        assert_eq!(daemon_atm_config(&env), None);
     }
 
     #[test]
     fn daemon_atm_config_is_none_when_home_is_unresolvable() {
-        assert_eq!(daemon_atm_config(&FixedEnvSource(HashMap::new())), None);
+        assert_eq!(daemon_atm_config(&FakeEnvSource::empty()), None);
     }
 }

--- a/crates/atm-graft/src/runtime/mod.rs
+++ b/crates/atm-graft/src/runtime/mod.rs
@@ -1879,12 +1879,26 @@ mod tests {
             "initial announce must land before the sustained-load phase starts"
         );
 
-        // Sustain back-to-back deliveries for multiple refresh intervals so
-        // the accept loop never reaches an idle `Ok(None)` poll iteration.
-        const SUSTAINED_LOAD_DURATION: Duration = Duration::from_secs(4);
-        let deadline = Instant::now() + SUSTAINED_LOAD_DURATION;
+        // Sustain back-to-back deliveries so the accept loop never reaches
+        // an idle `Ok(None)` poll iteration, driving load while polling for
+        // the observable this AC actually cares about: at least two
+        // refreshes land while the receiver stays continuously busy. Per
+        // ADR-008, wait on the observable rather than asserting a minimum
+        // count within a fixed wall-clock window — the outer bound here is
+        // a generous hang-detector deadline only, not a pass/fail timing
+        // assertion.
+        const HANG_DETECTOR_TIMEOUT: Duration = Duration::from_secs(15);
+        let hang_deadline = Instant::now() + HANG_DETECTOR_TIMEOUT;
         let mut delivered = 0usize;
-        while Instant::now() < deadline {
+        while registry.refresh_count() < 2 {
+            assert!(
+                Instant::now() < hang_deadline,
+                "a continuously busy receiver never observed >= 2 refreshes \
+                 within the hang-detector deadline (got {} refreshes over {} \
+                 deliveries)",
+                registry.refresh_count(),
+                delivered
+            );
             assert_eq!(
                 deliver_request(endpoint, &capability, request_event()),
                 GraftPostSendResponse::Delivered
@@ -1898,14 +1912,6 @@ mod tests {
         assert_eq!(
             injector.nudges.lock().expect("nudges lock").len(),
             delivered
-        );
-
-        assert!(
-            registry.refresh_count() >= 2,
-            "a continuously busy receiver must still refresh on cadence \
-             (got {} refreshes over {:?})",
-            registry.refresh_count(),
-            SUSTAINED_LOAD_DURATION
         );
 
         stop_receiver(stop_tx, join);

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -1193,7 +1193,15 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(HerdrError::TimedOut)));
-        assert!(started.elapsed() < Duration::from_secs(5));
+        // Hang-detector bound only, not a pass/fail timing assertion: a
+        // tight upper bound here (e.g. the old 5s) is exactly what makes
+        // this flaky under CI/kill+reap scheduling contention. The
+        // semantic assertion above already proves the process timed out
+        // rather than completing its 30s `sleep`; this generous margin
+        // (comfortably above both the 2s caller deadline and the 5s
+        // `HERDR_PROCESS_CAP`) exists solely to catch the test genuinely
+        // hanging, never to assert *which* of the two bounds fired first.
+        assert!(started.elapsed() < Duration::from_secs(15));
     }
 
     #[test]

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -532,6 +532,16 @@ struct CommandOutput {
     success: bool,
 }
 
+/// Selects the timeout actually applied to a spawned `herdr` child process:
+/// whichever of the caller's `remaining` deadline or [`HERDR_PROCESS_CAP`] is
+/// smaller (HR-SAFE-002). A pure function so the caller-deadline-vs-process-
+/// cap precedence is unit-testable deterministically, without spawning a
+/// process or depending on wall-clock scheduling (see the
+/// `effective_process_timeout_*` tests below).
+fn effective_process_timeout(remaining: Duration) -> Duration {
+    remaining.min(HERDR_PROCESS_CAP)
+}
+
 async fn run_command(
     breaker: &HerdrSpawnBreaker,
     args: &[String],
@@ -563,7 +573,7 @@ async fn run_command_with_binary(
         }
         return Err(HerdrError::TimedOut);
     };
-    let effective_timeout = remaining.min(HERDR_PROCESS_CAP);
+    let effective_timeout = effective_process_timeout(remaining);
     let mut command = tokio::process::Command::new(binary);
     command
         .args(args)
@@ -1201,7 +1211,41 @@ mod tests {
         // (comfortably above both the 2s caller deadline and the 5s
         // `HERDR_PROCESS_CAP`) exists solely to catch the test genuinely
         // hanging, never to assert *which* of the two bounds fired first.
+        // The `effective_process_timeout_*` unit tests below are the actual
+        // deterministic proof that a 2s caller deadline governs over the 5s
+        // `HERDR_PROCESS_CAP` (HR-SAFE-002); this test only proves the
+        // end-to-end spawn path times out at all.
         assert!(started.elapsed() < Duration::from_secs(15));
+    }
+
+    /// HR-SAFE-002 precedence proof (deterministic, no wall-clock): a
+    /// caller deadline shorter than `HERDR_PROCESS_CAP` governs the
+    /// effective process timeout.
+    #[test]
+    fn effective_process_timeout_uses_the_shorter_caller_deadline() {
+        assert_eq!(
+            effective_process_timeout(Duration::from_secs(2)),
+            Duration::from_secs(2)
+        );
+    }
+
+    /// HR-SAFE-002 precedence proof (deterministic, no wall-clock): a
+    /// caller deadline longer than `HERDR_PROCESS_CAP` is clamped to the
+    /// cap, so a slow/misbehaving `herdr` child is never allowed to run
+    /// past it.
+    #[test]
+    fn effective_process_timeout_clamps_to_the_process_cap() {
+        assert_eq!(
+            effective_process_timeout(Duration::from_secs(30)),
+            HERDR_PROCESS_CAP
+        );
+    }
+
+    /// A caller deadline of zero (already expired) selects a zero timeout,
+    /// never a negative or the process cap.
+    #[test]
+    fn effective_process_timeout_of_zero_remaining_is_zero() {
+        assert_eq!(effective_process_timeout(Duration::ZERO), Duration::ZERO);
     }
 
     #[test]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -2294,23 +2294,12 @@ mod tests {
             recipients: Vec::new(),
             note: Some("fan-out test".to_string()),
         };
-        let env = std::collections::HashMap::from([(
+        let atm_temp_dir = fixture.home_dir.join("atm-temp");
+        let env = atm_core::test_support::FakeEnvSource::new([(
             "ATM_TEMP",
-            fixture
-                .home_dir
-                .join("atm-temp")
-                .to_str()
-                .expect("utf8")
-                .to_string(),
+            Some(atm_temp_dir.to_str().expect("utf8")),
         )]);
-        struct FixedEnvSource(std::collections::HashMap<&'static str, String>);
-        impl atm_core::atm_temp::EnvSource for FixedEnvSource {
-            fn var(&self, key: &str) -> Option<String> {
-                self.0.get(key).cloned()
-            }
-        }
-        let atm_temp =
-            atm_core::atm_temp::resolve_atm_temp(&FixedEnvSource(env)).expect("atm_temp resolves");
+        let atm_temp = atm_core::atm_temp::resolve_atm_temp(&env).expect("atm_temp resolves");
 
         let (delivered, not_delivered, failure) = command
             .send_fan_out_recipients(

--- a/crates/atm/src/commands/send_to.rs
+++ b/crates/atm/src/commands/send_to.rs
@@ -10,7 +10,9 @@ use std::sync::Once;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use atm_core::atm_temp::{AtmTemp, ProcessEnvSource, is_atm_temp_unset, resolve_atm_temp};
+use atm_core::atm_temp::{
+    AtmTemp, EnvSource, ProcessEnvSource, is_atm_temp_unset, resolve_atm_temp,
+};
 use atm_core::error::AtmError;
 use atm_core::send_to::{
     RecipientLocality, stage_same_host_attachments, validate_landed_dir_stdout,
@@ -84,7 +86,9 @@ pub(crate) async fn land_attachments(
             Ok(AttachmentLanding { landed_dir })
         }
         RecipientLocality::Remote(host) => {
-            let landed_dir = resolve_and_invoke_transfer_script(host, transfer_id, files).await?;
+            let landed_dir =
+                resolve_and_invoke_transfer_script(&ProcessEnvSource, host, transfer_id, files)
+                    .await?;
             Ok(AttachmentLanding { landed_dir })
         }
     }
@@ -108,6 +112,7 @@ fn transfer_not_enabled_error(host: &HostName) -> AtmError {
 }
 
 async fn resolve_and_invoke_transfer_script(
+    env: &dyn EnvSource,
     host: &HostName,
     transfer_id: Ulid,
     files: &[PathBuf],
@@ -120,6 +125,7 @@ async fn resolve_and_invoke_transfer_script(
         }
     };
     invoke_transfer_script(
+        env,
         &configured,
         transfer_id,
         files,
@@ -148,6 +154,7 @@ async fn resolve_and_invoke_transfer_script(
 /// (stderr, bounded, is included), is killed after exceeding `timeout`, or
 /// produces stdout that fails [`validate_landed_dir_stdout`].
 pub(crate) async fn invoke_transfer_script(
+    env: &dyn EnvSource,
     configured: &ConfiguredTransferScript,
     transfer_id: Ulid,
     files: &[PathBuf],
@@ -158,11 +165,11 @@ pub(crate) async fn invoke_transfer_script(
     command.args(&invocation.args);
     command.env_clear();
     for key in TRANSFER_SCRIPT_ALLOWED_ENV_KEYS {
-        if let Ok(value) = std::env::var(key) {
+        if let Some(value) = env.var(key) {
             command.env(key, value);
         }
     }
-    for (key, value) in synthesized_transfer_script_env(&ProcessEnvSource) {
+    for (key, value) in synthesized_transfer_script_env(env) {
         command.env(key, value);
     }
     command.stdin(Stdio::null());
@@ -306,6 +313,7 @@ mod tests {
         let configured = fixture_configured_script(script_path, host("m5"));
 
         let result = invoke_transfer_script(
+            &atm_core::test_support::FakeEnvSource::empty(),
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -329,6 +337,7 @@ mod tests {
         let configured = fixture_configured_script(script_path, host("m5"));
 
         let error = invoke_transfer_script(
+            &atm_core::test_support::FakeEnvSource::empty(),
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -348,6 +357,7 @@ mod tests {
         let configured = fixture_configured_script(script_path, host("m5"));
 
         let error = invoke_transfer_script(
+            &atm_core::test_support::FakeEnvSource::empty(),
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -367,6 +377,7 @@ mod tests {
         let configured = fixture_configured_script(script_path, host("m5"));
 
         let error = invoke_transfer_script(
+            &atm_core::test_support::FakeEnvSource::empty(),
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -396,7 +407,7 @@ mod tests {
         let script_path = write_script(dir.path(), "stub.sh", &script_contents);
         let configured = fixture_configured_script(script_path, host("m5"));
 
-        let _env = atm_core::test_support::EnvGuard::set_many([
+        let env = atm_core::test_support::FakeEnvSource::new([
             ("ATM_TEMP", Some("atm-temp-test-value")),
             ("ATM_IDENTITY", Some("test-agent")),
             ("ATM_TEAM", Some("test-team")),
@@ -404,6 +415,7 @@ mod tests {
         ]);
 
         let result = invoke_transfer_script(
+            &env,
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -447,7 +459,7 @@ mod tests {
         let script_path = write_script(dir.path(), "stub.sh", &script_contents);
         let configured = fixture_configured_script(script_path, host("m5"));
 
-        let _env = atm_core::test_support::EnvGuard::set_many([
+        let env = atm_core::test_support::FakeEnvSource::new([
             ("ATM_TEMP", Some("atm-temp-test-value")),
             ("ATM_IDENTITY", Some("test-agent")),
             ("ATM_TEAM", Some("test-team")),
@@ -458,6 +470,7 @@ mod tests {
         ]);
 
         invoke_transfer_script(
+            &env,
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -497,7 +510,7 @@ mod tests {
         let configured = fixture_configured_script(script_path, host("m5"));
 
         let distinctive_caller_path = "/definitely-not-a-real-dir/atm-caller-path-marker";
-        let _env = atm_core::test_support::EnvGuard::set_many([
+        let env = atm_core::test_support::FakeEnvSource::new([
             ("ATM_TEMP", Some("atm-temp-test-value")),
             ("ATM_IDENTITY", Some("test-agent")),
             ("ATM_TEAM", Some("test-team")),
@@ -505,6 +518,7 @@ mod tests {
         ]);
 
         invoke_transfer_script(
+            &env,
             &configured,
             Ulid::new(),
             &[PathBuf::from("/tmp/report.pdf")],
@@ -521,15 +535,13 @@ mod tests {
         );
         assert_eq!(
             child_path,
-            atm_core::transfer_script::synthesized_transfer_script_env(
-                &atm_core::atm_temp::ProcessEnvSource
-            )
-            .into_iter()
-            .find(|(key, _)| *key == "PATH")
-            .expect("synthesized env always includes PATH")
-            .1
-            .to_str()
-            .expect("synthesized PATH is UTF-8 in this test")
+            atm_core::transfer_script::synthesized_transfer_script_env(&env)
+                .into_iter()
+                .find(|(key, _)| *key == "PATH")
+                .expect("synthesized env always includes PATH")
+                .1
+                .to_str()
+                .expect("synthesized PATH is UTF-8 in this test")
         );
     }
 


### PR DESCRIPTION
Fixes from the Phase AQ post-merge flaky-test-qa audit (develop @ a7af7cf5c). Test-only plus one test-seam signature change; no production behaviour change.

- **a8eac8c48 — FTQ-001 (important, env leak):** the three `invoke_transfer_script_*` tests in `crates/atm/src/commands/send_to.rs` mutated real process env (PATH/ATM_TEMP/ATM_IDENTITY/ATM_TEAM) via `EnvGuard`, racing every other atm-crate test that reads `std::env::var`. `invoke_transfer_script`/`resolve_and_invoke_transfer_script` now take `env: &dyn EnvSource` (production passes `&ProcessEnvSource`; allow-list reads and `synthesized_transfer_script_env` both go through it); tests inject a new public `atm_core::test_support::FakeEnvSource` (test-utils gated) and no longer touch the process env.
- **4db81074d — FTQ-002 (important, timing):** `ac6_sustained_connection_load_never_starves_the_lease_refresh_cadence` (atm-graft) no longer asserts `refresh_count >= 2` inside a fixed 4 s window; it drives load until the observable is met, bounded by a 15 s hang detector.
- **a9cb5aec7 — FTQ-003 (minor):** `two_second_caller_deadline_preempts_the_five_second_process_cap` (atm-herdr) keeps `Err(HerdrError::TimedOut)` as the semantic assertion; the 5 s elapsed bound becomes a 15 s hang detector with a comment.

Gates: fmt ✓ · clippy -D warnings ✓ · `cargo test --workspace` 0 failed · each touched test 20/20 in a loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)