### PR TITLE
docs: record v1.4.6 integration contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- document that release archives nest their binaries under a top-level
+  `atm_<version>_<target-triple>/` directory (for example,
+  `atm_1.4.6_aarch64-unknown-linux-gnu/bin/atm`) rather than a flat archive
+  root (Phase AS, #1105)
 - enforce the request-budget ordering between SQLite storage, the replacement
   daemon, and same-host clients; rebuild local TCP and Unix transports after a
   daemon generation change, classify pre-send reconnects separately from

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Published archives:
 | macOS (Apple Silicon) | `atm_<version>_aarch64-apple-darwin.tar.gz` |
 | Windows (x86_64) | `atm_<version>_x86_64-pc-windows-msvc.zip` |
 
+Each archive contains a top-level directory named
+`atm_<version>_<target-triple>/`, rather than placing binaries at the archive
+root. For example, the arm64 Linux CLI is at
+`atm_1.4.6_aarch64-unknown-linux-gnu/bin/atm` after extraction.
+
 Extract the archive and place `atm` or `atm.exe` somewhere on your `PATH`.
 
 ### Homebrew

--- a/docs/adr/ADR-058-herdr-local-steer-backend-contract.md
+++ b/docs/adr/ADR-058-herdr-local-steer-backend-contract.md
@@ -84,6 +84,13 @@ Consequences atm-core adopts:
   `:161-171`). Default is `~/.config/herdr/herdr.sock`. A named session is a
   *separate server process*, not a workspace.
 
+**Operator path note.** When the ATM roster selects `--backend herdr
+--session <name>`, each daemon probe invokes Herdr with `HERDR_SESSION=<name>`
+on that child process, so Herdr probes `sessions/<name>/herdr.sock` under its
+configuration directory. Omit `--session` for the default Herdr server, which
+listens on `~/.config/herdr/herdr.sock`; the session selector is per member and
+per invocation, not a daemon-wide environment setting.
+
 **Resolution of I16 (workspace/team selection):** atm-core emits the member
 `AgentName` (= `ATM_IDENTITY`) as the bare `<TARGET>` and emits **no**
 workspace/team argument because Herdr has none. `ATM_TEAM` is **not**

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -1,5 +1,16 @@
 # ATM agent conventions
 
+## AQ2 dual-channel delivery
+
+For an `atm-graft` message-received delivery, the agent loop receives the
+canonical `<atm …>` dispatch payload followed by two newlines and the exact
+immutable message body admitted with that event:
+`rendered_nudge + "\n\n" + message_body`. The separate Telegram notification is
+plain text, formatted with the sender and subject; it is a visible notice, not
+the dispatch envelope and does not replace the message body. This is the
+contract implemented by `GraftReceiveHook` in
+`crates/atm-graft/src/nudge_sink.rs`.
+
 ## Send-To attachments (R8)
 
 Any path under `$ATM_TEMP/send-to/` named in an ATM Send-To message is


### PR DESCRIPTION
Docs-only follow-up for atm-core#1105 (Phase AS).

Closes findings 1105-2, 1105-3, and 1105-4-docs-only:
- document AQ2 dual-channel graft delivery from crates/atm-graft/src/nudge_sink.rs;
- document nested v1.4.6 release archive paths;
- document Herdr --session socket selection and default behavior.

Validation: python3 .just/run_lint.py spell; git diff --check.