### PR TITLE
ci: cover docs and plan pull request bases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*"]
+    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*", "docs/*", "plan/*"]
   push:
     branches: [develop, main]
 


### PR DESCRIPTION
## Summary\n- trigger the CI pull_request workflow for stacked PRs targeting docs/* and plan/* bases\n- keep push triggers unchanged (develop and main)\n\n## Validation\n- PyYAML parse passed\n- git diff --check passed\n- yamllint/actionlint unavailable in this environment\n- audited workflow pull_request triggers; no other workflow uses the same CI base filter\n\nFixes the zero-workflow-run coverage gap for stacked PRs such as AV.3.