### PR TITLE
test: prevent foreign PowerShell SIGSEGV in pytest sweep

### DIFF
--- a/.just/tests/test_picker_exclusion.py
+++ b/.just/tests/test_picker_exclusion.py
@@ -138,11 +138,20 @@ class PickerLinuxExclusionTests(PickerExclusionAssertions, unittest.TestCase):
         self.assert_dead_and_idle_are_excluded(result)
 
 
-@unittest.skipUnless(shutil.which("pwsh"), "picker-windows.ps1 requires pwsh")
+# `picker-windows.ps1` is a Windows adapter.  On non-Windows hosts an
+# opportunistically installed PowerShell is not a supported execution
+# environment: the Homebrew PowerShell 7.5.4 runtime on macOS 15.5 crashes
+# in .NET's MulticoreJitProfilePlayer before the script starts (SIGSEGV 11).
+# Keep this test on the platform whose adapter it exercises; otherwise a
+# broken foreign runtime turns an unrelated host lint run into a false failure.
+@unittest.skipUnless(
+    sys.platform == "win32" and shutil.which("pwsh"),
+    "picker-windows.ps1 is validated on Windows only; unsupported pwsh host",
+)
 class PickerWindowsExclusionTests(PickerExclusionAssertions, unittest.TestCase):
     def test_windows_adapter_excludes_dead_and_idle(self) -> None:
         # ATM_SEND_TO_SELECTION is consulted before Out-GridView, so this is
-        # hermetic wherever pwsh is installed (not only on Windows).
+        # hermetic on the Windows runner without opening a UI.
         result = run(["pwsh", "-NoProfile", "-File", str(PICKER_WINDOWS)])
         self.assert_dead_and_idle_are_excluded(result)
 

--- a/.just/tests/test_transfer_scripts.py
+++ b/.just/tests/test_transfer_scripts.py
@@ -470,16 +470,17 @@ class TailscaleShTests(_TransferScriptContractTestsMixin, unittest.TestCase):
         self.assertTrue(os.access(TAILSCALE_SH, os.X_OK))
 
 
-@unittest.skipUnless(sys.platform == "win32" or PWSH is not None, "sftp.ps1 needs pwsh, and only ships for win32; skipping with a recorded reason")
+@unittest.skipUnless(
+    sys.platform == "win32" and PWSH is not None,
+    "sftp.ps1 is validated on Windows only; unsupported pwsh host",
+)
 class SftpPs1Tests(unittest.TestCase):
     """`sftp.ps1` (Windows/`pwsh` example) exercises the identical
-    invocation contract as `sftp.sh`, through `pwsh`. Gated exactly like
-    the rest of this repository's cross-platform script suite: it always
-    runs on a `win32` CI lane (where `pwsh` -- PowerShell 7+ -- ships by
-    default on `windows-latest`), and opportunistically on any other
-    platform where a developer happens to have `pwsh` installed; everywhere
-    else it is skipped with an explicit, non-silent reason rather than
-    reporting a false pass."""
+    invocation contract as `sftp.sh`, through `pwsh`. It runs on the
+    `win32` CI lane (where `pwsh` -- PowerShell 7+ -- ships by default on
+    `windows-latest`). Non-Windows hosts skip this Windows adapter with an
+    explicit reason: foreign PowerShell runtimes are not a supported test
+    environment and can crash before the script starts."""
 
     def _invoke(self, args, env, cwd):
         assert PWSH is not None


### PR DESCRIPTION
Fixes FIX-DEVELOP-PYTEST-SIG11 / QA-001.

The Windows-only picker and sftp.ps1 tests were opportunistically invoking Homebrew PowerShell on macOS. On this host pwsh 7.5.4 consistently exits SIGSEGV 11 before script startup; the crash report points to .NET MulticoreJitProfilePlayer. Gate these Windows adapter tests to the Windows runner, where their native runtime is supported.

Validation:
- `just lint pytests` passes (893 tests, 20 skips) with no signal-11 failures.
- picker exclusion: 5 pass, 1 platform skip.
- transfer scripts: 21 pass, 8 platform skips.
- No product/legacy daemon code changed.