### PR TITLE
chore(release): bump workspace to 1.4.6 for prerelease/v1.4.6

### DIFF
--- a/.just/tests/test_prerelease_archive_workflow.py
+++ b/.just/tests/test_prerelease_archive_workflow.py
@@ -20,6 +20,7 @@ from lint_common import discover_repo_root
 from lint_common import resolve_posix_shell
 import prerelease_tag
 from prerelease_tag import patch_bump
+from prerelease_tag import workspace_version
 
 SHELL_COMMAND_TIMEOUT_SECONDS = 10
 
@@ -287,6 +288,7 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
             subprocess.run(["git", "commit", "-qm", "fixture"], cwd=tmp_path, check=True)
             output = tmp_path / "github-output"
             token_capture = tmp_path / "gh-token"
+            # Fixture-local tag/version: this test runs the extracted script in a synthetic repo.
             probe_env = {
                 **os.environ,
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
@@ -356,32 +358,35 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
         self.assertIn('"push", "origin", branch', helper)
 
     def test_prerelease_tag_helper_patch_bumps_the_workspace_version(self) -> None:
+        # Fixture-local values: this unit test exercises patch arithmetic, not the real workspace.
         self.assertEqual(patch_bump("1.4.5"), "1.4.6")
         self.assertEqual(patch_bump("9.99.0"), "9.99.1")
 
     def test_candidate_bump_updates_actual_lockfile_collision_safely(self) -> None:
         root = discover_repo_root()
-        changes = prerelease_tag.candidate_changes(root, "1.4.5", "1.4.6")
+        old_version = workspace_version(root)
+        new_version = patch_bump(old_version)
+        changes = prerelease_tag.candidate_changes(root, old_version, new_version)
         lock = tomllib.loads(changes[root / "Cargo.lock"])
         directives = [
             package for package in lock["package"] if package["name"] == "sc-lint-directives"
         ]
         self.assertEqual(
             [(package["version"], "source" in package) for package in directives],
-            [("0.5.0", True), ("1.4.6", False)],
+            [("0.5.0", True), (new_version, False)],
         )
         self.assertEqual(
             tomllib.loads(changes[root / "crates" / "atm-query-python" / "pyproject.toml"])[
                 "project"
             ]["version"],
-            "1.4.6",
+            new_version,
         )
         expected = {
             root / "Cargo.toml",
             *(
                 path
                 for path in prerelease_tag.workspace_manifest_paths(root)
-                if 'version = "1.4.5"' in path.read_text(encoding="utf-8")
+                if f'version = "{old_version}"' in path.read_text(encoding="utf-8")
             ),
             *(
                 path
@@ -397,12 +402,12 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
             if path not in changes:
                 continue
             project = tomllib.loads(changes[path])["project"]
-            self.assertEqual(project["version"], "1.4.6")
+            self.assertEqual(project["version"], new_version)
         winget = changes[root / ".winget" / "randlee.agent-team-mail.yaml"]
-        self.assertIn("PackageVersion: 1.4.6", winget)
-        self.assertIn("ManifestVersion: 1.4.6", winget)
+        self.assertIn(f"PackageVersion: {new_version}", winget)
+        self.assertIn(f"ManifestVersion: {new_version}", winget)
         self.assertIn(
-            "releases/download/v1.4.6/atm_1.4.6_x86_64-pc-windows-msvc.zip",
+            f"releases/download/v{new_version}/atm_{new_version}_x86_64-pc-windows-msvc.zip",
             winget,
         )
 
@@ -413,6 +418,7 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
             subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
             subprocess.run(["git", "config", "user.name", "AS1.1 test"], cwd=repo, check=True)
             manifest = repo / "Cargo.toml"
+            # Fixture-local versions: this test exercises rollback after a failed commit.
             original = "[workspace.package]\nversion = \"1.4.5\"\n"
             manifest.write_text(original, encoding="utf-8")
             subprocess.run(["git", "add", "Cargo.toml"], cwd=repo, check=True)
@@ -446,6 +452,8 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
 
     def test_just_prerelease_tag_dry_run_is_end_to_end_and_clean(self) -> None:
         root = discover_repo_root()
+        old_version = workspace_version(root)
+        new_version = patch_bump(old_version)
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory) / "atm-core"
 
@@ -464,8 +472,8 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("workspace version: 1.4.5 -> 1.4.6", result.stdout)
-            self.assertIn("would create tag: prerelease/v1.4.6", result.stdout)
+            self.assertIn(f"workspace version: {old_version} -> {new_version}", result.stdout)
+            self.assertIn(f"would create tag: prerelease/v{new_version}", result.stdout)
             self.assertEqual(
                 subprocess.run(
                     ["git", "status", "--porcelain"],

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.4.5
+PackageVersion: 1.4.6
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.5/atm_1.4.5_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.6/atm_1.4.6_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.4.5
+ManifestVersion: 1.4.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-herdr",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "atm-herdr"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "serde_json",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -388,14 +388,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "peer-tls"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "atm-storage",
  "rcgen",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1944,7 +1944,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sc-lint-attributes",
- "sc-lint-directives 1.4.5",
+ "sc-lint-directives 1.4.6",
  "serde",
  "serde_json",
  "syn 2.0.119",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.5"
+version = "1.4.6"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-error = { path = "../atm-error", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -39,7 +39,7 @@ sc-lint-attributes = "0.5"
 
 [dev-dependencies]
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.5", features = ["test-utils"] }
+atm-storage = { path = "../atm-storage", version = "1.4.6", features = ["test-utils"] }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -18,14 +18,14 @@ path = "src/bin/atm-daemon-benchmark.rs"
 required-features = ["benchmark-harness"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-herdr = { path = "../atm-herdr", version = "1.4.5" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.5" }
-atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.5" }
-peer-tls = { path = "../peer-tls", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-herdr = { path = "../atm-herdr", version = "1.4.6" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6" }
+atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.6" }
+peer-tls = { path = "../peer-tls", version = "1.4.6" }
 tokio.workspace = true
 tracing.workspace = true
 fs4 = "0.13"
@@ -33,9 +33,9 @@ serde_json.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-herdr = { path = "../atm-herdr", version = "1.4.5", features = ["test-utils"] }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-herdr = { path = "../atm-herdr", version = "1.4.6", features = ["test-utils"] }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6", features = ["test-support"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
@@ -20,5 +20,5 @@ tracing = "0.1"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -17,8 +17,8 @@ sc-observability-types.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.6" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -5,7 +5,7 @@ name = "atm-graft-python"
 publish = false
 # Maturin consumes this crate's Cargo version as Python package metadata; keep
 # it equivalent to the workspace release while using PEP 440-compatible form.
-version = "1.4.5"
+version = "1.4.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,12 +27,12 @@ abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.5" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
+atm-graft = { path = "../atm-graft", version = "1.4.6" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
 pyo3 = "0.29"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-graft = { path = "../atm-graft", version = "1.4.5", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.6", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,15 +13,15 @@ homepage.workspace = true
 test-support = ["atm-core/test-utils"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.6" }
 async-trait.workspace = true
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
 tracing.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.6" }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-herdr/Cargo.toml
+++ b/crates/atm-herdr/Cargo.toml
@@ -13,6 +13,6 @@ homepage.workspace = true
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -15,8 +15,8 @@ homepage.workspace = true
 test-support = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-herdr = { path = "../atm-herdr", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-herdr = { path = "../atm-herdr", version = "1.4.6" }
 base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
@@ -36,9 +36,9 @@ ulid.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-herdr = { path = "../atm-herdr", version = "1.4.5", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-herdr = { path = "../atm-herdr", version = "1.4.6", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -12,8 +12,8 @@ homepage.workspace = true
 description = "Provisioning and bounded curl mTLS interoperability fixture for ATM."
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 rustls.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atm-query-python"
 # This local analyst binding is not part of the current public release surface.
 publish = false
-version = "1.4.5"
+version = "1.4.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -20,9 +20,9 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.5" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6" }
 
 [dev-dependencies]
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.5", features = ["test-support"] }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6", features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-query"
-version = "1.4.5"
+version = "1.4.6"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.5" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.5", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.4.6" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,8 +16,8 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared audited storage contract and canonical domain types for AT
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.5" }
+atm-error = { path = "../atm-error", version = "1.4.6" }
 serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true

--- a/crates/atm-template-sc-compose/Cargo.toml
+++ b/crates/atm-template-sc-compose/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace = true
 name = "atm_template_sc_compose"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 sc-composer = "=1.5.0"
 sc-sha = "=1.5.0"
 serde_json.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,11 +33,11 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.5" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.5" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.5" }
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.6" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.6" }
+atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -54,8 +54,8 @@ tokio.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.5", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.5", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.6", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.4.5"
+version = "1.4.6"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/crates/peer-tls/Cargo.toml
+++ b/crates/peer-tls/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Concrete, bounded mTLS byte-stream adapter for ATM peers."
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.5" }
+atm-storage = { path = "../atm-storage", version = "1.4.6" }
 rustls.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true


### PR DESCRIPTION
Version-only bump (1.4.5 → 1.4.6) across Cargo/pyproject/winget manifests, produced by `just prerelease-tag` for the `prerelease/v1.4.6` tag (commit 713f17e20, already tagged and pushed).

Landing this on develop so `ci.yml` produces the 1.4.6 wheel artifacts at the exact tag sha — otherwise develop stays pinned at 1.4.5 while the tag references 1.4.6, breaking sha/version coherence for downstream consumers (loki@hermes AR integration testbed).

No functional changes — version fields only. Gate: CI green + diff-scope confirmation, no full QA review needed for a version-only diff (per fenix).