### PR TITLE
AV.2: requirements + ADR-059 hardening for read concurrency

### DIFF
--- a/docs/adr/ADR-059-async-mailbox-read-concurrency.md
+++ b/docs/adr/ADR-059-async-mailbox-read-concurrency.md
@@ -1,0 +1,144 @@
+# ADR-059 — Async Mailbox-Read Concurrency And State Handoff
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-059 |
+| Status | Proposed (Phase AV.2) |
+| Scope | Mailbox read-family scheduling, SQLite reader-lane ownership, and read-side state handoff |
+| Relates to | ADR-001, ADR-036, phase-av-plan §1.1–§1.2, AV.1a D1/D1a, AV.1b D2, AV.3 D1/D2/D2b/D3/D4, `av-closeout-record.md` |
+
+## Context
+
+The AL3 implementation admitted every core job through one single-permit
+`WriteAdmission`. AL13-G7 renamed the resulting runtime wrapper to
+`BlockingCoreBridge` but retained that permit for mailbox reads. The result is
+head-of-line blocking: a slow write or housekeeping operation can consume the
+only permit while an unrelated `atm read` waits past its client deadline. The
+history and the affected current paths are recorded in
+[`phase-av-plan.md`](../phase-av-plan.md) §1.1 and
+[`av-closeout-record.md`](../av-closeout-record.md).
+
+The storage topology remains the one in ADR-036: backend-owned SQLite
+connections and transactions stay behind storage traits, while
+`atm-runtime` composes those traits and `atm-http-runtime` routes requests.
+This ADR changes scheduling ownership, not that topology.
+
+## Decision
+
+### D1. Independent bounded reader lane
+
+AV.1a defines the storage-owned `AsyncMailboxReader` capability and
+`ReadDeadline` value in the reader-lane contract described by
+[`sprint-AV.1a-reader-lane-foundation.md`](../sprint-AV.1a-reader-lane-foundation.md)
+§D1/D1a. The selected backend owns a bounded pool of read-only WAL
+connections. Each job has its own read transaction and cancellable deadline;
+no cursor or transaction outlives the job.
+
+The composition path is:
+
+1. `atm-runtime` provides the `AsyncMailboxReader` handle and translates the
+   runtime request deadline to storage-owned `ReadDeadline` once at the
+   boundary.
+2. `atm-storage-rusqlite` owns the pool and its read-only SQLite connections.
+   Its existing `search_reader.rs` is re-hosted as a separate instance of
+   the same bounded-pool shape, so search capacity cannot consume mailbox
+   capacity.
+3. `atm-http-runtime` read handlers consume only the reader capability (and
+   the dedicated doctor projection for `doctor`). They do not acquire a
+   writer permit and do not submit pure reads to the writer lane.
+
+The reader lane is bounded by explicit pool and queue capacities. Saturation
+is an explicit error, not an unbounded wait. Cancellation releases capacity
+after the job stops, and read deadlines are enforced independently of writer
+work.
+
+### D2. Ordered writer lane and non-blocking state handoff
+
+Durable message admission and mutable state transitions remain ordered on the
+single writer lane. A read response is eligible after read-only selection and
+body loading; its read/seen transition is then offered synchronously with a
+non-blocking `try_push` to the bounded `StateHandoffSupervisor` specified by
+AV.1b D2. The read path never awaits writer admission or retry.
+
+`R-STATE-HANDOFF-1` is a product decision. The supervisor is readiness-gated,
+monitored, and owns retry. On task fault it atomically enters `Unavailable`,
+preserves buffered work, and attempts restart within a bounded budget.
+Handoff-buffer overflow (counted and surfaced by `atm doctor`) and process
+exit are the only permitted loss cases. Both are fail-safe: the message stays
+unread/unseen and is re-presented. Restart exhaustion or permanent writer
+failure fails the runtime closed. `R-STATE-RACE-1` describes observation
+under concurrent state changes; it never authorizes dropping a transition.
+
+The concrete AV.1b contract types are `StateHandoffSupervisor` and
+`HandoffConfig`, with the transition represented by
+`WriteOp::ApplyReadDisplayState`. They are documented in
+[`sprint-AV.1b-read-handler-cutover.md`](../sprint-AV.1b-read-handler-cutover.md)
+§D2 and are not a second reader/writer queue.
+
+### D3. Explicit bridge retirement boundary
+
+AV.3 renames the residual synchronous wrapper
+`BlockingCoreBridge` to `ControlPathSyncBridge`. The rename is intentionally
+mechanical and scope-limited: it prevents a read path from silently restoring
+the old name while leaving the eight non-read/control-path call sites
+enumerated in [`av-closeout-record.md`](../av-closeout-record.md).
+
+AV.3 also removes the pure-read `WriteOp::ListMessages` variant,
+`SharedDb::submit_list_messages_async`, and the bespoke
+`crates/atm-storage-rusqlite/src/search_reader.rs` loop in favor of the
+reader-lane capability. Its D1 exact-call-site gate, D2 dependency allowlist,
+D2b instrumented-writer behavior gate, D3 deny-list checker, and D4 liveness
+tests are the enforcement surface. Any new bridge, semaphore, blocking spawn,
+or writer submission on a read-family path is non-compliant.
+
+### D4. Concrete current and target modules
+
+The current revision (`db08f4591`) contains the following symbols and paths;
+AV.3 changes their ownership as stated, without changing ADR-036's storage
+boundary:
+
+| Concern | Current path/symbol | AV target |
+| --- | --- | --- |
+| HTTP control wrapper | `crates/atm-http-runtime/src/storage_and_nudge_router.rs:BlockingCoreBridge` | `ControlPathSyncBridge`, residual control paths only |
+| Pure-read writer op | `crates/atm-storage-rusqlite/src/writer/ops.rs:WriteOp::ListMessages` | removed; reader lane owns projection |
+| Pure-read async submission | `crates/atm-storage-rusqlite/src/shared_db.rs:SharedDb::submit_list_messages_async` and `crates/atm-storage-rusqlite/src/lib.rs:SqliteMessageStore::list_messages_async` | removed/repointed to `AsyncMailboxReader` |
+| Search reader loop | `crates/atm-storage-rusqlite/src/search_reader.rs` | second bounded reader-pool instance |
+| Reader capability/deadline | AV.1a D1/D1a contract in `crates/atm-storage/src/contract.rs` | `AsyncMailboxReader` + storage-owned `ReadDeadline` |
+
+### D5. Product alternatives and operator consequences
+
+Two alternatives were considered and rejected:
+
+* **Permanent drop:** return the read response and discard a rejected
+  read/seen transition. This can permanently hide a message and makes
+  operator state unverifiable; it violates the fail-safe unread/unseen
+  consequence.
+* **Synchronous write-through:** await the writer before returning the read
+  response. This restores head-of-line blocking, couples read latency to
+  writer health, and defeats the independent reader deadline.
+
+The chosen bounded handoff exposes overflow, supervisor state, restart count,
+retry-deadline exhaustion, and buffered depth to `atm doctor`. Operators can
+therefore distinguish a safely re-presented message from a runtime that has
+failed closed.
+
+## Consequences
+
+* Read/list/peek/doctor/query capacity is independently bounded and can make
+  progress while the writer lane is busy.
+* Read observations are intentionally race-tolerant; callers cannot rely on
+  read-your-writes, snapshot pinning, or reader/writer fencing.
+* Durable admission and state transitions retain ordered writer semantics.
+* The residual synchronous control-path work remains visible and bounded
+  until the explicit `AV-FU-1` follow-up migrates it; it is not mislabeled as
+  a completed bridge deletion.
+
+## Verification and references
+
+The normative requirements are `R-READ-CONC-1`, `R-READ-CONC-2`,
+`R-STATE-RACE-1`, and `R-STATE-HANDOFF-1` in
+[`docs/requirements.md`](../requirements.md). AV.3's mechanical gates are
+defined in [`sprint-AV.3-mechanical-hard-gates.md`](../sprint-AV.3-mechanical-hard-gates.md).
+The phase-owned path inventory is
+[`docs/plans/phase-av/av-closeout-record.md`](../plans/phase-av/av-closeout-record.md);
+the Phase-AM ledger remains frozen and is not edited by AV.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -65,6 +65,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-056 — Graft Receiver Registration And Lease Semantics](./ADR-056-graft-receiver-registration-and-lease.md)
 - [ADR-057 — Peer-Write Redial and Delivery-Attempt Invariant](./ADR-057-peer-write-redial-and-delivery-attempt-invariant.md)
 - [ADR-058 — Herdr Local Steer Backend Contract](./ADR-058-herdr-local-steer-backend-contract.md)
+- [ADR-059 — Async Mailbox-Read Concurrency And State Handoff](./ADR-059-async-mailbox-read-concurrency.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/plans/phase-av/av-closeout-record.md
+++ b/docs/plans/phase-av/av-closeout-record.md
@@ -1,0 +1,60 @@
+# Phase AV Closeout Record
+
+This record is the path-based inventory for the AV.3 mechanical cutover. It
+is written against repository revision `db08f4591` (the AV.2 starting
+revision). It distinguishes the four read-path removals/renames from the
+eight synchronous control-path call sites that remain intentionally in scope
+for the later `AV-FU-1` follow-up.
+
+## AV.3 removals and renames
+
+AV.3 must make each of these changes mechanically and gate the old shape:
+
+| Current path and symbol | AV.3 disposition |
+| --- | --- |
+| `crates/atm-http-runtime/src/storage_and_nudge_router.rs` — `BlockingCoreBridge` | Rename to `ControlPathSyncBridge`; the old identifier must disappear from `crates/`. The renamed wrapper is permitted only at the residual call sites below. |
+| `crates/atm-storage-rusqlite/src/writer/ops.rs` — `WriteOp::ListMessages` | Remove the pure-read writer operation; list/peek/read/doctor response data comes from the bounded reader/projection lanes. |
+| `crates/atm-storage-rusqlite/src/shared_db.rs` — `SharedDb::submit_list_messages_async` | Remove the writer-backed mailbox projection submission and route the capability through `AsyncMailboxReader`. |
+| `crates/atm-storage-rusqlite/src/search_reader.rs` — bespoke `SearchReader` worker loop | Remove this bespoke loop as the canonical implementation; AV.1a's bounded reader-pool type owns the search-reader instance. Existing search semantics remain unchanged. |
+
+The corresponding composition and capability contracts are documented in
+[`sprint-AV.1a-reader-lane-foundation.md`](./sprint-AV.1a-reader-lane-foundation.md)
+§D1/D1a and in [`ADR-059`](../../adr/ADR-059-async-mailbox-read-concurrency.md).
+
+## Residual AV-FU-1 bridge call sites
+
+After AV.1b migrates the four read-family handlers, exactly these eight
+`ControlPathSyncBridge::run` call sites remain by design at
+`crates/atm-http-runtime/src/storage_and_nudge_router.rs`:
+
+1. `StorageAndNudgeRouter::commit_write` — deferred-write marker
+   (`prepared.mark_pending_if_deferred`), the synchronous post-admission
+   marker transaction.
+2. `StorageAndNudgeRouter::heartbeat` — synchronous roster validation before
+   the in-memory heartbeat projection.
+3. `StorageAndNudgeRouter::queue_get_next` — synchronous roster validation
+   and bare-CLI FIFO drain.
+4. `StorageAndNudgeRouter::graft_receiver_register` — synchronous roster
+   validation and `GraftReceiverEndpointStore::register`.
+5. `StorageAndNudgeRouter::graft_receiver_refresh` — synchronous roster
+   validation and `GraftReceiverEndpointStore::refresh`.
+6. `StorageAndNudgeRouter::graft_receiver_unregister` — synchronous roster
+   validation and `GraftReceiverEndpointStore::unregister`.
+7. `StorageAndNudgeRouter::graft_receiver_lookup` — synchronous roster
+   validation and `GraftReceiverEndpointStore::lookup`.
+8. `StorageAndNudgeRouter::clear_messages` — synchronous
+   `atm_core::clear::clear_mail_with_runtime` mutation; this is not a
+   read-family operation and has no writer-ingress equivalent in AV.
+
+The eight sites are intentionally not presented as completed bridge deletion.
+`AV-FU-1` owns a future async roster/member-validation port, async graft
+receiver-store port, and `WriteOp::ClearMailbox` ingress. Until that work
+lands, AV.3's exact-call-site architecture test MUST reject any additional
+bridge use, especially a new read-family use.
+
+## Ledger boundary
+
+The Phase-AM closeout ledger
+[`am1-removal-ledger.md`](../phase-am/am1-removal-ledger.md) is frozen. AV
+adds no entries to it and does not edit it. This AV-owned record is the sole
+place for the AV.3 residual inventory.

--- a/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
+++ b/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
@@ -5,7 +5,7 @@ title: Requirements and ADR hardening for read concurrency
 branch: docs/av2-read-concurrency-requirements
 integration_branch: integrate/phase-av
 stack_parent: feature/av1b-read-handler-cutover (stack-order convenience only; no dependency) — planned; stack provisioned by task AV.0 (phase plan §4)
-status: planned
+status: complete
 recommended_agent: Cipher-311d
 recommended_model: fast
 dependency_relations:
@@ -37,18 +37,18 @@ deliverable is expected to land at a production-ready level for the
 scope this sprint claims; partial or shape-only completion fails the
 sprint.
 
-- [ ] D1 — `docs/requirements.md` amendments (normative MUST language):
+- [x] D1 — `docs/requirements.md` amendments (normative MUST language):
       read-family operations (read/peek/list/doctor/query) MUST be
       serviced concurrently; MUST NOT share a concurrency bound with, or
       be ordered behind, any write or housekeeping lane; read deadlines
       MUST be enforced (cancellable); bounded overload MUST fail
       explicitly.
-- [ ] D2 — Race-tolerance codified in `docs/requirements.md`: primary
+- [x] D2 — Race-tolerance codified in `docs/requirements.md`: primary
       message records are immutable; mutable state (read/ack/seen) is
       race-tolerant — a read racing a state change may return either
       value; consequently no requirement may demand read-your-writes,
       snapshot pinning, or reader/writer fencing on mailbox reads.
-- [ ] D2a — Read-state handoff semantics codified (`R-STATE-HANDOFF-1`):
+- [x] D2a — Read-state handoff semantics codified (`R-STATE-HANDOFF-1`):
       read/seen state transitions requested by a read flow MUST be
       handed to a supervised, non-blocking, bounded in-process handoff
       that owns writer admission and retry; the read path MUST NOT
@@ -66,13 +66,13 @@ sprint.
       supervisor fault can strand transitions behind successful
       responses. Recorded as a product decision in the D3 ADR (decision, alternatives considered incl. permanent drop and
       write-through, consequence for operators).
-- [ ] D3 — New ADR `docs/adr/` (next free number): reader/writer lane
+- [x] D3 — New ADR `docs/adr/` (next free number): reader/writer lane
       architecture — bounded RO WAL reader pool, ordered writer lane
       scoped to durable admission + state transitions, deadline
       semantics split (reads cancellable, writes run-to-completion),
       with the AL3→AL13-G7 single-permit regression recorded as
       motivating history (phase-av-plan.md §1.1).
-- [ ] D4 — Phase-AV closeout record (phase-owned; the Phase-AM ledger
+- [x] D4 — Phase-AV closeout record (phase-owned; the Phase-AM ledger
       `docs/plans/phase-am/am1-removal-ledger.md` is a **frozen closeout
       ledger** and receives no new entries): create
       `docs/plans/phase-av/av-closeout-record.md` listing, with file
@@ -120,19 +120,19 @@ discarding a transition.
 
 This is the authoritative acceptance checklist.
 
-- [ ] A1 — Requirements text uses testable MUST/MUST NOT statements; no
+- [x] A1 — Requirements text uses testable MUST/MUST NOT statements; no
       aspirational "should" for the lane-separation rules.
-- [ ] A2 — The ADR names the concrete types/modules (BlockingCoreBridge
+- [x] A2 — The ADR names the concrete types/modules (BlockingCoreBridge
       → ControlPathSyncBridge, WriteOp, AsyncMailboxReader, ReadDeadline)
       and cross-references the AV.3 gates that enforce it, the AV.1a D1a
       boundary records, and the D4 closeout record.
-- [ ] A3 — No contradiction with ADR-036 storage topology or the frozen
+- [x] A3 — No contradiction with ADR-036 storage topology or the frozen
       Phase-AM closeout ledger (which is read, never edited); every path
       in the AV closeout record exists at the cited revision.
-- [ ] A4 — D2 language matches the phase plan §1.2 contract verbatim in
+- [x] A4 — D2 language matches the phase plan §1.2 contract verbatim in
       substance (either-value race outcome, zero writer-lane
       coordination).
-- [ ] A5 — D2a/`R-STATE-HANDOFF-1` matches AV.1b D2 protocol exactly
+- [x] A5 — D2a/`R-STATE-HANDOFF-1` matches AV.1b D2 protocol exactly
       (supervised handoff, two explicit loss cases, fail-safe unread
       consequence) and the ADR records it as a product decision with
       alternatives.
@@ -141,8 +141,8 @@ This is the authoritative acceptance checklist.
 
 This is the authoritative validation checklist.
 
-- [ ] `just lint` (doc checks)
-- [ ] Cross-reference check: every file path cited in the ADR and the
+- [x] `just lint` (doc checks)
+- [x] Cross-reference check: every file path cited in the ADR and the
       AV closeout record exists at the cited revision; `git diff --stat`
       shows no change under `docs/plans/phase-am/`.
 - [ ] quality-mgr doc review PASS.

--- a/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
+++ b/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
@@ -3,6 +3,7 @@ phase: AV
 sprint: AV.2
 title: Requirements and ADR hardening for read concurrency
 branch: docs/av2-read-concurrency-requirements
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/docs/av2-read-concurrency-requirements
 integration_branch: integrate/phase-av
 stack_parent: feature/av1b-read-handler-cutover (stack-order convenience only; no dependency) — planned; stack provisioned by task AV.0 (phase plan §4)
 status: complete

--- a/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
+++ b/docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
@@ -2,8 +2,8 @@
 phase: AV
 sprint: AV.2
 title: Requirements and ADR hardening for read concurrency
-branch: docs/av2-read-concurrency-requirements
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/docs/av2-read-concurrency-requirements
+branch: feature/av2-read-concurrency-requirements
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/av2-read-concurrency-requirements
 integration_branch: integrate/phase-av
 stack_parent: feature/av1b-read-handler-cutover (stack-order convenience only; no dependency) — planned; stack provisioned by task AV.0 (phase plan §4)
 status: complete

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1581,6 +1581,12 @@ The authoritative plan is
 [phase-av-plan](./plans/phase-av/phase-av-plan.md) with per-sprint docs
 under `docs/plans/phase-av/`, authored on branch `plan/phase-av` (PR #1108).
 
+Phase AV sprint status:
+
+| Sprint | Status | Branch | Artifacts |
+| --- | --- | --- | --- |
+| `AV.2` | `complete` | `docs/av2-read-concurrency-requirements` | `docs/requirements.md`, `docs/adr/ADR-059-async-mailbox-read-concurrency.md`, `docs/plans/phase-av/av-closeout-record.md` |
+
 ## Publishing Improvements
 
 Implementation Branches:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1713,6 +1713,46 @@ only. When additional matches exist, they must state that more matches were
 found and direct the operator to `atm list` for metadata inspection instead of
 emitting additional full bodies.
 
+### 7.13 Read-Lane Concurrency And Read-State Handoff
+
+The following requirements make the AV mailbox-read cutover observable and
+non-regressible. They apply to the daemon's mailbox read-family operations,
+regardless of whether the caller is the CLI, an HTTP client, or a graft
+adapter.
+
+- `R-READ-CONC-1` Mailbox read-family operations (`read`, `peek`, `list`,
+  `doctor`, and `query`) MUST be serviced concurrently by a bounded
+  read-only reader lane. They MUST NOT share a concurrency bound with, or be
+  ordered behind, any write or housekeeping lane. A write-lane permit MUST
+  NOT be required to select or load read response data.
+- `R-READ-CONC-2` Read deadlines MUST be enforced cancellably. A request that
+  cannot acquire reader capacity before its deadline MUST fail explicitly
+  with a saturation or deadline outcome; it MUST NOT remain in an indefinite
+  queue. Reader capacity MUST be reclaimed when a cancelled request stops.
+- `R-STATE-RACE-1` Durable primary message records MUST be immutable after
+  admission. Mutable read, acknowledgement, and seen state is
+  race-tolerant: a read racing a state change MAY return either value. No
+  mailbox-read requirement may demand read-your-writes, snapshot pinning, or
+  reader/writer fencing.
+- `R-STATE-HANDOFF-1` Read-flow read/seen state transitions MUST be submitted
+  to a supervised, bounded, non-blocking in-process handoff. That handoff
+  owns writer admission and retry; the read path MUST NOT await the writer
+  lane. A transition MAY be lost only when the handoff buffer overflows or
+  the process exits. Buffer overflow MUST be counted and surfaced by
+  `atm doctor`. In either loss case the behavior MUST be fail-safe: the
+  affected message remains unread/unseen and is re-presented on a subsequent
+  read; it MUST NOT be hidden or discarded.
+  Its lifecycle MUST include readiness-gated startup, a monitored supervisor
+  task, and an atomic `Unavailable` state that rejects new handoffs while
+  preserving the buffered work if the task faults. The supervisor MUST
+  restart within a bounded budget. Restart exhaustion or permanent writer
+  failure MUST fail the runtime closed. `R-STATE-RACE-1` governs observation
+  only and MUST NOT authorize discarding a transition.
+
+The handoff behavior is a product decision recorded in ADR-059. The ADR
+records permanent drop and synchronous write-through as rejected alternatives
+and their operator consequences.
+
 ## 8. `atm ack`
 
 Product requirement ID:


### PR DESCRIPTION
Sprint AV.2 (docs only). Codifies R-READ-CONC-1/2, R-STATE-RACE-1, R-STATE-HANDOFF-1 in docs/requirements.md; adds ADR-059 (reader/writer lane architecture); adds phase-owned AV closeout record listing the eight residual AV-FU-1 bridge sites. No change under docs/plans/phase-am/.

Authoritative sprint doc: docs/plans/phase-av/sprint-AV.2-requirements-adr-hardening.md
Stack: integrate/phase-av ← av1a ← av1b ← **av2** ← av3 ← av4 (parallel_safe; stack-order base only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> Recreated from PR #1110, closed as a side effect of renaming the head branch docs/av2-read-concurrency-requirements -> feature/av2-read-concurrency-requirements (sprint-branch naming defect, confirmed by Rand). Same head SHA a9fc11c8c; QA history lives on #1110.
