### PR TITLE
refactor/test: shared flag parsing in peer_launch_config; guard Send-To test-only seams (RBQA-F103/F104)

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -232,6 +232,113 @@ def require_macos_development_signatures(cli: Path, daemon: Path) -> None:
             )
 
 
+def homebrew_release_metadata() -> dict[str, object]:
+    """Return the installed ATM formula metadata used for release provenance."""
+    brew = shutil.which("brew")
+    if brew is None:
+        raise SwitchError("cannot verify Homebrew release provenance: brew is not installed")
+    try:
+        result = run([brew, "info", "--json=v2", "--installed", "atm"], timeout=10.0)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SwitchError(f"cannot verify Homebrew release provenance: {error}") from error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise SwitchError(f"cannot verify Homebrew release provenance: {detail or 'brew info failed'}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SwitchError("cannot verify Homebrew release provenance: brew info returned invalid JSON") from error
+    formulae = payload.get("formulae") if isinstance(payload, dict) else None
+    if not isinstance(formulae, list) or len(formulae) != 1 or not isinstance(formulae[0], dict):
+        raise SwitchError("cannot verify Homebrew release provenance: ATM formula metadata is missing")
+    return formulae[0]
+
+
+def require_homebrew_release_provenance(cli: Path, daemon: Path) -> None:
+    """Accept an ad-hoc Homebrew pair only when Homebrew proves its release origin.
+
+    Homebrew verifies the release archive checksum before installing it.  The
+    formula metadata is therefore the provenance boundary for the extracted
+    binaries: it must identify this project, the same release version in both
+    installed and stable metadata, the v-tagged GitHub Release asset, and a
+    valid SHA-256 checksum.  This gate is intentionally restore-only; source
+    switches continue to require the Apple Development identity.
+    """
+    if platform.system() != "Darwin":
+        return
+    cli = require_executable(cli, "Homebrew atm CLI")
+    daemon = require_executable(daemon, "Homebrew atm daemon")
+    brew = shutil.which("brew")
+    if brew is None:
+        raise SwitchError("cannot verify Homebrew release provenance: brew is not installed")
+    try:
+        prefix_result = run([brew, "--prefix", "atm"], timeout=10.0)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SwitchError(f"cannot verify Homebrew release provenance: {error}") from error
+    if prefix_result.returncode != 0:
+        raise SwitchError("cannot verify Homebrew release provenance: brew prefix failed")
+    try:
+        prefix = Path(prefix_result.stdout.strip()).expanduser().resolve()
+    except (OSError, RuntimeError) as error:
+        raise SwitchError(f"cannot verify Homebrew release provenance: invalid formula prefix: {error}") from error
+    expected_bin_dir = (prefix / "bin").resolve()
+    for label, binary in (("CLI", cli), ("daemon", daemon)):
+        try:
+            binary.relative_to(expected_bin_dir)
+        except ValueError as error:
+            raise SwitchError(
+                f"{label} target is not the installed Homebrew ATM binary under {expected_bin_dir}: {binary}"
+            ) from error
+
+    formula = homebrew_release_metadata()
+    if formula.get("homepage") != "https://github.com/randlee/atm-core":
+        raise SwitchError("Homebrew ATM formula has an unexpected project homepage")
+    cli_version = selected_release_version(cli)
+    daemon_version = selected_release_version(daemon)
+    if cli_version != daemon_version:
+        raise SwitchError(
+            f"Homebrew ATM pair has mismatched versions: CLI {cli_version}, daemon {daemon_version}"
+        )
+    versions = formula.get("versions")
+    installed = formula.get("installed")
+    if not isinstance(versions, dict) or versions.get("stable") != cli_version:
+        raise SwitchError("Homebrew ATM formula stable version does not match the selected binaries")
+    if (
+        not isinstance(installed, list)
+        or len(installed) != 1
+        or not isinstance(installed[0], dict)
+        or installed[0].get("version") != cli_version
+    ):
+        raise SwitchError("Homebrew ATM installed version does not match the selected binaries")
+    urls = formula.get("urls")
+    stable = urls.get("stable") if isinstance(urls, dict) else None
+    release_url = stable.get("url") if isinstance(stable, dict) else None
+    checksum = stable.get("checksum") if isinstance(stable, dict) else None
+    expected_prefix = f"https://github.com/randlee/atm-core/releases/download/v{cli_version}/"
+    if not isinstance(release_url, str) or not release_url.startswith(expected_prefix):
+        raise SwitchError("Homebrew ATM formula does not point at the matching GitHub Release asset")
+    if not isinstance(checksum, str) or re.fullmatch(r"[0-9a-fA-F]{64}", checksum) is None:
+        raise SwitchError("Homebrew ATM formula has no valid SHA-256 release asset checksum")
+
+
+def require_macos_restore_provenance(cli: Path, daemon: Path) -> None:
+    """Validate restore targets as either a verified Homebrew release or dev pair."""
+    if platform.system() != "Darwin":
+        return
+    brew_pair = homebrew_pair()
+    try:
+        selected = (cli.expanduser().resolve(), daemon.expanduser().resolve())
+    except (OSError, RuntimeError) as error:
+        raise SwitchError(f"cannot resolve restore targets: {error}") from error
+    if brew_pair is not None and selected == brew_pair:
+        require_homebrew_release_provenance(*brew_pair)
+        return
+    # A non-Homebrew restore remains a development restore and keeps the
+    # original strict signing policy. Only the managed Homebrew release gets
+    # the ad-hoc-signature exception.
+    require_macos_development_signatures(cli, daemon)
+
+
 def homebrew_pair() -> tuple[Path, Path] | None:
     brew = shutil.which("brew")
     if brew is None:
@@ -768,7 +875,13 @@ def temporary_launch_evidence(session: TemporaryLaunchSession, outcome: str) -> 
     }
 
 
-def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path) -> None:
+def switch_pair(
+    args: argparse.Namespace,
+    cli_target: Path,
+    daemon_target: Path,
+    *,
+    require_development_signature: bool = True,
+) -> None:
     require_no_active_temporary_launch_session()
     cli_link, daemon_link = selected_links(args)
     validate_selectors(cli_link, daemon_link)
@@ -791,7 +904,8 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         raise SwitchError(
             "refusing targets from different release directories; build or install the matched pair together"
         )
-    require_macos_development_signatures(cli_target, daemon_target)
+    if require_development_signature:
+        require_macos_development_signatures(cli_target, daemon_target)
     if cli_link.resolve() == cli_target and daemon_link.resolve() == daemon_target:
         print("already selected; service left running")
         return
@@ -1074,7 +1188,8 @@ def main() -> int:
             switch_pair(args, Path(args.cli), Path(args.daemon))
         elif args.command == "restore":
             cli, daemon = restore_pair(args)
-            switch_pair(args, cli, daemon)
+            require_macos_restore_provenance(cli, daemon)
+            switch_pair(args, cli, daemon, require_development_signature=False)
         elif args.command == "restart":
             restart(args)
         elif args.command == "temporary-launch":

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import argparse
+import json
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 import plistlib
@@ -203,6 +204,124 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
             ],
         )
 
+    def test_restore_accepts_homebrew_pair_without_development_identity(self) -> None:
+        cli = Path("/opt/homebrew/opt/atm/bin/atm")
+        daemon = Path("/opt/homebrew/opt/atm/bin/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "homebrew_pair", return_value=(cli.resolve(), daemon.resolve())),
+            mock.patch.object(DAEMON_SWITCH, "require_homebrew_release_provenance") as provenance,
+            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signatures") as development,
+        ):
+            DAEMON_SWITCH.require_macos_restore_provenance(cli, daemon)
+
+        provenance.assert_called_once_with(cli.resolve(), daemon.resolve())
+        development.assert_not_called()
+
+    def test_restore_rejects_homebrew_pair_without_valid_provenance(self) -> None:
+        cli = Path("/opt/homebrew/opt/atm/bin/atm")
+        daemon = Path("/opt/homebrew/opt/atm/bin/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "homebrew_pair", return_value=(cli.resolve(), daemon.resolve())),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "require_homebrew_release_provenance",
+                side_effect=DAEMON_SWITCH.SwitchError("invalid release provenance"),
+            ),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "invalid release provenance"):
+                DAEMON_SWITCH.require_macos_restore_provenance(cli, daemon)
+
+    def test_homebrew_release_provenance_accepts_matching_release_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            prefix = Path(temporary) / "opt" / "atm"
+            binary_dir = prefix / "bin"
+            binary_dir.mkdir(parents=True)
+            cli = binary_dir / "atm"
+            daemon = binary_dir / "atm-daemon"
+            for binary in (cli, daemon):
+                binary.write_bytes(binary.name.encode("utf-8"))
+                binary.chmod(0o700)
+            formula = {
+                "homepage": "https://github.com/randlee/atm-core",
+                "versions": {"stable": "1.4.4"},
+                "installed": [{"version": "1.4.4"}],
+                "urls": {
+                    "stable": {
+                        "url": "https://github.com/randlee/atm-core/releases/download/v1.4.4/atm.tar.gz",
+                        "checksum": "a" * 64,
+                    }
+                },
+            }
+            with (
+                mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+                mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/opt/homebrew/bin/brew"),
+                mock.patch.object(
+                    DAEMON_SWITCH,
+                    "run",
+                    side_effect=[
+                        subprocess.CompletedProcess([], 0, f"{prefix}\n", ""),
+                        subprocess.CompletedProcess([], 0, json.dumps({"formulae": [formula]}), ""),
+                    ],
+                ),
+                mock.patch.object(DAEMON_SWITCH, "selected_release_version", side_effect=["1.4.4", "1.4.4"]),
+            ):
+                DAEMON_SWITCH.require_homebrew_release_provenance(cli, daemon)
+
+    def test_homebrew_release_provenance_rejects_invalid_release_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            prefix = Path(temporary) / "opt" / "atm"
+            binary_dir = prefix / "bin"
+            binary_dir.mkdir(parents=True)
+            cli = binary_dir / "atm"
+            daemon = binary_dir / "atm-daemon"
+            for binary in (cli, daemon):
+                binary.write_bytes(binary.name.encode("utf-8"))
+                binary.chmod(0o700)
+            formula = {
+                "homepage": "https://github.com/randlee/atm-core",
+                "versions": {"stable": "1.4.4"},
+                "installed": [{"version": "1.4.4"}],
+                "urls": {
+                    "stable": {
+                        "url": "https://example.invalid/atm.tar.gz",
+                        "checksum": "not-a-sha256",
+                    }
+                },
+            }
+            with (
+                mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+                mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/opt/homebrew/bin/brew"),
+                mock.patch.object(
+                    DAEMON_SWITCH,
+                    "run",
+                    side_effect=[
+                        subprocess.CompletedProcess([], 0, f"{prefix}\n", ""),
+                        subprocess.CompletedProcess([], 0, json.dumps({"formulae": [formula]}), ""),
+                    ],
+                ),
+                mock.patch.object(DAEMON_SWITCH, "selected_release_version", side_effect=["1.4.4", "1.4.4"]),
+            ):
+                with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "matching GitHub Release asset"):
+                    DAEMON_SWITCH.require_homebrew_release_provenance(cli, daemon)
+
+    def test_restore_dispatch_uses_provenance_gate_and_skips_dev_gate(self) -> None:
+        args = argparse.Namespace(command="restore")
+        cli = Path("/release/atm")
+        daemon = Path("/release/atm-daemon")
+        argument_parser = mock.Mock(parse_args=mock.Mock(return_value=args))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "parser", return_value=argument_parser),
+            mock.patch.object(DAEMON_SWITCH, "restore_pair", return_value=(cli, daemon)),
+            mock.patch.object(DAEMON_SWITCH, "require_macos_restore_provenance") as provenance,
+            mock.patch.object(DAEMON_SWITCH, "switch_pair") as switch,
+        ):
+            self.assertEqual(DAEMON_SWITCH.main(), 0)
+
+        provenance.assert_called_once_with(cli, daemon)
+        switch.assert_called_once_with(args, cli, daemon, require_development_signature=False)
+
     def test_signature_check_uses_shared_stable_identifier_verifier(self) -> None:
         daemon = Path("/candidate/atm-daemon")
         with (
@@ -362,6 +481,29 @@ class ReadinessAndRollbackTests(unittest.TestCase):
                 mock.call(daemon_link, old_daemon),
             ],
         )
+
+    def test_switch_path_retains_the_development_signature_gate(self) -> None:
+        args = argparse.Namespace(yes=False, dry_run=True, repair_orphan=False)
+        cli_link = Path("/selected/atm")
+        daemon_link = Path("/selected/atm-daemon")
+        old_cli = Path("/old/atm")
+        old_daemon = Path("/old/atm-daemon")
+        candidate_cli = Path("/candidate/atm")
+        candidate_daemon = Path("/candidate/atm-daemon")
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(cli_link, daemon_link)),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "require_executable",
+                side_effect=[old_cli, old_daemon, candidate_cli, candidate_daemon],
+            ),
+            mock.patch.object(DAEMON_SWITCH, "validate_selectors"),
+            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signatures") as development,
+            redirect_stdout(io.StringIO()),
+        ):
+            DAEMON_SWITCH.switch_pair(args, candidate_cli, candidate_daemon)
+
+        development.assert_called_once_with(candidate_cli, candidate_daemon)
 
 
 class TemporaryLaunchJournalTests(unittest.TestCase):

--- a/.just/tests/test_send_to_surface.py
+++ b/.just/tests/test_send_to_surface.py
@@ -327,5 +327,74 @@ class SendToSurfaceTests(unittest.TestCase):
             self.assertIn("send-to picker", result.stderr)
 
 
+# RBQA-F103: ATM_SEND_TO_PICKER / ATM_SEND_TO_NATIVE_PICKER are test-only
+# override seams shipped inside atm-send-to.sh/.ps1 with no mechanical
+# enforcement that they stay documented as test-only or stay confined to the
+# two scripts (plus their own test coverage). This is that enforcement.
+SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER")
+SEND_TO_SCRIPTS = (
+    ROOT / "scripts/send-to/atm-send-to.sh",
+    ROOT / "scripts/send-to/atm-send-to.ps1",
+)
+# Files other than the two send-to scripts and `test_*` files that
+# legitimately reference the seam today. Kept as an explicit allowlist
+# (rather than a broader glob) so any new reference is a deliberate,
+# reviewed addition rather than an accidental leak into a shipped path.
+SEND_TO_SEAM_REFERENCE_ALLOWLIST = (
+    ROOT / "scripts/phase-aq/run_aq5_wyvern_degradation_evidence.py",
+    # RBQA-F103's own release-environment guard (see
+    # validate_send_to_test_seams in scripts/validate_release.py).
+    ROOT / "scripts/validate_release.py",
+)
+
+
+class SendToTestOnlySeamLintTests(unittest.TestCase):
+    def test_both_scripts_document_the_seam_as_test_only(self) -> None:
+        for script in SEND_TO_SCRIPTS:
+            text = script.read_text(encoding="utf-8")
+            for var in SEND_TO_TEST_ONLY_ENV_VARS:
+                self.assertIn(var, text, f"{script}: expected a reference to {var}")
+                index = text.index(var)
+                # The documenting comment must sit close to the variable, not
+                # merely appear somewhere else in the file.
+                window = text[max(0, index - 600) : index]
+                self.assertIn(
+                    "test-only",
+                    window.lower(),
+                    f"{script}: {var} must be documented as a test-only seam near its use",
+                )
+
+    def test_no_other_shipped_script_or_workflow_references_the_seam(self) -> None:
+        candidate_roots = (
+            ROOT / ".github" / "workflows",
+            ROOT / "scripts",
+            ROOT / ".just",
+        )
+        allowed = {*SEND_TO_SCRIPTS, *SEND_TO_SEAM_REFERENCE_ALLOWLIST}
+        stray: list[str] = []
+        for root in candidate_roots:
+            if not root.exists():
+                continue
+            for path in sorted(root.rglob("*")):
+                if not path.is_file() or path in allowed:
+                    continue
+                if path.name.startswith("test_"):
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8")
+                except (UnicodeDecodeError, OSError):
+                    continue
+                for var in SEND_TO_TEST_ONLY_ENV_VARS:
+                    if var in text:
+                        stray.append(f"{path.relative_to(ROOT)}: references {var}")
+        self.assertEqual(
+            stray,
+            [],
+            "the Send-To test-only picker seam must stay confined to "
+            "scripts/send-to/atm-send-to.{sh,ps1}, their tests, and the "
+            "explicit SEND_TO_SEAM_REFERENCE_ALLOWLIST entries:\n" + "\n".join(stray),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -83,6 +84,50 @@ class ValidateReleaseContractTests(unittest.TestCase):
             VALIDATE_RELEASE.build_parser().parse_args(["phase-ad-readiness"]).target,
             "phase-ad-readiness",
         )
+
+    def test_default_release_targets_include_send_to_test_seams(self) -> None:
+        self.assertIn("send-to-test-seams", VALIDATE_RELEASE.DEFAULT_RELEASE_TARGETS)
+        self.assertEqual(
+            VALIDATE_RELEASE.build_parser().parse_args(["send-to-test-seams"]).target,
+            "send-to-test-seams",
+        )
+
+    @mock.patch.dict(os.environ, {}, clear=False)
+    def test_send_to_test_seams_pass_when_the_release_environment_is_clean(self) -> None:
+        for var in VALIDATE_RELEASE.SEND_TO_TEST_ONLY_ENV_VARS:
+            os.environ.pop(var, None)
+        findings: list[VALIDATE_RELEASE.Finding] = []
+
+        VALIDATE_RELEASE.validate_send_to_test_seams(self.root, findings)
+
+        self.assertFalse(findings)
+
+    @mock.patch.dict(os.environ, {"ATM_SEND_TO_PICKER": "/tmp/fake-picker"}, clear=False)
+    def test_send_to_test_seams_block_when_the_picker_override_leaks(self) -> None:
+        os.environ.pop("ATM_SEND_TO_NATIVE_PICKER", None)
+        findings: list[VALIDATE_RELEASE.Finding] = []
+
+        VALIDATE_RELEASE.validate_send_to_test_seams(self.root, findings)
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding.check, "send-to-test-seams")
+        self.assertTrue(finding.blocks)
+        self.assertIn("ATM_SEND_TO_PICKER", finding.detail)
+
+    @mock.patch.dict(
+        os.environ,
+        {"ATM_SEND_TO_PICKER": "/tmp/fake-picker", "ATM_SEND_TO_NATIVE_PICKER": "/tmp/fake-native"},
+        clear=False,
+    )
+    def test_send_to_test_seams_report_every_leaked_variable(self) -> None:
+        findings: list[VALIDATE_RELEASE.Finding] = []
+
+        VALIDATE_RELEASE.validate_send_to_test_seams(self.root, findings)
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("ATM_SEND_TO_PICKER", findings[0].detail)
+        self.assertIn("ATM_SEND_TO_NATIVE_PICKER", findings[0].detail)
 
     @mock.patch.object(VALIDATE_RELEASE, "run_capture")
     def test_validate_cli_surface_uses_the_feature_gated_contract(self, run_capture: mock.Mock) -> None:

--- a/crates/atm-daemon-bootstrap/src/peer_launch_config.rs
+++ b/crates/atm-daemon-bootstrap/src/peer_launch_config.rs
@@ -5,6 +5,28 @@ use atm_core::error::AtmError;
 use atm_core::peer_wire::PeerWireMode;
 use atm_http_runtime::PeerPoolConfig;
 
+/// Extracts the value for a single-value CLI `flag` from one already-dequeued,
+/// UTF-8-validated `argument`, honoring both `--flag value` (space-separated,
+/// consuming the next item from `arguments`) and `--flag=value` syntaxes.
+///
+/// Returns `Ok(None)` when `argument` does not name `flag` at all. The
+/// `missing_value` closure supplies the error used when `--flag` is the final
+/// daemon-launch argument (space-separated form with no following value).
+fn take_single_flag_value(
+    arguments: &mut impl Iterator<Item = std::ffi::OsString>,
+    argument: &str,
+    flag: &str,
+    missing_value: impl FnOnce() -> AtmError,
+) -> Result<Option<std::ffi::OsString>, AtmError> {
+    if argument == flag {
+        return arguments.next().map(Some).ok_or_else(missing_value);
+    }
+    let prefixed = format!("{flag}=");
+    Ok(argument
+        .strip_prefix(prefixed.as_str())
+        .map(std::ffi::OsString::from))
+}
+
 /// Parse the sole non-durable peer-wire launch policy before composition.
 pub fn parse_peer_wire_mode(
     arguments: impl IntoIterator<Item = std::ffi::OsString>,
@@ -21,18 +43,15 @@ pub fn parse_peer_wire_mode(
         let argument = argument.into_string().map_err(|_| {
             AtmError::peer_wire_mode_invalid("daemon launch arguments must be valid UTF-8")
         })?;
-        let value = if argument == "--peer-wire-security" {
-            Some(arguments.next().ok_or_else(|| {
+        let Some(value) =
+            take_single_flag_value(&mut arguments, &argument, "--peer-wire-security", || {
                 AtmError::peer_wire_mode_invalid(
                     "--peer-wire-security requires `mutual-tls` or `plaintext-test`",
                 )
-            })?)
-        } else {
-            argument
-                .strip_prefix("--peer-wire-security=")
-                .map(std::ffi::OsString::from)
+            })?
+        else {
+            continue;
         };
-        let Some(value) = value else { continue };
         let value = value.into_string().map_err(|_| {
             AtmError::peer_wire_mode_invalid("peer-wire launch mode must be valid UTF-8")
         })?;
@@ -65,16 +84,13 @@ pub fn parse_direct_peer_port(
         let argument = argument
             .into_string()
             .map_err(|_| AtmError::config("direct-peer launch arguments must be valid UTF-8"))?;
-        let value = if argument == "--direct-peer-port" {
-            Some(arguments.next().ok_or_else(|| {
+        let Some(value) =
+            take_single_flag_value(&mut arguments, &argument, "--direct-peer-port", || {
                 AtmError::config("--direct-peer-port requires a non-zero TCP port")
-            })?)
-        } else {
-            argument
-                .strip_prefix("--direct-peer-port=")
-                .map(std::ffi::OsString::from)
+            })?
+        else {
+            continue;
         };
-        let Some(value) = value else { continue };
         let value = value
             .into_string()
             .map_err(|_| AtmError::config("direct-peer launch port must be valid UTF-8"))?;
@@ -184,53 +200,18 @@ fn peer_pool_launch_argument(
     let argument = argument
         .into_string()
         .map_err(|_| AtmError::config("peer-pool launch arguments must be valid UTF-8"))?;
-    let selected = match argument.as_str() {
-        "--peer-pool-max-per-peer" => Some((
-            "--peer-pool-max-per-peer",
-            next_pool_argument(arguments, &argument)?,
-        )),
-        "--peer-pool-max-pooled-total" => Some((
-            "--peer-pool-max-pooled-total",
-            next_pool_argument(arguments, &argument)?,
-        )),
-        "--peer-pool-idle-timeout-ms" => Some((
-            "--peer-pool-idle-timeout-ms",
-            next_pool_argument(arguments, &argument)?,
-        )),
-        _ => argument
-            .strip_prefix("--peer-pool-max-per-peer=")
-            .map(|value| ("--peer-pool-max-per-peer", std::ffi::OsString::from(value)))
-            .or_else(|| {
-                argument
-                    .strip_prefix("--peer-pool-max-pooled-total=")
-                    .map(|value| {
-                        (
-                            "--peer-pool-max-pooled-total",
-                            std::ffi::OsString::from(value),
-                        )
-                    })
-            })
-            .or_else(|| {
-                argument
-                    .strip_prefix("--peer-pool-idle-timeout-ms=")
-                    .map(|value| {
-                        (
-                            "--peer-pool-idle-timeout-ms",
-                            std::ffi::OsString::from(value),
-                        )
-                    })
-            }),
-    };
-    Ok(selected)
-}
-
-fn next_pool_argument(
-    arguments: &mut impl Iterator<Item = std::ffi::OsString>,
-    flag: &str,
-) -> Result<std::ffi::OsString, AtmError> {
-    arguments
-        .next()
-        .ok_or_else(|| AtmError::config(format!("{flag} requires a positive integer")))
+    for flag in [
+        "--peer-pool-max-per-peer",
+        "--peer-pool-max-pooled-total",
+        "--peer-pool-idle-timeout-ms",
+    ] {
+        if let Some(value) = take_single_flag_value(arguments, &argument, flag, || {
+            AtmError::config(format!("{flag} requires a positive integer"))
+        })? {
+            return Ok(Some((flag, value)));
+        }
+    }
+    Ok(None)
 }
 
 fn parse_pool_usize(name: &str, value: std::ffi::OsString) -> Result<usize, AtmError> {
@@ -253,4 +234,164 @@ fn parse_pool_u64(name: &str, value: std::ffi::OsString) -> Result<u64, AtmError
         .ok()
         .filter(|value| *value > 0)
         .ok_or_else(|| AtmError::config(format!("{name} requires a positive integer")))
+}
+
+#[cfg(test)]
+mod take_single_flag_value_tests {
+    use std::ffi::OsString;
+
+    use super::{AtmError, take_single_flag_value};
+
+    fn unreachable_missing_value() -> AtmError {
+        panic!("missing_value must not be invoked when a value is present")
+    }
+
+    #[test]
+    fn space_syntax_consumes_the_next_argument() {
+        let mut arguments = vec![OsString::from("value")].into_iter();
+        let value = take_single_flag_value(
+            &mut arguments,
+            "--flag",
+            "--flag",
+            unreachable_missing_value,
+        )
+        .expect("space syntax resolves")
+        .expect("flag matched");
+        assert_eq!(value, OsString::from("value"));
+        assert_eq!(
+            arguments.next(),
+            None,
+            "the value argument must be consumed from the iterator"
+        );
+    }
+
+    #[test]
+    fn equals_syntax_does_not_consume_the_iterator() {
+        let mut arguments = vec![OsString::from("--unrelated")].into_iter();
+        let value = take_single_flag_value(
+            &mut arguments,
+            "--flag=value",
+            "--flag",
+            unreachable_missing_value,
+        )
+        .expect("equals syntax resolves")
+        .expect("flag matched");
+        assert_eq!(value, OsString::from("value"));
+        assert_eq!(
+            arguments.next(),
+            Some(OsString::from("--unrelated")),
+            "the equals syntax must not consume a following argument"
+        );
+    }
+
+    #[test]
+    fn non_matching_argument_returns_none() {
+        let mut arguments = std::iter::empty();
+        let selected = take_single_flag_value(
+            &mut arguments,
+            "--other-flag",
+            "--flag",
+            unreachable_missing_value,
+        )
+        .expect("non-matching argument is not an error");
+        assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn prefix_that_is_not_the_flag_does_not_match() {
+        // `--flag-extra=value` shares a prefix with `--flag` but is a
+        // different flag entirely and must not be treated as `--flag=`.
+        let mut arguments = std::iter::empty();
+        let selected = take_single_flag_value(
+            &mut arguments,
+            "--flag-extra=value",
+            "--flag",
+            unreachable_missing_value,
+        )
+        .expect("non-matching argument is not an error");
+        assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn missing_value_invokes_the_supplied_closure() {
+        let mut arguments = std::iter::empty();
+        let error = take_single_flag_value(&mut arguments, "--flag", "--flag", || {
+            AtmError::config("--flag requires a value")
+        })
+        .expect_err("space syntax with nothing following is an error");
+        assert!(error.message().contains("--flag requires a value"));
+    }
+
+    #[test]
+    fn returned_value_is_not_utf8_validated_by_the_helper() {
+        // The helper hands back the raw `OsString` unchanged; UTF-8
+        // validation of the value remains each caller's responsibility so
+        // every call site can keep its own existing error message.
+        let mut arguments = vec![non_utf8_os_string()].into_iter();
+        let value = take_single_flag_value(
+            &mut arguments,
+            "--flag",
+            "--flag",
+            unreachable_missing_value,
+        )
+        .expect("helper does not itself validate UTF-8")
+        .expect("flag matched");
+        assert_eq!(value, non_utf8_os_string());
+        assert!(value.into_string().is_err(), "value remains non-UTF-8");
+    }
+
+    #[cfg(unix)]
+    fn non_utf8_os_string() -> OsString {
+        use std::os::unix::ffi::OsStringExt;
+        OsString::from_vec(vec![0xff, 0xfe])
+    }
+
+    #[cfg(not(unix))]
+    fn non_utf8_os_string() -> OsString {
+        use std::os::windows::ffi::OsStringExt;
+        // An unpaired surrogate is valid `OsString` on Windows but not valid
+        // UTF-8.
+        OsString::from_wide(&[0xd800])
+    }
+
+    #[test]
+    fn duplicate_rejection_is_the_callers_responsibility() {
+        // The helper only decides whether one argument names the flag; each
+        // call site composes it with its own "supplied only once" tracking,
+        // the same way `parse_peer_wire_mode` and `parse_direct_peer_port` do.
+        fn parse_with_duplicate_guard(
+            arguments: impl IntoIterator<Item = OsString>,
+        ) -> Result<OsString, AtmError> {
+            let mut arguments = arguments.into_iter();
+            let mut seen = None;
+            while let Some(argument) = arguments.next() {
+                let argument = argument.into_string().expect("test arguments are UTF-8");
+                let Some(value) = take_single_flag_value(
+                    &mut arguments,
+                    &argument,
+                    "--flag",
+                    unreachable_missing_value,
+                )?
+                else {
+                    continue;
+                };
+                if seen.replace(value).is_some() {
+                    return Err(AtmError::config("--flag may be supplied only once"));
+                }
+            }
+            Ok(seen.expect("fixture always supplies --flag at least once"))
+        }
+
+        let error = parse_with_duplicate_guard([
+            OsString::from("--flag"),
+            OsString::from("first"),
+            OsString::from("--flag=second"),
+        ])
+        .expect_err("second match must be rejected by the caller's duplicate guard");
+        assert!(error.message().contains("only once"));
+
+        let value = parse_with_duplicate_guard([OsString::from("--flag"), OsString::from("only")])
+            .expect("a single match is accepted");
+        assert_eq!(value, OsString::from("only"));
+    }
 }

--- a/scripts/send-to/atm-send-to.ps1
+++ b/scripts/send-to/atm-send-to.ps1
@@ -11,6 +11,10 @@ $pickerDir = $PSScriptRoot
 if ($Files.Count -eq 0) { throw "atm-send-to: provide at least one file" }
 $inputJson = (& $atm teams --json --members | Out-String).Trim()
 $pickerOutput = $null
+# Test-only seam: overrides the whole picker step (skipping both Wyvern and
+# the native fallback picker) with an arbitrary PickerInput -> PickerOutput
+# command, so end-to-end send-to coverage never depends on a real UI.
+# Production launches never set this.
 if ($env:ATM_SEND_TO_PICKER) {
     $pickerOutput = $inputJson | & $env:ATM_SEND_TO_PICKER | Out-String
 } else {

--- a/scripts/send-to/atm-send-to.sh
+++ b/scripts/send-to/atm-send-to.sh
@@ -9,6 +9,10 @@ fi
 send_to_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 files=("$@")
 atm_bin=${ATM_BIN:-atm}
+# Test-only seam: overrides the whole picker step (skipping both Wyvern and
+# the native fallback picker) with an arbitrary PickerInput -> PickerOutput
+# command, so end-to-end send-to coverage never depends on a real UI.
+# Production launches never set this.
 picker_override=${ATM_SEND_TO_PICKER:-}
 # Test-only seam: overrides which native fallback picker runs once Wyvern is
 # unavailable or incompatible, so degradation-harness coverage never depends

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -23,11 +23,15 @@ REQUIRED_RELEASE_FILES = (
     "release/RELEASE-NOTES-TEMPLATE.md",
 )
 REQUIRED_RELEASE_BINARIES = ("atm", "atm-daemon")
+# RBQA-F103: test-only override seams from scripts/send-to/atm-send-to.sh /
+# .ps1 that must never be set in a real release environment.
+SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER")
 KIT_RELEASE_ARTIFACTS = ".github/scripts/release_artifacts.py"
 CHECK_DEP_CURRENCY_ENV = "ATMD_CHECK_DEP_CURRENCY"
 GITHUB_ISSUE_ENV = "ATMD_GH_AUTOFIX_ISSUES"
 DEFAULT_RELEASE_TARGETS = (
     "support-files",
+    "send-to-test-seams",
     "lint",
     "cli-surface",
     "manifest",
@@ -268,6 +272,28 @@ def validate_support_files(root: Path, findings: list[Finding]) -> None:
                 severity="error",
                 summary="missing required release support files",
                 detail=", ".join(missing),
+            )
+        )
+
+
+def validate_send_to_test_seams(root: Path, findings: list[Finding]) -> None:
+    """Fail release validation if a Send-To test-only picker override leaked
+    into the release environment.
+
+    ATM_SEND_TO_PICKER / ATM_SEND_TO_NATIVE_PICKER exist only so the
+    degradation harness can exercise scripts/send-to/atm-send-to.sh / .ps1
+    without a real UI (see .just/tests/test_send_to_surface.py). Neither
+    variable has a legitimate reason to be set while validating a release.
+    """
+    _ = root  # signature kept uniform with the other validate_* targets
+    leaked = sorted(name for name in SEND_TO_TEST_ONLY_ENV_VARS if os.environ.get(name))
+    if leaked:
+        findings.append(
+            Finding(
+                check="send-to-test-seams",
+                severity="error",
+                summary="Send-To test-only picker override is set in the release environment",
+                detail=", ".join(leaked),
             )
         )
 
@@ -1344,6 +1370,7 @@ def build_parser() -> argparse.ArgumentParser:
             "lint",
             "cli-surface",
             "support-files",
+            "send-to-test-seams",
             "manifest",
             "publish-surface",
             "release-binaries",
@@ -1377,6 +1404,7 @@ def main(argv: list[str] | None = None) -> int:
     findings: list[Finding] = []
     actions = {
         "support-files": lambda: validate_support_files(root, findings),
+        "send-to-test-seams": lambda: validate_send_to_test_seams(root, findings),
         "lint": lambda: validate_lint(root, findings),
         "cli-surface": lambda: validate_cli_surface(root, findings),
         "manifest": lambda: validate_manifest(


### PR DESCRIPTION
Minor findings from the Phase AQ post-merge ruthless-boundary-qa phase review (develop @ a7af7cf5c).

- **6f6451d57 — RBQA-F104:** `crates/atm-daemon-bootstrap/src/peer_launch_config.rs` hand-rolled the same argv decisions three times (`--flag value` vs `--flag=value`, supplied-once rejection, UTF-8 validation). One private `take_single_flag_value` helper now serves `parse_peer_wire_mode`, `parse_direct_peer_port` and `peer_pool_launch_argument`; every error message/behaviour unchanged at each call site (existing tests untouched and green); dead `next_pool_argument` removed; 7 new unit tests.
- **4492517cd — RBQA-F103:** the shipped Send-To scripts expose test-only override seams `ATM_SEND_TO_PICKER` / `ATM_SEND_TO_NATIVE_PICKER` with no enforcement. No runtime change: both seams now documented test-only in `atm-send-to.sh/.ps1`; `scripts/validate_release.py` gains `validate_send_to_test_seams` (new default target `send-to-test-seams`) failing release validation if either is set (+4 tests); `.just/tests/test_send_to_surface.py` gains a grep-based lint over `.github/workflows/**`, `scripts/**`, `.just/**` asserting no shipped file references the seams outside an explicit allowlist (`run_aq5_wyvern_degradation_evidence.py`, `validate_release.py`).

Noted, not changed (out of scope): `crates/atm-daemon-bootstrap/src/peer_pool_config.rs` is never `mod`-declared in `lib.rs` — dead file duplicating similar parsing; candidate for deletion in a follow-up.

Gates: fmt ✓ · clippy -D warnings ✓ · `cargo test -p atm-daemon-bootstrap` 49 passed · run_pytests 877 OK (+4) · codespell ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)