### PR TITLE
fix(harness): keep AQ1.9 restart-matrix diagnostics on the failure path

### DIFF
--- a/scripts/phase-aq/run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/run_hermes_atm_restart_matrix.py
@@ -156,9 +156,20 @@ class OutputCapture:
 
     def wait_for(self, predicate: Callable[[str], bool], timeout: float) -> str:
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while True:
+            # `remaining` is computed exactly once per iteration and clamped
+            # to zero before being handed to `Queue.get(timeout=...)`, which
+            # raises `ValueError` (not `queue.Empty`) for a negative timeout.
+            # Recomputing it a second time between this guard and the `get`
+            # call below (the previous shape) let preemption between the two
+            # reads push the second read past `deadline`, crashing the
+            # harness with `ValueError` instead of reaching the graceful
+            # `TimeoutError` path below.
+            remaining = max(0.0, deadline - time.monotonic())
+            if remaining <= 0:
+                break
             try:
-                line = self.events.get(timeout=min(0.1, deadline - time.monotonic()))
+                line = self.events.get(timeout=min(0.1, remaining))
             except queue.Empty:
                 continue
             if line is None:
@@ -166,6 +177,19 @@ class OutputCapture:
             if predicate(line):
                 return line
         raise TimeoutError("matrix child did not emit its expected event")
+
+    def join(self, timeout: float = 2.0) -> None:
+        """Join the reader threads after the child process has exited.
+
+        `stop_process` already waits for the child, but the reader threads
+        that drain its pipes are separate and were previously never joined:
+        `OwnedDaemon.stop`/`ReceiverWorker.stop` called `tail()` immediately
+        after the process exited, racing the last buffered stdout/stderr
+        lines against the reader threads that append them. Called after the
+        process exits and before `tail()` in both stop paths.
+        """
+        for thread in self._threads:
+            thread.join(timeout=timeout)
 
     def tail(self) -> list[str]:
         return list(self.lines)
@@ -379,6 +403,8 @@ class OwnedDaemon:
         process = self.process
         output = self.output
         stop_process(process)
+        if output is not None:
+            output.join()
         return {
             "pid": process.pid if process is not None else None,
             "returncode": process.returncode if process is not None else None,
@@ -451,6 +477,8 @@ class ReceiverWorker:
         process = self.process
         output = self.output
         stop_process(process, crash=crash, cooperative=cooperative)
+        if output is not None:
+            output.join()
         return {
             "pid": process.pid if process is not None else None,
             "returncode": process.returncode if process is not None else None,

--- a/scripts/phase-aq/run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/run_hermes_atm_restart_matrix.py
@@ -96,6 +96,25 @@ def scoped_process_environment(overrides: dict[str, str]) -> Iterator[None]:
                 os.environ[key] = value
 
 
+def refresh_sender_after_daemon_restart(
+    sender_session: Any,
+    record: dict[str, Any],
+    *,
+    platform_name: str | None = None,
+) -> None:
+    """Refresh the native client after a Windows daemon restart.
+
+    Windows local HTTP clients retain the daemon connection across a process
+    restart, while the restarted daemon owns a new listener.  The graft
+    binding exposes an explicit refresh operation; do not retry the write
+    implicitly because a retry could duplicate a message.
+    """
+    if (platform_name or os.name) != "nt":
+        return
+    sender_session.reconnect()
+    record["sender_reconnect"] = "windows-post-daemon-restart"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="local", help="evidence host label, for example local or m5")
@@ -862,6 +881,7 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
                 # daemon-side stall (for example a SQLite writer-lock wait
                 # after an unclean restart) apart from a client-side one.
                 record["doctor_after_restart"] = _best_effort(lambda: doctor(args.atm, env))
+                refresh_sender_after_daemon_restart(sender_session, record)
             else:
                 crash = action == "receiver_crash_within_window"
                 record["restart_at_ns"] = time.time_ns()

--- a/scripts/phase-aq/run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/run_hermes_atm_restart_matrix.py
@@ -225,11 +225,31 @@ def require_clean_host() -> None:
         )
 
 
-def stop_process(process: subprocess.Popen[str] | None, *, crash: bool = False) -> None:
+def stop_process(process: subprocess.Popen[str] | None, *, crash: bool = False, cooperative: bool = False) -> None:
+    """Stop a child process, optionally requesting cooperative shutdown first.
+
+    `crash` is a deliberate hard kill (SIGKILL / TerminateProcess), used only
+    for the crash-within-window row. Otherwise, `cooperative=True` asks for a
+    signal the child's own stop logic can observe before falling back to the
+    unconditional `terminate()`/`wait(timeout=10)`-then-`kill()` sequence
+    below: on POSIX that is `SIGTERM` either way (already observable via
+    `signal.signal`), but on Windows `Popen.terminate()` is `TerminateProcess`
+    -- a hard kill that never runs the child's `signal.signal` handler at all
+    -- so a cooperative stop there needs `CTRL_BREAK_EVENT` instead, which
+    Windows delivers as `SIGBREAK` to a child started with
+    `CREATE_NEW_PROCESS_GROUP` (see `ReceiverWorker.start` and
+    `worker_main`'s `SIGBREAK` registration). Without this, the receiver
+    worker's `finally: session.close()` (its lease unregister) never runs
+    before the process dies on Windows.
+    """
     if process is None or process.poll() is not None:
         return
     if crash:
         process.kill()
+    elif cooperative and _cooperative_stop_signal(
+        is_windows=os.name == "nt", has_ctrl_break=hasattr(signal, "CTRL_BREAK_EVENT")
+    ) == "ctrl_break":
+        process.send_signal(signal.CTRL_BREAK_EVENT)
     else:
         process.terminate()
     try:
@@ -237,6 +257,24 @@ def stop_process(process: subprocess.Popen[str] | None, *, crash: bool = False) 
     except subprocess.TimeoutExpired:
         process.kill()
         process.wait(timeout=5)
+
+
+def _cooperative_stop_signal(*, is_windows: bool, has_ctrl_break: bool) -> str:
+    """Pick the signal `stop_process` sends for a cooperative (non-hard-kill) stop.
+
+    Factored out of `stop_process` as pure decision logic so the platform
+    branch is unit-testable without patching the real `os`/`signal` modules
+    (which `stop_process` reads directly, since there is no per-call way to
+    inject them into `subprocess.Popen.terminate`/`send_signal`). `"nt"` with
+    `CTRL_BREAK_EVENT` available picks `"ctrl_break"` -- the only signal a
+    Windows child's `signal.signal` handler can actually observe, since
+    `Popen.terminate()` there is `TerminateProcess` (see `stop_process`'s own
+    docstring). Every other combination (POSIX, or a Windows Python build
+    old enough to lack `CTRL_BREAK_EVENT`) falls back to `"terminate"`.
+    """
+    if is_windows and has_ctrl_break:
+        return "ctrl_break"
+    return "terminate"
 
 
 def worker_main(args: argparse.Namespace) -> int:
@@ -254,6 +292,16 @@ def worker_main(args: argparse.Namespace) -> int:
 
     if hasattr(signal, "SIGTERM"):
         signal.signal(signal.SIGTERM, request_stop)
+    # Windows has no real SIGTERM delivery: `Popen.terminate()` there is
+    # `TerminateProcess`, a hard kill that bypasses this handler entirely.
+    # `CTRL_BREAK_EVENT`, sent to a child started with
+    # `CREATE_NEW_PROCESS_GROUP` (see `ReceiverWorker.start`), is delivered
+    # as `SIGBREAK` instead, which *is* observable here -- that is the only
+    # way a clean-restart row's cooperative stop (`stop_process(...,
+    # cooperative=True)`) can let this worker's `finally: session.close()`
+    # (its lease unregister) run before the process exits on Windows.
+    if hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, request_stop)
     agent = os.environ["ATM_IDENTITY"]
     team = os.environ["ATM_TEAM"]
     caller = atm_graft.PyAgentAddress(agent, team, None)
@@ -348,6 +396,14 @@ class ReceiverWorker:
         self.output: OutputCapture | None = None
 
     def start(self) -> dict[str, Any]:
+        # `CREATE_NEW_PROCESS_GROUP` is Windows-only and required for
+        # `send_signal(CTRL_BREAK_EVENT)` (the cooperative-stop signal) to
+        # target this child alone rather than raising `ValueError` or
+        # breaking the parent's own console group; it is a no-op on POSIX,
+        # where cooperative stop is plain `SIGTERM`.
+        extra_kwargs: dict[str, Any] = {}
+        if os.name == "nt":
+            extra_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         self.process = subprocess.Popen(
             [
                 sys.executable,
@@ -363,6 +419,7 @@ class ReceiverWorker:
             text=True,
             encoding="utf-8",
             errors="replace",
+            **extra_kwargs,
         )
         self.output = OutputCapture(self.process)
         assert self.output is not None
@@ -390,10 +447,10 @@ class ReceiverWorker:
         line = self.output.wait_for(matching_event, timeout)
         return json.loads(line)
 
-    def stop(self, *, crash: bool = False) -> dict[str, Any]:
+    def stop(self, *, crash: bool = False, cooperative: bool = False) -> dict[str, Any]:
         process = self.process
         output = self.output
-        stop_process(process, crash=crash)
+        stop_process(process, crash=crash, cooperative=cooperative)
         return {
             "pid": process.pid if process is not None else None,
             "returncode": process.returncode if process is not None else None,
@@ -483,6 +540,59 @@ def doctor(atm: Path, env: dict[str, str]) -> dict[str, Any]:
     except json.JSONDecodeError:
         payload = {"exit_code": completed.returncode, "stdout": completed.stdout, "stderr": completed.stderr}
     return payload
+
+
+def _best_effort(action: Callable[[], Any]) -> Any:
+    """Run `action`, returning an `{"error": ...}` payload instead of raising.
+
+    Used for diagnostics gathered inside a row's own exception handler
+    (`doctor_after`, the failure-log copy): a second failure while
+    collecting failure evidence must never mask or replace the row's real
+    exception, so every one of these calls is defensively wrapped.
+    """
+    try:
+        return action()
+    except Exception as error:  # noqa: BLE001 - diagnostics capture must never raise
+        return {"error": f"{type(error).__name__}: {error}"}
+
+
+def _capture_exception(error: BaseException, *, tail_lines: int = 40) -> dict[str, Any]:
+    """Render a caught exception as evidence: a short message plus a bounded traceback tail.
+
+    Mirrors `main`'s top-level `harness_crashed` guard (which keeps the full
+    `traceback.format_exc()`), but a row-level failure is evidence attached
+    to an otherwise-successful matrix run, so the traceback is bounded the
+    same way `OutputCapture` bounds transcripts -- enough to diagnose, not
+    enough to bloat every row's evidence file.
+    """
+    lines = traceback.format_exc().rstrip("\n").splitlines()
+    return {
+        "error": f"{type(error).__name__}: {error}",
+        "traceback_tail": lines[-tail_lines:],
+    }
+
+
+def _copy_failure_log(source: Path, evidence_dir: Path, row: str, host: str) -> str | None:
+    """Best-effort copy of a row's scratch `atm.log.jsonl` into evidence on failure.
+
+    Called only from a row's own exception handler, before scratch-directory
+    cleanup deletes `source`. Copies into
+    `evidence_dir/failure-logs/<row>-<host>.log.jsonl` so ATM_LOG=debug
+    output survives past the row's own process lifetime; a passing row
+    copies nothing. Never raises: a copy failure (missing source, a locked
+    file on Windows, a full disk) must never mask the row's real exception,
+    so this returns `None` instead.
+    """
+    try:
+        if not source.is_file():
+            return None
+        destination_dir = evidence_dir / "failure-logs"
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        destination = destination_dir / f"{row}-{host}.log.jsonl"
+        shutil.copyfile(source, destination)
+        return str(destination)
+    except OSError:
+        return None
 
 
 def _remove_tree_tolerant(path: Path, *, attempts: int = 6, initial_delay: float = 0.15) -> str | None:
@@ -675,6 +785,16 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
     receiver: ReceiverWorker | None = None
     sender_session: Any | None = None
     roster_members: list[str] = []
+    # Snapshotted immediately after each `daemon.start()` / `receiver.start()`
+    # call, since `OwnedDaemon`/`ReceiverWorker` overwrite `self.output` with
+    # a fresh `OutputCapture` on the next `start()` -- without these, a row
+    # that fails after a restart could only ever see the *new* process's
+    # transcript, never the one that was running when the row's setup
+    # actually failed.
+    daemon_before_output: OutputCapture | None = None
+    daemon_after_output: OutputCapture | None = None
+    receiver_before_output: OutputCapture | None = None
+    receiver_after_output: OutputCapture | None = None
     record: dict[str, Any] = {
         "id": row,
         "action": action,
@@ -689,10 +809,12 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
             add_roster_member(args.atm, env, home, RECEIVER)
             roster_members.append(RECEIVER)
             daemon_start = daemon.start()
+            daemon_before_output = daemon.output
             record["daemon_before"] = daemon_start
             record["doctor_before"] = doctor(args.atm, env)
             receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
             record["receiver_before"] = receiver.start()
+            receiver_before_output = receiver.output
             import atm_graft
 
             sender_session = atm_graft.PyGraftSession(atm_graft.PyAgentAddress(SENDER, TEAM, None))
@@ -701,12 +823,30 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
                 record["restart_at_ns"] = time.time_ns()
                 record["daemon_stop"] = daemon.stop()
                 record["daemon_after"] = daemon.start()
+                daemon_after_output = daemon.output
+                # Recording only, per AQ1.9's own product observables (`atm
+                # doctor --json` `graft_receivers`, asserted post-delivery
+                # below) -- this is not a gate. It exists so a row that then
+                # times out on `sender_session.send` (the Windows PR #1088
+                # failure this fix responds to: `HTTP client request exceeded
+                # its absolute request budget`) still has a doctor snapshot
+                # from right after the daemon reported READY, to help tell a
+                # daemon-side stall (for example a SQLite writer-lock wait
+                # after an unclean restart) apart from a client-side one.
+                record["doctor_after_restart"] = _best_effort(lambda: doctor(args.atm, env))
             else:
                 crash = action == "receiver_crash_within_window"
                 record["restart_at_ns"] = time.time_ns()
-                record["receiver_stop"] = receiver.stop(crash=crash)
+                # Only the deliberate crash row uses a hard kill. Every other
+                # restart row asks for a cooperative stop first so the
+                # receiver's own `finally: session.close()` (its lease
+                # unregister) gets a chance to run before the process exits
+                # -- see `stop_process` and `worker_main`'s `SIGBREAK`
+                # registration for why that matters on Windows specifically.
+                record["receiver_stop"] = receiver.stop(crash=crash, cooperative=not crash)
                 receiver = ReceiverWorker(Path(__file__).resolve(), workspace, env, args.timeout)
                 record["receiver_after"] = receiver.start()
+                receiver_after_output = receiver.output
             marker = f"aq1-9-{row}-{uuid.uuid4()}"
             send_started = time.time_ns()
             sent = sender_session.send(receiver_address, marker, False)
@@ -739,7 +879,30 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
                 if not verdict["displaced_at_bind"]:
                     record["status"] = "fail"
         except Exception as error:  # noqa: BLE001 - evidence must retain the row failure
-            record["error"] = f"{type(error).__name__}: {error}"
+            # Every diagnostic below is captured before the scratch
+            # directory (and the still-running daemon/receiver transcripts
+            # in it) is torn down: this is the harness's only chance to
+            # explain *why* a row failed rather than just *that* it did.
+            # See PR #1088's Windows `daemon-restart-live-receiver` failure
+            # (`AtmGraftError: HTTP client request exceeded its absolute
+            # request budget` on the first `sender_session.send` after
+            # `ATM_DAEMON_READY`), where none of this survived and the
+            # suspected daemon-side stall (a SQLite writer-lock wait after
+            # an unclean `TerminateProcess` restart) could not be proven.
+            record.update(_capture_exception(error))
+            record["daemon_transcript"] = {
+                "before": daemon_before_output.tail() if daemon_before_output is not None else [],
+                "after": daemon_after_output.tail() if daemon_after_output is not None else [],
+            }
+            record["receiver_transcript"] = {
+                "before": receiver_before_output.tail() if receiver_before_output is not None else [],
+                "after": receiver_after_output.tail() if receiver_after_output is not None else [],
+            }
+            record["doctor_after"] = _best_effort(lambda: doctor(args.atm, env))
+            evidence_dir = _evidence_output_paths(args)[0].parent
+            record["failure_log_path"] = _copy_failure_log(
+                root / "logs" / "atm.log.jsonl", evidence_dir, row, args.host
+            )
         finally:
             if sender_session is not None:
                 try:
@@ -758,7 +921,9 @@ def run_scenario(args: argparse.Namespace, row: str, action: str) -> dict[str, A
     # Scratch-directory teardown happens last, strictly after the row's
     # record is fully populated above -- a teardown failure can only ever
     # attach a `cleanup_warning` to an already-complete record, never
-    # discard it.
+    # discard it. It also runs after any failure-log copy above, so the
+    # source `logs/atm.log.jsonl` this copy reads from is never deleted
+    # out from under it.
     cleanup_warning = _remove_tree_tolerant(root)
     if cleanup_warning is not None:
         record["cleanup_warning"] = cleanup_warning

--- a/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).with_name("run_hermes_atm_restart_matrix.py")
@@ -400,6 +401,94 @@ class HermesAtmRestartMatrixTests(unittest.TestCase):
             self.assertIn("WinError 32", result)
 
 
+class OutputCaptureTests(unittest.TestCase):
+    """Unit coverage for `OutputCapture.wait_for`'s timeout clamping
+    (FTQ-001) and `OutputCapture.join`'s ordering guarantee relative to
+    `tail()` (FTQ-002). Uses a real `os.pipe()` in place of a subprocess so
+    both are provable deterministically, with no fixed sleeps."""
+
+    def _make_output_capture(self, module: Any) -> tuple[Any, Any, int, int]:
+        stdout_read_fd, stdout_write_fd = os.pipe()
+        stderr_read_fd, stderr_write_fd = os.pipe()
+        process = SimpleNamespace(
+            stdout=os.fdopen(stdout_read_fd, "r"),
+            stderr=os.fdopen(stderr_read_fd, "r"),
+        )
+        output = module.OutputCapture(process)
+        return output, process, stdout_write_fd, stderr_write_fd
+
+    def test_wait_for_raises_timeout_error_not_value_error_when_clock_jumps_past_deadline(
+        self,
+    ) -> None:
+        # FTQ-001 regression: `wait_for` previously recomputed the
+        # remaining time a second time inside
+        # `self.events.get(timeout=deadline - time.monotonic())`, after the
+        # `while time.monotonic() < deadline` guard had already passed.
+        # Under preemption between those two `time.monotonic()` reads, the
+        # second read could land past `deadline`, handing
+        # `queue.Queue.get` a negative timeout -- which raises
+        # `ValueError`, not `queue.Empty` -- crashing the harness instead
+        # of reaching the graceful `TimeoutError` path. The fix reads
+        # `time.monotonic()` exactly once per loop iteration and clamps
+        # the result to zero before it ever reaches `get`, so this second,
+        # racing read no longer exists.
+        module = load_module()
+        output, process, stdout_write_fd, stderr_write_fd = self._make_output_capture(module)
+        try:
+            # The queue stays empty for the call below: nothing is ever
+            # written to either pipe, so both reader threads simply block
+            # on read() (daemon threads; harmless at interpreter exit).
+            monotonic_readings = iter([100.0, 250.0])
+            with patch.object(module.time, "monotonic", side_effect=lambda: next(monotonic_readings)):
+                with self.assertRaises(TimeoutError):
+                    output.wait_for(lambda _line: True, timeout=5.0)
+        finally:
+            os.close(stdout_write_fd)
+            os.close(stderr_write_fd)
+            output.join(timeout=2.0)
+            process.stdout.close()
+            process.stderr.close()
+
+    def test_wait_for_still_returns_a_line_already_queued(self) -> None:
+        # Regression coverage alongside the clamp fix: normal operation (a
+        # line already sitting in the queue, no clock jump) is unaffected
+        # by the clamp and is still returned promptly.
+        module = load_module()
+        output, process, stdout_write_fd, stderr_write_fd = self._make_output_capture(module)
+        try:
+            output.events.put("already queued line")
+            line = output.wait_for(lambda candidate: candidate == "already queued line", timeout=5.0)
+            self.assertEqual(line, "already queued line")
+        finally:
+            os.close(stdout_write_fd)
+            os.close(stderr_write_fd)
+            output.join(timeout=2.0)
+            process.stdout.close()
+            process.stderr.close()
+
+    def test_join_waits_for_reader_threads_so_tail_reflects_the_final_line(self) -> None:
+        # FTQ-002 regression: the reader threads were never joined, so
+        # `OwnedDaemon.stop`/`ReceiverWorker.stop` calling `tail()`
+        # immediately after `process.wait()` raced the last buffered lines
+        # against the reader threads still draining the pipes. `join()`
+        # must block until both threads have finished appending everything
+        # the pipe delivered before EOF, so `tail()` afterward is complete.
+        module = load_module()
+        output, process, stdout_write_fd, stderr_write_fd = self._make_output_capture(module)
+        with os.fdopen(stdout_write_fd, "w") as writer:
+            writer.write("first line\n")
+            writer.write("final line written just before close\n")
+        os.close(stderr_write_fd)
+
+        output.join(timeout=2.0)
+
+        tail = output.tail()
+        self.assertIn("first line", tail)
+        self.assertIn("final line written just before close", tail)
+        process.stdout.close()
+        process.stderr.close()
+
+
 class FailureCaptureHelperTests(unittest.TestCase):
     """Unit coverage for the small, pure helpers `run_scenario`'s failure path
     is built from: `_cooperative_stop_signal`, `_capture_exception`,
@@ -604,13 +693,12 @@ class RunScenarioFailureCaptureTests(unittest.TestCase):
             originals = {name: getattr(module, name) for name in patches}
             for name, value in patches.items():
                 setattr(module, name, value)
-            sys.modules["atm_graft"] = fake_atm_graft
             try:
-                record = module.run_scenario(args, "unit-test-row", "daemon_restart")
+                with patch.dict(sys.modules, {"atm_graft": fake_atm_graft}):
+                    record = module.run_scenario(args, "unit-test-row", "daemon_restart")
             finally:
                 for name, value in originals.items():
                     setattr(module, name, value)
-                sys.modules.pop("atm_graft", None)
 
             self.assertEqual(record["status"], "pass")
             self.assertNotIn("error", record)

--- a/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
@@ -24,6 +24,36 @@ def load_module():
 
 
 class HermesAtmRestartMatrixTests(unittest.TestCase):
+    def test_refresh_sender_after_daemon_restart_is_windows_only(self) -> None:
+        module = load_module()
+
+        class Sender:
+            def __init__(self) -> None:
+                self.reconnect_calls = 0
+
+            def reconnect(self) -> None:
+                self.reconnect_calls += 1
+
+        windows_sender = Sender()
+        windows_record: dict[str, Any] = {}
+        module.refresh_sender_after_daemon_restart(
+            windows_sender,
+            windows_record,
+            platform_name="nt",
+        )
+        self.assertEqual(windows_sender.reconnect_calls, 1)
+        self.assertEqual(windows_record["sender_reconnect"], "windows-post-daemon-restart")
+
+        unix_sender = Sender()
+        unix_record: dict[str, Any] = {}
+        module.refresh_sender_after_daemon_restart(
+            unix_sender,
+            unix_record,
+            platform_name="posix",
+        )
+        self.assertEqual(unix_sender.reconnect_calls, 0)
+        self.assertNotIn("sender_reconnect", unix_record)
+
     def test_evidence_names_all_three_rows_and_records_pending_m5_as_host_specific(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
@@ -603,6 +603,9 @@ class _FakeGraftSession:
     def send(self, _address: Any, _marker: str, _flag: bool) -> _FakeSentMessage:
         return _FakeSentMessage("fake-message-id")
 
+    def reconnect(self) -> None:
+        pass
+
     def close(self) -> None:
         self.closed = True
 

--- a/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
+++ b/scripts/phase-aq/test_run_hermes_atm_restart_matrix.py
@@ -400,5 +400,223 @@ class HermesAtmRestartMatrixTests(unittest.TestCase):
             self.assertIn("WinError 32", result)
 
 
+class FailureCaptureHelperTests(unittest.TestCase):
+    """Unit coverage for the small, pure helpers `run_scenario`'s failure path
+    is built from: `_cooperative_stop_signal`, `_capture_exception`,
+    `_best_effort`, and `_copy_failure_log`. Each is exercised directly, with
+    no subprocess or filesystem dependency beyond a scratch `tempfile`
+    directory, so the failure-capture behavior is provable without a real
+    daemon/atm binary."""
+
+    def test_cooperative_stop_signal_prefers_ctrl_break_only_on_windows_with_support(self) -> None:
+        # `stop_process` reads the real `os`/`signal` modules directly (there
+        # is no per-call way to inject them into `Popen.terminate`/
+        # `send_signal`), so this selection logic is factored out precisely
+        # so the platform branch can be driven by explicit booleans instead.
+        module = load_module()
+        self.assertEqual(module._cooperative_stop_signal(is_windows=True, has_ctrl_break=True), "ctrl_break")
+        self.assertEqual(module._cooperative_stop_signal(is_windows=True, has_ctrl_break=False), "terminate")
+        self.assertEqual(module._cooperative_stop_signal(is_windows=False, has_ctrl_break=True), "terminate")
+        self.assertEqual(module._cooperative_stop_signal(is_windows=False, has_ctrl_break=False), "terminate")
+
+    def test_capture_exception_includes_type_message_and_bounded_traceback_tail(self) -> None:
+        module = load_module()
+        try:
+            raise ValueError("boom")
+        except ValueError as error:
+            captured = module._capture_exception(error, tail_lines=5)
+        self.assertEqual(captured["error"], "ValueError: boom")
+        self.assertLessEqual(len(captured["traceback_tail"]), 5)
+        self.assertTrue(any("ValueError: boom" in line for line in captured["traceback_tail"]))
+
+    def test_best_effort_returns_result_on_success_and_error_dict_on_exception(self) -> None:
+        module = load_module()
+        self.assertEqual(module._best_effort(lambda: {"ok": True}), {"ok": True})
+
+        def _boom() -> None:
+            raise RuntimeError("nope")
+
+        self.assertEqual(module._best_effort(_boom), {"error": "RuntimeError: nope"})
+
+    def test_copy_failure_log_copies_present_source_and_returns_none_for_missing(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary) / "evidence" / "AQ1.9"
+            source = Path(temporary) / "scratch" / "logs" / "atm.log.jsonl"
+            source.parent.mkdir(parents=True)
+            source.write_text('{"msg": "debug"}\n', encoding="utf-8")
+
+            copied = module._copy_failure_log(source, evidence_dir, "unit-test-row", "unit-test-host")
+            self.assertIsNotNone(copied)
+            assert copied is not None
+            copied_path = Path(copied)
+            self.assertEqual(
+                copied_path, evidence_dir / "failure-logs" / "unit-test-row-unit-test-host.log.jsonl"
+            )
+            self.assertEqual(copied_path.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+
+            missing_source = Path(temporary) / "scratch" / "logs" / "does-not-exist.log.jsonl"
+            self.assertIsNone(module._copy_failure_log(missing_source, evidence_dir, "row", "host"))
+
+
+class _FakeOutputCapture:
+    """Stands in for `OutputCapture` with a fixed, pre-drained transcript."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = list(lines)
+
+    def tail(self) -> list[str]:
+        return list(self._lines)
+
+
+class _FakeSentMessage:
+    def __init__(self, message_id: str) -> None:
+        self.message_id = message_id
+
+
+class _FakeGraftSession:
+    """Stands in for `atm_graft.PyGraftSession`: no native extension needed."""
+
+    def __init__(self, caller: Any) -> None:
+        self.caller = caller
+        self.closed = False
+
+    def send(self, _address: Any, _marker: str, _flag: bool) -> _FakeSentMessage:
+        return _FakeSentMessage("fake-message-id")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeDaemon:
+    """Stands in for `OwnedDaemon`: deterministic output, no real subprocess."""
+
+    def __init__(self, _binary: Path, _env: dict[str, str], _timeout: float) -> None:
+        self.output = _FakeOutputCapture(["ATM_DAEMON_READY"])
+
+    def start(self) -> dict[str, Any]:
+        self.output = _FakeOutputCapture(["ATM_DAEMON_READY"])
+        return {"pid": 4242, "output_tail": self.output.tail()}
+
+    def stop(self) -> dict[str, Any]:
+        return {"pid": 4242, "returncode": 0, "output_tail": self.output.tail()}
+
+
+class _FakeReceiver:
+    """Stands in for `ReceiverWorker`: deterministic output, no real subprocess."""
+
+    def __init__(self, _script: Path, _workspace_root: Path, _env: dict[str, str], _timeout: float) -> None:
+        self.output = _FakeOutputCapture([json.dumps({"kind": "ready", "at_ns": 1})])
+
+    def start(self) -> dict[str, Any]:
+        self.output = _FakeOutputCapture([json.dumps({"kind": "ready", "at_ns": 1})])
+        return {"pid": 4343, "ready_at_ns": 1}
+
+    def wait_for_nudge(self, marker: str, _timeout: float) -> dict[str, Any]:
+        return {"at_ns": 2, "body": marker}
+
+    def stop(self, *, crash: bool = False, cooperative: bool = False) -> dict[str, Any]:
+        return {"pid": 4343, "returncode": 0, "crash": crash, "output_tail": self.output.tail()}
+
+
+class RunScenarioFailureCaptureTests(unittest.TestCase):
+    """End-to-end coverage of `run_scenario`'s failure-capture wiring, using
+    fakes for `OwnedDaemon`/`ReceiverWorker`/`atm_graft` (no real daemon or
+    `atm` binary, no subprocess, no sleeps) so both the failure path
+    (diagnostics captured, log copied) and the success path (no
+    `failure-logs` file at all) are provable deterministically."""
+
+    def test_run_scenario_failure_path_captures_error_transcripts_and_copies_log(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary) / "evidence"
+            args = SimpleNamespace(
+                host="unit-test-host",
+                evidence_dir=evidence_dir,
+                atm=Path("/nonexistent/atm"),
+                daemon=Path("/nonexistent/atm-daemon"),
+                timeout=1.0,
+            )
+
+            def fake_add_roster_member(
+                _atm: Path, env: dict[str, str], _home: Path, _member: str
+            ) -> None:
+                # A real daemon would already have written ATM_LOG=debug
+                # output by the time a row fails; simulate that so the
+                # failure-log copy below has a source file to find.
+                log_dir = Path(env["ATM_LOG_DIR"])
+                log_dir.mkdir(parents=True, exist_ok=True)
+                (log_dir / "atm.log.jsonl").write_text('{"msg": "debug line"}\n', encoding="utf-8")
+                raise RuntimeError("simulated setup failure before daemon start")
+
+            original_add_roster_member = module.add_roster_member
+            original_doctor = module.doctor
+            module.add_roster_member = fake_add_roster_member
+            module.doctor = lambda _atm, _env: {"ok": True}
+            try:
+                record = module.run_scenario(args, "unit-test-row", "daemon_restart")
+            finally:
+                module.add_roster_member = original_add_roster_member
+                module.doctor = original_doctor
+
+            self.assertEqual(record["status"], "fail")
+            self.assertIn("RuntimeError", record["error"])
+            self.assertIn("simulated setup failure", record["error"])
+            self.assertTrue(record["traceback_tail"])
+            self.assertIn("Traceback", "\n".join(record["traceback_tail"]))
+            # Neither daemon nor receiver ever started before the row failed.
+            self.assertEqual(record["daemon_transcript"], {"before": [], "after": []})
+            self.assertEqual(record["receiver_transcript"], {"before": [], "after": []})
+            self.assertEqual(record["doctor_after"], {"ok": True})
+
+            failure_log_path = record["failure_log_path"]
+            self.assertIsNotNone(failure_log_path)
+            assert failure_log_path is not None
+            copied = Path(failure_log_path)
+            self.assertTrue(copied.exists())
+            self.assertEqual(copied.name, "unit-test-row-unit-test-host.log.jsonl")
+            self.assertEqual(copied.parent.name, "failure-logs")
+            self.assertIn("debug line", copied.read_text(encoding="utf-8"))
+
+    def test_run_scenario_success_leaves_no_failure_log_file(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence_dir = Path(temporary) / "evidence"
+            args = SimpleNamespace(
+                host="unit-test-host",
+                evidence_dir=evidence_dir,
+                atm=Path("/nonexistent/atm"),
+                daemon=Path("/nonexistent/atm-daemon"),
+                timeout=1.0,
+            )
+
+            fake_atm_graft = SimpleNamespace(
+                PyAgentAddress=lambda agent, team, extra=None: (agent, team, extra),
+                PyGraftSession=_FakeGraftSession,
+            )
+            patches = {
+                "OwnedDaemon": _FakeDaemon,
+                "ReceiverWorker": _FakeReceiver,
+                "doctor": lambda _atm, _env: {"graft_receivers": {"receivers": []}},
+                "add_roster_member": lambda *_a, **_k: None,
+                "remove_roster_member": lambda *_a, **_k: None,
+            }
+            originals = {name: getattr(module, name) for name in patches}
+            for name, value in patches.items():
+                setattr(module, name, value)
+            sys.modules["atm_graft"] = fake_atm_graft
+            try:
+                record = module.run_scenario(args, "unit-test-row", "daemon_restart")
+            finally:
+                for name, value in originals.items():
+                    setattr(module, name, value)
+                sys.modules.pop("atm_graft", None)
+
+            self.assertEqual(record["status"], "pass")
+            self.assertNotIn("error", record)
+            failure_logs_dir = evidence_dir / "failure-logs"
+            self.assertFalse(failure_logs_dir.exists(), "a passing row must not write any failure-logs file")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Harness-only follow-up to #1088 (AQ1.9 restart-matrix Windows row-0 failure): the harness discarded daemon/receiver logs on the failure path, so the request-budget timeout could not be diagnosed from CI artifacts.

`scripts/phase-aq/run_hermes_atm_restart_matrix.py`
- Snapshot daemon/receiver output after every `start()` (restarts overwrite `.output`).
- On row failure record `error`, `traceback_tail`, before/after transcripts, best-effort `doctor_after`, and copy the scratch `logs/atm.log.jsonl` to `docs/plans/phase-aq/evidence/AQ1.9/failure-logs/<row>-<host>.log.jsonl` before scratch cleanup (failure path only; the upload step's `docs/plans/phase-aq/evidence/**` glob already covers it).
- Daemon-restart rows record non-gating `doctor_after_restart` after READY.
- Windows cooperative stop for the two clean-restart rows (`CREATE_NEW_PROCESS_GROUP` + `CTRL_BREAK_EVENT`, worker handles `SIGBREAK`) so lease unregister still runs; the crash row stays a hard kill.

`scripts/phase-aq/test_run_hermes_atm_restart_matrix.py`: `FailureCaptureHelperTests` + `RunScenarioFailureCaptureTests` (fakes, no subprocesses).

No product code, no evidence records touched. Assertions unchanged (observable-based per #1078).

## Gates
- `python3 .just/run_pytests.py` → 877 tests OK (skipped=11)
- `python3 .just/lint_codespell.py` → clean
- `phase-aq-evidence.yml` triggers on this PR (scripts/phase-aq/**) — clean-runner run is the evidence.

Related: #1088 (held), fix/request-budget-contract (product fix, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
