### PR TITLE
fix(daemon-switch): repair Homebrew restore provenance

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -249,9 +249,26 @@ def homebrew_release_metadata() -> dict[str, object]:
     except json.JSONDecodeError as error:
         raise SwitchError("cannot verify Homebrew release provenance: brew info returned invalid JSON") from error
     formulae = payload.get("formulae") if isinstance(payload, dict) else None
-    if not isinstance(formulae, list) or len(formulae) != 1 or not isinstance(formulae[0], dict):
+    if not isinstance(formulae, list):
         raise SwitchError("cannot verify Homebrew release provenance: ATM formula metadata is missing")
-    return formulae[0]
+    # Homebrew returns every installed formula when --installed is present,
+    # even when a formula name is supplied. Select ATM explicitly instead of
+    # assuming the response contains one item.
+    atm_formulae = [
+        formula
+        for formula in formulae
+        if isinstance(formula, dict)
+        and (
+            formula.get("name") == "atm"
+            or (
+                isinstance(formula.get("full_name"), str)
+                and formula["full_name"].rsplit("/", maxsplit=1)[-1] == "atm"
+            )
+        )
+    ]
+    if len(atm_formulae) != 1:
+        raise SwitchError("cannot verify Homebrew release provenance: ATM formula metadata is missing")
+    return atm_formulae[0]
 
 
 def require_homebrew_release_provenance(cli: Path, daemon: Path) -> None:
@@ -293,12 +310,12 @@ def require_homebrew_release_provenance(cli: Path, daemon: Path) -> None:
     formula = homebrew_release_metadata()
     if formula.get("homepage") != "https://github.com/randlee/atm-core":
         raise SwitchError("Homebrew ATM formula has an unexpected project homepage")
+    # atm-daemon has no side-effect-free --version mode: while the singleton
+    # is running, probing it attempts startup and returns the owner-lock error.
+    # Both binaries are extracted from Homebrew's one checksummed release
+    # archive, so the CLI version plus formula provenance establishes pairing
+    # without probing the live daemon.
     cli_version = selected_release_version(cli)
-    daemon_version = selected_release_version(daemon)
-    if cli_version != daemon_version:
-        raise SwitchError(
-            f"Homebrew ATM pair has mismatched versions: CLI {cli_version}, daemon {daemon_version}"
-        )
     versions = formula.get("versions")
     installed = formula.get("installed")
     if not isinstance(versions, dict) or versions.get("stable") != cli_version:

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -244,6 +244,8 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
                 binary.write_bytes(binary.name.encode("utf-8"))
                 binary.chmod(0o700)
             formula = {
+                "name": "atm",
+                "full_name": "randlee/tap/atm",
                 "homepage": "https://github.com/randlee/atm-core",
                 "versions": {"stable": "1.4.4"},
                 "installed": [{"version": "1.4.4"}],
@@ -262,10 +264,23 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
                     "run",
                     side_effect=[
                         subprocess.CompletedProcess([], 0, f"{prefix}\n", ""),
-                        subprocess.CompletedProcess([], 0, json.dumps({"formulae": [formula]}), ""),
+                        subprocess.CompletedProcess(
+                            [],
+                            0,
+                            json.dumps(
+                                {
+                                    "formulae": [
+                                        {"name": "openssl", "full_name": "homebrew/core/openssl"},
+                                        formula,
+                                        {"name": "python", "full_name": "homebrew/core/python"},
+                                    ]
+                                }
+                            ),
+                            "",
+                        ),
                     ],
                 ),
-                mock.patch.object(DAEMON_SWITCH, "selected_release_version", side_effect=["1.4.4", "1.4.4"]),
+                mock.patch.object(DAEMON_SWITCH, "selected_release_version", return_value="1.4.4"),
             ):
                 DAEMON_SWITCH.require_homebrew_release_provenance(cli, daemon)
 
@@ -280,6 +295,8 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
                 binary.write_bytes(binary.name.encode("utf-8"))
                 binary.chmod(0o700)
             formula = {
+                "name": "atm",
+                "full_name": "randlee/tap/atm",
                 "homepage": "https://github.com/randlee/atm-core",
                 "versions": {"stable": "1.4.4"},
                 "installed": [{"version": "1.4.4"}],
@@ -301,10 +318,58 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
                         subprocess.CompletedProcess([], 0, json.dumps({"formulae": [formula]}), ""),
                     ],
                 ),
-                mock.patch.object(DAEMON_SWITCH, "selected_release_version", side_effect=["1.4.4", "1.4.4"]),
+                mock.patch.object(DAEMON_SWITCH, "selected_release_version", return_value="1.4.4"),
             ):
                 with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "matching GitHub Release asset"):
                     DAEMON_SWITCH.require_homebrew_release_provenance(cli, daemon)
+
+    def test_homebrew_release_provenance_does_not_probe_daemon_owner_lock_as_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            prefix = Path(temporary) / "opt" / "atm"
+            binary_dir = prefix / "bin"
+            binary_dir.mkdir(parents=True)
+            cli = binary_dir / "atm"
+            daemon = binary_dir / "atm-daemon"
+            for binary in (cli, daemon):
+                binary.write_bytes(binary.name.encode("utf-8"))
+                binary.chmod(0o700)
+            formula = {
+                "name": "atm",
+                "full_name": "randlee/tap/atm",
+                "homepage": "https://github.com/randlee/atm-core",
+                "versions": {"stable": "1.4.4"},
+                "installed": [{"version": "1.4.4"}],
+                "urls": {
+                    "stable": {
+                        "url": "https://github.com/randlee/atm-core/releases/download/v1.4.4/atm.tar.gz",
+                        "checksum": "a" * 64,
+                    }
+                },
+            }
+            probed: list[Path] = []
+
+            def version_probe(binary: Path) -> str:
+                probed.append(binary)
+                if binary == daemon:
+                    return "an ATM daemon already owns ~/.atm/daemon/owner.lock ... retry."
+                return "atm 1.4.4"
+
+            with (
+                mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+                mock.patch.object(DAEMON_SWITCH.shutil, "which", return_value="/opt/homebrew/bin/brew"),
+                mock.patch.object(
+                    DAEMON_SWITCH,
+                    "run",
+                    side_effect=[
+                        subprocess.CompletedProcess([], 0, f"{prefix}\n", ""),
+                        subprocess.CompletedProcess([], 0, json.dumps({"formulae": [formula]}), ""),
+                    ],
+                ),
+                mock.patch.object(DAEMON_SWITCH, "version", side_effect=version_probe),
+            ):
+                DAEMON_SWITCH.require_homebrew_release_provenance(cli, daemon)
+
+            self.assertEqual(probed, [cli.resolve()])
 
     def test_restore_dispatch_uses_provenance_gate_and_skips_dev_gate(self) -> None:
         args = argparse.Namespace(command="restore")


### PR DESCRIPTION
Fixes FIX-DAEMON-SWITCH-RESTORE-002.

- Select the ATM formula from Homebrew's real multi-formula --installed JSON response.
- Stop probing atm-daemon with --version during restore; the running owner lock makes that probe non-version output. CLI version plus the single checksummed Homebrew release archive establishes pairing.
- Preserve strict Apple Development signing for switch and non-Homebrew restore paths.
- Add regression coverage for multi-formula metadata and the daemon owner-lock behavior.

Validation: daemon-switch 53/53, .just mirror 17/17, py_compile, and git diff --check pass. No live restore/switch/restart or brew install/upgrade/link was run.