### PR TITLE
chore: centralize workspace crate versioning

### DIFF
--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -164,6 +164,9 @@ def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
     if not manifests:
         fail("no workspace member manifests found")
 
+    root_manifest = tomllib.loads(read_text(repo_root / "Cargo.toml"))
+    workspace = root_manifest.get("workspace", {})
+    workspace_dependencies = workspace.get("dependencies", {}) if isinstance(workspace, dict) else {}
     workspace_member_dirs = {manifest_path.parent.resolve() for manifest_path in manifests}
     manifest_payloads: dict[Path, tuple[str, dict, str]] = {}
     expected_versions: dict[Path, str] = {}
@@ -189,6 +192,26 @@ def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
         for section_name, dependencies in dependency_sections(manifest):
             for dependency_name, dependency in dependencies.items():
                 if not isinstance(dependency, dict):
+                    continue
+                if dependency.get("workspace") is True:
+                    workspace_dependency = workspace_dependencies.get(dependency_name)
+                    if not isinstance(workspace_dependency, dict):
+                        continue
+                    dependency_path = workspace_dependency.get("path")
+                    if not isinstance(dependency_path, str):
+                        continue
+                    resolved_path = (repo_root / dependency_path).resolve()
+                    if resolved_path not in workspace_member_dirs:
+                        continue
+                    if not publish_flags.get(resolved_path, True):
+                        continue
+                    dependency_version = expected_versions[resolved_path]
+                    pinned_version = workspace_dependency.get("version")
+                    if pinned_version != dependency_version:
+                        fail(
+                            f"{rel_manifest} [{section_name}.{dependency_name}]: "
+                            f'internal workspace dependency version must match target crate version "{dependency_version}"'
+                        )
                     continue
                 dependency_path = dependency.get("path")
                 if not isinstance(dependency_path, str):

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -1671,6 +1671,7 @@ def collect_manifest_consistency_violations(repo_root: Path, records: list[Bound
 def collect_allowed_dependent_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
     violations: list[BoundaryViolation] = []
     infos = manifest_info(repo_root)
+    alias_map = manifest_by_alias(repo_root)
     workspace_aliases = {alias for info in infos for alias in info.aliases}
     records_by_owner: dict[str, list[BoundaryRecord]] = {}
     for record in records:
@@ -1691,7 +1692,8 @@ def collect_allowed_dependent_violations(repo_root: Path, records: list[Boundary
                     continue
                 for dependency_name, dependency in dependencies.items():
                     package_name = dependency_package_name(dependency_name, dependency)
-                    if package_name != owner_info.package_name:
+                    dependency_info = alias_map.get(package_name) or alias_map.get(dependency_name)
+                    if dependency_info is None or dependency_info.path != owner_info.path:
                         continue
                     depender_aliases = set(depender_info.aliases)
                     live_allowed_aliases.update(depender_aliases)

--- a/.just/lint_manifests.py
+++ b/.just/lint_manifests.py
@@ -51,25 +51,6 @@ def relative_manifest_display(manifest_path: Path, repo_root: Path) -> str:
     return manifest_path.relative_to(repo_root).as_posix()
 
 
-def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
-    sections: list[tuple[str, dict]] = []
-    for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
-        dependencies = manifest.get(section_name)
-        if isinstance(dependencies, dict):
-            sections.append((section_name, dependencies))
-
-    targets = manifest.get("target", {})
-    if isinstance(targets, dict):
-        for target_name, target in targets.items():
-            if not isinstance(target, dict):
-                continue
-            for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
-                dependencies = target.get(section_name)
-                if isinstance(dependencies, dict):
-                    sections.append((f"target.{target_name}.{section_name}", dependencies))
-    return sections
-
-
 def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
     violations: list[ManifestViolation] = []
     try:
@@ -78,32 +59,22 @@ def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
         return [ManifestViolation("version sync", str(error))]
 
     manifests = member_manifests(repo_root)
-    expected_versions: dict[Path, str] = {}
-    publish_flags: dict[Path, bool] = {}
-
     for manifest_path in manifests:
         manifest = tomllib_load(manifest_path)
         rel_manifest = relative_manifest_display(manifest_path, repo_root)
-        member_dir = manifest_path.parent.resolve()
-        expected_versions[member_dir] = expected_package_version(
+        expected_version = expected_package_version(
             manifest,
             version,
             rel_manifest,
         )
-        if expected_versions[member_dir] != version:
+        if expected_version != version:
             violations.append(
                 ManifestViolation(
                     "version sync",
-                    f"{rel_manifest} [package].version ({expected_versions[member_dir]}) "
+                    f"{rel_manifest} [package].version ({expected_version}) "
                     f"must equal expected workspace member version ({version})",
                 )
             )
-        package = manifest.get("package", {}) if isinstance(manifest.get("package"), dict) else {}
-        publish_value = package.get("publish", True)
-        # `publish = false` (bool) marks the crate as internal-only; treat any
-        # other value (True or registry allowlist) as publishable.
-        publish_flags[member_dir] = publish_value is not False
-
     for manifest_path in manifests:
         manifest = tomllib_load(manifest_path)
         rel_manifest = relative_manifest_display(manifest_path, repo_root)
@@ -118,32 +89,6 @@ def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
                 violations.append(
                     ManifestViolation(rel_manifest, f"set [package].{field}.workspace = true")
                 )
-
-        for section_name, dependencies in dependency_sections(manifest):
-            for dependency_name, dependency in dependencies.items():
-                if not isinstance(dependency, dict):
-                    continue
-                dependency_path = dependency.get("path")
-                if not isinstance(dependency_path, str):
-                    continue
-                resolved_path = (manifest_path.parent / dependency_path).resolve()
-                expected_dependency_version = expected_versions.get(resolved_path)
-                if expected_dependency_version is None:
-                    continue
-                # Skip version-pin enforcement when the target crate is publish=false.
-                # Versioned deps on publish=false crates break `cargo publish` (cargo
-                # tries to resolve the pin on crates.io, where the crate never appears).
-                if not publish_flags.get(resolved_path, True):
-                    continue
-                dependency_path = dependency.get("path")
-                pinned_version = dependency.get("version")
-                if pinned_version != expected_dependency_version:
-                    violations.append(
-                        ManifestViolation(
-                            f"{rel_manifest} [{section_name}.{dependency_name}]",
-                            f'path dependency version must match target crate version "{expected_dependency_version}"',
-                        )
-                    )
 
     return violations
 

--- a/.just/prerelease_tag.py
+++ b/.just/prerelease_tag.py
@@ -15,7 +15,6 @@ import tomllib
 from pathlib import Path
 
 from lint_common import discover_repo_root
-from lint_common import workspace_manifest_paths
 from check_version_sync import sync_winget_manifests
 from check_version_sync import version_sync_config
 
@@ -88,10 +87,6 @@ def replace_package_version(text: str, section: str, old: str, new: str) -> tupl
     return text[: match.start(2)] + updated + text[match.end(2) :], True
 
 
-def cargo_manifest_paths(repo_root: Path) -> list[Path]:
-    return [repo_root / "Cargo.toml", *workspace_manifest_paths(repo_root)]
-
-
 def sync_python_version(repo_root: Path, pyproject: Path) -> None:
     result = subprocess.run(
         [
@@ -114,30 +109,24 @@ def sync_python_version(repo_root: Path, pyproject: Path) -> None:
 
 
 def update_manifest_versions(repo_root: Path, old: str, new: str) -> dict[Path, str]:
-    manifests = cargo_manifest_paths(repo_root)
-    if not manifests:
-        raise SystemExit("no workspace manifests found")
-
+    root_manifest = repo_root / "Cargo.toml"
     python_projects = python_project_paths(repo_root)
     before = {
         manifest_path: manifest_path.read_text(encoding="utf-8")
-        for manifest_path in [*manifests, *python_projects]
+        for manifest_path in [root_manifest, *python_projects]
     }
-    for manifest_path in manifests:
-        original = before[manifest_path]
-        if manifest_path == repo_root / "Cargo.toml":
-            section = "workspace.package"
-        else:
-            section = "package"
-        after, _did_change = replace_package_version(original, section, old, new)
-        lines = []
-        for line in after.splitlines(keepends=True):
-            if "path =" in line:
-                line = line.replace(f'version = "{old}"', f'version = "{new}"')
-            lines.append(line)
-        manifest_path.write_text("".join(lines), encoding="utf-8")
+    original = before[root_manifest]
+    after, _did_change = replace_package_version(original, "workspace.package", old, new)
+    # Workspace dependency versions live here so member manifests remain stable
+    # across release bumps and do not need per-crate rewrites.
+    lines = []
+    for line in after.splitlines(keepends=True):
+        if "path =" in line:
+            line = line.replace(f'version = "{old}"', f'version = "{new}"')
+        lines.append(line)
+    root_manifest.write_text("".join(lines), encoding="utf-8")
 
-    if before[repo_root / "Cargo.toml"] == (repo_root / "Cargo.toml").read_text(encoding="utf-8"):
+    if before[root_manifest] == root_manifest.read_text(encoding="utf-8"):
         raise SystemExit("workspace package version was not found in Cargo.toml")
 
     for pyproject in python_projects:
@@ -145,7 +134,7 @@ def update_manifest_versions(repo_root: Path, old: str, new: str) -> dict[Path, 
 
     winget_paths = sync_winget_manifests(repo_root, old, new, version_sync_config(repo_root))
 
-    tracked_manifests = [*manifests, *python_projects]
+    tracked_manifests = [root_manifest, *python_projects]
     tracked_manifests.extend(winget_paths)
     return {
         path: path.read_text(encoding="utf-8")

--- a/.just/tests/test_lint_manifests.py
+++ b/.just/tests/test_lint_manifests.py
@@ -80,40 +80,6 @@ class LintManifestsTests(unittest.TestCase):
             rendered = [violation.render() for violation in violations]
             self.assertIn("crates/atm-core/Cargo.toml: set [package].homepage.workspace = true", rendered)
 
-    def test_collect_manifest_violations_flags_mismatched_internal_path_version(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo_root = Path(tempdir)
-            (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST.replace('"crates/atm"]', '"crates/atm", "crates/atm-core"]'), encoding="utf-8")
-            atm_core_dir = repo_root / "crates/atm-core"
-            atm_core_dir.mkdir(parents=True)
-            (atm_core_dir / "Cargo.toml").write_text(GOOD_MEMBER, encoding="utf-8")
-            atm_dir = repo_root / "crates/atm"
-            atm_dir.mkdir(parents=True)
-            (atm_dir / "Cargo.toml").write_text(
-                """\
-[package]
-name = "agent-team-mail"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
-homepage.workspace = true
-
-[dependencies]
-atm-core = { path = "../atm-core", version = "9.9.9" }
-""",
-                encoding="utf-8",
-            )
-
-            violations = collect_manifest_violations(repo_root)
-            rendered = [violation.render() for violation in violations]
-            self.assertIn(
-                'crates/atm/Cargo.toml [dependencies.atm-core]: path dependency version must match target crate version "1.1.2"',
-                rendered,
-            )
-
     def test_collect_manifest_violations_flags_unreferenced_explicit_version_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)

--- a/.just/tests/test_prerelease_archive_workflow.py
+++ b/.just/tests/test_prerelease_archive_workflow.py
@@ -18,6 +18,7 @@ if str(JUST_DIR) not in sys.path:
 
 from lint_common import discover_repo_root
 from lint_common import resolve_posix_shell
+from lint_common import workspace_manifest_paths
 import prerelease_tag
 from prerelease_tag import patch_bump
 from prerelease_tag import workspace_version
@@ -385,11 +386,6 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
             root / "Cargo.toml",
             *(
                 path
-                for path in prerelease_tag.workspace_manifest_paths(root)
-                if f'version = "{old_version}"' in path.read_text(encoding="utf-8")
-            ),
-            *(
-                path
                 for path in prerelease_tag.python_project_paths(root)
                 if "version =" in path.read_text(encoding="utf-8")
             ),
@@ -410,6 +406,40 @@ class PrereleaseArchiveWorkflowTests(unittest.TestCase):
             f"releases/download/v{new_version}/atm_{new_version}_x86_64-pc-windows-msvc.zip",
             winget,
         )
+
+    def test_workspace_versions_and_internal_dependencies_are_centralized(self) -> None:
+        root = discover_repo_root()
+        root_manifest = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+        workspace_dependencies = root_manifest["workspace"]["dependencies"]
+        member_paths = workspace_manifest_paths(root)
+        member_dirs = {path.parent.resolve() for path in member_paths}
+        internal_dependency_names = {
+            name
+            for name, dependency in workspace_dependencies.items()
+            if isinstance(dependency, dict)
+            and isinstance(dependency.get("path"), str)
+            and (root / dependency["path"]).resolve() in member_dirs
+        }
+
+        for manifest_path in member_paths:
+            manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                manifest["package"]["version"],
+                {"workspace": True},
+                manifest_path.relative_to(root),
+            )
+            for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+                for dependency_name, dependency in manifest.get(section_name, {}).items():
+                    if dependency_name not in internal_dependency_names:
+                        continue
+                    self.assertIsInstance(dependency, dict)
+                    self.assertTrue(
+                        dependency.get("workspace") is True,
+                        f"{manifest_path.relative_to(root)} [{section_name}.{dependency_name}] "
+                        "must inherit its workspace dependency",
+                    )
+                    self.assertNotIn("version", dependency)
+                    self.assertNotIn("path", dependency)
 
     def test_write_and_commit_restores_files_when_commit_fails(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = "0.3"
 cargo_metadata = "0.23"
 sc-observability = "=1.2.0"
 sc-observability-types = "=1.2.0"
+sc-lint-directives = { path = "crates/sc-lint-directives" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tokio-rustls = "0.26"
 x509-parser = "0.16"
@@ -61,3 +62,16 @@ getrandom = "0.3"
 syn = { version = "2", features = ["full", "visit"] }
 semver = { version = "1", features = ["serde"] }
 async-trait = "0.1"
+atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.4.6" }
+atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.4.6" }
+atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.4.6" }
+atm-error = { path = "crates/atm-error", version = "1.4.6" }
+atm-graft = { path = "crates/atm-graft", version = "1.4.6" }
+atm-herdr = { path = "crates/atm-herdr", version = "1.4.6" }
+atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.4.6" }
+atm-runtime = { path = "crates/atm-runtime", version = "1.4.6" }
+atm-runtime-test-support = { path = "crates/atm-runtime-test-support" }
+atm-storage = { path = "crates/atm-storage", version = "1.4.6" }
+atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.4.6" }
+atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.4.6" }
+peer-tls = { path = "crates/peer-tls", version = "1.4.6" }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-error.workspace = true
+atm-storage.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -38,8 +38,8 @@ async-trait.workspace = true
 sc-lint-attributes = "0.5"
 
 [dev-dependencies]
-atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.6", features = ["test-utils"] }
+atm-runtime-test-support.workspace = true
+atm-storage = { workspace = true, features = ["test-utils"] }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -18,14 +18,14 @@ path = "src/bin/atm-daemon-benchmark.rs"
 required-features = ["benchmark-harness"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-herdr = { path = "../atm-herdr", version = "1.4.6" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6" }
-atm-template-sc-compose = { path = "../atm-template-sc-compose", version = "1.4.6" }
-peer-tls = { path = "../peer-tls", version = "1.4.6" }
+atm-core.workspace = true
+atm-herdr.workspace = true
+atm-http-runtime.workspace = true
+atm-runtime.workspace = true
+atm-storage.workspace = true
+atm-storage-rusqlite.workspace = true
+atm-template-sc-compose.workspace = true
+peer-tls.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 fs4 = "0.13"
@@ -33,9 +33,9 @@ serde_json.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-herdr = { path = "../atm-herdr", version = "1.4.6", features = ["test-utils"] }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6", features = ["test-support"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support" }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-herdr = { workspace = true, features = ["test-utils"] }
+atm-http-runtime = { workspace = true, features = ["test-support"] }
+atm-runtime-test-support.workspace = true
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core.workspace = true
+atm-http-runtime.workspace = true
+atm-storage.workspace = true
 fs4 = "0.13"
 interprocess = "2.4"
 serde_json.workspace = true
@@ -20,5 +20,5 @@ tracing = "0.1"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-core.workspace = true
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -17,8 +17,8 @@ sc-observability-types.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.6" }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-daemon-bootstrap.workspace = true
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -5,7 +5,7 @@ name = "atm-graft-python"
 publish = false
 # Maturin consumes this crate's Cargo version as Python package metadata; keep
 # it equivalent to the workspace release while using PEP 440-compatible form.
-version = "1.4.6"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,12 +27,12 @@ abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.6" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-graft.workspace = true
+atm-core.workspace = true
 pyo3 = "0.29"
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-graft = { path = "../atm-graft", version = "1.4.6", features = ["test-support"] }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-graft = { workspace = true, features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,15 +13,15 @@ homepage.workspace = true
 test-support = ["atm-core/test-utils"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.6" }
+atm-core.workspace = true
+atm-daemon-client.workspace = true
 async-trait.workspace = true
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
+atm-http-runtime.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.4.6" }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-runtime-test-support.workspace = true
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-herdr/Cargo.toml
+++ b/crates/atm-herdr/Cargo.toml
@@ -13,6 +13,6 @@ homepage.workspace = true
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
+atm-core.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -15,8 +15,8 @@ homepage.workspace = true
 test-support = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-herdr = { path = "../atm-herdr", version = "1.4.6" }
+atm-core.workspace = true
+atm-herdr.workspace = true
 base64.workspace = true
 axum.workspace = true
 hyper.workspace = true
@@ -36,9 +36,9 @@ ulid.workspace = true
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-herdr = { path = "../atm-herdr", version = "1.4.6", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-herdr = { workspace = true, features = ["test-utils"] }
+atm-runtime-test-support.workspace = true
+atm-storage.workspace = true
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-peer-tls-interop/Cargo.toml
+++ b/crates/atm-peer-tls-interop/Cargo.toml
@@ -12,8 +12,8 @@ homepage.workspace = true
 description = "Provisioning and bounded curl mTLS interoperability fixture for ATM."
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core.workspace = true
+atm-storage.workspace = true
 rustls.workspace = true
 
 [dev-dependencies]

--- a/crates/atm-query-python/Cargo.toml
+++ b/crates/atm-query-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atm-query-python"
 # This local analyst binding is not part of the current public release surface.
 publish = false
-version = "1.4.6"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -20,9 +20,9 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.29"
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6" }
+atm-storage.workspace = true
+atm-storage-rusqlite.workspace = true
 
 [dev-dependencies]
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6", features = ["test-support"] }
+atm-storage-rusqlite = { workspace = true, features = ["test-support"] }
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.6" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.6", features = ["test-support"] }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-runtime.workspace = true
+atm-storage-rusqlite = { workspace = true, features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,8 +16,8 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core.workspace = true
+atm-storage.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-storage.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-storage.workspace = true

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared audited storage contract and canonical domain types for AT
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.6" }
+atm-error.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true

--- a/crates/atm-template-sc-compose/Cargo.toml
+++ b/crates/atm-template-sc-compose/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace = true
 name = "atm_template_sc_compose"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core.workspace = true
+atm-storage.workspace = true
 sc-composer = "=1.5.0"
 sc-sha = "=1.5.0"
 serde_json.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,11 +33,11 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.6" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.6" }
-atm-http-runtime = { path = "../atm-http-runtime", version = "1.4.6" }
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-core.workspace = true
+atm-daemon-bootstrap.workspace = true
+atm-daemon-client.workspace = true
+atm-http-runtime.workspace = true
+atm-storage.workspace = true
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -54,9 +54,9 @@ tokio.workspace = true
 ulid.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.6", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.6", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support" }
+atm-graft = { workspace = true, features = ["test-support"] }
+atm-core = { workspace = true, features = ["test-utils"] }
+atm-runtime-test-support.workspace = true
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/peer-tls/Cargo.toml
+++ b/crates/peer-tls/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Concrete, bounded mTLS byte-stream adapter for ATM peers."
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.6" }
+atm-storage.workspace = true
 rustls.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true

--- a/crates/sc-lint-boundary/Cargo.toml
+++ b/crates/sc-lint-boundary/Cargo.toml
@@ -23,7 +23,7 @@ anyhow.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sc-lint-directives = { path = "../sc-lint-directives" }
+sc-lint-directives.workspace = true
 sc-lint-attributes = "0.5"
 clap = { version = "4", features = ["derive"] }
 syn = { version = "2", features = ["full", "parsing", "visit"] }


### PR DESCRIPTION
## Summary
- convert atm-graft-python and atm-query-python to version.workspace = true
- centralize internal workspace dependencies and preserve feature overrides
- simplify prerelease version updates to root Cargo.toml, lockfile, Python metadata, and Winget manifests
- add regression coverage and make version and boundary checks understand inherited dependencies

Finding: item-2-workspace-versioning-graft-query

Rand relay: workspace versioning was not reverted. Rust crates have used version.workspace = true since bootstrap commit 30d679ae8; only the two Python bridge crates were created with literal versions and never converted.

Validation is reported to team-lead separately. Do not merge this PR from the contributor branch.