### PR TITLE
docs: release-readiness gate plan (evidence manifest schema + RRG sprints)

### DIFF
--- a/.claude/skills/publishing/evals/publisher-preflight.md
+++ b/.claude/skills/publishing/evals/publisher-preflight.md
@@ -17,8 +17,11 @@ sanitized channel result set without creating a release side effect.
 3. Launch it with `rmux` using either supported runtime and the current
    `<team-name>`. Confirm its ATM team, identity, hooks, and pane registration
    before assignment.
-4. Render `../preflight.xml.j2` with the derived `manifest_path`, the separate
-   named evaluator/coordinator identity as `recipient`, not the evaluated publisher
+4. Render `../preflight.xml.j2` with the derived `manifest_path` for the
+   publish-channel manifest and the distinct
+   `release_readiness_manifest_path` for the release-readiness evidence
+   manifest, plus the separate named evaluator/coordinator identity as
+   `recipient`, not the evaluated publisher
    teammate; use a deliberately invalid candidate tag and `preflight_stage=readiness`.
    The assignment must say preflight-only and must not authorize tag creation or workflow
    dispatch.

--- a/.claude/skills/publishing/preflight.xml.j2
+++ b/.claude/skills/publishing/preflight.xml.j2
@@ -14,6 +14,7 @@ required_variables:
   - worktree_path
   - branch
   - manifest_path
+  - release_readiness_manifest_path
 ---
 <atm-task id="{{ task_id }}" assignee="publisher">
   <recipient>{{ recipient }}</recipient>
@@ -26,7 +27,9 @@ required_variables:
     <candidate-commit>{{ candidate_commit }}</candidate-commit>
     <starting-state>{{ starting_state }}</starting-state>
     <stage>{{ preflight_stage }}</stage>
-    <manifest>{{ manifest_path }}</manifest>
+    <!-- manifest_path is the publish-channel manifest; the readiness gate has its own explicit destination. -->
+    <publish-manifest>{{ manifest_path }}</publish-manifest>
+    <release-readiness-manifest>{{ release_readiness_manifest_path }}</release-readiness-manifest>
     <already-published-channels>{{ already_published_channels | default('') }}</already-published-channels>
   </release>
   <references>

--- a/.github/scripts/tests/test_release_artifacts.py
+++ b/.github/scripts/tests/test_release_artifacts.py
@@ -2784,6 +2784,7 @@ def test_publishing_task_templates_render_recipient_contract(tmp_path: Path) -> 
                 "worktree_path": "/tmp/eval",
                 "branch": "develop",
                 "manifest_path": "release/publish-artifacts.toml",
+                "release_readiness_manifest_path": "site/reports/release-readiness/v1.4.2-1.4.1/manifest.json",
                 "already_published_channels": "crates_io",
             },
         ),
@@ -2811,6 +2812,8 @@ def test_publishing_task_templates_render_recipient_contract(tmp_path: Path) -> 
         assert f"Send {context['recipient']}" in rendered
         if template_path.endswith("preflight.xml.j2"):
             assert root.findtext("release/already-published-channels") == "crates_io"
+            assert root.findtext("release/publish-manifest") == context["manifest_path"]
+            assert root.findtext("release/release-readiness-manifest") == context["release_readiness_manifest_path"]
 
 
 def test_release_preflight_collects_independent_failures_before_denial() -> None:

--- a/docs/plans/release-readiness-gate/release-duration-bounds.example.json
+++ b/docs/plans/release-readiness-gate/release-duration-bounds.example.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "revision": 1,
   "approved_by": "Rand",
-  "approved_at": "2026-09-16T00:00:00Z",
+  "effective_from": "2026-09-16T00:00:00Z",
   "bounds": {
     "smoke-full": { "min_seconds": 900, "max_seconds": 3600 },
     "benchmark-send": { "min_seconds": 1200, "max_seconds": 3600 },

--- a/docs/plans/release-readiness-gate/release-duration-bounds.example.json
+++ b/docs/plans/release-readiness-gate/release-duration-bounds.example.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "revision": 1,
+  "approved_by": "Rand",
+  "approved_at": "2026-09-16T00:00:00Z",
+  "bounds": {
+    "smoke-full": { "min_seconds": 900, "max_seconds": 3600 },
+    "benchmark-send": { "min_seconds": 1200, "max_seconds": 3600 },
+    "benchmark-read-query": { "min_seconds": 1200, "max_seconds": 3600 },
+    "testbed-integration": { "min_seconds": 5400, "max_seconds": 14400 }
+  }
+}

--- a/docs/plans/release-readiness-gate/release-duration-bounds.schema.json
+++ b/docs/plans/release-readiness-gate/release-duration-bounds.schema.json
@@ -5,7 +5,7 @@
   "description": "Committed single source of truth for the §2.3.5 wall-clock duration-bounds anomaly checks (AC-14): exactly one min/max entry per catalog suite. Seeded from the durations of historical committed evidence runs and Rand-approved before first use — the same revision convention as §3.2 baselines.json (never self-seeded by the harness; a bounds revision is a reviewed commit, never a run-time adjustment). Fail-closed consumption (AC-14): a missing file, failed schema validation, missing catalog-suite entry, or an entry with min_seconds >= max_seconds is a harness defect — the gate aborts with the named startup failure 'duration bounds unusable' (§2.2 rule 7), never a silent skip of the check.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "revision", "approved_by", "approved_at", "bounds"],
+  "required": ["schema_version", "revision", "approved_by", "effective_from", "bounds"],
   "properties": {
     "schema_version": {
       "type": "integer",
@@ -21,10 +21,10 @@
       "minLength": 1,
       "description": "Who approved this revision for gate use (Rand — §2.3.5: bounds are Rand-approved before first use). Mechanized approval marker: the self-verifier requires this field's presence via this schema; an unapproved (field-less) seed cannot validate."
     },
-    "approved_at": {
+    "effective_from": {
       "type": "string",
       "format": "date-time",
-      "description": "UTC timestamp of the approval for this revision."
+      "description": "UTC timestamp from which this approved revision is effective, matching the §3.2 baselines.json convention."
     },
     "bounds": {
       "type": "object",

--- a/docs/plans/release-readiness-gate/release-duration-bounds.schema.json
+++ b/docs/plans/release-readiness-gate/release-duration-bounds.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "atm-core/release-duration-bounds/v1",
+  "title": "Release-readiness wall-clock duration bounds",
+  "description": "Committed single source of truth for the §2.3.5 wall-clock duration-bounds anomaly checks (AC-14): exactly one min/max entry per catalog suite. Seeded from the durations of historical committed evidence runs and Rand-approved before first use — the same revision convention as §3.2 baselines.json (never self-seeded by the harness; a bounds revision is a reviewed commit, never a run-time adjustment). Fail-closed consumption (AC-14): a missing file, failed schema validation, missing catalog-suite entry, or an entry with min_seconds >= max_seconds is a harness defect — the gate aborts with the named startup failure 'duration bounds unusable' (§2.2 rule 7), never a silent skip of the check.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "revision", "approved_by", "approved_at", "bounds"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic bounds revision, exactly the §3.2 baselines.json convention (e.g. baselines.json revision 1, approved 2026-08-31). Bumped by every reviewed bounds change."
+    },
+    "approved_by": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Who approved this revision for gate use (Rand — §2.3.5: bounds are Rand-approved before first use). Mechanized approval marker: the self-verifier requires this field's presence via this schema; an unapproved (field-less) seed cannot validate."
+    },
+    "approved_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp of the approval for this revision."
+    },
+    "bounds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["smoke-full", "benchmark-send", "benchmark-read-query", "testbed-integration"],
+      "description": "Closed catalog keyed by §3 suite_id — exactly one entry per catalog suite, no extras. min_seconds flags a short-circuited/truncated workload (a suite finishing implausibly fast means work was skipped, not that speed is penalized); max_seconds flags a stalled or contaminated run.",
+      "properties": {
+        "smoke-full": { "$ref": "#/$defs/bound" },
+        "benchmark-send": { "$ref": "#/$defs/bound" },
+        "benchmark-read-query": { "$ref": "#/$defs/bound" },
+        "testbed-integration": { "$ref": "#/$defs/bound" }
+      }
+    }
+  },
+  "$defs": {
+    "bound": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min_seconds", "max_seconds"],
+      "properties": {
+        "min_seconds": { "type": "number", "exclusiveMinimum": 0 },
+        "max_seconds": { "type": "number", "exclusiveMinimum": 0 }
+      },
+      "description": "min_seconds < max_seconds is required; JSON Schema cannot compare sibling numerics, so the gate's startup validation enforces it (AC-14 ii) — a violating entry is 'duration bounds unusable', fail-closed."
+    }
+  }
+}

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
@@ -142,8 +142,14 @@
       "commit_sha": "0000000000000000000000000000000000000000"
     },
     {
-      "suite_id": "test-queue-hooks",
+      "suite_id": "test-queue-hooks-python",
       "run_id": 123456795,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks-codex",
+      "run_id": 123456796,
       "conclusion": "success",
       "commit_sha": "0000000000000000000000000000000000000000"
     }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
@@ -2,9 +2,10 @@
   "schema_version": 1,
   "run_kind": "release",
   "candidate": {
-    "tag_candidate": "v1.5.0-rc1",
+    "tag_candidate": "v1.6.0",
     "commit_sha": "0000000000000000000000000000000000000000",
-    "branch": "develop"
+    "branch": "develop",
+    "workspace_version": "1.5.7"
   },
   "testbed_definitions": {
     "repo": "randlee/atm-hermes-testbed",

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
@@ -116,6 +116,36 @@
       "run_id": 123456790,
       "conclusion": "success",
       "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-graft-python",
+      "run_id": 123456791,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-bridge",
+      "run_id": 123456792,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-smoke",
+      "run_id": 123456793,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-admission-capacity",
+      "run_id": 123456794,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks",
+      "run_id": 123456795,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
     }
   ],
   "verdict": "READY",

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-ready.json
@@ -17,12 +17,12 @@
       "terminal_state": "pass",
       "evidence": [
         {
-          "path": "site/reports/smoke/macos/m5-atmbench/2026-09-15-run.json",
+          "path": "site/reports/smoke/macos/m5-atmbench/2026-09-16-run.json",
           "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         }
       ],
-      "started_at": "2026-09-15T18:00:00Z",
-      "ended_at": "2026-09-15T18:42:11Z",
+      "started_at": "2026-09-16T18:00:00Z",
+      "ended_at": "2026-09-16T18:41:02Z",
       "host": "rand-m5.local",
       "execution_identity": {
         "execution_account": "m5-atmbench",
@@ -37,12 +37,12 @@
       "terminal_state": "pass",
       "evidence": [
         {
-          "path": "site/reports/send-message-benchmark/2026-09-15-campaign.json",
+          "path": "site/reports/send-message-benchmark/2026-09-16-campaign.json",
           "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
         }
       ],
-      "started_at": "2026-09-15T18:45:00Z",
-      "ended_at": "2026-09-15T19:20:33Z",
+      "started_at": "2026-09-16T18:45:00Z",
+      "ended_at": "2026-09-16T19:19:12Z",
       "host": "rand-m5.local",
       "execution_identity": {
         "execution_account": "m5-atmbench",
@@ -54,16 +54,15 @@
     {
       "suite_id": "benchmark-read-query",
       "entrypoint": "just benchmark-read",
-      "terminal_state": "fail",
-      "fail_reason": "floor-breach",
+      "terminal_state": "pass",
       "evidence": [
         {
-          "path": "site/reports/read-query-benchmark/2026-09-15-campaign.json",
+          "path": "site/reports/read-query-benchmark/2026-09-16-campaign.json",
           "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
       ],
-      "started_at": "2026-09-15T19:25:00Z",
-      "ended_at": "2026-09-15T20:15:47Z",
+      "started_at": "2026-09-16T19:25:00Z",
+      "ended_at": "2026-09-16T20:12:41Z",
       "host": "rand-m5.local",
       "execution_identity": {
         "execution_account": "m5-atmbench",
@@ -75,11 +74,22 @@
     {
       "suite_id": "testbed-integration",
       "entrypoint": "testbed runner, full tier set AT0-AT8",
-      "terminal_state": "declared-skip",
-      "skip_reason": "EXAMPLE ONLY — illustrates the declared-skip shape: no host or execution_identity may be recorded because nothing executed; real skips require a Rand-approved standing reason",
-      "evidence": [],
-      "started_at": "2026-09-15T19:00:00Z",
-      "ended_at": "2026-09-15T19:00:00Z"
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/testbed-integration/2026-09-16-tier-results.json",
+          "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        }
+      ],
+      "started_at": "2026-09-16T19:00:00Z",
+      "ended_at": "2026-09-16T21:30:19Z",
+      "host": "colima-host",
+      "execution_identity": {
+        "execution_account": "testbed-runner",
+        "uid": 502,
+        "home": "/home/testbed-runner",
+        "hostname": "colima-host"
+      }
     }
   ],
   "floors": [
@@ -87,28 +97,29 @@
       "family": "send",
       "metric": "send_p50_msgs_per_sec",
       "floor": 17000.0,
-      "observed_p50": 17350.0,
+      "observed_p50": 17420.0,
       "met": true,
-      "ratchet_proposal": 16482.5
+      "ratchet_proposal": 16549.0
     },
     {
       "family": "read-query",
       "metric": "read_fanout_p50_msgs_per_sec",
       "floor": 12000.0,
-      "observed_p50": 11400.0,
-      "met": false
+      "observed_p50": 13100.0,
+      "met": true,
+      "ratchet_proposal": 12445.0
     }
   ],
   "ci_runs": [
     {
       "suite_id": "just-ci",
-      "run_id": 123456789,
+      "run_id": 123456790,
       "conclusion": "success",
       "commit_sha": "0000000000000000000000000000000000000000"
     }
   ],
-  "verdict": "NOT-READY",
-  "generated_at": "2026-09-15T21:00:00Z",
+  "verdict": "READY",
+  "generated_at": "2026-09-16T22:00:00Z",
   "self_verification": {
     "validated": true,
     "validator_version": "example-0"

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-skip.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-skip.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "run_kind": "release",
+  "candidate": {
+    "tag_candidate": "v1.5.0-rc1",
+    "commit_sha": "0000000000000000000000000000000000000000",
+    "branch": "develop"
+  },
+  "testbed_definitions": {
+    "repo": "randlee/atm-hermes-testbed",
+    "commit_sha": "1111111111111111111111111111111111111111"
+  },
+  "suites": [
+    {
+      "suite_id": "smoke-full",
+      "entrypoint": "just smoke thorough",
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/smoke/macos/m5-atmbench/2026-09-17-run.json",
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "started_at": "2026-09-17T18:00:00Z",
+      "ended_at": "2026-09-17T18:40:12Z",
+      "host": "rand-m5.local",
+      "execution_identity": {
+        "execution_account": "m5-atmbench",
+        "uid": 503,
+        "home": "/Users/m5-atmbench",
+        "hostname": "rand-m5.local"
+      }
+    },
+    {
+      "suite_id": "benchmark-send",
+      "entrypoint": "just benchmark-official",
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/send-message-benchmark/2026-09-17-campaign.json",
+          "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        }
+      ],
+      "started_at": "2026-09-17T18:45:00Z",
+      "ended_at": "2026-09-17T19:18:44Z",
+      "host": "rand-m5.local",
+      "execution_identity": {
+        "execution_account": "m5-atmbench",
+        "uid": 503,
+        "home": "/Users/m5-atmbench",
+        "hostname": "rand-m5.local"
+      }
+    },
+    {
+      "suite_id": "benchmark-read-query",
+      "entrypoint": "just benchmark-read",
+      "terminal_state": "declared-skip",
+      "skip_reason": "EXAMPLE ONLY — illustrates a Rand-approved standing skip of a benchmark FAMILY (§2.1/AC-3): no floors row exists for read-query because no measurement ran — the family-level floors requirement is conditional on the suite executing (schema root allOf); real skips must cite the Rand-approved standing reason",
+      "evidence": [],
+      "started_at": "2026-09-17T19:20:00Z",
+      "ended_at": "2026-09-17T19:20:00Z"
+    },
+    {
+      "suite_id": "testbed-integration",
+      "entrypoint": "testbed runner, full tier set AT0-AT8",
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/testbed-integration/2026-09-17-tier-results.json",
+          "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        }
+      ],
+      "started_at": "2026-09-17T19:00:00Z",
+      "ended_at": "2026-09-17T21:28:03Z",
+      "host": "colima-host",
+      "execution_identity": {
+        "execution_account": "testbed-runner",
+        "uid": 502,
+        "home": "/home/testbed-runner",
+        "hostname": "colima-host"
+      }
+    }
+  ],
+  "floors": [
+    {
+      "family": "send",
+      "metric": "send_p50_msgs_per_sec",
+      "floor": 17000.0,
+      "observed_p50": 17510.0,
+      "met": true,
+      "ratchet_proposal": 16634.5
+    }
+  ],
+  "ci_runs": [
+    {
+      "suite_id": "just-ci",
+      "run_id": 123456800,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-graft-python",
+      "run_id": 123456801,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-bridge",
+      "run_id": 123456802,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-smoke",
+      "run_id": 123456803,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-admission-capacity",
+      "run_id": 123456804,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks-python",
+      "run_id": 123456805,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks-codex",
+      "run_id": 123456806,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    }
+  ],
+  "verdict": "READY",
+  "generated_at": "2026-09-17T22:00:00Z",
+  "self_verification": {
+    "validated": true,
+    "validator_version": "example-0"
+  }
+}

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example-skip.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example-skip.json
@@ -2,9 +2,10 @@
   "schema_version": 1,
   "run_kind": "release",
   "candidate": {
-    "tag_candidate": "v1.5.0-rc1",
+    "tag_candidate": "v1.6.0",
     "commit_sha": "0000000000000000000000000000000000000000",
-    "branch": "develop"
+    "branch": "develop",
+    "workspace_version": "1.5.7"
   },
   "testbed_definitions": {
     "repo": "randlee/atm-hermes-testbed",
@@ -55,7 +56,7 @@
       "suite_id": "benchmark-read-query",
       "entrypoint": "just benchmark-read",
       "terminal_state": "declared-skip",
-      "skip_reason": "EXAMPLE ONLY — illustrates a Rand-approved standing skip of a benchmark FAMILY (§2.1/AC-3): no floors row exists for read-query because no measurement ran — the family-level floors requirement is conditional on the suite executing (schema root allOf); real skips must cite the Rand-approved standing reason",
+      "skip_reason": "EXAMPLE ONLY \u2014 illustrates a Rand-approved standing skip of a benchmark FAMILY (\u00a72.1/AC-3): no floors row exists for read-query because no measurement ran \u2014 the family-level floors requirement is conditional on the suite executing (schema root allOf); real skips must cite the Rand-approved standing reason",
       "evidence": [],
       "started_at": "2026-09-17T19:20:00Z",
       "ended_at": "2026-09-17T19:20:00Z"

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "run_kind": "release",
+  "candidate": {
+    "tag_candidate": "v1.5.0-rc1",
+    "commit_sha": "0000000000000000000000000000000000000000",
+    "branch": "develop"
+  },
+  "testbed_definitions": {
+    "repo": "randlee/atm-hermes-testbed",
+    "commit_sha": "1111111111111111111111111111111111111111"
+  },
+  "suites": [
+    {
+      "suite_id": "smoke-full",
+      "entrypoint": "just smoke thorough",
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/smoke/macos/m5-atmbench/2026-09-15-run.json",
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "started_at": "2026-09-15T18:00:00Z",
+      "ended_at": "2026-09-15T18:42:11Z",
+      "host": "rand-m5.local",
+      "execution_identity": {
+        "execution_account": "m5-atmbench",
+        "uid": 503,
+        "home": "/Users/m5-atmbench",
+        "hostname": "rand-m5.local"
+      }
+    },
+    {
+      "suite_id": "benchmark-read-query",
+      "entrypoint": "just benchmark-read",
+      "terminal_state": "pass",
+      "evidence": [
+        {
+          "path": "site/reports/read-query-benchmark/2026-09-15-campaign.json",
+          "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ],
+      "started_at": "2026-09-15T19:00:00Z",
+      "ended_at": "2026-09-15T20:15:47Z",
+      "host": "rand-m5.local",
+      "execution_identity": {
+        "execution_account": "m5-atmbench",
+        "uid": 503,
+        "home": "/Users/m5-atmbench",
+        "hostname": "rand-m5.local"
+      }
+    },
+    {
+      "suite_id": "testbed-integration",
+      "entrypoint": "testbed runner, full tier set AT0-AT8",
+      "terminal_state": "declared-skip",
+      "skip_reason": "EXAMPLE ONLY — real runs require pass or a Rand-approved standing skip reason",
+      "evidence": [],
+      "started_at": "2026-09-15T19:00:00Z",
+      "ended_at": "2026-09-15T19:00:00Z",
+      "host": "colima-host",
+      "execution_identity": {
+        "execution_account": "randlee",
+        "uid": 501,
+        "home": "/Users/randlee",
+        "hostname": "rand-m4.local"
+      }
+    }
+  ],
+  "floors": [
+    {
+      "family": "read-query",
+      "metric": "read_fanout_p50_msgs_per_sec",
+      "floor": 12000.0,
+      "observed_p50": 13100.0,
+      "met": true,
+      "ratchet_proposal": 12445.0
+    }
+  ],
+  "ci_runs": [
+    {
+      "suite_id": "just-ci",
+      "run_id": 123456789,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    }
+  ],
+  "verdict": "NOT-READY",
+  "generated_at": "2026-09-15T21:00:00Z",
+  "self_verification": {
+    "validated": true,
+    "validator_version": "example-0"
+  }
+}

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
@@ -2,9 +2,10 @@
   "schema_version": 1,
   "run_kind": "release",
   "candidate": {
-    "tag_candidate": "v1.5.0-rc1",
+    "tag_candidate": "v1.6.0",
     "commit_sha": "0000000000000000000000000000000000000000",
-    "branch": "develop"
+    "branch": "develop",
+    "workspace_version": "1.5.7"
   },
   "testbed_definitions": {
     "repo": "randlee/atm-hermes-testbed",

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
@@ -76,7 +76,7 @@
       "suite_id": "testbed-integration",
       "entrypoint": "testbed runner, full tier set AT0-AT8",
       "terminal_state": "declared-skip",
-      "skip_reason": "EXAMPLE ONLY — illustrates the declared-skip shape: no host or execution_identity may be recorded because nothing executed; real skips require a Rand-approved standing reason",
+      "skip_reason": "EXAMPLE ONLY \u2014 illustrates the declared-skip shape: no host or execution_identity may be recorded because nothing executed; real skips require a Rand-approved standing reason per AC-10/\u00a77.4 (e.g. the AT3 standing skip)",
       "evidence": [],
       "started_at": "2026-09-15T19:00:00Z",
       "ended_at": "2026-09-15T19:00:00Z"
@@ -102,7 +102,37 @@
   "ci_runs": [
     {
       "suite_id": "just-ci",
-      "run_id": 123456789,
+      "run_id": 123456780,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-graft-python",
+      "run_id": 123456781,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-bridge",
+      "run_id": 123456782,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-hermes-graft-smoke",
+      "run_id": 123456783,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-admission-capacity",
+      "run_id": 123456784,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks",
+      "run_id": 123456785,
       "conclusion": "success",
       "commit_sha": "0000000000000000000000000000000000000000"
     }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.example.json
@@ -131,8 +131,14 @@
       "commit_sha": "0000000000000000000000000000000000000000"
     },
     {
-      "suite_id": "test-queue-hooks",
+      "suite_id": "test-queue-hooks-python",
       "run_id": 123456785,
+      "conclusion": "success",
+      "commit_sha": "0000000000000000000000000000000000000000"
+    },
+    {
+      "suite_id": "test-queue-hooks-codex",
+      "run_id": 123456786,
       "conclusion": "success",
       "commit_sha": "0000000000000000000000000000000000000000"
     }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -41,7 +41,7 @@
         "workspace_version": {
           "type": "string",
           "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
-          "description": "The gated commit's Cargo.toml [workspace.package] version — the §5.1 mandatory per-attempt patch++ version (AC-13). Recorded by the orchestrator's first act from the checked-out gated tree; the self-verifier cross-checks it against Cargo.toml and refuses emission if any previously committed run_kind:release manifest under the evidence root records the same value — attempt distinctness is checkable, never asserted."
+          "description": "The gated commit's Cargo.toml [workspace.package] version — the §5.1 mandatory per-attempt patch++ version (AC-13). Recorded by the orchestrator's first act from the checked-out gated tree; the self-verifier cross-checks it against Cargo.toml and refuses emission if any previously committed run_kind:release manifest under the §4 release-manifest path convention (site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json; rehearsal/ excluded) records the same value — attempt distinctness is checkable, never asserted."
         }
       }
     },

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -133,18 +133,32 @@
             }
           },
           {
+            "if": { "properties": { "terminal_state": { "const": "pass" } }, "required": ["terminal_state"] },
+            "then": {
+              "properties": {
+                "fail_reason": false,
+                "skip_reason": false
+              },
+              "description": "A pass carries no failure or skip narrative — stray template values are the clerical class §2.3 bans."
+            }
+          },
+          {
             "if": { "properties": { "terminal_state": { "const": "fail" } }, "required": ["terminal_state"] },
-            "then": { "required": ["fail_reason"] }
+            "then": {
+              "required": ["fail_reason"],
+              "properties": { "skip_reason": false }
+            }
           },
           {
             "if": { "properties": { "terminal_state": { "const": "declared-skip" } }, "required": ["terminal_state"] },
             "then": {
               "required": ["skip_reason"],
               "properties": {
+                "fail_reason": false,
                 "host": false,
                 "execution_identity": false
               },
-              "description": "A declared-skip executed nothing: it must not fabricate execution identity."
+              "description": "A declared-skip executed nothing: it must not fabricate execution identity or carry a fail_reason."
             }
           }
         ]
@@ -163,19 +177,51 @@
           "observed_p50": { "type": "number" },
           "met": { "type": "boolean" },
           "ratchet_proposal": { "type": "number" }
-        }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "met": { "const": false } }, "required": ["met"] },
+            "then": {
+              "properties": { "ratchet_proposal": false },
+              "description": "A ratchet proposal exists only for a met floor (§4): the harness never proposes ratcheting from a breached measurement."
+            }
+          }
+        ]
       }
     },
     "ci_runs": {
       "type": "array",
+      "minItems": 6,
+      "description": "Closed repo-suite catalog (§3.4). Every catalog entry must be present with conclusion 'success' — the gate records green CI runs pinned to the candidate commit; a missing or non-green repo suite means no manifest is emitted (the gate refuses, INCOMPLETE-by-absence), so a partial ci_runs set is schema-invalid, never silently accepted.",
+      "allOf": [
+        { "contains": { "properties": { "suite_id": { "const": "just-ci" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-graft-python" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-hermes-graft-bridge" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-hermes-graft-smoke" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-admission-capacity" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-queue-hooks" } } } }
+      ],
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["suite_id", "run_id", "conclusion", "commit_sha"],
         "properties": {
-          "suite_id": { "type": "string", "minLength": 1 },
+          "suite_id": {
+            "enum": [
+              "just-ci",
+              "test-graft-python",
+              "test-hermes-graft-bridge",
+              "test-hermes-graft-smoke",
+              "test-admission-capacity",
+              "test-queue-hooks"
+            ],
+            "description": "Closed catalog of §3.4 repo suites. test-queue-hooks covers both the python and codex variants of that CI job."
+          },
           "run_id": { "type": "integer", "minimum": 1 },
-          "conclusion": { "type": "string", "minLength": 1 },
+          "conclusion": {
+            "const": "success",
+            "description": "Only green runs are recordable release evidence (§3.4)."
+          },
           "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
         }
       }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "atm-core/release-evidence-manifest/v1",
+  "title": "Release evidence manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_kind",
+    "candidate",
+    "suites",
+    "floors",
+    "ci_runs",
+    "verdict",
+    "generated_at",
+    "self_verification"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Manifest schema revision the emitting harness validated against. Review pins to this generation-time revision."
+    },
+    "run_kind": {
+      "enum": ["release", "rehearsal"],
+      "description": "rehearsal manifests are never release evidence and must live under the rehearsal output root."
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tag_candidate", "commit_sha", "branch"],
+      "properties": {
+        "tag_candidate": { "type": "string", "minLength": 1 },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "branch": { "type": "string", "minLength": 1 }
+      }
+    },
+    "testbed_definitions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "commit_sha"],
+      "description": "Pinned atm-hermes-testbed tier-definition revision the integration suite executed 1:1.",
+      "properties": {
+        "repo": { "type": "string" },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+      }
+    },
+    "suites": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "suite_id",
+          "entrypoint",
+          "terminal_state",
+          "evidence",
+          "started_at",
+          "ended_at",
+          "host",
+          "execution_identity"
+        ],
+        "properties": {
+          "suite_id": { "type": "string", "minLength": 1 },
+          "entrypoint": { "type": "string", "minLength": 1 },
+          "terminal_state": { "enum": ["pass", "fail", "declared-skip"] },
+          "fail_reason": {
+            "type": "string",
+            "description": "Required when terminal_state=fail. Machine-set reasons include provenance-missing, tier-detail-missing, tier-definitions-mismatch, sentinel-mismatch, floor-breach, test-failure."
+          },
+          "skip_reason": {
+            "type": "string",
+            "description": "Required when terminal_state=declared-skip; must cite the Rand-approved standing reason."
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["path", "sha256"],
+              "properties": {
+                "path": { "type": "string", "minLength": 1 },
+                "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+              }
+            }
+          },
+          "started_at": { "type": "string", "format": "date-time" },
+          "ended_at": { "type": "string", "format": "date-time" },
+          "host": { "type": "string", "minLength": 1 },
+          "execution_identity": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["execution_account", "uid", "home", "hostname"],
+            "properties": {
+              "execution_account": { "type": "string", "minLength": 1 },
+              "uid": { "type": "integer", "minimum": 0 },
+              "home": { "type": "string", "minLength": 1 },
+              "hostname": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "terminal_state": { "const": "fail" } } },
+            "then": { "required": ["fail_reason"] }
+          },
+          {
+            "if": { "properties": { "terminal_state": { "const": "declared-skip" } } },
+            "then": { "required": ["skip_reason"] }
+          }
+        ]
+      }
+    },
+    "floors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["family", "metric", "floor", "observed_p50", "met"],
+        "properties": {
+          "family": { "type": "string", "minLength": 1 },
+          "metric": { "type": "string", "minLength": 1 },
+          "floor": { "type": "number" },
+          "observed_p50": { "type": "number" },
+          "met": { "type": "boolean" },
+          "ratchet_proposal": { "type": "number" }
+        }
+      }
+    },
+    "ci_runs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["suite_id", "run_id", "conclusion", "commit_sha"],
+        "properties": {
+          "suite_id": { "type": "string", "minLength": 1 },
+          "run_id": { "type": "integer", "minimum": 1 },
+          "conclusion": { "type": "string", "minLength": 1 },
+          "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+        }
+      }
+    },
+    "verdict": { "enum": ["READY", "NOT-READY", "INCOMPLETE"] },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "self_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["validated", "validator_version"],
+      "properties": {
+        "validated": { "const": true },
+        "validator_version": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "run_kind",
     "candidate",
+    "testbed_definitions",
     "suites",
     "floors",
     "ci_runs",
@@ -39,7 +40,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["repo", "commit_sha"],
-      "description": "Pinned atm-hermes-testbed tier-definition revision the integration suite executed 1:1.",
+      "description": "Pinned atm-hermes-testbed tier-definition revision the integration suite executed 1:1. Required unconditionally: the testbed suite is always in the catalog.",
       "properties": {
         "repo": { "type": "string" },
         "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
@@ -47,7 +48,14 @@
     },
     "suites": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 4,
+      "description": "Every catalog suite must be present exactly once (the four contains-clauses under allOf enforce presence; the self-verifier additionally rejects duplicate suite_id values). A manifest missing any catalog suite is schema-invalid — completeness is verifiable from the manifest alone.",
+      "allOf": [
+        { "contains": { "properties": { "suite_id": { "const": "smoke-full" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "benchmark-send" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "benchmark-read-query" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "testbed-integration" } } } }
+      ],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -57,20 +65,36 @@
           "terminal_state",
           "evidence",
           "started_at",
-          "ended_at",
-          "host",
-          "execution_identity"
+          "ended_at"
         ],
         "properties": {
-          "suite_id": { "type": "string", "minLength": 1 },
+          "suite_id": {
+            "enum": [
+              "smoke-full",
+              "benchmark-send",
+              "benchmark-read-query",
+              "testbed-integration"
+            ],
+            "description": "Closed suite catalog (§3). Repo test suites are recorded in ci_runs, not here. Windows enters the catalog only when an isolated Windows evidence account exists (§7.6)."
+          },
           "entrypoint": { "type": "string", "minLength": 1 },
           "terminal_state": { "enum": ["pass", "fail", "declared-skip"] },
           "fail_reason": {
-            "type": "string",
-            "description": "Required when terminal_state=fail. Machine-set reasons include provenance-missing, tier-detail-missing, tier-definitions-mismatch, sentinel-mismatch, floor-breach, test-failure."
+            "enum": [
+              "provenance-missing",
+              "tier-detail-missing",
+              "tier-definitions-mismatch",
+              "sentinel-mismatch",
+              "floor-breach",
+              "test-failure",
+              "measurement-anomaly",
+              "suite-error"
+            ],
+            "description": "Required when terminal_state=fail. Closed taxonomy: any new failure class is a schema revision, never free text."
           },
           "skip_reason": {
             "type": "string",
+            "minLength": 1,
             "description": "Required when terminal_state=declared-skip; must cite the Rand-approved standing reason."
           },
           "evidence": {
@@ -102,12 +126,26 @@
         },
         "allOf": [
           {
-            "if": { "properties": { "terminal_state": { "const": "fail" } } },
+            "if": { "properties": { "terminal_state": { "enum": ["pass", "fail"] } }, "required": ["terminal_state"] },
+            "then": {
+              "required": ["host", "execution_identity"],
+              "description": "A suite that executed must carry host + execution-identity provenance (AC-4)."
+            }
+          },
+          {
+            "if": { "properties": { "terminal_state": { "const": "fail" } }, "required": ["terminal_state"] },
             "then": { "required": ["fail_reason"] }
           },
           {
-            "if": { "properties": { "terminal_state": { "const": "declared-skip" } } },
-            "then": { "required": ["skip_reason"] }
+            "if": { "properties": { "terminal_state": { "const": "declared-skip" } }, "required": ["terminal_state"] },
+            "then": {
+              "required": ["skip_reason"],
+              "properties": {
+                "host": false,
+                "execution_identity": false
+              },
+              "description": "A declared-skip executed nothing: it must not fabricate execution identity."
+            }
           }
         ]
       }
@@ -119,7 +157,7 @@
         "additionalProperties": false,
         "required": ["family", "metric", "floor", "observed_p50", "met"],
         "properties": {
-          "family": { "type": "string", "minLength": 1 },
+          "family": { "enum": ["send", "read-query"] },
           "metric": { "type": "string", "minLength": 1 },
           "floor": { "type": "number" },
           "observed_p50": { "type": "number" },
@@ -142,7 +180,10 @@
         }
       }
     },
-    "verdict": { "enum": ["READY", "NOT-READY", "INCOMPLETE"] },
+    "verdict": {
+      "enum": ["READY", "NOT-READY"],
+      "description": "INCOMPLETE is deliberately not representable: a manifest exists only after every suite reached a terminal state (§2.2.2). An incomplete run is signaled by the ABSENCE of a validated manifest (INCOMPLETE-by-absence, §2.2.1)."
+    },
     "generated_at": { "type": "string", "format": "date-time" },
     "self_verification": {
       "type": "object",

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -195,7 +195,7 @@
       "type": "array",
       "minItems": 7,
       "maxItems": 7,
-      "description": "Closed repo-suite catalog (§3.4), each entry present EXACTLY once (seven contains-clauses + maxItems 7; self-verifier re-checks duplicates as defense-in-depth). conclusion is const 'success' because CI-greenness of all seven runs on the candidate commit is a §2.2.6 PRE-launch eligibility check, RE-VERIFIED at manifest-emission time (a conclusion that went red or disappeared in the window refuses the manifest with a refusal record — no snapshot-stale READY): a red or missing run refuses launch/emission with the 'candidate not CI-eligible' state — the manifest records verified-green runs, it is never the reporting channel for a red CI run (that failure surfaces in CI itself).",
+      "description": "Closed repo-suite catalog (§3.4), each entry present EXACTLY once (seven contains-clauses + maxItems 7; self-verifier re-checks duplicates as defense-in-depth). conclusion is const 'success' because CI-greenness of all seven runs on the candidate commit is a §2.2.6 PRE-launch eligibility check, RE-VERIFIED at manifest-emission time (a conclusion that went red or disappeared in the window refuses the manifest with a refusal record — no snapshot-stale READY): a red or missing run refuses with the point-specific named state — 'candidate not CI-eligible' at pre-launch, 'candidate no longer CI-eligible at emission' at emission — the manifest records verified-green runs, it is never the reporting channel for a red CI run (that failure surfaces in CI itself).",
       "allOf": [
         { "contains": { "properties": { "suite_id": { "const": "just-ci" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-graft-python" } } } },
@@ -252,11 +252,23 @@
         "properties": {
           "suites": {
             "contains": {
-              "properties": {
-                "suite_id": { "const": "benchmark-send" },
-                "terminal_state": { "enum": ["pass", "fail"] }
-              },
-              "required": ["suite_id", "terminal_state"]
+              "anyOf": [
+                {
+                  "properties": {
+                    "suite_id": { "const": "benchmark-send" },
+                    "terminal_state": { "const": "pass" }
+                  },
+                  "required": ["suite_id", "terminal_state"]
+                },
+                {
+                  "properties": {
+                    "suite_id": { "const": "benchmark-send" },
+                    "terminal_state": { "const": "fail" },
+                    "fail_reason": { "enum": ["floor-breach", "test-failure", "measurement-anomaly", "provenance-missing"] }
+                  },
+                  "required": ["suite_id", "terminal_state", "fail_reason"]
+                }
+              ]
             }
           }
         },
@@ -271,7 +283,7 @@
             }
           }
         },
-        "description": "An executed (pass/fail) benchmark-send suite requires at least one send floors row; a declared-skip does not (§2.1/AC-3 — never fabricate a measurement that never ran)."
+        "description": "A benchmark-send suite that produced a measurement (pass, or fail with a measurement-bearing fail_reason: floor-breach/test-failure/measurement-anomaly/provenance-missing) requires at least one send floors row. A declared-skip requires none, and neither does fail/suite-error — the suite could not execute at all (§2.2.5/AC-5), so requiring a floors row would force fabricating observed_p50 for a measurement that never ran (§2.1/AC-3). The measurement-bearing set is a closed whitelist: a future fail_reason defaults to NOT forcing a floors row; the §2.3.3 self-verifier's metric-level cross-check remains the completeness backstop."
       }
     },
     {
@@ -279,11 +291,23 @@
         "properties": {
           "suites": {
             "contains": {
-              "properties": {
-                "suite_id": { "const": "benchmark-read-query" },
-                "terminal_state": { "enum": ["pass", "fail"] }
-              },
-              "required": ["suite_id", "terminal_state"]
+              "anyOf": [
+                {
+                  "properties": {
+                    "suite_id": { "const": "benchmark-read-query" },
+                    "terminal_state": { "const": "pass" }
+                  },
+                  "required": ["suite_id", "terminal_state"]
+                },
+                {
+                  "properties": {
+                    "suite_id": { "const": "benchmark-read-query" },
+                    "terminal_state": { "const": "fail" },
+                    "fail_reason": { "enum": ["floor-breach", "test-failure", "measurement-anomaly", "provenance-missing"] }
+                  },
+                  "required": ["suite_id", "terminal_state", "fail_reason"]
+                }
+              ]
             }
           }
         },
@@ -298,7 +322,7 @@
             }
           }
         },
-        "description": "An executed (pass/fail) benchmark-read-query suite requires at least one read-query floors row; a declared-skip does not (§2.1/AC-3)."
+        "description": "A benchmark-read-query suite that produced a measurement (pass, or fail with a measurement-bearing fail_reason) requires at least one read-query floors row; declared-skip and fail/suite-error require none (§2.1/AC-3/AC-5 — same rule as the send-family conditional above)."
       }
     }
   ]

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -49,7 +49,8 @@
     "suites": {
       "type": "array",
       "minItems": 4,
-      "description": "Every catalog suite must be present exactly once (the four contains-clauses under allOf enforce presence; the self-verifier additionally rejects duplicate suite_id values). A manifest missing any catalog suite is schema-invalid — completeness is verifiable from the manifest alone.",
+      "maxItems": 4,
+      "description": "Every catalog suite must be present EXACTLY once, schema-mechanized: the four contains-clauses enforce at-least-once and maxItems 4 forbids any duplicate. The self-verifier re-checks duplicate suite_id rejection as defense-in-depth. A manifest missing any catalog suite is schema-invalid — completeness is verifiable from the manifest alone.",
       "allOf": [
         { "contains": { "properties": { "suite_id": { "const": "smoke-full" } } } },
         { "contains": { "properties": { "suite_id": { "const": "benchmark-send" } } } },
@@ -166,6 +167,12 @@
     },
     "floors": {
       "type": "array",
+      "minItems": 2,
+      "description": "Both benchmark families must carry at least one floor row (contains clauses); metric-level completeness per §3.2 (every tracked metric for a pass-terminal benchmark suite has a floors row) is a §2.3.3 self-verifier cross-check.",
+      "allOf": [
+        { "contains": { "properties": { "family": { "const": "send" } } } },
+        { "contains": { "properties": { "family": { "const": "read-query" } } } }
+      ],
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -191,15 +198,17 @@
     },
     "ci_runs": {
       "type": "array",
-      "minItems": 6,
-      "description": "Closed repo-suite catalog (§3.4). Every catalog entry must be present with conclusion 'success' — the gate records green CI runs pinned to the candidate commit; a missing or non-green repo suite means no manifest is emitted (the gate refuses, INCOMPLETE-by-absence), so a partial ci_runs set is schema-invalid, never silently accepted.",
+      "minItems": 7,
+      "maxItems": 7,
+      "description": "Closed repo-suite catalog (§3.4), each entry present EXACTLY once (seven contains-clauses + maxItems 7; self-verifier re-checks duplicates as defense-in-depth). conclusion is const 'success' because CI-greenness of all seven runs on the candidate commit is a §2.2.6 PRE-launch eligibility check: a red or missing run refuses the launch with the distinct 'candidate not CI-eligible' state before any suite executes — the manifest records the verified-green runs, it is never the reporting channel for a red CI run (that failure surfaces in CI itself, pre-launch).",
       "allOf": [
         { "contains": { "properties": { "suite_id": { "const": "just-ci" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-graft-python" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-hermes-graft-bridge" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-hermes-graft-smoke" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-admission-capacity" } } } },
-        { "contains": { "properties": { "suite_id": { "const": "test-queue-hooks" } } } }
+        { "contains": { "properties": { "suite_id": { "const": "test-queue-hooks-python" } } } },
+        { "contains": { "properties": { "suite_id": { "const": "test-queue-hooks-codex" } } } }
       ],
       "items": {
         "type": "object",
@@ -213,14 +222,15 @@
               "test-hermes-graft-bridge",
               "test-hermes-graft-smoke",
               "test-admission-capacity",
-              "test-queue-hooks"
+              "test-queue-hooks-python",
+              "test-queue-hooks-codex"
             ],
-            "description": "Closed catalog of §3.4 repo suites. test-queue-hooks covers both the python and codex variants of that CI job."
+            "description": "Closed catalog of §3.4 repo suites. The queue-hooks python and codex variants are separate entries — each must independently be green; there is no combined entry and no combination rule to get wrong."
           },
           "run_id": { "type": "integer", "minimum": 1 },
           "conclusion": {
             "const": "success",
-            "description": "Only green runs are recordable release evidence (§3.4)."
+            "description": "Only green runs are recordable (§2.2.6 CI-eligibility precondition; §3.4)."
           },
           "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
         }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -91,7 +91,7 @@
               "measurement-anomaly",
               "suite-error"
             ],
-            "description": "Required when terminal_state=fail. Closed taxonomy: any new failure class is a schema revision, never free text."
+            "description": "Required when terminal_state=fail. Closed taxonomy: any new failure class is a schema revision, never free text. Each suite_id admits only its own subset (per-suite allOf conditionals below): a suite-inappropriate reason is a mislabel, rejected at the schema (§2.3.3 re-checks compatibility as defense-in-depth)."
           },
           "skip_reason": {
             "type": "string",
@@ -160,6 +160,27 @@
                 "execution_identity": false
               },
               "description": "A declared-skip executed nothing: it must not fabricate execution identity or carry a fail_reason."
+            }
+          },
+          {
+            "if": { "properties": { "suite_id": { "const": "smoke-full" }, "terminal_state": { "const": "fail" } }, "required": ["suite_id", "terminal_state"] },
+            "then": {
+              "properties": { "fail_reason": { "enum": ["test-failure", "provenance-missing", "suite-error"] } },
+              "description": "suite_id-scoped fail_reason subset: smoke has no floors, no measurement, and no tier/sentinel concepts — a benchmark- or testbed-only reason on a smoke row is a mislabel, rejected at the schema."
+            }
+          },
+          {
+            "if": { "properties": { "suite_id": { "enum": ["benchmark-send", "benchmark-read-query"] }, "terminal_state": { "const": "fail" } }, "required": ["suite_id", "terminal_state"] },
+            "then": {
+              "properties": { "fail_reason": { "enum": ["floor-breach", "test-failure", "measurement-anomaly", "provenance-missing", "suite-error"] } },
+              "description": "suite_id-scoped fail_reason subset: benchmark rows never carry testbed-only reasons (tier-detail-missing, tier-definitions-mismatch, sentinel-mismatch) — a mislabeled benchmark fail cannot dodge the floors-row requirement by borrowing a non-measurement-bearing reason."
+            }
+          },
+          {
+            "if": { "properties": { "suite_id": { "const": "testbed-integration" }, "terminal_state": { "const": "fail" } }, "required": ["suite_id", "terminal_state"] },
+            "then": {
+              "properties": { "fail_reason": { "enum": ["tier-detail-missing", "tier-definitions-mismatch", "sentinel-mismatch", "test-failure", "provenance-missing", "suite-error"] } },
+              "description": "suite_id-scoped fail_reason subset: testbed rows never carry benchmark-only reasons (floor-breach, measurement-anomaly)."
             }
           }
         ]

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -41,7 +41,7 @@
         "workspace_version": {
           "type": "string",
           "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
-          "description": "The gated commit's Cargo.toml [workspace.package] version — the §5.1 mandatory per-attempt patch++ version (AC-13). Recorded by the orchestrator's first act from the checked-out gated tree; the self-verifier cross-checks it against Cargo.toml and refuses emission if any previously committed run_kind:release manifest under the §4 release-manifest path convention (site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json; rehearsal/ excluded) records the same value — attempt distinctness is checkable, never asserted."
+          "description": "The gated commit's Cargo.toml [workspace.package] version — the §5.1 mandatory per-attempt patch++ version (AC-13). Recorded from the checked-out gated tree as the first of the gate's two ordered opening acts (§5.1: record version, then the §2.2.6 precondition); the self-verifier cross-checks it against Cargo.toml and refuses emission if any previously committed run_kind:release manifest under the §4 release-manifest path convention (site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json; rehearsal/ excluded) records the same value — attempt distinctness is checkable, never asserted."
         }
       }
     },

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -167,12 +167,7 @@
     },
     "floors": {
       "type": "array",
-      "minItems": 2,
-      "description": "Both benchmark families must carry at least one floor row (contains clauses); metric-level completeness per §3.2 (every tracked metric for a pass-terminal benchmark suite has a floors row) is a §2.3.3 self-verifier cross-check.",
-      "allOf": [
-        { "contains": { "properties": { "family": { "const": "send" } } } },
-        { "contains": { "properties": { "family": { "const": "read-query" } } } }
-      ],
+      "description": "Family-level completeness is CONDITIONAL on execution (root-level allOf): a benchmark family's floors row is required exactly when that family's suite reached pass/fail; a Rand-approved declared-skip of a benchmark family (§2.1/AC-3) requires no floors row for it — a measurement that never ran is never fabricated. Metric-level completeness per §3.2 (every tracked metric for a pass-terminal benchmark suite has a floors row) and the forbid direction (no floors row for a family whose suite did not execute) are §2.3.3 self-verifier cross-checks.",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -200,7 +195,7 @@
       "type": "array",
       "minItems": 7,
       "maxItems": 7,
-      "description": "Closed repo-suite catalog (§3.4), each entry present EXACTLY once (seven contains-clauses + maxItems 7; self-verifier re-checks duplicates as defense-in-depth). conclusion is const 'success' because CI-greenness of all seven runs on the candidate commit is a §2.2.6 PRE-launch eligibility check: a red or missing run refuses the launch with the distinct 'candidate not CI-eligible' state before any suite executes — the manifest records the verified-green runs, it is never the reporting channel for a red CI run (that failure surfaces in CI itself, pre-launch).",
+      "description": "Closed repo-suite catalog (§3.4), each entry present EXACTLY once (seven contains-clauses + maxItems 7; self-verifier re-checks duplicates as defense-in-depth). conclusion is const 'success' because CI-greenness of all seven runs on the candidate commit is a §2.2.6 PRE-launch eligibility check, RE-VERIFIED at manifest-emission time (a conclusion that went red or disappeared in the window refuses the manifest with a refusal record — no snapshot-stale READY): a red or missing run refuses launch/emission with the 'candidate not CI-eligible' state — the manifest records verified-green runs, it is never the reporting channel for a red CI run (that failure surfaces in CI itself).",
       "allOf": [
         { "contains": { "properties": { "suite_id": { "const": "just-ci" } } } },
         { "contains": { "properties": { "suite_id": { "const": "test-graft-python" } } } },
@@ -250,5 +245,61 @@
         "validator_version": { "type": "string", "minLength": 1 }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "suites": {
+            "contains": {
+              "properties": {
+                "suite_id": { "const": "benchmark-send" },
+                "terminal_state": { "enum": ["pass", "fail"] }
+              },
+              "required": ["suite_id", "terminal_state"]
+            }
+          }
+        },
+        "required": ["suites"]
+      },
+      "then": {
+        "properties": {
+          "floors": {
+            "contains": {
+              "properties": { "family": { "const": "send" } },
+              "required": ["family"]
+            }
+          }
+        },
+        "description": "An executed (pass/fail) benchmark-send suite requires at least one send floors row; a declared-skip does not (§2.1/AC-3 — never fabricate a measurement that never ran)."
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "suites": {
+            "contains": {
+              "properties": {
+                "suite_id": { "const": "benchmark-read-query" },
+                "terminal_state": { "enum": ["pass", "fail"] }
+              },
+              "required": ["suite_id", "terminal_state"]
+            }
+          }
+        },
+        "required": ["suites"]
+      },
+      "then": {
+        "properties": {
+          "floors": {
+            "contains": {
+              "properties": { "family": { "const": "read-query" } },
+              "required": ["family"]
+            }
+          }
+        },
+        "description": "An executed (pass/fail) benchmark-read-query suite requires at least one read-query floors row; a declared-skip does not (§2.1/AC-3)."
+      }
+    }
+  ]
 }

--- a/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
+++ b/docs/plans/release-readiness-gate/release-evidence-manifest.schema.json
@@ -29,11 +29,20 @@
     "candidate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["tag_candidate", "commit_sha", "branch"],
+      "required": ["tag_candidate", "commit_sha", "branch", "workspace_version"],
       "properties": {
-        "tag_candidate": { "type": "string", "minLength": 1 },
+        "tag_candidate": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.0$",
+          "description": "Proposed release version label (§5.1): always the clean vX.Y.0 the post-READY minor bump will produce. BINDING at the readiness preflight (AC-12 iii): the release-candidate tag's version must equal this value."
+        },
         "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-        "branch": { "type": "string", "minLength": 1 }
+        "branch": { "type": "string", "minLength": 1 },
+        "workspace_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "description": "The gated commit's Cargo.toml [workspace.package] version — the §5.1 mandatory per-attempt patch++ version (AC-13). Recorded by the orchestrator's first act from the checked-out gated tree; the self-verifier cross-checks it against Cargo.toml and refuses emission if any previously committed run_kind:release manifest under the evidence root records the same value — attempt distinctness is checkable, never asserted."
+        }
       }
     },
     "testbed_definitions": {
@@ -179,8 +188,8 @@
           {
             "if": { "properties": { "suite_id": { "const": "testbed-integration" }, "terminal_state": { "const": "fail" } }, "required": ["suite_id", "terminal_state"] },
             "then": {
-              "properties": { "fail_reason": { "enum": ["tier-detail-missing", "tier-definitions-mismatch", "sentinel-mismatch", "test-failure", "provenance-missing", "suite-error"] } },
-              "description": "suite_id-scoped fail_reason subset: testbed rows never carry benchmark-only reasons (floor-breach, measurement-anomaly)."
+              "properties": { "fail_reason": { "enum": ["tier-detail-missing", "tier-definitions-mismatch", "sentinel-mismatch", "test-failure", "provenance-missing", "measurement-anomaly", "suite-error"] } },
+              "description": "suite_id-scoped fail_reason subset: testbed rows never carry floor-breach (the only benchmark-exclusive reason — floors exist only for benchmark families). measurement-anomaly IS admitted: §3.3's one-continuous-session guarantee is validated by a testbed-scoped duration-bounds anomaly check (built in RRG.3a, wired in RRG.4) that emits fail/measurement-anomaly. The root-level floors conditionals are unaffected — they key on benchmark suite_ids only, so a testbed measurement-anomaly row never forces a floors row."
             }
           }
         ]

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -56,21 +56,26 @@ just release-readiness <release-tag-candidate>
 ### 2.2 Execution-to-completeness rules
 
 1. The gate runs all suites to a terminal state (`pass` / `fail` /
-   `declared-skip`) before rendering any verdict. A crash or abandonment of
-   any suite makes the whole gate `INCOMPLETE`, which is a failure state.
-   The terminal-state taxonomy is exactly the manifest enum: `fail` means
+   `declared-skip`) before rendering any verdict. The suite terminal-state
+   taxonomy is exactly the manifest's `terminal_state` enum: `fail` means
    the suite ran and either produced a failing/invalid result or was
-   machine-invalidated (rule 4); `INCOMPLETE` is reserved for a suite that
-   never reached a terminal state (crash, abandonment, runner death).
+   machine-invalidated (rule 4). **INCOMPLETE-by-absence**: a run where any
+   suite never reaches a terminal state (crash, abandonment, runner death)
+   writes NO manifest at all — the gate outcome `INCOMPLETE` is signaled by
+   the absence of a validated manifest for the launch, never by a manifest
+   value. `INCOMPLETE` is therefore deliberately unrepresentable in the
+   schema (its `verdict` enum is `READY`/`NOT-READY` only): a manifest
+   claiming completeness for an incomplete run cannot exist. INCOMPLETE is
+   a failure state.
 2. Evidence is written incrementally per suite, but the **release evidence
    manifest** (§4) is written only after all suites reach a terminal state.
    The manifest is the **sole release-evidence pointer**: an artifact —
    including per-suite artifacts committed incrementally by existing suite
    conventions (§3.1 smoke) — is release evidence only when referenced,
    with its sha256, by a validated `run_kind: "release"` manifest. Artifacts
-   left behind by an `INCOMPLETE` or failed run remain committed history but
-   are inert: no manifest references them, so they are never release
-   evidence.
+   left behind by an incomplete run (no manifest — rule 1) or a failed run
+   remain committed history but are inert as release evidence unless a
+   validated manifest references them.
 3. The gate verdict is `READY` only when every suite passes (or is
    `declared-skip` with a Rand-approved standing reason) **and** the
    evidence manifest validates against its committed schema (§4).
@@ -120,8 +125,11 @@ The mechanism that makes §1's first-time-pass requirement real:
    carry `run_kind: "rehearsal"` and all rehearsal output is written under a
    dedicated rehearsal root (`site/reports/release-readiness/rehearsal/`)
    that the reports index and release tooling treat as non-evidence; the
-   self-verifier refuses a `release` manifest that references any path under
-   the rehearsal root, and vice versa. A green rehearsal is a hard
+   self-verifier owns *both* refusal directions — it refuses a `release`
+   manifest that references any path under the rehearsal root, and a
+   `rehearsal` manifest that references any path outside it
+   (`reports-index --check` re-checks only the release→rehearsal-root
+   direction as defense-in-depth; see §4). A green rehearsal is a hard
    acceptance criterion of the final implementation sprint (§6, RRG.4) —
    the gate is not "implemented" without one — and is also the pre-launch
    check before the real release run. (Rehearsal runs no tests, so it
@@ -129,16 +137,26 @@ The mechanism that makes §1's first-time-pass requirement real:
 5. **Single QA round by contract.** quality-mgr reviews a real gate run
    once. That review consists of (i) re-running the §2.3.3 machine checks —
    which the gate already ran, so they are green by construction — and
-   (ii) product-result judgment **only**: is a floor breach / test failure
-   real, and are the measured results plausible as product behavior.
-   Floor honesty itself is mechanized: the harness computes the manifest
-   `floors` section (observed p50 vs committed baselines, ratchet
-   proposals) — QA judges the product result, not the arithmetic. There is
-   **no third failure category**: a product-result finding renders the run
-   `NOT-READY` as a product failure (Rand's accepted exception); any other
-   reviewer finding is by definition a harness defect — the fix goes into
-   the validator/self-verifier (never "redo the form"), so that class can
-   never recur.
+   (ii) product-result review **only**: is a reported floor breach / test
+   failure real. Floor honesty itself is mechanized: the harness computes
+   the manifest `floors` section (observed p50 vs committed baselines,
+   ratchet proposals) — QA reviews the product result, not the arithmetic.
+   Result plausibility is **not reviewer discretion**: it is the enumerated
+   anomaly-check set the harness itself runs as part of §2.3.3 (per-family
+   D7 clean-run criteria; observed p50 within the family's historical
+   sanity band; wall-clock duration within declared bounds; evidence-row
+   counts matching the declared workload). Any anomaly-check hit is emitted
+   by the harness as suite `fail` with `fail_reason:
+   "measurement-anomaly"`, which is treated as a harness/environment defect:
+   fix the check or the environment and re-run — it is never a manual
+   override of a computed `READY`, and QA may not fail a `READY` manifest
+   on unenumerated plausibility grounds (a missing anomaly check is itself
+   a harness defect: add the check, don't hand-adjudicate). There is
+   **no third failure category**: a confirmed floor breach / test failure
+   renders the run `NOT-READY` as a product failure (Rand's accepted
+   exception); any other reviewer finding is by definition a harness
+   defect — the fix goes into the validator/self-verifier (never "redo the
+   form"), so that class can never recur.
 
 ### 2.4 Hosts and isolation
 
@@ -160,11 +178,18 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - AC-1: one launch (`just release-readiness <tag-candidate>`) drives every
   declared suite to a terminal state without operator input (§2.1, §2.2.1).
 - AC-2: manifest written only after all suites terminal; validates against
-  the committed schema; is the sole release-evidence pointer (§2.2.2, §4).
+  the committed schema (closed suite catalog present exactly once, verdict
+  `READY`/`NOT-READY` only — an incomplete run writes no manifest,
+  INCOMPLETE-by-absence); is the sole release-evidence pointer (§2.2.1,
+  §2.2.2, §4).
 - AC-3: `READY` requires all suites `pass` or Rand-approved
-  `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3).
-- AC-4: missing execution-identity provenance ⇒ suite `fail`
-  (`provenance-missing`); never `READY` (§2.2.4).
+  `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3);
+  anything else renders `NOT-READY`.
+- AC-4: every executed suite (`pass`/`fail`) carries `host` + in-band
+  execution-identity provenance — schema-required, so
+  missing provenance ⇒ suite `fail` (`provenance-missing`); a
+  `declared-skip` must NOT carry host/identity; never `READY` with a
+  provenance gap (§2.2.4, §4).
 - AC-5: mechanical READY-refusal for absent declared benchmark families and
   unpinned/mismatched testbed tier definitions (§2.2.5).
 - AC-6: validate-at-emit in every suite adapter (§2.3.2).
@@ -238,8 +263,11 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 
 One committed JSON manifest per gate run. The schema is a committed plan
 artifact — [release-evidence-manifest.schema.json](release-evidence-manifest.schema.json)
-(JSON Schema 2020-12), with a worked example at
-[release-evidence-manifest.example.json](release-evidence-manifest.example.json).
+(JSON Schema 2020-12), with two worked examples:
+[release-evidence-manifest.example.json](release-evidence-manifest.example.json)
+(a `NOT-READY` run with a floor-breach fail and a declared-skip) and
+[release-evidence-manifest.example-ready.json](release-evidence-manifest.example-ready.json)
+(a fully green `READY` run — all four suites `pass`, both floors met).
 RRG.1 lifts these into their final in-repo home next to the validator; the
 schema content in this plan is the reviewed baseline.
 
@@ -248,23 +276,45 @@ Summary of the committed schema (normative source is the schema file):
 - `schema_version` (integer) — generation-time schema revision pin;
 - `run_kind` — `release` | `rehearsal` (§2.3.4 separation);
 - `candidate` — tag-candidate, 40-hex commit SHA, branch;
-- `testbed_definitions` — pinned testbed repo + commit SHA (AC-5);
-- `suites[]` — suite id, entrypoint, terminal state
-  (`pass`/`fail`+`fail_reason`/`declared-skip`+`skip_reason`), evidence
-  paths each with sha256, start/end timestamps, host, and the
-  execution-identity provenance object;
-- `floors[]` — family, metric, floor vs observed p50, met flag, optional
-  ratchet proposal (harness-computed, §2.3.5);
+- `testbed_definitions` — pinned testbed repo + commit SHA (AC-5;
+  top-level **required**);
+- `suites[]` — **closed catalog**: `suite_id` is the enum
+  `smoke-full` / `benchmark-send` / `benchmark-read-query` /
+  `testbed-integration`, and four `contains` clauses require every catalog
+  suite to be present (duplicate `suite_id` rejection is a §2.3.3
+  self-verifier check). Per suite: entrypoint, terminal state
+  (`pass`/`fail`/`declared-skip`), evidence paths each with sha256, and
+  start/end timestamps. Conditionals: `pass`/`fail` **require** `host` +
+  the execution-identity provenance object (AC-4); `fail` **requires**
+  `fail_reason` from the closed taxonomy (`provenance-missing`,
+  `tier-detail-missing`, `tier-definitions-mismatch`, `sentinel-mismatch`,
+  `floor-breach`, `test-failure`, `measurement-anomaly`, `suite-error` —
+  a new failure class is a schema revision, never free text);
+  `declared-skip` **requires** `skip_reason` and **forbids**
+  `host`/`execution_identity` (nothing executed — identity must not be
+  fabricated);
+- `floors[]` — family (`send` | `read-query`), metric, floor vs observed
+  p50, met flag, optional ratchet proposal (harness-computed, §2.3.5);
 - `ci_runs[]` — run ids + conclusions for the repo suites (§3.4) pinned to
   the candidate commit;
-- `verdict` — `READY` / `NOT-READY` / `INCOMPLETE`;
+- `verdict` — `READY` / `NOT-READY` only. `INCOMPLETE` is deliberately
+  unrepresentable: an incomplete run writes no manifest at all
+  (INCOMPLETE-by-absence, §2.2.1);
 - `self_verification` — must record `validated: true` + validator version.
 
 Manifest and all referenced artifacts are committed and pushed
 (discarded/unpublished attempts cannot be release evidence — same rule as
-benchmark D7). `just reports-index --check` extends to validate the
-manifest's referenced paths exist and that no `release` manifest references
-the rehearsal root.
+benchmark D7).
+
+Rehearsal/release separation ownership (two mechanisms, explicit
+direction split): the §2.3.4 **self-verifier** owns *both* directions —
+it refuses a `release` manifest referencing any path under the rehearsal
+root and a `rehearsal` manifest referencing any path outside it — and is
+the acceptance mechanism for AC-8. `just reports-index --check`
+additionally validates that the manifest's referenced paths exist and
+re-checks the release→rehearsal-root direction as defense-in-depth on
+every index run; it is a redundant backstop, not the owner of either
+direction.
 
 ## 5. Streamlined coordination (who runs what)
 
@@ -288,7 +338,7 @@ the rehearsal root.
 | RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4 | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks) | RRG.1 | Cipher |
-| RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1 (parallel-safe with RRG.3a) | Cipher (atm-hermes-testbed PR) |
+| RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1. Parallel-safe with RRG.3a: disjoint repos (RRG.3b edits only atm-hermes-testbed; RRG.3a edits only atm-core) — their sole coupling is the pin value RRG.3a's manifest records, fixed at RRG.3b merge (or Rand-approved fallback SHA) | Cipher (atm-hermes-testbed PR) |
 | RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs. Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 All sprints are ordinary dev worktrees off develop with quality-mgr QA;
@@ -369,3 +419,29 @@ owns; no sprint-local reinterpretation.
   order-vs-concurrency tension → §5: completeness is the guarantee, order
   carries no correctness weight. Also added §7.8 (send-family provenance
   gap, lane-3 minor (b)) discovered in the same window.
+- **r2 (2026-08-31, quality-mgr verdict FAIL @ 65998f2d1, msg
+  01M1D9D0FWS1FC59WQBKE4HC55)**: 14/16 r1 findings confirmed fixed; 4
+  Blocking, 3 Important, 2 Minor new/residual. B1r2 §2.3.5 "plausibility"
+  was reviewer discretion by another name → rewritten: plausibility is the
+  enumerated anomaly-check set the harness runs itself (D7 clean-run
+  criteria, historical sanity band, duration bounds, evidence-row counts);
+  a hit emits suite `fail`/`measurement-anomaly`; QA may not fail a `READY`
+  manifest on unenumerated grounds. B2r2 `INCOMPLETE` verdict unreachable
+  (manifest only written after all suites terminal) → INCOMPLETE-by-absence:
+  dropped from the verdict enum (`READY`/`NOT-READY` only); an incomplete
+  run writes no manifest (§2.2.1, §2.2.2, §4). B3r2 `testbed_definitions`
+  not in schema `required[]` → now top-level required. B4r2 no suite
+  catalog (free-text suite_id, minItems:1) → closed `suite_id` enum + four
+  `contains` clauses requiring every catalog suite; duplicates rejected by
+  self-verifier. I1r2 free-text `fail_reason` → closed 8-value enum (new
+  class = schema revision). I2r2 example fabricated interactive-account
+  identity on a declared-skip → schema conditionals: `pass`/`fail` require
+  host+identity, `declared-skip` forbids them; example rewritten. I3r2
+  example never demonstrated benchmark-send or READY →
+  example.json (NOT-READY, all four suites incl. benchmark-send) +
+  new example-ready.json (READY). M1r2 §4 vs §2.3.4
+  rehearsal-direction ambiguity → explicit ownership: self-verifier owns
+  both refusal directions; reports-index --check is release→rehearsal-root
+  defense-in-depth only. M2r2 RRG.3b parallel-safe annotation → §6 cell now
+  states disjoint repos + sole coupling (pin value). §2.5 AC-2/AC-3/AC-4
+  reconciled with the schema changes.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -27,7 +27,7 @@ created: 2026-08-31
   first time, assuming there is no performance failure. Multiple rounds of
   QA ceremony because a field was not filled out properly in an evidence
   form are **not acceptable**. Consequence: evidence correctness is enforced
-  by the harness at generation time (§2.4), never discovered by a reviewer
+  by the harness at generation time (§2.3), never discovered by a reviewer
   afterward. The only legitimate first-run QA failures are real product
   failures (performance floor breach, test failure) — never clerical.
 - **No tests are run now.** This plan, its review, and the gate
@@ -49,52 +49,96 @@ just release-readiness <release-tag-candidate>
   setup failures, and does not stop for operator input mid-run.
 - Every suite runs in **full** — no sampling, no "quick" profiles, no
   suite skipped silently. A suite that is intentionally not runnable in the
-  release environment must be declared in the manifest as `skipped` with a
-  recorded reason (e.g. Windows benchmark policy), never absent.
+  release environment must be declared in the manifest as `declared-skip`
+  with a Rand-approved standing reason (e.g. Windows benchmark policy),
+  never absent.
 
 ### 2.2 Execution-to-completeness rules
 
-1. The gate runs all suites to a terminal state (pass / fail / declared-skip)
-   before rendering any verdict. A crash or abandonment of any suite makes
-   the whole gate `INCOMPLETE`, which is a failure state.
+1. The gate runs all suites to a terminal state (`pass` / `fail` /
+   `declared-skip`) before rendering any verdict. A crash or abandonment of
+   any suite makes the whole gate `INCOMPLETE`, which is a failure state.
+   The terminal-state taxonomy is exactly the manifest enum: `fail` means
+   the suite ran and either produced a failing/invalid result or was
+   machine-invalidated (rule 4); `INCOMPLETE` is reserved for a suite that
+   never reached a terminal state (crash, abandonment, runner death).
 2. Evidence is written incrementally per suite, but the **release evidence
    manifest** (§4) is written only after all suites reach a terminal state.
-   No manifest ⇒ no release evidence.
+   The manifest is the **sole release-evidence pointer**: an artifact —
+   including per-suite artifacts committed incrementally by existing suite
+   conventions (§3.1 smoke) — is release evidence only when referenced,
+   with its sha256, by a validated `run_kind: "release"` manifest. Artifacts
+   left behind by an `INCOMPLETE` or failed run remain committed history but
+   are inert: no manifest references them, so they are never release
+   evidence.
 3. The gate verdict is `READY` only when every suite passes (or is
-   declared-skip with a Rand-approved standing reason) **and** the evidence
-   manifest validates against its schema.
+   `declared-skip` with a Rand-approved standing reason) **and** the
+   evidence manifest validates against its committed schema (§4).
 4. Fail-closed provenance: every evidence artifact must carry the in-band
    execution-identity fields (execution_account, uid, home, hostname —
-   AV-PROD-001R contract). Artifacts missing provenance invalidate the run
-   for the suites they belong to.
+   AV-PROD-001R contract). A suite emitting any artifact without them
+   reaches terminal state `fail` with `fail_reason: "provenance-missing"` —
+   it is a suite failure, not `INCOMPLETE`, and the run cannot render
+   `READY`.
+5. Mechanical READY-refusal guards (no forbidden path may depend on operator
+   discipline):
+   - a declared benchmark family absent from the tree (e.g. read/query
+     before PR #1120 merges) ⇒ runner refuses to render `READY`;
+   - testbed tier-definition state not pinned and matched — the manifest's
+     `testbed_definitions.commit_sha` must identify the tier-definition
+     revision actually executed, 1:1 (§3.3) — otherwise the testbed suite is
+     `fail` with `fail_reason: "tier-definitions-mismatch"`.
 
-#### 2.3 First-time-pass enforcement (no clerical QA rounds)
+### 2.3 First-time-pass enforcement (no clerical QA rounds)
 
 The mechanism that makes §1's first-time-pass requirement real:
 
 1. **One schema, shared by harness and QA.** The evidence/manifest JSON
-   schema is committed in-repo and is the *same* artifact the gate validates
-   against at generation time and quality-mgr validates against at review
-   time. There is no reviewer-side checklist that the harness cannot run
-   itself.
+   schema is committed in-repo
+   ([release-evidence-manifest.schema.json](release-evidence-manifest.schema.json),
+   with a worked example in
+   [release-evidence-manifest.example.json](release-evidence-manifest.example.json))
+   and is the *same* artifact the gate validates against at generation time
+   and quality-mgr validates against at review time. The manifest's
+   `schema_version` field pins the generation-time schema revision so review
+   validates against exactly what the harness enforced. There is no
+   reviewer-side checklist that the harness cannot run itself.
 2. **Validate-at-emit.** Every suite adapter validates each artifact against
    the schema the moment it is written; an invalid artifact aborts that
    suite as a harness error immediately (fail fast mid-run), not at review.
 3. **Whole-set self-verification.** Before rendering a verdict, the gate
-   re-validates the complete evidence set + manifest exactly as QA would
-   (schema, sha256s, provenance fields, cross-references, reports-index).
-   `READY` is unreachable with a clerical defect present.
+   re-validates the complete evidence set + manifest exactly as QA would:
+   schema, sha256s, provenance fields, cross-references, reports-index,
+   **and the testbed evidence-form classes that caused the v1.4.6 churn
+   (§7.2/§7.3): every tier row has populated `detail`, version sentinels are
+   consistent across prompt files, and executed tiers match the pinned
+   tier-definition revision 1:1**. `READY` is unreachable with a clerical
+   defect present.
 4. **Rehearsal mode.** `just release-readiness --rehearse` exercises the
    entire evidence pipeline with synthetic suite results — schema, manifest,
-   index, self-verification — without running any test. RRG sprints must
-   ship a green rehearsal before the gate is declared implemented; the
-   rehearsal is also the pre-launch check before the real release run.
-   (Rehearsal runs no tests, so it complies with the current no-test-runs
-   directive.)
-5. **Single QA round by contract.** quality-mgr reviews a real gate run once,
-   against the same machine checks plus judgment items (were results
-   plausible, floors honest). Clerical findings on a gate run are treated as
-   harness defects (fix the validator, not the form) — they can never recur.
+   index, self-verification — without running any test. Rehearsal manifests
+   carry `run_kind: "rehearsal"` and all rehearsal output is written under a
+   dedicated rehearsal root (`site/reports/release-readiness/rehearsal/`)
+   that the reports index and release tooling treat as non-evidence; the
+   self-verifier refuses a `release` manifest that references any path under
+   the rehearsal root, and vice versa. A green rehearsal is a hard
+   acceptance criterion of the final implementation sprint (§6, RRG.4) —
+   the gate is not "implemented" without one — and is also the pre-launch
+   check before the real release run. (Rehearsal runs no tests, so it
+   complies with the current no-test-runs directive.)
+5. **Single QA round by contract.** quality-mgr reviews a real gate run
+   once. That review consists of (i) re-running the §2.3.3 machine checks —
+   which the gate already ran, so they are green by construction — and
+   (ii) product-result judgment **only**: is a floor breach / test failure
+   real, and are the measured results plausible as product behavior.
+   Floor honesty itself is mechanized: the harness computes the manifest
+   `floors` section (observed p50 vs committed baselines, ratchet
+   proposals) — QA judges the product result, not the arithmetic. There is
+   **no third failure category**: a product-result finding renders the run
+   `NOT-READY` as a product failure (Rand's accepted exception); any other
+   reviewer finding is by definition a harness defect — the fix goes into
+   the validator/self-verifier (never "redo the form"), so that class can
+   never recur.
 
 ### 2.4 Hosts and isolation
 
@@ -108,6 +152,31 @@ The mechanism that makes §1's first-time-pass requirement real:
 The shared randlee daemon and interactive-account environments are never
 touched by the gate (standing constraints).
 
+### 2.5 Authoritative acceptance checklist (single source)
+
+This checklist is the one place gate acceptance lives; §3 pass criteria and
+§6 sprint acceptance criteria reference it and add nothing normative.
+
+- AC-1: one launch (`just release-readiness <tag-candidate>`) drives every
+  declared suite to a terminal state without operator input (§2.1, §2.2.1).
+- AC-2: manifest written only after all suites terminal; validates against
+  the committed schema; is the sole release-evidence pointer (§2.2.2, §4).
+- AC-3: `READY` requires all suites `pass` or Rand-approved
+  `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3).
+- AC-4: missing execution-identity provenance ⇒ suite `fail`
+  (`provenance-missing`); never `READY` (§2.2.4).
+- AC-5: mechanical READY-refusal for absent declared benchmark families and
+  unpinned/mismatched testbed tier definitions (§2.2.5).
+- AC-6: validate-at-emit in every suite adapter (§2.3.2).
+- AC-7: self-verification covers schema, sha256s, provenance,
+  cross-references, reports-index, tier-row `detail` populated, version
+  sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
+- AC-8: rehearsal mode green, `run_kind` separation enforced both
+  directions, rehearsal output confined to the rehearsal root (§2.3.4).
+- AC-9: hosts per §2.4; shared daemon and interactive accounts untouched.
+- AC-10: AT2 unresolved (#1121) ⇒ testbed suite `fail`, unless Rand grants
+  a standing skip (§7.4, §8 Q3).
+
 ## 3. Suite inventory (definition — existing tests only)
 
 ### 3.1 Smoke — full
@@ -117,9 +186,12 @@ touched by the gate (standing constraints).
   run_inbound_peer_smoke.py, run_peer_pair.py, daemon_lifecycle.py,
   run_admission_capacity.py).
 - Evidence: `site/reports/smoke/<os>/<host>/…` per the smoke-test skill
-  contract; committed and indexed.
+  contract; committed and indexed incrementally per the existing skill
+  convention. Per §2.2.2 those incremental commits are provisional: they
+  become release evidence only when a validated release manifest references
+  them.
 - Pass criteria: per-lane pass with no suppressed failures; analyze_logs
-  clean.
+  clean; acceptance per §2.5.
 
 ### 3.2 Benchmarks — full
 
@@ -132,23 +204,27 @@ touched by the gate (standing constraints).
   `site/reports/read-query-benchmark/`; floors per `baselines.json`
   revision 1 (approved 2026-08-31), unrounded p50 comparison, ratchet up.
 - Pass criteria: clean-run criteria per each family's D7-style contract;
-  all floors met; `just reports-index --check` green.
+  all floors met; `just reports-index --check` green; acceptance per §2.5.
 - Dependency: **PR #1120 must merge before the gate can run the read/query
-  family**; the gate definition references it now and the runner refuses to
-  render `READY` if a declared family is absent from the tree.
+  family**; per AC-5 the runner refuses to render `READY` if a declared
+  family is absent from the tree.
 
 ### 3.3 Integration — atm-hermes-testbed (full)
 
 - Fixture: https://github.com/randlee/atm-hermes-testbed (Colima test
   fixture; tier definitions in testbed PR #2, tiers AT0–AT8).
-- Entry: testbed runner against the release-candidate build, full tier set
-  (prompt tiers + infra tiers), executed in one continuous session.
+- Entry: testbed runner, full tier set (prompt tiers + infra tiers),
+  executed in one continuous session. The build under test is decided by
+  Rand at plan review (§8 Q2: tagged candidate build only, or also
+  integrate builds); this plan does not preempt that decision.
 - Evidence: committed under an `evidence/…` branch/dir in atm-core exactly
   as PR #1123 did, plus sha256 verification of all artifacts.
-- Pass criteria (tightened from the PR #1123 lessons — see §7): every tier
-  row carries populated `detail`; provenance (digest/SHA/CI run id) recorded
-  in-band; version sentinels consistent across prompt files; tier
-  definitions in the testbed repo (PR #2 merged) match what is executed 1:1.
+- Pass criteria (tightened from the PR #1123 lessons — see §7, mechanized
+  in §2.3.3/AC-7): every tier row carries populated `detail`; provenance
+  (digest/SHA/CI run id) recorded in-band; version sentinels consistent
+  across prompt files; tier definitions pinned by testbed commit SHA in the
+  manifest (`testbed_definitions`) and matched 1:1 by the executed set.
+- AT2/AT3 handling per §7.4 and AC-10.
 
 ### 3.4 Repo test suites (recorded, not re-run)
 
@@ -160,60 +236,83 @@ touched by the gate (standing constraints).
 
 ## 4. Release evidence manifest
 
-One committed JSON manifest per gate run, schema versioned:
+One committed JSON manifest per gate run. The schema is a committed plan
+artifact — [release-evidence-manifest.schema.json](release-evidence-manifest.schema.json)
+(JSON Schema 2020-12), with a worked example at
+[release-evidence-manifest.example.json](release-evidence-manifest.example.json).
+RRG.1 lifts these into their final in-repo home next to the validator; the
+schema content in this plan is the reviewed baseline.
 
-- release candidate identity: tag-candidate, commit SHA, branch;
-- per-suite entries: suite id, entrypoint, terminal state
-  (pass/fail/declared-skip+reason), evidence paths, sha256 of each artifact,
-  start/end timestamps, host + execution-identity provenance;
-- floors section: each benchmark family's floor vs observed p50;
-- CI section: run ids + conclusions for the repo suites (§3.4);
-- gate verdict: READY / NOT-READY / INCOMPLETE.
+Summary of the committed schema (normative source is the schema file):
+
+- `schema_version` (integer) — generation-time schema revision pin;
+- `run_kind` — `release` | `rehearsal` (§2.3.4 separation);
+- `candidate` — tag-candidate, 40-hex commit SHA, branch;
+- `testbed_definitions` — pinned testbed repo + commit SHA (AC-5);
+- `suites[]` — suite id, entrypoint, terminal state
+  (`pass`/`fail`+`fail_reason`/`declared-skip`+`skip_reason`), evidence
+  paths each with sha256, start/end timestamps, host, and the
+  execution-identity provenance object;
+- `floors[]` — family, metric, floor vs observed p50, met flag, optional
+  ratchet proposal (harness-computed, §2.3.5);
+- `ci_runs[]` — run ids + conclusions for the repo suites (§3.4) pinned to
+  the candidate commit;
+- `verdict` — `READY` / `NOT-READY` / `INCOMPLETE`;
+- `self_verification` — must record `validated: true` + validator version.
 
 Manifest and all referenced artifacts are committed and pushed
 (discarded/unpublished attempts cannot be release evidence — same rule as
 benchmark D7). `just reports-index --check` extends to validate the
-manifest's referenced paths exist.
+manifest's referenced paths exist and that no `release` manifest references
+the rehearsal root.
 
 ## 5. Streamlined coordination (who runs what)
 
-- The gate is launched once by the operator (Rand or a designated runner
-  identity) on the evidence host(s).
-- The runner script coordinates suite order: smoke → benchmarks →
-  testbed integration (order rationale: cheapest-fail-first; final order
-  fixed at review). Suites without shared resources may run concurrently
-  where the hosts differ (benchmarks on m5-atmbench, testbed on the Colima
-  host).
+- The gate is launched once by an operator on the evidence host(s). Whether
+  that operator is Rand personally or a dedicated runner identity is an
+  open decision (§8 Q1); nothing in this plan depends on the answer.
+- The runner script coordinates suite order. The correctness guarantee is
+  **completeness, not order** (§2.2): execution order can never change a
+  verdict. Within one host, cheapest-fail-first is the scheduling
+  preference (smoke → benchmarks); across hosts, suites without shared
+  resources run concurrently (benchmarks on m5-atmbench, testbed on the
+  Colima host) — permitted precisely because order carries no correctness
+  weight. Final within-host order is fixed at review.
 - No mid-run team messaging is required; the run is attended only by its
   runner. Findings from a failed gate route through fenix triage as usual.
 
 ## 6. Implementation sprints (post-approval, definition→code)
 
-| # | Deliverable | Assignee (proposed) |
-|---|---|---|
-| RRG.1 | Manifest schema + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) | Cipher |
-| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only) | Cipher |
-| RRG.3 | Testbed integration adapter + testbed-side tier definitions update (merge testbed PR #2; add Phase-AV coverage definitions from §7) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + docs | Cipher |
+| # | Deliverable | must_follow | Assignee (proposed) |
+|---|---|---|---|
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
+| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4 | RRG.1 | Cipher |
+| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks) | RRG.1 | Cipher |
+| RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1 (parallel-safe with RRG.3a) | Cipher (atm-hermes-testbed PR) |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs. Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 All sprints are ordinary dev worktrees off develop with quality-mgr QA;
-no test executions beyond each sprint's own new unit tests.
+no test executions beyond each sprint's own new unit tests (rehearsal mode
+runs no tests). Sprint acceptance = the §2.5 checklist rows each sprint
+owns; no sprint-local reinterpretation.
 
 ## 7. Known gaps (accepted as missing test cases, recorded not fixed here)
 
 1. **Phase-AV integration coverage in the testbed** (agreed with Rand
    2026-08-31): concurrent read fan-out, read-under-write-load, query/FTS
    functional tests, cross-host read via the Colima topology. To be defined
-   in the testbed as part of RRG.3.
+   in the testbed as part of RRG.3b.
 2. **Testbed PR #2 is still OPEN**; 28/37 executed rows in the v1.4.6
    evidence had no reviewed definition; AT8 diverged (8 defined → 14
-   emitted, renamed). RRG.3 reconciles definitions before the gate's first
+   emitted, renamed). RRG.3b reconciles definitions before the gate's first
    run.
 3. **Infra-tier detail fields**: all 27 infra tier rows in the v1.4.6 run
-   had `detail:null`; the gate's pass criteria (§3.3) make populated detail
-   mandatory.
-4. **AT2 skip** filed as atm-core #1121; **AT3 skip** legitimate — both are
-   declared-skips until resolved.
+   had `detail:null`; §2.3.3/AC-7 make populated detail a mechanized check.
+4. **AT2 skip**: filed as atm-core #1121 — an open bug, not a standing
+   policy. Default disposition: while #1121 is unresolved the testbed suite
+   is `fail`, blocking `READY` (AC-10). Rand may instead grant a standing
+   declared-skip at plan review (§8 Q3). **AT3 skip** is a legitimate
+   standing declared-skip.
 5. **Runtime reader gauges** (AV-PROD-002): mixed-mode health signal remains
    the interim 1000 ms p95 ceiling; the manifest records this as a known
    observability limitation until the gauges ship.
@@ -225,14 +324,48 @@ no test executions beyond each sprint's own new unit tests.
    approved-account allowlist for official runs. If Rand wants official
    evidence rejected — not just flagged — when produced by a non-approved
    account, that is a small scoped harness change; candidate for RRG.2.
+8. **Send-family execution-identity provenance** (quality-mgr lane-3
+   finding, 2026-08-31): the send-benchmark pipeline
+   (benchmark_official/benchmark_schema) has no equivalent of the
+   AV-PROD-001R in-band execution-identity capture. Closed by RRG.2 so both
+   benchmark families satisfy AC-4 before the gate's first run.
 
 ## 8. Open questions for Rand (at plan review)
 
 1. Gate launch identity: does Rand launch manually, or is a dedicated
-   runner identity/automation wanted for the first release?
+   runner identity/automation wanted for the first release? (§5 is neutral
+   to the answer.)
 2. Should the testbed integration run against the tagged candidate build
    (post-#1120 merge) only, or also pre-merge against integrate builds?
+   (§3.3 defers to this answer.)
+3. AT2 (#1121): keep the fail-closed default (testbed suite `fail` while
+   unresolved) or grant a standing declared-skip? (§7.4/AC-10.)
 
 ## QA history
 
 *(rounds recorded inline per plan-doc convention)*
+
+- **r1 (2026-08-31, quality-mgr verdict FAIL @ 4b5d2dded, msg
+  01M1D8BYF5MMQ80D4PE1T66ARZ)**: 4 Blocking, 10 Important, 2 Minor from
+  plan-scope + critical-plan reviewers, deduped and re-verified firsthand.
+  B1 manifest schema existed only as prose → committed schema + example
+  files, `schema_version` pin (§4). B2 undefined third QA category →
+  §2.3.5 rewritten: machine checks + product-result judgment only, floor
+  arithmetic mechanized, no third category. B3 testbed churn classes not
+  mechanized → added to §2.3.3/AC-7. B4 AT2 skip mislabeled → fail-closed
+  default + §8 Q3 (AC-10). I1 §1 cited §2.4 for §2.3 machinery + heading
+  demotion → fixed. I2 no testbed READY-refusal guard → §2.2.5/AC-5 +
+  `testbed_definitions` manifest field. I3 RRG.3 bundling/no fallback →
+  split RRG.3a/3b with stall fallback + §7 acceptance mapping. I4 no
+  dependency relations → must_follow column. I5 scattered acceptance
+  criteria → §2.5 single authoritative checklist. I6 false closure on §8
+  open questions → §3.3/§5 made explicitly neutral. I7 rehearsal/release
+  indistinguishable → `run_kind` + rehearsal root + two-way refusal. I8
+  incremental smoke commits vs manifest-only evidence → §2.2.2
+  sole-pointer rule (provisional until referenced). I9 provenance
+  invalidation unmapped → suite `fail`/`provenance-missing` (§2.2.4,
+  distinct from INCOMPLETE). I10 rehearsal-green unowned → RRG.4 hard
+  acceptance criterion. M1 ADR requirement → RRG.1 deliverable. M2
+  order-vs-concurrency tension → §5: completeness is the guarantee, order
+  carries no correctness weight. Also added §7.8 (send-family provenance
+  gap, lane-3 minor (b)) discovered in the same window.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -1,0 +1,232 @@
+---
+title: Release-readiness gate — full-suite evidence run
+status: draft
+branch: plan/release-readiness-gate
+worktree: ../atm-core-worktrees/plan/release-readiness-gate
+owner: fenix (coordinator), Rand (authority)
+created: 2026-08-31
+---
+
+# Release-readiness gate — full-suite evidence run
+
+## 1. Mandate (Rand, 2026-08-31)
+
+- Define a **full release-readiness suite of tests** from the tests that
+  already exist. This plan **defines** the suite; it does not create new
+  tests. Missing test cases are acceptable and are recorded in §7 as named
+  gaps, not silently omitted.
+- Add a **new gate** that runs full smoke, full benchmark, and full
+  integration tests (atm-hermes-testbed) and produces a complete
+  **release evidence set** for the upcoming release.
+- The gate must be a **streamlined process that coordinates execution to
+  completeness**: one launch drives every suite end-to-end. A launch that
+  cannot complete every declared suite fails closed — it never publishes a
+  partial evidence set as release evidence.
+- **First-time QA pass is a design requirement** (Rand, verbatim intent):
+  when this set of tests is launched it runs and everything passes QA the
+  first time, assuming there is no performance failure. Multiple rounds of
+  QA ceremony because a field was not filled out properly in an evidence
+  form are **not acceptable**. Consequence: evidence correctness is enforced
+  by the harness at generation time (§2.4), never discovered by a reviewer
+  afterward. The only legitimate first-run QA failures are real product
+  failures (performance floor breach, test failure) — never clerical.
+- **No tests are run now.** This plan, its review, and the gate
+  implementation are all definition work. The first execution of the gate
+  happens when Rand launches it for the upcoming release.
+
+## 2. Gate contract
+
+### 2.1 Entry point
+
+One command launches the entire gate (working name, final name at review):
+
+```
+just release-readiness <release-tag-candidate>
+```
+
+- Single launch, no per-suite manual invocation. The runner is the
+  coordinator: it sequences suites, retries per-suite bounded recoverable
+  setup failures, and does not stop for operator input mid-run.
+- Every suite runs in **full** — no sampling, no "quick" profiles, no
+  suite skipped silently. A suite that is intentionally not runnable in the
+  release environment must be declared in the manifest as `skipped` with a
+  recorded reason (e.g. Windows benchmark policy), never absent.
+
+### 2.2 Execution-to-completeness rules
+
+1. The gate runs all suites to a terminal state (pass / fail / declared-skip)
+   before rendering any verdict. A crash or abandonment of any suite makes
+   the whole gate `INCOMPLETE`, which is a failure state.
+2. Evidence is written incrementally per suite, but the **release evidence
+   manifest** (§4) is written only after all suites reach a terminal state.
+   No manifest ⇒ no release evidence.
+3. The gate verdict is `READY` only when every suite passes (or is
+   declared-skip with a Rand-approved standing reason) **and** the evidence
+   manifest validates against its schema.
+4. Fail-closed provenance: every evidence artifact must carry the in-band
+   execution-identity fields (execution_account, uid, home, hostname —
+   AV-PROD-001R contract). Artifacts missing provenance invalidate the run
+   for the suites they belong to.
+
+#### 2.3 First-time-pass enforcement (no clerical QA rounds)
+
+The mechanism that makes §1's first-time-pass requirement real:
+
+1. **One schema, shared by harness and QA.** The evidence/manifest JSON
+   schema is committed in-repo and is the *same* artifact the gate validates
+   against at generation time and quality-mgr validates against at review
+   time. There is no reviewer-side checklist that the harness cannot run
+   itself.
+2. **Validate-at-emit.** Every suite adapter validates each artifact against
+   the schema the moment it is written; an invalid artifact aborts that
+   suite as a harness error immediately (fail fast mid-run), not at review.
+3. **Whole-set self-verification.** Before rendering a verdict, the gate
+   re-validates the complete evidence set + manifest exactly as QA would
+   (schema, sha256s, provenance fields, cross-references, reports-index).
+   `READY` is unreachable with a clerical defect present.
+4. **Rehearsal mode.** `just release-readiness --rehearse` exercises the
+   entire evidence pipeline with synthetic suite results — schema, manifest,
+   index, self-verification — without running any test. RRG sprints must
+   ship a green rehearsal before the gate is declared implemented; the
+   rehearsal is also the pre-launch check before the real release run.
+   (Rehearsal runs no tests, so it complies with the current no-test-runs
+   directive.)
+5. **Single QA round by contract.** quality-mgr reviews a real gate run once,
+   against the same machine checks plus judgment items (were results
+   plausible, floors honest). Clerical findings on a gate run are treated as
+   harness defects (fix the validator, not the form) — they can never recur.
+
+### 2.4 Hosts and isolation
+
+| Suite | Host requirement |
+|---|---|
+| Smoke (full) | isolated benchmark/smoke account (m5-atmbench on rand-m5.local); never an interactive account |
+| Benchmarks (send + read/query) | m5-atmbench on rand-m5.local (official-evidence policy); floors gate against committed `baselines.json` |
+| Integration (atm-hermes-testbed) | Colima host per testbed topology (as exercised by evidence/colima-v146-smoke, PR #1123) |
+| Repo suites (`just ci` etc.) | CI runners (already gate merges); gate records the CI run ids for the release candidate commit rather than re-running locally |
+
+The shared randlee daemon and interactive-account environments are never
+touched by the gate (standing constraints).
+
+## 3. Suite inventory (definition — existing tests only)
+
+### 3.1 Smoke — full
+
+- Entry: `just smoke thorough` composition (scripts/smoke/run.py,
+  run_feature_smoke.py, run_thorough.py, run_thorough_shared_host.py,
+  run_inbound_peer_smoke.py, run_peer_pair.py, daemon_lifecycle.py,
+  run_admission_capacity.py).
+- Evidence: `site/reports/smoke/<os>/<host>/…` per the smoke-test skill
+  contract; committed and indexed.
+- Pass criteria: per-lane pass with no suppressed failures; analyze_logs
+  clean.
+
+### 3.2 Benchmarks — full
+
+- **Send family**: `just benchmark-official` → evidence under
+  `site/reports/send-message-benchmark/`; floors per committed baselines
+  (AO2 ratchet convention).
+- **Read/query family (Phase AV — lands with PR #1120)**:
+  `just benchmark-read` → benchmark-read-fanout, benchmark-query-fts,
+  benchmark-read-under-write-load → evidence under
+  `site/reports/read-query-benchmark/`; floors per `baselines.json`
+  revision 1 (approved 2026-08-31), unrounded p50 comparison, ratchet up.
+- Pass criteria: clean-run criteria per each family's D7-style contract;
+  all floors met; `just reports-index --check` green.
+- Dependency: **PR #1120 must merge before the gate can run the read/query
+  family**; the gate definition references it now and the runner refuses to
+  render `READY` if a declared family is absent from the tree.
+
+### 3.3 Integration — atm-hermes-testbed (full)
+
+- Fixture: https://github.com/randlee/atm-hermes-testbed (Colima test
+  fixture; tier definitions in testbed PR #2, tiers AT0–AT8).
+- Entry: testbed runner against the release-candidate build, full tier set
+  (prompt tiers + infra tiers), executed in one continuous session.
+- Evidence: committed under an `evidence/…` branch/dir in atm-core exactly
+  as PR #1123 did, plus sha256 verification of all artifacts.
+- Pass criteria (tightened from the PR #1123 lessons — see §7): every tier
+  row carries populated `detail`; provenance (digest/SHA/CI run id) recorded
+  in-band; version sentinels consistent across prompt files; tier
+  definitions in the testbed repo (PR #2 merged) match what is executed 1:1.
+
+### 3.4 Repo test suites (recorded, not re-run)
+
+- `just ci` (lint + test), test-graft-python, test-hermes-graft-bridge,
+  test-hermes-graft-smoke, test-admission-capacity,
+  test-queue-hooks-python(+codex).
+- The gate records the green CI run ids for the exact release-candidate
+  commit in the manifest instead of re-executing them on the evidence host.
+
+## 4. Release evidence manifest
+
+One committed JSON manifest per gate run, schema versioned:
+
+- release candidate identity: tag-candidate, commit SHA, branch;
+- per-suite entries: suite id, entrypoint, terminal state
+  (pass/fail/declared-skip+reason), evidence paths, sha256 of each artifact,
+  start/end timestamps, host + execution-identity provenance;
+- floors section: each benchmark family's floor vs observed p50;
+- CI section: run ids + conclusions for the repo suites (§3.4);
+- gate verdict: READY / NOT-READY / INCOMPLETE.
+
+Manifest and all referenced artifacts are committed and pushed
+(discarded/unpublished attempts cannot be release evidence — same rule as
+benchmark D7). `just reports-index --check` extends to validate the
+manifest's referenced paths exist.
+
+## 5. Streamlined coordination (who runs what)
+
+- The gate is launched once by the operator (Rand or a designated runner
+  identity) on the evidence host(s).
+- The runner script coordinates suite order: smoke → benchmarks →
+  testbed integration (order rationale: cheapest-fail-first; final order
+  fixed at review). Suites without shared resources may run concurrently
+  where the hosts differ (benchmarks on m5-atmbench, testbed on the Colima
+  host).
+- No mid-run team messaging is required; the run is attended only by its
+  runner. Findings from a failed gate route through fenix triage as usual.
+
+## 6. Implementation sprints (post-approval, definition→code)
+
+| # | Deliverable | Assignee (proposed) |
+|---|---|---|
+| RRG.1 | Manifest schema + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) | Cipher |
+| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only) | Cipher |
+| RRG.3 | Testbed integration adapter + testbed-side tier definitions update (merge testbed PR #2; add Phase-AV coverage definitions from §7) | Cipher (atm-hermes-testbed PR) |
+| RRG.4 | reports-index manifest validation + docs | Cipher |
+
+All sprints are ordinary dev worktrees off develop with quality-mgr QA;
+no test executions beyond each sprint's own new unit tests.
+
+## 7. Known gaps (accepted as missing test cases, recorded not fixed here)
+
+1. **Phase-AV integration coverage in the testbed** (agreed with Rand
+   2026-08-31): concurrent read fan-out, read-under-write-load, query/FTS
+   functional tests, cross-host read via the Colima topology. To be defined
+   in the testbed as part of RRG.3.
+2. **Testbed PR #2 is still OPEN**; 28/37 executed rows in the v1.4.6
+   evidence had no reviewed definition; AT8 diverged (8 defined → 14
+   emitted, renamed). RRG.3 reconciles definitions before the gate's first
+   run.
+3. **Infra-tier detail fields**: all 27 infra tier rows in the v1.4.6 run
+   had `detail:null`; the gate's pass criteria (§3.3) make populated detail
+   mandatory.
+4. **AT2 skip** filed as atm-core #1121; **AT3 skip** legitimate — both are
+   declared-skips until resolved.
+5. **Runtime reader gauges** (AV-PROD-002): mixed-mode health signal remains
+   the interim 1000 ms p95 ceiling; the manifest records this as a known
+   observability limitation until the gauges ship.
+6. **Windows**: no isolated Windows benchmark account exists; Windows
+   evidence remains a declared-skip per standing policy.
+
+## 8. Open questions for Rand (at plan review)
+
+1. Gate launch identity: does Rand launch manually, or is a dedicated
+   runner identity/automation wanted for the first release?
+2. Should the testbed integration run against the tagged candidate build
+   (post-#1120 merge) only, or also pre-merge against integrate builds?
+
+## QA history
+
+*(rounds recorded inline per plan-doc convention)*

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -294,7 +294,12 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   (`suite-error`), the provenance identifies the **runner process that
   adjudicated the terminal state** (the orchestrator's own
   host/identity) — always real, never fabricated, so requiring it for
-  every `fail` does not recreate the fabricate-or-reject class.
+  every `fail` does not recreate the fabricate-or-reject class. The same
+  source rule applies to `fail`/`provenance-missing` (rule 4: the
+  suite's **own artifact** lacked identity fields): the manifest row's
+  `host`/`execution_identity` are populated from the orchestrator's own
+  runtime context — recording who adjudicated the provenance gap, never
+  guessing what the suite's identity would have been.
 - AC-5: mechanical READY-refusal for absent declared benchmark families
   (suite `fail`/`suite-error`) and unpinned/mismatched testbed tier
   definitions (§2.2.5). A `fail`/`suite-error` benchmark row is
@@ -309,7 +314,11 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   row exists for a family whose suite did not execute), the §2.3.5
   anomaly-check set (checks built in RRG.2, wired in RRG.4), tier-row
   `detail` populated and conformant to the RRG.3a tier-row schema (§3.3),
-  version sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
+  version sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3),
+  and the suite_id↔`fail_reason` compatibility re-check (each suite's
+  `fail_reason` drawn from its own schema-scoped subset — defense-in-depth
+  behind the schema's per-suite conditionals; a suite-inappropriate
+  reason is a mislabel, never a valid row).
 - AC-8: rehearsal mode green, `run_kind` separation enforced both
   directions, rehearsal output confined to the rehearsal root (§2.3.4).
 - AC-9: hosts per §2.4; shared daemon and interactive accounts untouched.
@@ -329,6 +338,25 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   `READY`, and never evidence discarded, over a red repo suite — including
   one that went red between launch and emission (§2.2.6, §3.4, §4).
   A refused launch is AC-1's sole carve-out.
+- AC-12: **readiness-preflight release gate (§5.1).** The publisher's
+  readiness preflight — the rendered
+  `.claude/skills/publishing/preflight.xml.j2` assignment executed by the
+  named `publisher` teammate per the publishing skill's
+  `ref/release-state-strategy.md` (readiness preflight before a `main`
+  merge) — must, **mechanically** (RRG.4 delivers the check as code the
+  preflight invokes, not checklist prose; §2.3 no-clerical mandate
+  applies), before authorizing the `main` merge: (i) locate and
+  schema-validate the committed `run_kind: "release"` manifest and
+  require `verdict: "READY"`; (ii) verify the diff between the manifest's
+  `candidate.commit_sha` and the release-candidate tag commit is
+  version-metadata-only (the §5.1 minor-bump commit: `Cargo.toml`
+  workspace version, `Cargo.lock`, changelog — nothing else); and
+  (iii) verify the release-candidate tag's version equals the manifest's
+  `candidate.tag_candidate` — **the label is binding**: evidence approved
+  under one proposed version never authorizes releasing another. Any
+  check failing ⇒ readiness preflight fails; a non-metadata diff requires
+  a fresh gate run (§5.1). The final preflight on the exact `main` commit
+  is unchanged and never re-runs the gate.
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -453,10 +481,19 @@ Summary of the committed schema (normative source is the schema file):
   (`pass`/`fail`/`declared-skip`), evidence paths each with sha256, and
   start/end timestamps. Conditionals: `pass`/`fail` **require** `host` +
   the execution-identity provenance object (AC-4); `fail` **requires**
-  `fail_reason` from the closed taxonomy (`provenance-missing`,
-  `tier-detail-missing`, `tier-definitions-mismatch`, `sentinel-mismatch`,
-  `floor-breach`, `test-failure`, `measurement-anomaly`, `suite-error` —
-  a new failure class is a schema revision, never free text);
+  `fail_reason` from the closed taxonomy (`provenance-missing` — rule 4
+  provenance gap; `tier-detail-missing` — unpopulated tier-row detail,
+  §3.3/§7.3; `tier-definitions-mismatch` — executed tiers not 1:1 vs the
+  pinned definitions, §2.2.5; `sentinel-mismatch` — version-sentinel
+  inconsistency caught by the §2.3.3 sentinel-consistency check;
+  `floor-breach`, `test-failure`, `measurement-anomaly` — §2.3.5;
+  `suite-error` — §2.2.5. A new failure class is a schema revision, never
+  free text). **Each `suite_id` admits only its own subset**
+  (schema-mechanized per-suite conditionals; §2.3.3/AC-7 re-check):
+  smoke never carries benchmark/testbed-only reasons, benchmark rows
+  never carry tier/sentinel reasons (so a mislabeled benchmark `fail`
+  cannot dodge the AC-3 floors-row requirement), testbed rows never carry
+  `floor-breach`/`measurement-anomaly`;
   `declared-skip` **requires** `skip_reason` and **forbids**
   `host`/`execution_identity` (nothing executed — identity must not be
   fabricated);
@@ -534,53 +571,67 @@ direction.
   against the intended `develop` commit. Nothing triggers the gate
   automatically; the §2.2.6 CI-eligibility precondition is the gate's
   own first act, not a separate manual step.
-- **Version-number management (Rand, 2026-08-31): the version bump is
-  gated BEHIND the gate, not ahead of it.** The gate runs against
-  `develop` at its **current** workspace version; the manifest's
-  `candidate.tag_candidate` is the **proposed** release version (a
-  label, e.g. `v1.5.0-rc1`) and makes no claim about `Cargo.toml`. No
-  minor-version bump commit may land until a `READY` manifest exists.
-  Order after `READY`: (1) the mechanical bump commit (workspace
-  `version` in `Cargo.toml`, `Cargo.lock`, changelog — nothing else)
-  lands on `develop`; (2) `release-candidate-vX.Y.Z` is cut on that
-  bump commit via `release-candidate.yml` (publishing skill
-  release-state strategy); (3) publisher preflights proceed. The
-  readiness preflight accepts the manifest for gated commit C against
-  candidate-tag commit C′ **iff `diff C..C′` is version-metadata-only**
-  (mechanically verified); any other delta fails the preflight and
-  requires a fresh gate run on the new tree. The seven §3.4 CI suites
-  still run green on C′ as ordinary merge hygiene — the manifest's
-  `ci_runs[]` remain pinned to C, the commit whose behavior the
-  evidence actually measured (a version-string bump changes no measured
-  behavior; that claim is exactly what the bump-only diff check
-  verifies). A failed gate therefore never strands a spent version
-  number: `NOT-READY` (or refusal/INCOMPLETE) means no bump commit
-  exists yet at all.
-- **Gate point (publisher readiness preflight):** the gate's output — a
-  committed, validated `run_kind: "release"` manifest with
-  `verdict: "READY"` — becomes a **required input of the publisher's
-  readiness preflight**, i.e. it blocks the `main` merge, before any
-  tag/publish action. Because the version bump lands only after `READY`
-  (above), the manifest's `candidate.commit_sha` **never equals the
-  release-candidate tag commit by definition**; the preflight's
-  acceptance rule is therefore match-modulo-bump: the tag commit's diff
-  against the gated commit must be version-metadata-only (mechanically
-  verified, see above). Anything else ⇒ readiness preflight fails and a
-  fresh gate run is required; the final preflight on `main`
-  (candidate-tag ancestry) is unchanged and does not re-run the gate.
-  Wiring the manifest + bump-only-diff check into the preflight
-  checklist is an RRG.4 documentation deliverable; the publishing
-  skill's preflight remains the enforcement location.
+- **Version-number management (Rand, 2026-08-31): patch++ per gate run;
+  the minor bump is gated BEHIND a passing run, never ahead of it.**
+  - **Every gate run is preceded by a mandated patch bump** on
+    `develop` (workspace `version` patch++ in `Cargo.toml` +
+    `Cargo.lock` — mechanical commit). Each attempt therefore executes
+    at a unique patch version (e.g. 1.5.1, 1.5.2, … across attempts),
+    so every attempt's manifest and evidence set are
+    version-distinguishable and no two runs ever share a version. The
+    patch++ commit must itself be CI-green before launch (§2.2.6
+    applies to the gated commit as always).
+  - **The release version is a minor bump applied only after `READY`**:
+    a passing run at e.g. 1.5.7 is followed by the mechanical minor
+    bump commit to 1.6.0 (version metadata + changelog, nothing else) —
+    the published version is always a clean `X.Y.0`, never the
+    accumulated attempt-patch number, and a failing gate never spends a
+    minor version. Order after `READY`: (1) minor bump commit lands on
+    `develop`; (2) `release-candidate-vX.Y.0` is cut on that bump
+    commit via `release-candidate.yml` (publishing skill release-state
+    strategy); (3) publisher preflights proceed.
+  - The manifest's `candidate.tag_candidate` names the **proposed**
+    release version (e.g. `v1.6.0`); `candidate.commit_sha` pins the
+    gated commit at its attempt-patch version — the manifest claims
+    what was measured, not what will be published.
+  - **Readiness-preflight acceptance is match-modulo-bump**: the
+    preflight accepts the `READY` manifest for gated commit C against
+    candidate-tag commit C′ **iff `diff C..C′` is version-metadata-only
+    (the minor bump)** — mechanically verified; any other delta fails
+    the preflight and requires a fresh gate run (which starts with its
+    own patch++). The seven §3.4 CI suites still run green on C′ as
+    ordinary merge hygiene — the manifest's `ci_runs[]` remain pinned
+    to C, the commit whose behavior the evidence actually measured (a
+    version-string bump changes no measured behavior; that claim is
+    exactly what the bump-only diff check verifies).
+- **Gate point (publisher readiness preflight — normative home:
+  AC-12):** the gate's output — a committed, validated
+  `run_kind: "release"` manifest with `verdict: "READY"` — is a
+  **required input of the publisher's readiness preflight**, i.e. it
+  blocks the `main` merge, before any tag/publish action. The concrete
+  enforcement mechanism, the three mechanized checks (READY manifest
+  schema-validation; bump-only diff between gated commit and candidate
+  tag commit; **binding** `tag_candidate` ↔ candidate-tag version
+  equality — evidence approved under one version label never releases
+  another), and the code-not-prose requirement live in **AC-12**; RRG.4
+  owns delivering that check as code invoked by the publishing skill's
+  readiness preflight (`preflight.xml.j2` / `publisher` teammate,
+  `ref/release-state-strategy.md`). Because the minor bump lands only
+  after `READY` (above), the manifest's `candidate.commit_sha` never
+  equals the tag commit by definition — hence AC-12's match-modulo-bump
+  rule. A non-metadata diff ⇒ fresh gate run (starting with its own
+  patch++); the final preflight on `main` (candidate-tag ancestry) is
+  unchanged and never re-runs the gate.
 
 ## 6. Implementation sprints (post-approval, definition→code)
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -852,3 +903,46 @@ owns; no sprint-local reinterpretation.
   seven CI suites additionally run green on the bump commit as ordinary
   merge hygiene. A NOT-READY/refused/incomplete run therefore never
   strands a spent version number.
+- **r8 (2026-08-31, fix round for quality-mgr r7 FAIL @ 1fe4b07be —
+  1B/4I/1M — plus Rand's second version-management directive)**:
+  - Rand directive (supersedes part of the r7 amendment): **patch++ per
+    gate run** — every gate attempt is preceded by a mandated mechanical
+    patch-bump commit on `develop`, so each attempt executes at a unique
+    patch version and no two runs share a version; the **minor bump to
+    `X.(Y+1).0` lands only after `READY`** (the published version is
+    always a clean `X.Y.0`, never an accumulated attempt-patch like
+    1.6.7). §5.1 version-management block rewritten accordingly;
+    match-modulo-bump preflight rule unchanged in substance.
+  - B1r7 (§5.1 requirements had no acceptance home) → new **AC-12** in
+    §2.5 (READY-manifest input + bump-only diff + binding tag_candidate
+    check, mechanized, named enforcement location) + explicit AC-12
+    acceptance item in §6 RRG.4 row; §5.1 gate-point bullet now defers
+    normatively to AC-12.
+  - I1r7 (global fail_reason enum permits suite-inappropriate mislabels)
+    → schema: per-suite `fail_reason` subset conditionals (smoke:
+    test-failure/provenance-missing/suite-error; benchmarks: + floor-
+    breach/measurement-anomaly, no tier/sentinel reasons; testbed: tier/
+    sentinel reasons + test-failure/provenance-missing/suite-error, no
+    floor-breach/measurement-anomaly); suite_id↔fail_reason
+    compatibility re-check named in §2.3.3/AC-7 and wired in RRG.4.
+  - I2r7 (provenance-missing row's identity source unstated) → AC-4
+    extended: orchestrator's own runtime context populates the row,
+    same source rule as the suite-error carve-out.
+  - I3r7 (documentation-only enforcement) → AC-12 names the concrete
+    mechanism (`preflight.xml.j2` assignment / `publisher` teammate /
+    `ref/release-state-strategy.md` readiness preflight) and requires
+    the check be delivered as code the preflight invokes (RRG.4
+    acceptance), not checklist prose.
+  - I4r7 (tag_candidate binding ambiguity) → resolved **binding**:
+    AC-12 check (iii) requires candidate-tag version == manifest
+    `tag_candidate`; evidence approved under one version label never
+    releases another.
+  - M1r7 → closed-taxonomy prose now cross-references every enum value
+    (tier-detail-missing → §3.3/§7.3; sentinel-mismatch → §2.3.3
+    sentinel-consistency check; etc.).
+  - Schema revalidated (probe battery + new suite-scoping probes): all
+    prior positives/negatives unchanged; benchmark fail with
+    tier-detail-missing / sentinel-mismatch now REJECTED; testbed fail
+    with floor-breach REJECTED; smoke fail with measurement-anomaly
+    REJECTED; testbed fail with tier-definitions-mismatch still VALID;
+    examples all VALID.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -529,24 +529,48 @@ direction.
 
 ### 5.1 Release-pipeline placement (trigger and gate point)
 
-- **Trigger (manual, once per candidate):** after the release-candidate
-  tag (`release-candidate-vX.Y.Z`, cut from `develop` via
-  `release-candidate.yml` per the publishing skill's release-state
-  strategy) exists, the operator (§8 Q1) launches
-  `just release-readiness <tag-candidate>` on the evidence host(s).
-  Nothing triggers the gate automatically; the §2.2.6 CI-eligibility
-  precondition is the gate's own first act, not a separate manual step.
+- **Trigger (manual, once per candidate):** the operator (§8 Q1) launches
+  `just release-readiness <tag-candidate>` on the evidence host(s)
+  against the intended `develop` commit. Nothing triggers the gate
+  automatically; the §2.2.6 CI-eligibility precondition is the gate's
+  own first act, not a separate manual step.
+- **Version-number management (Rand, 2026-08-31): the version bump is
+  gated BEHIND the gate, not ahead of it.** The gate runs against
+  `develop` at its **current** workspace version; the manifest's
+  `candidate.tag_candidate` is the **proposed** release version (a
+  label, e.g. `v1.5.0-rc1`) and makes no claim about `Cargo.toml`. No
+  minor-version bump commit may land until a `READY` manifest exists.
+  Order after `READY`: (1) the mechanical bump commit (workspace
+  `version` in `Cargo.toml`, `Cargo.lock`, changelog — nothing else)
+  lands on `develop`; (2) `release-candidate-vX.Y.Z` is cut on that
+  bump commit via `release-candidate.yml` (publishing skill
+  release-state strategy); (3) publisher preflights proceed. The
+  readiness preflight accepts the manifest for gated commit C against
+  candidate-tag commit C′ **iff `diff C..C′` is version-metadata-only**
+  (mechanically verified); any other delta fails the preflight and
+  requires a fresh gate run on the new tree. The seven §3.4 CI suites
+  still run green on C′ as ordinary merge hygiene — the manifest's
+  `ci_runs[]` remain pinned to C, the commit whose behavior the
+  evidence actually measured (a version-string bump changes no measured
+  behavior; that claim is exactly what the bump-only diff check
+  verifies). A failed gate therefore never strands a spent version
+  number: `NOT-READY` (or refusal/INCOMPLETE) means no bump commit
+  exists yet at all.
 - **Gate point (publisher readiness preflight):** the gate's output — a
   committed, validated `run_kind: "release"` manifest with
-  `verdict: "READY"` whose `candidate.commit_sha` equals the
-  release-candidate tag commit — becomes a **required input of the
-  publisher's readiness preflight**, i.e. it blocks the `main` merge,
-  before any tag/publish action. No READY manifest for the exact
-  candidate commit ⇒ readiness preflight fails; the final preflight on
-  `main` (exact-commit re-check, candidate-tag ancestry) is unchanged
-  and does not re-run the gate. Wiring the manifest check into the
-  preflight checklist is an RRG.4 documentation deliverable; the
-  publishing skill's preflight remains the enforcement location.
+  `verdict: "READY"` — becomes a **required input of the publisher's
+  readiness preflight**, i.e. it blocks the `main` merge, before any
+  tag/publish action. Because the version bump lands only after `READY`
+  (above), the manifest's `candidate.commit_sha` **never equals the
+  release-candidate tag commit by definition**; the preflight's
+  acceptance rule is therefore match-modulo-bump: the tag commit's diff
+  against the gated commit must be version-metadata-only (mechanically
+  verified, see above). Anything else ⇒ readiness preflight fails and a
+  fresh gate run is required; the final preflight on `main`
+  (candidate-tag ancestry) is unchanged and does not re-run the gate.
+  Wiring the manifest + bump-only-diff check into the preflight
+  checklist is an RRG.4 documentation deliverable; the publishing
+  skill's preflight remains the enforcement location.
 
 ## 6. Implementation sprints (post-approval, definition→code)
 
@@ -814,3 +838,17 @@ owns; no sprint-local reinterpretation.
   floor-breach-without-floors REJECTED, pre-launch record with
   suite_evidence_paths REJECTED, missing-state record with run_id
   REJECTED; all prior negative cases still REJECTED.
+- **r7 amendment (2026-08-31, Rand version-management directive during
+  r7 review)**: §5.1 extended — the version bump is gated behind the
+  gate: the gate runs at develop's current version, `tag_candidate` is
+  the proposed version label only, and the minor bump commit may land
+  only after a READY manifest exists (bump → candidate cut → publisher
+  preflights). Consequence made explicit (Rand): the manifest's
+  `candidate.commit_sha` never equals the candidate tag commit by
+  definition; readiness preflight acceptance is match-modulo-bump — the
+  tag commit's diff against the gated commit must be
+  version-metadata-only (mechanically verified), anything else requires
+  a fresh gate run. `ci_runs[]` stays pinned to the gated commit; the
+  seven CI suites additionally run green on the bump commit as ordinary
+  merge hygiene. A NOT-READY/refused/incomplete run therefore never
+  strands a spent version number.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -312,7 +312,9 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   exactly-once), the floors cross-check (every §3.2 tracked metric of a
   pass-terminal benchmark suite has a `floors[]` row, and no `floors[]`
   row exists for a family whose suite did not execute), the §2.3.5
-  anomaly-check set (checks built in RRG.2, wired in RRG.4), tier-row
+  anomaly-check set (benchmark/smoke checks built in RRG.2, the
+  testbed-scoped duration-bounds check built in RRG.3a — all wired in
+  RRG.4), the AC-13 `workspace_version` cross-checks, tier-row
   `detail` populated and conformant to the RRG.3a tier-row schema (§3.3),
   version sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3),
   and the suite_id↔`fail_reason` compatibility re-check (each suite's
@@ -357,6 +359,19 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   check failing ⇒ readiness preflight fails; a non-metadata diff requires
   a fresh gate run (§5.1). The final preflight on the exact `main` commit
   is unchanged and never re-runs the gate.
+- AC-13: **per-attempt version distinctness is mechanized (§5.1
+  patch++).** The manifest's `candidate` block carries a required
+  `workspace_version` (schema-patterned `X.Y.Z`): the orchestrator's
+  first act records it from the checked-out gated tree's `Cargo.toml`
+  `[workspace.package] version`, and the §2.3.3 self-verifier
+  (i) cross-checks the manifest value against that `Cargo.toml` value
+  and (ii) refuses emission if any previously committed
+  `run_kind: "release"` manifest under the evidence root records the
+  same `workspace_version` — a repeated/unbumped version is detected
+  mechanically, never asserted in prose. `tag_candidate` is
+  schema-patterned to the clean `vX.Y.0` release shape (§5.1; binding
+  per AC-12 iii). RRG.1 owns the recording, RRG.4 wires both
+  self-verifier checks.
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -397,8 +412,12 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - Fixture: https://github.com/randlee/atm-hermes-testbed (Colima test
   fixture; tier definitions in testbed PR #2, tiers AT0–AT8).
 - Entry: testbed runner, full tier set (prompt tiers + infra tiers),
-  executed in one continuous session (validated by the §2.3.5 wall-clock
-  duration-bounds anomaly check). The build under test is decided by
+  executed in one continuous session (validated by a **testbed-scoped
+  wall-clock duration-bounds anomaly check** — built in RRG.3a with the
+  other tier checks, wired into §2.3.3 whole-set self-verification in
+  RRG.4, emitting `fail`/`measurement-anomaly` per the §2.3.5 emission
+  convention; the testbed `fail_reason` subset admits it for exactly this
+  check). The build under test is decided by
   Rand at plan review (§8 Q2: tagged candidate build only, or also
   integrate builds); this plan does not preempt that decision.
 - Evidence: committed under an `evidence/…` branch/dir in atm-core exactly
@@ -493,7 +512,16 @@ Summary of the committed schema (normative source is the schema file):
   smoke never carries benchmark/testbed-only reasons, benchmark rows
   never carry tier/sentinel reasons (so a mislabeled benchmark `fail`
   cannot dodge the AC-3 floors-row requirement), testbed rows never carry
-  `floor-breach`/`measurement-anomaly`;
+  `floor-breach` (the only benchmark-exclusive reason — floors exist only
+  for benchmark families). Testbed rows DO admit `measurement-anomaly`:
+  §3.3's one-continuous-session guarantee is validated by a
+  **testbed-scoped duration-bounds anomaly check** (built in RRG.3a
+  alongside the other §2.3.3 tier checks, wired into whole-set
+  self-verification in RRG.4) whose failure emission is
+  `fail`/`measurement-anomaly` — the §2.3.5 emission convention, applied
+  to the testbed suite. The root-level floors conditionals are
+  unaffected: they key on benchmark suite_ids only, so a testbed
+  `measurement-anomaly` row never forces a floors row;
   `declared-skip` **requires** `skip_reason` and **forbids**
   `host`/`execution_identity` (nothing executed — identity must not be
   fabricated);
@@ -578,9 +606,18 @@ direction.
     `Cargo.lock` — mechanical commit). Each attempt therefore executes
     at a unique patch version (e.g. 1.5.1, 1.5.2, … across attempts),
     so every attempt's manifest and evidence set are
-    version-distinguishable and no two runs ever share a version. The
+    version-distinguishable and no two runs ever share a version —
+    mechanized, not asserted: the manifest records the gated commit's
+    workspace version and the self-verifier enforces both the
+    `Cargo.toml` match and cross-attempt uniqueness (**AC-13**). The
     patch++ commit must itself be CI-green before launch (§2.2.6
-    applies to the gated commit as always).
+    applies to the gated commit as always). **Launch sequencing
+    (normative):** the launching operator waits until all seven §3.4
+    repo-suite runs have reached a conclusion on the just-pushed
+    patch++ commit before invoking the gate — the operator owns this
+    wait (manual launch, §5.1); an early invocation is safe but wasted:
+    the §2.2.6 pre-launch check refuses fail-closed ("candidate not
+    CI-eligible", missing-state rows), spending no evidence.
   - **The release version is a minor bump applied only after `READY`**:
     a passing run at e.g. 1.5.7 is followed by the mechanical minor
     bump commit to 1.6.0 (version metadata + changelog, nothing else) —
@@ -627,11 +664,11 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**; **explicit acceptance item (AC-13): the orchestrator's first act records the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`** (self-verifier cross-checks wired in RRG.4)) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
-| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
+| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -946,3 +983,41 @@ owns; no sprint-local reinterpretation.
     with floor-breach REJECTED; smoke fail with measurement-anomaly
     REJECTED; testbed fail with tier-definitions-mismatch still VALID;
     examples all VALID.
+- **r9 (2026-08-31, fix round for quality-mgr r8 FAIL @ cee04a817 —
+  2B/2I/1M, all introduced by r8's own additions)**:
+  - B1r8 (testbed subset forbade the reason §3.3's own guarantee emits)
+    → **arm (a)** chosen: `measurement-anomaly` added to the testbed
+    subset; a **testbed-scoped wall-clock duration-bounds anomaly
+    check** is explicitly owned — built in RRG.3a (with the other tier
+    checks), wired into whole-set self-verification in RRG.4 — and §3.3
+    now cites that check instead of the (RRG.2-scoped) §2.3.5 set.
+    Noted per the fix guidance: the root floors conditionals need no
+    carve-out — they key on benchmark suite_ids only, so a testbed
+    measurement-anomaly row never forces a floors row (probe-verified).
+    Testbed subset now excludes only `floor-breach`.
+  - B2r8 (patch++ mandate had no acceptance home, "no two runs share a
+    version" unmechanized) → new **AC-13**: required
+    `candidate.workspace_version` field (schema-patterned `X.Y.Z`)
+    recorded by the orchestrator's first act from the gated tree's
+    `Cargo.toml`; self-verifier cross-checks (i) manifest value ==
+    Cargo.toml value and (ii) no previously committed release manifest
+    records the same value (cross-attempt uniqueness). Explicit RRG.1
+    acceptance item (recording) + RRG.4 wiring (both checks); §5.1
+    cross-references AC-13.
+  - I1r8 (patch++ CI-greenness launch sequencing unstated) → normative
+    §5.1 sentence: the launching operator owns waiting for all seven
+    §3.4 runs to reach a conclusion on the patch++ commit before
+    invoking the gate; an early invocation refuses fail-closed
+    pre-launch, spending no evidence.
+  - I2r8 (examples taught stale `v1.5.0-rc1`) → all four examples now
+    carry `tag_candidate: "v1.6.0"`; the three manifest examples add
+    `workspace_version: "1.5.7"` (gated attempt-patch version, teaching
+    the §5.1 model: measured at 1.5.7, proposing v1.6.0).
+  - M1r8 (tag_candidate free text) → schema-patterned `^v\d+\.\d+\.0$`
+    (clean release shape, consistent with binding AC-12 iii).
+  - Schema + examples revalidated: full probe battery green; new
+    probes — testbed fail/measurement-anomaly VALID (and forces no
+    floors row), testbed fail/floor-breach still REJECTED, benchmark
+    fail/tier-sentinel reasons still REJECTED, missing
+    `workspace_version` REJECTED, malformed `workspace_version`/
+    `tag_candidate` (e.g. `v1.6.1`, `1.6.0`) REJECTED.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -197,9 +197,15 @@ The mechanism that makes §1's first-time-pass requirement real:
    CI re-verification** (all seven `ci_runs[]` conclusions re-fetched and
    still `success` — see §2.2 rule 6), **the §2.3.5
    anomaly-check set** (per-family D7 clean-run criteria, historical p50
-   sanity band, wall-clock duration bounds, evidence-row counts vs declared
-   workload — built in RRG.2, wired into this self-verification in RRG.4),
-   **and the testbed evidence-form classes that caused the v1.4.6 churn
+   sanity band, wall-clock duration bounds per the committed
+   `release/duration-bounds.json` (§2.3.5), evidence-row counts vs
+   declared workload — the benchmark/smoke checks built in RRG.2, the
+   testbed-scoped duration-bounds check built in RRG.3a, all wired into
+   this self-verification in RRG.4), **the AC-13 `workspace_version`
+   cross-checks** (manifest value matches the gated tree's `Cargo.toml`;
+   no previously committed release manifest under the §4 release-manifest
+   path convention records the same value), **and the testbed
+   evidence-form classes that caused the v1.4.6 churn
    (§7.2/§7.3): every tier row has populated `detail`, version sentinels are
    consistent across prompt files, and executed tiers match the pinned
    tier-definition revision 1:1**. `READY` is unreachable with a clerical
@@ -233,7 +239,14 @@ The mechanism that makes §1's first-time-pass requirement real:
    Result plausibility is **not reviewer discretion**: it is the enumerated
    anomaly-check set the harness itself runs as part of §2.3.3 (per-family
    D7 clean-run criteria; observed p50 within the family's historical
-   sanity band; wall-clock duration within declared bounds; evidence-row
+   sanity band; wall-clock duration within the bounds declared in the
+   committed `release/duration-bounds.json` — the bounds' single source
+   of truth, one min/max entry per catalog suite, seeded from the
+   durations of historical committed evidence runs and Rand-approved
+   before first use, exactly the `baselines.json` discipline (never
+   self-seeded by the harness; a bounds revision is a reviewed commit,
+   never a run-time adjustment) — RRG.2 declares the smoke + benchmark
+   entries, RRG.3a the testbed entry; evidence-row
    counts matching the declared workload). Any anomaly-check hit is emitted
    by the harness as suite `fail` with `fail_reason:
    "measurement-anomaly"`, which is treated as a harness/environment defect:
@@ -347,7 +360,10 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   `ref/release-state-strategy.md` (readiness preflight before a `main`
   merge) — must, **mechanically** (RRG.4 delivers the check as code the
   preflight invokes, not checklist prose; §2.3 no-clerical mandate
-  applies), before authorizing the `main` merge: (i) locate and
+  applies), before authorizing the `main` merge: (i) locate — via the §4
+  release-manifest path convention
+  (`site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json`,
+  `rehearsal/` excluded) — and
   schema-validate the committed `run_kind: "release"` manifest and
   require `verdict: "READY"`; (ii) verify the diff between the manifest's
   `candidate.commit_sha` and the release-candidate tag commit is
@@ -361,14 +377,20 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   is unchanged and never re-runs the gate.
 - AC-13: **per-attempt version distinctness is mechanized (§5.1
   patch++).** The manifest's `candidate` block carries a required
-  `workspace_version` (schema-patterned `X.Y.Z`): the orchestrator's
-  first act records it from the checked-out gated tree's `Cargo.toml`
-  `[workspace.package] version`, and the §2.3.3 self-verifier
+  `workspace_version` (schema-patterned `X.Y.Z`): the orchestrator
+  records it from the checked-out gated tree's `Cargo.toml`
+  `[workspace.package] version` as the first of the gate's two ordered
+  opening acts (§5.1: record version, then §2.2.6 precondition), and
+  the §2.3.3 self-verifier
   (i) cross-checks the manifest value against that `Cargo.toml` value
   and (ii) refuses emission if any previously committed
-  `run_kind: "release"` manifest under the evidence root records the
-  same `workspace_version` — a repeated/unbumped version is detected
-  mechanically, never asserted in prose. `tag_candidate` is
+  `run_kind: "release"` manifest under the §4 release-manifest path
+  convention (`site/reports/release-readiness/`, `rehearsal/` excluded)
+  records the same `workspace_version` — a repeated/unbumped version is
+  detected mechanically, never asserted in prose. Uniqueness is
+  guaranteed under the §5 single-runner concurrency model (gate
+  launches are serialized — stated precondition, not an assumption):
+  concurrent gate launches are outside the contract. `tag_candidate` is
   schema-patterned to the clean `vX.Y.0` release shape (§5.1; binding
   per AC-12 iii). RRG.1 owns the recording, RRG.4 wires both
   self-verifier checks.
@@ -464,7 +486,21 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 
 ## 4. Release evidence manifest
 
-One committed JSON manifest per gate run. The schema is a committed plan
+One committed JSON manifest per gate run. **Committed release-manifest
+path convention (normative — the single lookup space AC-12(i) and
+AC-13(ii) execute against):**
+`site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json`.
+`run_kind: "release"` manifests live ONLY there; the rehearsal root
+`site/reports/release-readiness/rehearsal/` (§2.3.4) is a sibling
+subtree excluded from every release lookup, and the refusal-record dir
+`release/refusals/<tag_candidate>/` (§2.2.6) is outside it entirely.
+"Previously committed release manifests" (AC-13 ii) therefore means:
+every `manifest.json` under `site/reports/release-readiness/` excluding
+`rehearsal/`; "locate the committed READY manifest" (AC-12 i) resolves
+the same convention for the candidate's `tag_candidate`. The per-suite
+evidence roots (`site/reports/smoke/`, benchmark report dirs, the
+testbed `evidence/…` location) hold suite evidence the manifest points
+INTO — never manifests. The schema is a committed plan
 artifact — [release-evidence-manifest.schema.json](release-evidence-manifest.schema.json)
 (JSON Schema 2020-12), with three worked examples:
 [release-evidence-manifest.example.json](release-evidence-manifest.example.json)
@@ -597,8 +633,10 @@ direction.
 - **Trigger (manual, once per candidate):** the operator (§8 Q1) launches
   `just release-readiness <tag-candidate>` on the evidence host(s)
   against the intended `develop` commit. Nothing triggers the gate
-  automatically; the §2.2.6 CI-eligibility precondition is the gate's
-  own first act, not a separate manual step.
+  automatically. The gate's **first two acts, in order** (neither is a
+  separate manual step): (1) record the gated tree's `Cargo.toml`
+  workspace version into `candidate.workspace_version` (AC-13);
+  (2) run the §2.2.6 CI-eligibility precondition.
 - **Version-number management (Rand, 2026-08-31): patch++ per gate run;
   the minor bump is gated BEHIND a passing run, never ahead of it.**
   - **Every gate run is preceded by a mandated patch bump** on
@@ -664,9 +702,9 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**; **explicit acceptance item (AC-13): the orchestrator's first act records the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`** (self-verifier cross-checks wired in RRG.4)) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
-| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
-| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**; **explicit acceptance item (AC-13): the first of the gate's two ordered opening acts (§5.1) records the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`, and the manifest is written to the §4 release-manifest path convention** (self-verifier cross-checks wired in RRG.4)) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
+| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the benchmark/smoke instances of the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, smoke+benchmark duration bounds — declaring their `release/duration-bounds.json` entries per §2.3.5's seeding discipline, evidence-row counts) emitting `fail`/`measurement-anomaly`; the testbed-scoped duration-bounds instance is RRG.3a's (one row below) | RRG.1 | Cipher |
+| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`, declares the testbed entry of `release/duration-bounds.json` per §2.3.5's seeding discipline; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
 | RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
@@ -1021,3 +1059,47 @@ owns; no sprint-local reinterpretation.
     fail/tier-sentinel reasons still REJECTED, missing
     `workspace_version` REJECTED, malformed `workspace_version`/
     `tag_candidate` (e.g. `v1.6.1`, `1.6.0`) REJECTED.
+- **r10 (2026-08-31, fix round for quality-mgr r9 FAIL @ 093b30c23 —
+  1B/3I/2M, all propagation/definition seams of r9's own additions)**:
+  - B1r9 (AC-13's cross-attempt uniqueness scan executed against an
+    undefined "evidence root" lookup space) → §4 now opens with the
+    **committed release-manifest path convention**:
+    `site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json`;
+    `run_kind: "release"` manifests live ONLY there, the rehearsal root
+    (`site/reports/release-readiness/rehearsal/`) is excluded from every
+    release lookup, and the refusal dir is outside it entirely. AC-12(i)
+    and AC-13(ii) both cite the convention by name; the manifest
+    schema's `workspace_version` description cites it too.
+  - I1r9 (AC-13 not propagated to summarizing sites) → §2.3.3's
+    self-verification enumeration now includes the AC-13
+    `workspace_version` cross-checks; §6 RRG.1 row aligned with the
+    two-ordered-acts wording + §4 path convention; §6 RRG.2 row scoped
+    to the benchmark/smoke instances of the §2.3.5 anomaly-check set
+    with a cross-ref to RRG.3a's testbed instance.
+  - I2r9 (two contradictory "first act" claims: version recording vs
+    §2.2.6 precondition) → §5.1 trigger bullet defines the gate's
+    **first two acts, in order**: (1) record `workspace_version`
+    (AC-13), (2) run the §2.2.6 CI-eligibility precondition; AC-13 and
+    the RRG.1 row restate the same ordering.
+  - I3r9 (duration bounds had no committed source of truth) → §2.3.5
+    names committed **`release/duration-bounds.json`** (one min/max
+    entry per catalog suite, seeded from historical committed evidence
+    durations, Rand-approved before first use — baselines.json
+    discipline, never self-seeded); RRG.2 declares the smoke +
+    benchmark entries, RRG.3a the testbed entry (ownership recorded in
+    both §6 rows).
+  - M1r9 (refusal-record candidate block lagged the manifest's) →
+    refusal schema's `tag_candidate` now patterned `^v\d+\.\d+\.0$`
+    (same shape, same candidate) and an OPTIONAL `workspace_version`
+    (patterned `X.Y.Z`) added — present when the refusal fired after
+    the gate's first opening act recorded it, absent for a pre-launch
+    refusal that fired before the version was read.
+  - M2r9 (cross-attempt uniqueness assumed serialized launches) → AC-13
+    states the §5 single-runner serialized-launch **precondition**
+    explicitly: gate launches are serialized; concurrent launches are
+    outside the contract.
+  - Schema + examples revalidated: full probe battery green; new
+    refusal-schema probes — `v1.6.1` tag REJECTED, `1.6.0` (no `v`)
+    REJECTED, record without `workspace_version` still VALID (optional),
+    record with malformed `workspace_version` REJECTED; all manifest
+    probes unchanged.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -219,6 +219,12 @@ no test executions beyond each sprint's own new unit tests.
    observability limitation until the gauges ship.
 6. **Windows**: no isolated Windows benchmark account exists; Windows
    evidence remains a declared-skip per standing policy.
+7. **Execution-account admission control** (arch-ctm, post-AV-PROD-001R
+   review): the provenance fix *records* the executing account in-band
+   (getpwuid(geteuid()), not env-spoofable) but does not *enforce* an
+   approved-account allowlist for official runs. If Rand wants official
+   evidence rejected — not just flagged — when produced by a non-approved
+   account, that is a small scoped harness change; candidate for RRG.2.
 
 ## 8. Open questions for Rand (at plan review)
 

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -109,6 +109,36 @@ just release-readiness <release-tag-candidate>
    never reached a terminal state mid-run). The manifest's `ci_runs[]`
    records the verified-green runs; a non-green conclusion is deliberately
    unrepresentable there because the launch never happens.
+   Three edge rules seal this precondition:
+   - **Emission-time re-verification (no TOCTOU).** GitHub permits
+     re-running a completed workflow, so a run's conclusion can flip red
+     between the pre-launch check and manifest emission hours later. The
+     harness therefore **re-fetches all seven conclusions at
+     manifest-emission time**: if any is no longer `success` (or the run
+     disappeared), no manifest is written and the refusal record below is
+     emitted ("candidate no longer CI-eligible at emission") — a `READY`
+     manifest never asserts a conclusion that is red at
+     release-decision time. Suite evidence on disk is not discarded, but
+     per §2.2.2 it is not release evidence without a validated manifest.
+     Ownership: RRG.1 owns the pre-launch check; RRG.4 wires the
+     emission-time re-check into §2.3.3 self-verification (AC-11).
+   - **Refusal is observable.** Every refusal (pre-launch or
+     emission-time) writes a minimal **refusal record** — a status
+     artifact outside the evidence roots (never under `site/reports/`)
+     naming the candidate (tag + commit SHA), a timestamp, the refusal
+     point (pre-launch | emission), and the exact red/missing run ids.
+     An operator can always distinguish never-launched from
+     refused-N-times, and see why. This record is NOT evidence and is
+     never referenced by a manifest; producing it is an explicit RRG.1
+     acceptance item (§6).
+   - **Rehearsal carve-out.** For `run_kind: "rehearsal"` (§2.3.4) the
+     precondition and the emission-time re-check are **synthesized, not
+     fetched**: no GitHub API call is made; the rehearsal harness
+     fabricates the seven `ci_runs[]` rows with sentinel run ids
+     (1 through 7) and `commit_sha` = the rehearsal HEAD, `conclusion`
+     `success`. This is safe because rehearsal manifests are structurally
+     non-evidence (rehearsal root + two-way refusal, §2.3.4), and it keeps
+     RRG.4's green-rehearsal acceptance gate independent of live CI state.
 
 ### 2.3 First-time-pass enforcement (no clerical QA rounds)
 
@@ -134,7 +164,10 @@ The mechanism that makes §1's first-time-pass requirement real:
    (the schema's `contains` + `maxItems` clauses already mechanize
    exactly-once; this re-check is defense-in-depth), **the floors
    cross-check** (every §3.2 tracked metric of a pass-terminal benchmark
-   suite has a `floors[]` row for its family), **the §2.3.5
+   suite has a `floors[]` row for its family; no `floors[]` row exists
+   for a family whose suite did not execute), **the §2.2.6 emission-time
+   CI re-verification** (all seven `ci_runs[]` conclusions re-fetched and
+   still `success` — see §2.2 rule 6), **the §2.3.5
    anomaly-check set** (per-family D7 clean-run criteria, historical p50
    sanity band, wall-clock duration bounds, evidence-row counts vs declared
    workload — built in RRG.2, wired into this self-verification in RRG.4),
@@ -157,7 +190,11 @@ The mechanism that makes §1's first-time-pass requirement real:
    acceptance criterion of the final implementation sprint (§6, RRG.4) —
    the gate is not "implemented" without one — and is also the pre-launch
    check before the real release run. (Rehearsal runs no tests, so it
-   complies with the current no-test-runs directive.)
+   complies with the current no-test-runs directive.) Rehearsal also does
+   not call the GitHub API: the §2.2.6 CI-eligibility precondition and its
+   emission-time re-check are synthesized per the §2.2 rule 6 rehearsal
+   carve-out (sentinel run ids, rehearsal-HEAD sha), so the RRG.4
+   acceptance gate never depends on a real green candidate commit.
 5. **Single QA round by contract.** quality-mgr reviews a real gate run
    once. That review consists of (i) re-running the §2.3.3 machine checks —
    which the gate already ran, so they are green by construction — and
@@ -199,8 +236,11 @@ touched by the gate (standing constraints).
 This checklist is the one place gate acceptance lives; §3 pass criteria and
 §6 sprint acceptance criteria reference it and add nothing normative.
 
-- AC-1: one launch (`just release-readiness <tag-candidate>`) drives every
-  declared suite to a terminal state without operator input (§2.1, §2.2.1).
+- AC-1: once the §2.2.6/AC-11 CI-eligibility precondition admits the
+  launch, one launch (`just release-readiness <tag-candidate>`) drives
+  every declared suite to a terminal state without operator input (§2.1,
+  §2.2.1). A refused launch is the one exception: it drives no suites,
+  produces no manifest, and writes only the §2.2.6 refusal record.
 - AC-2: manifest written only after all suites terminal; validates against
   the committed schema **and** the §2.3.3 self-verifier (the schema
   mechanizes exactly-once catalog completeness for `suites[]` and
@@ -210,7 +250,9 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   manifest is the sole release-evidence pointer (§2.2.1, §2.2.2, §4).
 - AC-3: `READY` requires all suites `pass` or Rand-approved
   `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3);
-  anything else renders `NOT-READY`.
+  anything else renders `NOT-READY`. A declared-skip of a benchmark family
+  drops that family's `floors[]` requirement (schema-conditional, §4) —
+  the skip never forces a fabricated measurement.
 - AC-4: every executed suite (`pass`/`fail`) carries `host` + in-band
   execution-identity provenance — schema-required, so
   missing provenance ⇒ suite `fail` (`provenance-missing`); a
@@ -224,7 +266,8 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   cross-references, reports-index, duplicate-`suite_id` rejection in both
   `suites[]` and `ci_runs[]` (defense-in-depth behind the schema's
   exactly-once), the floors cross-check (every §3.2 tracked metric of a
-  pass-terminal benchmark suite has a `floors[]` row), the §2.3.5
+  pass-terminal benchmark suite has a `floors[]` row, and no `floors[]`
+  row exists for a family whose suite did not execute), the §2.3.5
   anomaly-check set (checks built in RRG.2, wired in RRG.4), tier-row
   `detail` populated and conformant to the RRG.3a tier-row schema (§3.3),
   version sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
@@ -238,10 +281,13 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - AC-11: `ci_runs` closed seven-id catalog, each entry exactly once with
   `conclusion: "success"` pinned to the candidate commit (schema), and the
   §2.2.6 CI-eligibility precondition: all seven runs verified green
-  **before any suite launches** — a red/missing run refuses the launch
-  ("candidate not CI-eligible", distinct from INCOMPLETE-by-absence);
-  never `READY`, and never evidence discarded, over a red repo suite
-  (§2.2.6, §3.4, §4).
+  **before any suite launches** (RRG.1) AND **re-verified at
+  manifest-emission time** (RRG.4 self-verification) — a red/missing run
+  at either point refuses with "candidate not CI-eligible" (distinct from
+  INCOMPLETE-by-absence) and writes the §2.2.6 refusal record; never
+  `READY`, and never evidence discarded, over a red repo suite — including
+  one that went red between launch and emission (§2.2.6, §3.4, §4).
+  A refused launch is AC-1's sole carve-out.
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -330,11 +376,15 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 
 One committed JSON manifest per gate run. The schema is a committed plan
 artifact — [release-evidence-manifest.schema.json](release-evidence-manifest.schema.json)
-(JSON Schema 2020-12), with two worked examples:
+(JSON Schema 2020-12), with three worked examples:
 [release-evidence-manifest.example.json](release-evidence-manifest.example.json)
-(a `NOT-READY` run with a floor-breach fail and a declared-skip) and
+(a `NOT-READY` run with a floor-breach fail and a declared-skip),
 [release-evidence-manifest.example-ready.json](release-evidence-manifest.example-ready.json)
-(a fully green `READY` run — all four suites `pass`, both floors met).
+(a fully green `READY` run — all four suites `pass`, both floors met), and
+[release-evidence-manifest.example-skip.json](release-evidence-manifest.example-skip.json)
+(a `READY` run with a Rand-approved declared-skip of a benchmark family —
+no floors row for the skipped family, demonstrating the conditional
+floors requirement).
 RRG.1 lifts these into their final in-repo home next to the validator; the
 schema content in this plan is the reviewed baseline.
 
@@ -367,10 +417,14 @@ Summary of the committed schema (normative source is the schema file):
   **Convention (schema-enforced): `ratchet_proposal` may be present only
   when `met` is true** — the harness never proposes ratcheting from a
   breached measurement. Family-level completeness is schema-mechanized
-  (`contains` clauses require at least one `send` and one `read-query`
-  row); metric-level completeness (every §3.2 tracked metric of a
-  pass-terminal benchmark suite has a floors row) is a named §2.3.3
-  self-verifier cross-check;
+  **conditionally on execution** (root-level `allOf`: a family's suite
+  reaching `pass`/`fail` requires at least one floors row for that
+  family; a Rand-approved `declared-skip` of a benchmark family requires
+  none — the schema never forces fabricating a measurement that never
+  ran, per §2.1/AC-3); metric-level completeness (every §3.2 tracked
+  metric of a pass-terminal benchmark suite has a floors row) and the
+  forbid direction (no floors row for a non-executed family) are named
+  §2.3.3 self-verifier cross-checks;
 - `ci_runs[]` — **closed repo-suite catalog, exactly-once
   schema-mechanized** (§3.4): `suite_id` is the seven-id enum (`just-ci`,
   `test-graft-python`, `test-hermes-graft-bridge`,
@@ -379,9 +433,11 @@ Summary of the committed schema (normative source is the schema file):
   variants are separate, independently green entries); seven `contains`
   clauses + `minItems`/`maxItems: 7` require each exactly once, each with
   run id and `conclusion` fixed to `success`, pinned to the candidate
-  commit. Greenness is verified pre-launch (§2.2.6 CI-eligibility
-  precondition) — a red/missing run refuses the launch, so a non-green
-  conclusion is unrepresentable in a manifest;
+  commit. Greenness is verified pre-launch AND re-verified at
+  manifest-emission time (§2.2.6 CI-eligibility precondition + TOCTOU
+  re-check) — a red/missing run at either point refuses with a §2.2.6
+  refusal record, so a non-green conclusion is unrepresentable in a
+  manifest and a `READY` manifest is never stale against CI;
 - `verdict` — `READY` / `NOT-READY` only. `INCOMPLETE` is deliberately
   unrepresentable: an incomplete run writes no manifest at all
   (INCOMPLETE-by-absence, §2.2.1);
@@ -420,11 +476,11 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state — AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the non-evidence refusal record (candidate, timestamp, refusal point, red/missing run ids) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, and the floors cross-check into §2.3.3 whole-set self-verification** (AC-7). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -594,3 +650,40 @@ owns; no sprint-local reinterpretation.
   examples VALID (each now carries all seven ci_runs), 5 new negative
   cases (duplicate suites row, duplicate ci_runs row, 6-of-7 ci_runs,
   missing read-query floor, empty floors) verified REJECTED.
+- **r6 (2026-08-31, addressing quality-mgr r5 FAIL @ 6b445ef0c, msg
+  01M1DBVS9V13KX3AKT1Z2WDYSK; all 6 r4 findings scored FIXED, no
+  regressions)**: all r5 findings were second-order edges of the r5
+  mechanisms themselves. B1r5 unconditional floors family-completeness
+  contradicted Rand-approved benchmark declared-skip (schema-forced
+  fabrication or unsatisfiable manifest) → option (b), fully
+  schema-mechanized: dropped floors `minItems`/unconditional `contains`;
+  root-level `allOf` conditionals require a family's floors row exactly
+  when that family's suite reached `pass`/`fail` — a declared-skip
+  requires none; forbid direction (no row for a non-executed family) is
+  a named §2.3.3/AC-7 self-verifier cross-check; new third example
+  (example-skip.json: READY with benchmark-read-query declared-skip, no
+  read-query floors row) demonstrates the skip path; AC-3/§4 updated.
+  B2r5 CI-eligibility TOCTOU (conclusion could flip red between
+  pre-launch check and emission) → §2.2 rule 6 emission-time
+  re-verification: all seven conclusions re-fetched at manifest emission;
+  red/missing ⇒ no manifest + refusal record ("candidate no longer
+  CI-eligible at emission"); ownership split RRG.1 (pre-launch) / RRG.4
+  (emission re-check in self-verification); AC-11 + schema description
+  updated. I1r5 §2.2.6 vs rehearsal undefined → rehearsal carve-out in
+  rule 6 + §2.3.4: precondition and re-check synthesized, no GH API;
+  fabrication defined (sentinel run ids 1–7, rehearsal-HEAD sha,
+  `success`), safe because rehearsal manifests are structurally
+  non-evidence; RRG.4 acceptance criterion references it. I2r5 AC-1
+  contradicted the refusal path → AC-1 reworded with the precondition as
+  admission condition and the refused launch as sole carve-out; mutual
+  AC-1/AC-11 xref. I3r5 refusal unobservable → §2.2 rule 6 non-evidence
+  refusal record (outside evidence roots; candidate, timestamp, refusal
+  point pre-launch|emission, red/missing run ids), never
+  manifest-referenced; explicit RRG.1 acceptance item (§6). I4r5 RRG.1
+  ADR scope omitted §2.2.6 → ADR topics now include CI-eligibility/
+  refusal-state semantics (snapshot-vs-emission, refusal observability,
+  INCOMPLETE-vs-refusal boundary). Schema revalidated: all THREE examples
+  VALID; negative cases re-run — executed-family-missing-floors REJECTED
+  (send pass without send row; read-query pass without read-query row),
+  duplicate rows and 6-of-7 ci_runs still REJECTED; skip-without-floors
+  VALID only when the family's suite is declared-skip.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -136,7 +136,9 @@ just release-readiness <release-tag-candidate>
      [release-refusal-record.schema.json](release-refusal-record.schema.json)
      (worked example:
      [release-refusal-record.example.json](release-refusal-record.example.json)):
-     candidate (tag + 40-hex commit SHA + branch), `refused_at`
+     candidate (tag + 40-hex commit SHA + branch + `workspace_version` —
+     always present: Act 1 records the version before Act 2 can refuse,
+     §5.1/AC-13), `refused_at`
      timestamp, `refusal_point` (`pre-launch` | `emission`), and the
      exact red/missing runs (`ci_runs_not_green`, red entries citing the
      run id, missing entries citing none). An emission-point record MAY
@@ -145,7 +147,14 @@ just release-readiness <release-tag-candidate>
      not grow into a shadow manifest); a pre-launch record must not.
      **Path convention:** records are written under
      `release/refusals/<tag_candidate>/` — outside the evidence roots,
-     never under `site/reports/`. An operator can always distinguish
+     never under `site/reports/` — with a **per-event filename**:
+     `<refused_at as compact UTC, e.g. 20260917T215500Z>-<refusal_point>.json`.
+     `tag_candidate` is constant across every §5.1 patch++ attempt, so
+     all of a candidate's refusals share one directory; the per-event
+     name is what preserves refused-N-times, and the writer **refuses to
+     overwrite an existing file** (fail-closed) rather than ever
+     collapsing two refusal events into one record (RRG.1 writer
+     acceptance item, §6). An operator can always distinguish
      never-launched from refused-N-times, and see why. This record is
      NOT evidence and is never referenced by a manifest; the writer is
      built once in RRG.1 (explicit acceptance item, §6) and **reused —
@@ -167,6 +176,25 @@ just release-readiness <release-tag-candidate>
      from release evidence — `run_id` values are not independently
      validated against GitHub. This is a recorded acceptance, not an
      oversight.
+7. **Named startup failures (distinct from the refusal taxonomy and from
+   INCOMPLETE-by-absence).** The gate's opening acts can themselves fail
+   before any suite runs, and each such failure is a **named,
+   self-describing pre-launch abort** — no suites run, no manifest is
+   written, and no refusal record is written (refusal records are
+   CI-eligibility-scoped, §2.2.6); the operator gets the named state,
+   never an unexplained crash:
+   - **"candidate version unreadable"** — Act 1 (§5.1/AC-13) cannot read
+     `[workspace.package] version` from the gated tree's `Cargo.toml`
+     (missing file, unparsable TOML, absent field). This is the only
+     scenario in which no `workspace_version` exists, which is why the
+     refusal record can require the field unconditionally.
+   - **"duration bounds unusable"** — the launch-time validation of the
+     committed `release/duration-bounds.json` (AC-14) fails: file
+     missing, schema-invalid, a catalog-suite entry absent, or an entry
+     with `min_seconds >= max_seconds`. A harness defect, never a
+     silent skip of the §2.3.5 duration checks.
+   Both states are adjudicated at launch, before the §2.2.6
+   precondition's cheap API check spends anything.
 
 ### 2.3 First-time-pass enforcement (no clerical QA rounds)
 
@@ -198,7 +226,7 @@ The mechanism that makes §1's first-time-pass requirement real:
    still `success` — see §2.2 rule 6), **the §2.3.5
    anomaly-check set** (per-family D7 clean-run criteria, historical p50
    sanity band, wall-clock duration bounds per the committed
-   `release/duration-bounds.json` (§2.3.5), evidence-row counts vs
+   `release/duration-bounds.json` (§2.3.5/AC-14), evidence-row counts vs
    declared workload — the benchmark/smoke checks built in RRG.2, the
    testbed-scoped duration-bounds check built in RRG.3a, all wired into
    this self-verification in RRG.4), **the AC-13 `workspace_version`
@@ -241,12 +269,22 @@ The mechanism that makes §1's first-time-pass requirement real:
    D7 clean-run criteria; observed p50 within the family's historical
    sanity band; wall-clock duration within the bounds declared in the
    committed `release/duration-bounds.json` — the bounds' single source
-   of truth, one min/max entry per catalog suite, seeded from the
-   durations of historical committed evidence runs and Rand-approved
-   before first use, exactly the `baselines.json` discipline (never
-   self-seeded by the harness; a bounds revision is a reviewed commit,
-   never a run-time adjustment) — RRG.2 declares the smoke + benchmark
-   entries, RRG.3a the testbed entry; evidence-row
+   of truth, one min/max entry per catalog suite, contracted by the
+   committed schema
+   [release-duration-bounds.schema.json](release-duration-bounds.schema.json)
+   (worked example:
+   [release-duration-bounds.example.json](release-duration-bounds.example.json))
+   and owned by **AC-14**: seeded from the durations of historical
+   committed evidence runs and Rand-approved before first use, exactly
+   the §3.2 `baselines.json` revision convention — mechanized via the
+   schema's required `revision`/`approved_by`/`approved_at` fields, so
+   an unapproved seed cannot validate (never self-seeded by the harness;
+   a bounds revision is a reviewed commit, never a run-time adjustment).
+   The **min** bound flags a short-circuited or truncated workload — a
+   suite finishing implausibly fast means work was skipped, not that a
+   genuine speedup is penalized; the **max** bound flags a stalled or
+   contaminated run. RRG.2 declares the smoke + benchmark
+   entries, RRG.3a the testbed entry (AC-14); evidence-row
    counts matching the declared workload). Any anomaly-check hit is emitted
    by the harness as suite `fail` with `fail_reason:
    "measurement-anomaly"`, which is treated as a harness/environment defect:
@@ -360,12 +398,18 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   `ref/release-state-strategy.md` (readiness preflight before a `main`
   merge) — must, **mechanically** (RRG.4 delivers the check as code the
   preflight invokes, not checklist prose; §2.3 no-clerical mandate
-  applies), before authorizing the `main` merge: (i) locate — via the §4
-  release-manifest path convention
-  (`site/reports/release-readiness/<tag_candidate>-<workspace_version>/manifest.json`,
-  `rehearsal/` excluded) — and
-  schema-validate the committed `run_kind: "release"` manifest and
-  require `verdict: "READY"`; (ii) verify the diff between the manifest's
+  applies), before authorizing the `main` merge: (i) locate the
+  committed `run_kind: "release"` manifest via the **§4 lookup
+  algorithm** — the preflight holds only `tag_candidate`, so it globs
+  `site/reports/release-readiness/<tag_candidate>-*/manifest.json`
+  (excluding `rehearsal/`), schema-validates each match, and selects
+  the one whose `verdict` is `"READY"`; §5.1 patch++ legitimately
+  leaves multiple attempt directories (NOT-READY ones included), so
+  **exactly one READY match is required**: zero READY matches fails
+  the preflight ("no READY manifest for candidate"), and more than one
+  fails closed ("ambiguous READY evidence" — impossible under the §5
+  serialized-launch precondition, checked anyway; the preflight never
+  picks arbitrarily); (ii) verify the diff between the manifest's
   `candidate.commit_sha` and the release-candidate tag commit is
   version-metadata-only (the §5.1 minor-bump commit: `Cargo.toml`
   workspace version, `Cargo.lock`, changelog — nothing else); and
@@ -394,6 +438,29 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   schema-patterned to the clean `vX.Y.0` release shape (§5.1; binding
   per AC-12 iii). RRG.1 owns the recording, RRG.4 wires both
   self-verifier checks.
+- AC-14: **the duration-bounds artifact is contracted, approved, and
+  fail-closed.** `release/duration-bounds.json` — the single source of
+  truth for the §2.3.5 wall-clock duration checks — must (i) conform to
+  the committed schema
+  [release-duration-bounds.schema.json](release-duration-bounds.schema.json)
+  (worked example
+  [release-duration-bounds.example.json](release-duration-bounds.example.json)):
+  a closed catalog with exactly one `min_seconds`/`max_seconds` entry
+  per §3 catalog suite, no extras; (ii) be validated at gate launch,
+  before the §2.2.6 precondition — a missing file, schema-invalid
+  content, a missing catalog-suite entry, or `min_seconds >=
+  max_seconds` aborts with the named §2.2 rule 7 startup failure
+  **"duration bounds unusable"** (a harness defect, never a silent skip
+  of the check), and the §2.3.3 self-verifier re-validates the artifact
+  at emission time as defense-in-depth; and (iii) carry the mechanized
+  approval marker — schema-required `revision`, `approved_by`,
+  `approved_at` fields per the §3.2 `baselines.json` revision
+  convention (e.g. revision 1, approved 2026-08-31) — so an unapproved
+  or self-seeded bounds file cannot validate; a bounds revision is a
+  reviewed commit, never a run-time adjustment. Ownership: RRG.2
+  declares the smoke + benchmark entries, RRG.3a the testbed entry,
+  RRG.4 wires launch-time validation, the emission-time re-validation,
+  and the named startup failure.
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -496,8 +563,16 @@ subtree excluded from every release lookup, and the refusal-record dir
 `release/refusals/<tag_candidate>/` (§2.2.6) is outside it entirely.
 "Previously committed release manifests" (AC-13 ii) therefore means:
 every `manifest.json` under `site/reports/release-readiness/` excluding
-`rehearsal/`; "locate the committed READY manifest" (AC-12 i) resolves
-the same convention for the candidate's `tag_candidate`. The per-suite
+`rehearsal/`. **Lookup algorithm (AC-12 i)** — the readiness preflight
+holds only `tag_candidate`, while the convention is keyed by
+`tag_candidate` AND `workspace_version`, and §5.1 patch++ legitimately
+leaves multiple `<tag_candidate>-<wv>/` attempt directories (NOT-READY
+ones included): the preflight globs
+`site/reports/release-readiness/<tag_candidate>-*/manifest.json`
+(excluding `rehearsal/`), schema-validates each match, and requires
+**exactly one** with `verdict: "READY"` — zero READY matches fails the
+preflight ("no READY manifest for candidate"); more than one fails
+closed ("ambiguous READY evidence"), never an arbitrary pick. The per-suite
 evidence roots (`site/reports/smoke/`, benchmark report dirs, the
 testbed `evidence/…` location) hold suite evidence the manifest points
 INTO — never manifests. The schema is a committed plan
@@ -515,7 +590,9 @@ The §2.2.6 refusal record has its own committed schema and worked
 example — [release-refusal-record.schema.json](release-refusal-record.schema.json)
 and [release-refusal-record.example.json](release-refusal-record.example.json)
 — so RRG.1 and RRG.4 implement one reviewed shape rather than each
-interpreting prose.
+interpreting prose. The §2.3.5/AC-14 duration-bounds artifact likewise —
+[release-duration-bounds.schema.json](release-duration-bounds.schema.json)
+and [release-duration-bounds.example.json](release-duration-bounds.example.json).
 RRG.1 lifts these into their final in-repo home next to the validator; the
 schema content in this plan is the reviewed baseline.
 
@@ -702,11 +779,11 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline, **including the suite_id-scoped `fail_reason` subsets** — per-suite schema conditionals) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**; **explicit acceptance item (AC-13): the first of the gate's two ordered opening acts (§5.1) records the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`, and the manifest is written to the §4 release-manifest path convention** (self-verifier cross-checks wired in RRG.4)) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
-| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the benchmark/smoke instances of the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, smoke+benchmark duration bounds — declaring their `release/duration-bounds.json` entries per §2.3.5's seeding discipline, evidence-row counts) emitting `fail`/`measurement-anomaly`; the testbed-scoped duration-bounds instance is RRG.3a's (one row below) | RRG.1 | Cipher |
-| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`, declares the testbed entry of `release/duration-bounds.json` per §2.3.5's seeding discipline; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
+| RRG.1 | Gate foundation — five enumerated deliverables: **(1)** manifest schema, lifted from this plan's committed baseline **including the suite_id-scoped `fail_reason` subsets** (per-suite schema conditionals); **(2)** `just release-readiness` orchestrator skeleton — suite registry, terminal-state tracking, fail-closed manifest render written to the §4 release-manifest path convention, **the two ordered opening acts (§5.1/AC-13: record the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`, then the §2.2.6 precondition)**, and the **§2.2 rule 7 named startup failures** ("candidate version unreadable"; "duration bounds unusable" via the AC-14 launch-time bounds validation) — explicit acceptance items (self-verifier cross-checks wired in RRG.4); **(3)** the **§2.2.6 CI-eligibility precondition check** with the "candidate not CI-eligible" refusal state (AC-11) — explicit acceptance item; **(4)** the **refusal-record writer** implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) — per-event filenames `<refused_at compact UTC>-<refusal_point>.json` under `release/refusals/<tag_candidate>/`, refusing to overwrite an existing record (§2.2 rule 6); built once here, reused by RRG.4 — explicit acceptance item; **(5)** short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary) | — | Cipher |
+| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the benchmark/smoke instances of the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, smoke+benchmark duration bounds — declaring their `release/duration-bounds.json` entries per AC-14/§2.3.5, evidence-row counts) emitting `fail`/`measurement-anomaly`; the testbed-scoped duration-bounds instance is RRG.3a's (one row below) | RRG.1 | Cipher |
+| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`, declares the testbed entry of `release/duration-bounds.json` per AC-14/§2.3.5; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, **the AC-14 duration-bounds artifact validation (launch-time gate on the committed [release-duration-bounds.schema.json](release-duration-bounds.schema.json), the "duration bounds unusable" named startup failure, and the emission-time re-validation)**, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13, AC-14). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — the §4 lookup algorithm with both fail-closed edges (zero READY matches / more than one READY match), READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -1090,10 +1167,11 @@ owns; no sprint-local reinterpretation.
     both §6 rows).
   - M1r9 (refusal-record candidate block lagged the manifest's) →
     refusal schema's `tag_candidate` now patterned `^v\d+\.\d+\.0$`
-    (same shape, same candidate) and an OPTIONAL `workspace_version`
-    (patterned `X.Y.Z`) added — present when the refusal fired after
-    the gate's first opening act recorded it, absent for a pre-launch
-    refusal that fired before the version was read.
+    (same shape, same candidate) and a `workspace_version`
+    (patterned `X.Y.Z`) added. *(Corrected in r11 per I1r10: the field
+    is REQUIRED — Act 1 always precedes any refusal point, so the
+    original present-when/absent-when framing was impossible under the
+    plan's own ordering.)*
   - M2r9 (cross-attempt uniqueness assumed serialized launches) → AC-13
     states the §5 single-runner serialized-launch **precondition**
     explicitly: gate launches are serialized; concurrent launches are
@@ -1103,3 +1181,62 @@ owns; no sprint-local reinterpretation.
     REJECTED, record without `workspace_version` still VALID (optional),
     record with malformed `workspace_version` REJECTED; all manifest
     probes unchanged.
+- **r11 (2026-09-01, fix round for quality-mgr r10 FAIL @ 1b18cb1b4 —
+  1B/4I/3M; r9 dispositions 4 Fixed / 2 Partial)**:
+  - B1r10 (duration-bounds artifact named but not contracted — the
+    B1r7/B2r8 unowned-normative-artifact class) → committed
+    **`release-duration-bounds.schema.json`** + worked example
+    (`release-duration-bounds.example.json`): closed catalog, exactly
+    one `min_seconds`/`max_seconds` entry per §3 suite, required
+    `revision`/`approved_by`/`approved_at` approval marker per the §3.2
+    `baselines.json` revision convention (unapproved seed cannot
+    validate). New **AC-14** owns shape, launch-time validation with
+    the fail-closed named startup failure **"duration bounds unusable"**
+    (missing file / schema-invalid / missing entry / `min >= max` —
+    harness defect, never silent skip), emission-time re-validation,
+    and RRG.2/RRG.3a entry-declaration + RRG.4 wiring ownership (all
+    three §6 rows updated).
+  - I1r10 (refusal `workspace_version` presence semantics impossible
+    under the plan's own ordering; example violated them) → field now
+    **REQUIRED** (Act 1 always records the version before Act 2 — the
+    only refusal source — can fire); present-when/absent-when framing
+    dropped from schema description, §2.2 rule 6, and the r10 M1r9
+    changelog line (corrected in place); example carries
+    `workspace_version: "1.5.7"`. The genuinely version-less scenario
+    is Act-1 failure — §2.2 rule 7's "candidate version unreadable",
+    not a refusal (I4r10).
+  - I2r10 (AC-12(i) locate step underdefined) → **§4 lookup algorithm**
+    stated in §4 and AC-12(i): glob
+    `site/reports/release-readiness/<tag_candidate>-*/manifest.json`
+    excluding `rehearsal/`, schema-validate matches, require **exactly
+    one** `verdict: "READY"` — zero fails ("no READY manifest for
+    candidate"), more than one fails closed ("ambiguous READY
+    evidence", never an arbitrary pick); RRG.4's AC-12 acceptance item
+    names both edges.
+  - I3r10 (refusal records under one constant-`tag_candidate` dir could
+    silently overwrite, falsifying refused-N-times) → **per-event
+    filename convention** in §2.2 rule 6:
+    `<refused_at compact UTC>-<refusal_point>.json`, writer refuses to
+    overwrite an existing record (fail-closed); named in the RRG.1
+    writer acceptance item.
+  - I4r10 (Act-1 failure had no named state) → new **§2.2 rule 7:
+    named startup failures**, distinct from the refusal taxonomy and
+    INCOMPLETE-by-absence: "candidate version unreadable" (Act-1
+    `Cargo.toml` read failure) and "duration bounds unusable" (AC-14);
+    both are pre-launch aborts — no suites, no manifest, no refusal
+    record, self-describing operator-facing state.
+  - M1r10 (RRG.1 cell consumability) → rewritten as five enumerated
+    deliverables.
+  - M2r10 (seeding discipline repeated verbatim) → canonical statement
+    lives in §2.3.5 + AC-14; §2.3.3 and the §6 rows cross-reference
+    (`per AC-14/§2.3.5`).
+  - M3r10 (min-bound rationale unstated) → §2.3.5 (and the bounds
+    schema description): min flags a short-circuited/truncated
+    workload — work skipped, not speed penalized; max flags a
+    stalled/contaminated run.
+  - Schema + examples revalidated: full probe battery green; new
+    probes — duration-bounds example VALID; missing suite entry,
+    extra non-catalog entry, missing `approved_by`/`revision`, and
+    malformed bound REJECTED; refusal record without
+    `workspace_version` now REJECTED (required); all prior manifest and
+    refusal probes unchanged.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -154,7 +154,12 @@ just release-readiness <release-tag-candidate>
      name is what preserves refused-N-times, and the writer **refuses to
      overwrite an existing file** (fail-closed) rather than ever
      collapsing two refusal events into one record (RRG.1 writer
-     acceptance item, §6). An operator can always distinguish
+     acceptance item, §6). If the computed per-event path already exists
+     (including a same-second collision for the same refusal point), the
+     writer emits the named harness failure `refusal-record-collision`,
+     writes neither record nor manifest, and stops; it never drops,
+     overwrites, or silently suffixes the event. The operator must resolve
+     the collision before re-running the full gate. An operator can always distinguish
      never-launched from refused-N-times, and see why. This record is
      NOT evidence and is never referenced by a manifest; the writer is
      built once in RRG.1 (explicit acceptance item, §6) and **reused —
@@ -268,24 +273,9 @@ The mechanism that makes §1's first-time-pass requirement real:
    anomaly-check set the harness itself runs as part of §2.3.3 (per-family
    D7 clean-run criteria; observed p50 within the family's historical
    sanity band; wall-clock duration within the bounds declared in the
-   committed `release/duration-bounds.json` — the bounds' single source
-   of truth, one min/max entry per catalog suite, contracted by the
-   committed schema
-   [release-duration-bounds.schema.json](release-duration-bounds.schema.json)
-   (worked example:
-   [release-duration-bounds.example.json](release-duration-bounds.example.json))
-   and owned by **AC-14**: seeded from the durations of historical
-   committed evidence runs and Rand-approved before first use, exactly
-   the §3.2 `baselines.json` revision convention — mechanized via the
-   schema's required `revision`/`approved_by`/`approved_at` fields, so
-   an unapproved seed cannot validate (never self-seeded by the harness;
-   a bounds revision is a reviewed commit, never a run-time adjustment).
-   The **min** bound flags a short-circuited or truncated workload — a
-   suite finishing implausibly fast means work was skipped, not that a
-   genuine speedup is penalized; the **max** bound flags a stalled or
-   contaminated run. RRG.2 declares the smoke + benchmark
-   entries, RRG.3a the testbed entry (AC-14); evidence-row
-   counts matching the declared workload). Any anomaly-check hit is emitted
+   committed `release/duration-bounds.json`; its contract, approval and
+   seeding discipline, bound semantics, and ownership are defined once in
+   **AC-14** below. Any anomaly-check hit is emitted
    by the harness as suite `fail` with `fail_reason:
    "measurement-anomaly"`, which is treated as a harness/environment defect:
    fix the check or the environment and re-run — it is never a manual
@@ -398,7 +388,11 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   `ref/release-state-strategy.md` (readiness preflight before a `main`
   merge) — must, **mechanically** (RRG.4 delivers the check as code the
   preflight invokes, not checklist prose; §2.3 no-clerical mandate
-  applies), before authorizing the `main` merge: (i) locate the
+  applies), before authorizing the `main` merge. The template's
+  `release_readiness_manifest_path` is the release-evidence manifest
+  destination for this check; its existing `manifest_path` variable
+  remains the unrelated publish-channel manifest. The preflight must then,
+  mechanically: (i) locate the
   committed `run_kind: "release"` manifest via the **§4 lookup
   algorithm** — the preflight holds only `tag_candidate`, so it globs
   `site/reports/release-readiness/<tag_candidate>-*/manifest.json`
@@ -422,9 +416,11 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - AC-13: **per-attempt version distinctness is mechanized (§5.1
   patch++).** The manifest's `candidate` block carries a required
   `workspace_version` (schema-patterned `X.Y.Z`): the orchestrator
-  records it from the checked-out gated tree's `Cargo.toml`
-  `[workspace.package] version` as the first of the gate's two ordered
-  opening acts (§5.1: record version, then §2.2.6 precondition), and
+  records it by reusing the existing
+  `.just/run_version.py::workspace_version(repo_root)` reader (the same
+  reader used by `just version current`), against the checked-out gated
+  tree as the first of the gate's two ordered opening acts (§5.1: record
+  version, then §2.2.6 precondition), and
   the §2.3.3 self-verifier
   (i) cross-checks the manifest value against that `Cargo.toml` value
   and (ii) refuses emission if any previously committed
@@ -454,13 +450,16 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   of the check), and the §2.3.3 self-verifier re-validates the artifact
   at emission time as defense-in-depth; and (iii) carry the mechanized
   approval marker — schema-required `revision`, `approved_by`,
-  `approved_at` fields per the §3.2 `baselines.json` revision
+  `effective_from` fields per the §3.2 `baselines.json` revision
   convention (e.g. revision 1, approved 2026-08-31) — so an unapproved
   or self-seeded bounds file cannot validate; a bounds revision is a
-  reviewed commit, never a run-time adjustment. Ownership: RRG.2
-  declares the smoke + benchmark entries, RRG.3a the testbed entry,
-  RRG.4 wires launch-time validation, the emission-time re-validation,
-  and the named startup failure.
+  reviewed commit, never a run-time adjustment. Ownership: RRG.1 owns the
+  launch-time validation and named startup failure; RRG.2 declares the
+  smoke + benchmark entries, RRG.3a the testbed entry, and RRG.4 wires the
+  emission-time re-validation. The **min** bound flags a short-circuited
+  or truncated workload — an implausibly fast suite means work was skipped,
+  not that a genuine speedup is penalized; the **max** bound flags a stalled
+  or contaminated run.
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -712,7 +711,8 @@ direction.
   against the intended `develop` commit. Nothing triggers the gate
   automatically. The gate's **first two acts, in order** (neither is a
   separate manual step): (1) record the gated tree's `Cargo.toml`
-  workspace version into `candidate.workspace_version` (AC-13);
+  workspace version into `candidate.workspace_version` (AC-13) by reusing
+  the existing `.just/run_version.py::workspace_version(repo_root)` reader;
   (2) run the §2.2.6 CI-eligibility precondition.
 - **Version-number management (Rand, 2026-08-31): patch++ per gate run;
   the minor bump is gated BEHIND a passing run, never ahead of it.**
@@ -779,11 +779,11 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Gate foundation — five enumerated deliverables: **(1)** manifest schema, lifted from this plan's committed baseline **including the suite_id-scoped `fail_reason` subsets** (per-suite schema conditionals); **(2)** `just release-readiness` orchestrator skeleton — suite registry, terminal-state tracking, fail-closed manifest render written to the §4 release-manifest path convention, **the two ordered opening acts (§5.1/AC-13: record the gated tree's `Cargo.toml` workspace version into `candidate.workspace_version`, then the §2.2.6 precondition)**, and the **§2.2 rule 7 named startup failures** ("candidate version unreadable"; "duration bounds unusable" via the AC-14 launch-time bounds validation) — explicit acceptance items (self-verifier cross-checks wired in RRG.4); **(3)** the **§2.2.6 CI-eligibility precondition check** with the "candidate not CI-eligible" refusal state (AC-11) — explicit acceptance item; **(4)** the **refusal-record writer** implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) — per-event filenames `<refused_at compact UTC>-<refusal_point>.json` under `release/refusals/<tag_candidate>/`, refusing to overwrite an existing record (§2.2 rule 6); built once here, reused by RRG.4 — explicit acceptance item; **(5)** short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary) | — | Cipher |
+| RRG.1 | Gate foundation — five enumerated deliverables: **(1)** manifest schema, lifted from this plan's committed baseline **including the suite_id-scoped `fail_reason` subsets** (per-suite schema conditionals); **(2)** `just release-readiness` orchestrator skeleton — suite registry, terminal-state tracking, fail-closed manifest render written to the §4 release-manifest path convention, **the two ordered opening acts (§5.1/AC-13: reuse `.just/run_version.py::workspace_version(repo_root)` to record the gated tree's workspace version into `candidate.workspace_version`, then the §2.2.6 precondition)**, and the **§2.2 rule 7 named startup failures** ("candidate version unreadable"; "duration bounds unusable" via the AC-14 launch-time bounds validation) — explicit acceptance items (self-verifier cross-checks wired in RRG.4); **(3)** the **§2.2.6 CI-eligibility precondition check** with the "candidate not CI-eligible" refusal state (AC-11) — explicit acceptance item; **(4)** the **refusal-record writer** implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) — per-event filenames `<refused_at compact UTC>-<refusal_point>.json` under `release/refusals/<tag_candidate>/`, refusing to overwrite an existing record and failing as `refusal-record-collision` on a same-second same-point collision (§2.2 rule 6); built once here, reused by RRG.4 — explicit acceptance item; **(5)** short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary) | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the benchmark/smoke instances of the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, smoke+benchmark duration bounds — declaring their `release/duration-bounds.json` entries per AC-14/§2.3.5, evidence-row counts) emitting `fail`/`measurement-anomaly`; the testbed-scoped duration-bounds instance is RRG.3a's (one row below) | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)**, **owns the testbed-scoped wall-clock duration-bounds anomaly check** (validates §3.3's one-continuous-session guarantee, emits `fail`/`measurement-anomaly`, declares the testbed entry of `release/duration-bounds.json` per AC-14/§2.3.5; wired into whole-set self-verification by RRG.4), and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, **the AC-14 duration-bounds artifact validation (launch-time gate on the committed [release-duration-bounds.schema.json](release-duration-bounds.schema.json), the "duration bounds unusable" named startup failure, and the emission-time re-validation)**, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13, AC-14). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — the §4 lookup algorithm with both fail-closed edges (zero READY matches / more than one READY match), READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), the suite_id↔`fail_reason` compatibility re-check, the RRG.3a testbed duration-bounds check, **the AC-14 emission-time re-validation of the committed [release-duration-bounds.schema.json](release-duration-bounds.schema.json) artifact**, the AC-13 `workspace_version` cross-checks (Cargo.toml match + cross-attempt uniqueness), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11, AC-13, AC-14). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** **Explicit acceptance item (AC-12): the publisher readiness preflight invokes an RRG.4-delivered mechanized check — the §4 lookup algorithm with both fail-closed edges (zero READY matches / more than one READY match), READY-manifest schema validation, bump-only diff (gated commit ↔ candidate tag commit), and binding `tag_candidate` ↔ tag-version equality — as code, not checklist prose; the release gate is not deliverable without it.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -1188,7 +1188,7 @@ owns; no sprint-local reinterpretation.
     **`release-duration-bounds.schema.json`** + worked example
     (`release-duration-bounds.example.json`): closed catalog, exactly
     one `min_seconds`/`max_seconds` entry per §3 suite, required
-    `revision`/`approved_by`/`approved_at` approval marker per the §3.2
+    `revision`/`approved_by`/`effective_from` approval marker per the §3.2
     `baselines.json` revision convention (unapproved seed cannot
     validate). New **AC-14** owns shape, launch-time validation with
     the fail-closed named startup failure **"duration bounds unusable"**
@@ -1227,16 +1227,37 @@ owns; no sprint-local reinterpretation.
     record, self-describing operator-facing state.
   - M1r10 (RRG.1 cell consumability) → rewritten as five enumerated
     deliverables.
-  - M2r10 (seeding discipline repeated verbatim) → canonical statement
-    lives in §2.3.5 + AC-14; §2.3.3 and the §6 rows cross-reference
-    (`per AC-14/§2.3.5`).
-  - M3r10 (min-bound rationale unstated) → §2.3.5 (and the bounds
-    schema description): min flags a short-circuited/truncated
-    workload — work skipped, not speed penalized; max flags a
-    stalled/contaminated run.
+  - M2r10 (seeding discipline repeated verbatim) → r12 consolidated the
+    policy at AC-14; §2.3.5 and the §6 rows now cross-reference that one
+    canonical acceptance site.
+  - M3r10 (min-bound rationale unstated) → AC-14 (and the bounds schema
+    description): min flags a short-circuited/truncated workload — work
+    skipped, not speed penalized; max flags a stalled/contaminated run.
   - Schema + examples revalidated: full probe battery green; new
     probes — duration-bounds example VALID; missing suite entry,
     extra non-catalog entry, missing `approved_by`/`revision`, and
     malformed bound REJECTED; refusal record without
     `workspace_version` now REJECTED (required); all prior manifest and
     refusal probes unchanged.
+- **r12 (2026-09-02, fix round for quality-mgr r11 FAIL @ 49a4ff987 —
+  M2r10 plus 2I/3M)**:
+  - M2r10 / ATM-QA-001 → AC-14 is the single canonical duration-bounds
+    policy site; §2.3.5 now contains only the anomaly-check cross-reference.
+  - ATM-QA-002 → a same-second, same-refusal-point filename collision is
+    an explicit `refusal-record-collision` harness failure: neither record
+    nor manifest is written, and the event is never overwritten, dropped,
+    or silently suffixed.
+  - ARCH-001 → AC-14 assigns launch-time bounds validation and its named
+    startup failure to RRG.1, while RRG.4 owns only emission-time
+    re-validation, matching the §6 ownership row.
+  - RBQA-F011a → renamed the bounds approval timestamp to
+    `effective_from`, matching the §3.2 `baselines.json` convention in the
+    schema, example, and plan.
+  - RBQA-F011b → AC-13 and §5.1 explicitly reuse
+    `.just/run_version.py::workspace_version(repo_root)`; no parallel
+    `Cargo.toml` reader is authorized.
+  - RBQA-F011c → preflight now carries distinct
+    `release_readiness_manifest_path` and `manifest_path` destinations;
+    the former is the release-evidence manifest and the latter remains the
+    publish-channel manifest. The template fixture and evaluation guidance
+    cover both names.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -96,6 +96,19 @@ just release-readiness <release-tag-candidate>
      `testbed_definitions.commit_sha` must identify the tier-definition
      revision actually executed, 1:1 (§3.3) — otherwise the testbed suite is
      `fail` with `fail_reason: "tier-definitions-mismatch"`.
+6. **CI-eligibility precondition** (distinct from INCOMPLETE-by-absence):
+   before launching any suite, the runner verifies that all seven §3.4
+   repo-suite CI runs are green (`success`) on the exact candidate commit —
+   a cheap API check, no test execution. If any is red or missing, the gate
+   refuses to launch with the named state **"candidate not CI-eligible"**:
+   no suite runs, no evidence is produced, and nothing is discarded. A red
+   CI run is a genuine product/test failure, but it terminated in CI and is
+   recorded there — CI itself is its evidence channel; the gate surfaces it
+   pre-launch instead of erasing hours of suite evidence after the fact.
+   INCOMPLETE-by-absence stays scoped to rule 1's definition (a suite that
+   never reached a terminal state mid-run). The manifest's `ci_runs[]`
+   records the verified-green runs; a non-green conclusion is deliberately
+   unrepresentable there because the launch never happens.
 
 ### 2.3 First-time-pass enforcement (no clerical QA rounds)
 
@@ -117,8 +130,11 @@ The mechanism that makes §1's first-time-pass requirement real:
 3. **Whole-set self-verification.** Before rendering a verdict, the gate
    re-validates the complete evidence set + manifest exactly as QA would:
    schema, sha256s, provenance fields, cross-references, reports-index,
-   duplicate-`suite_id` rejection (the schema's `contains` clauses enforce
-   at-least-once; exactly-once is completed here), **the §2.3.5
+   duplicate-`suite_id` rejection in **both `suites[]` and `ci_runs[]`**
+   (the schema's `contains` + `maxItems` clauses already mechanize
+   exactly-once; this re-check is defense-in-depth), **the floors
+   cross-check** (every §3.2 tracked metric of a pass-terminal benchmark
+   suite has a `floors[]` row for its family), **the §2.3.5
    anomaly-check set** (per-family D7 clean-run criteria, historical p50
    sanity band, wall-clock duration bounds, evidence-row counts vs declared
    workload — built in RRG.2, wired into this self-verification in RRG.4),
@@ -186,12 +202,12 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - AC-1: one launch (`just release-readiness <tag-candidate>`) drives every
   declared suite to a terminal state without operator input (§2.1, §2.2.1).
 - AC-2: manifest written only after all suites terminal; validates against
-  the committed schema **and** the §2.3.3 self-verifier (schema enforces
-  every catalog suite at-least-once; the self-verifier completes
-  exactly-once via duplicate-`suite_id` rejection — AC-7); verdict
-  `READY`/`NOT-READY` only — an incomplete run writes no manifest,
-  INCOMPLETE-by-absence; the manifest is the sole release-evidence pointer
-  (§2.2.1, §2.2.2, §4).
+  the committed schema **and** the §2.3.3 self-verifier (the schema
+  mechanizes exactly-once catalog completeness for `suites[]` and
+  `ci_runs[]` via `contains` + `maxItems`; the self-verifier re-checks
+  duplicates as defense-in-depth — AC-7); verdict `READY`/`NOT-READY`
+  only — an incomplete run writes no manifest, INCOMPLETE-by-absence; the
+  manifest is the sole release-evidence pointer (§2.2.1, §2.2.2, §4).
 - AC-3: `READY` requires all suites `pass` or Rand-approved
   `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3);
   anything else renders `NOT-READY`.
@@ -205,11 +221,13 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   definitions (§2.2.5).
 - AC-6: validate-at-emit in every suite adapter (§2.3.2).
 - AC-7: self-verification covers schema, sha256s, provenance,
-  cross-references, reports-index, duplicate-`suite_id` rejection
-  (exactly-once catalog completion), the §2.3.5 anomaly-check set
-  (checks built in RRG.2, wired in RRG.4), tier-row `detail` populated
-  and conformant to the RRG.3a tier-row schema (§3.3), version
-  sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
+  cross-references, reports-index, duplicate-`suite_id` rejection in both
+  `suites[]` and `ci_runs[]` (defense-in-depth behind the schema's
+  exactly-once), the floors cross-check (every §3.2 tracked metric of a
+  pass-terminal benchmark suite has a `floors[]` row), the §2.3.5
+  anomaly-check set (checks built in RRG.2, wired in RRG.4), tier-row
+  `detail` populated and conformant to the RRG.3a tier-row schema (§3.3),
+  version sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
 - AC-8: rehearsal mode green, `run_kind` separation enforced both
   directions, rehearsal output confined to the rehearsal root (§2.3.4).
 - AC-9: hosts per §2.4; shared daemon and interactive accounts untouched.
@@ -217,6 +235,13 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   a standing skip (§7.4, §8 Q3); tier-level dispositions (per-tier state
   incl. declared-skip, skip-vs-1:1 rule) are encoded per the RRG.3a
   tier-row schema (§3.3).
+- AC-11: `ci_runs` closed seven-id catalog, each entry exactly once with
+  `conclusion: "success"` pinned to the candidate commit (schema), and the
+  §2.2.6 CI-eligibility precondition: all seven runs verified green
+  **before any suite launches** — a red/missing run refuses the launch
+  ("candidate not CI-eligible", distinct from INCOMPLETE-by-absence);
+  never `READY`, and never evidence discarded, over a red repo suite
+  (§2.2.6, §3.4, §4).
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -255,7 +280,8 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - Fixture: https://github.com/randlee/atm-hermes-testbed (Colima test
   fixture; tier definitions in testbed PR #2, tiers AT0–AT8).
 - Entry: testbed runner, full tier set (prompt tiers + infra tiers),
-  executed in one continuous session. The build under test is decided by
+  executed in one continuous session (validated by the §2.3.5 wall-clock
+  duration-bounds anomaly check). The build under test is decided by
   Rand at plan review (§8 Q2: tagged candidate build only, or also
   integrate builds); this plan does not preempt that decision.
 - Evidence: committed under an `evidence/…` branch/dir in atm-core exactly
@@ -281,20 +307,24 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 
 ### 3.4 Repo test suites (recorded, not re-run)
 
-- Closed catalog, manifest `ci_runs[].suite_id` ids in parentheses:
-  `just ci` (lint + test → `just-ci`), test-graft-python
+- Closed catalog of seven, manifest `ci_runs[].suite_id` ids in
+  parentheses: `just ci` (lint + test → `just-ci`), test-graft-python
   (`test-graft-python`), test-hermes-graft-bridge
   (`test-hermes-graft-bridge`), test-hermes-graft-smoke
   (`test-hermes-graft-smoke`), test-admission-capacity
-  (`test-admission-capacity`), and test-queue-hooks-python + codex variant
-  (recorded as one entry, `test-queue-hooks`).
-- The gate records the green CI run ids for the exact release-candidate
-  commit in the manifest instead of re-executing them on the evidence
-  host. The schema requires all six catalog entries with
-  `conclusion: "success"`: a missing or non-green repo suite means no
-  manifest can be emitted for the launch (INCOMPLETE-by-absence) — a
-  partial `ci_runs` set is schema-invalid, never a silently reduced
-  evidence bar.
+  (`test-admission-capacity`), test-queue-hooks-python
+  (`test-queue-hooks-python`), and test-queue-hooks-codex
+  (`test-queue-hooks-codex`). The queue-hooks variants are **separate
+  entries, each independently green** — there is no combined entry and no
+  combination rule to get wrong.
+- CI-greenness of all seven runs on the exact release-candidate commit is
+  the §2.2.6 **pre-launch eligibility check**: a red or missing run
+  refuses the launch ("candidate not CI-eligible") before any suite
+  executes — the red run's evidence lives in CI itself. The gate records
+  the verified-green run ids in the manifest instead of re-executing them
+  on the evidence host; the schema requires all seven entries exactly once
+  with `conclusion: "success"`, so a partial `ci_runs` set is
+  schema-invalid, never a silently reduced evidence bar.
 
 ## 4. Release evidence manifest
 
@@ -315,11 +345,13 @@ Summary of the committed schema (normative source is the schema file):
 - `candidate` — tag-candidate, 40-hex commit SHA, branch;
 - `testbed_definitions` — pinned testbed repo + commit SHA (AC-5;
   top-level **required**);
-- `suites[]` — **closed catalog**: `suite_id` is the enum
-  `smoke-full` / `benchmark-send` / `benchmark-read-query` /
-  `testbed-integration`, and four `contains` clauses require every catalog
-  suite to be present (duplicate `suite_id` rejection is a §2.3.3
-  self-verifier check). Per suite: entrypoint, terminal state
+- `suites[]` — **closed catalog, exactly-once schema-mechanized**:
+  `suite_id` is the enum `smoke-full` / `benchmark-send` /
+  `benchmark-read-query` / `testbed-integration`; four `contains` clauses
+  require every catalog suite present and `maxItems: 4` forbids any
+  duplicate (the §2.3.3 self-verifier re-checks duplicate `suite_id`
+  rejection in both `suites[]` and `ci_runs[]` as defense-in-depth).
+  Per suite: entrypoint, terminal state
   (`pass`/`fail`/`declared-skip`), evidence paths each with sha256, and
   start/end timestamps. Conditionals: `pass`/`fail` **require** `host` +
   the execution-identity provenance object (AC-4); `fail` **requires**
@@ -334,15 +366,22 @@ Summary of the committed schema (normative source is the schema file):
   p50, met flag, optional ratchet proposal (harness-computed, §2.3.5).
   **Convention (schema-enforced): `ratchet_proposal` may be present only
   when `met` is true** — the harness never proposes ratcheting from a
-  breached measurement;
-- `ci_runs[]` — **closed repo-suite catalog** (§3.4): `suite_id` is the
-  enum `just-ci` / `test-graft-python` / `test-hermes-graft-bridge` /
-  `test-hermes-graft-smoke` / `test-admission-capacity` /
-  `test-queue-hooks` (covering both python and codex variants), all six
-  required present via `contains` clauses, each with run id and
-  `conclusion` fixed to `success` (only green runs are recordable — a
-  missing/non-green repo suite means the gate refuses to emit a manifest),
-  pinned to the candidate commit;
+  breached measurement. Family-level completeness is schema-mechanized
+  (`contains` clauses require at least one `send` and one `read-query`
+  row); metric-level completeness (every §3.2 tracked metric of a
+  pass-terminal benchmark suite has a floors row) is a named §2.3.3
+  self-verifier cross-check;
+- `ci_runs[]` — **closed repo-suite catalog, exactly-once
+  schema-mechanized** (§3.4): `suite_id` is the seven-id enum (`just-ci`,
+  `test-graft-python`, `test-hermes-graft-bridge`,
+  `test-hermes-graft-smoke`, `test-admission-capacity`,
+  `test-queue-hooks-python`, `test-queue-hooks-codex` — the queue-hooks
+  variants are separate, independently green entries); seven `contains`
+  clauses + `minItems`/`maxItems: 7` require each exactly once, each with
+  run id and `conclusion` fixed to `success`, pinned to the candidate
+  commit. Greenness is verified pre-launch (§2.2.6 CI-eligibility
+  precondition) — a red/missing run refuses the launch, so a non-green
+  conclusion is unrepresentable in a manifest;
 - `verdict` — `READY` / `NOT-READY` only. `INCOMPLETE` is deliberately
   unrepresentable: an incomplete run writes no manifest at all
   (INCOMPLETE-by-absence, §2.2.1);
@@ -381,11 +420,11 @@ direction.
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state — AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set and duplicate-`suite_id` rejection into §2.3.3 whole-set self-verification** (AC-7). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, and the floors cross-check into §2.3.3 whole-set self-verification** (AC-7). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -523,3 +562,35 @@ owns; no sprint-local reinterpretation.
   both examples VALID, 6 new negative cases (partial ci_runs, non-green
   run, fail_reason-on-pass, skip_reason-on-fail, fail_reason-on-skip,
   ratchet-on-unmet-floor) verified REJECTED.
+- **r5 (2026-08-31, addressing quality-mgr r4 FAIL @ 8f354e2d2, msg
+  01M1DB4VKZH2BVDCR2VR7EC18T; all 10 r3 findings scored FIXED)**:
+  B1r4 `ci_runs` catalog had no §2.5 acceptance criterion → new AC-11
+  (closed seven-id catalog, exactly-once, const-success, §2.2.6
+  precondition), cross-referenced from §3.4/§4; precondition check owned
+  by RRG.1 (§6 cell). B2r4 red-CI runs were an evidentiary blackhole
+  (const-success unrecordable ⇒ INCOMPLETE-by-absence overloaded) —
+  design choice delegated to fenix, option (b) chosen → §2.2 rule 6
+  CI-eligibility precondition: before any suite launches, all seven §3.4
+  repo-suite runs are verified green on the exact candidate commit; a
+  red/missing run refuses the launch with the distinct named state
+  "candidate not CI-eligible" (no suite runs, no evidence produced,
+  nothing discarded — the red run's evidence lives in CI itself);
+  INCOMPLETE-by-absence stays scoped to §2.2.1's definition. I1r4
+  duplicate-`suite_id` scoping ambiguous → exactly-once is now
+  schema-mechanized for BOTH arrays (`contains` + `maxItems`: suites 4,
+  ci_runs 7); self-verifier duplicate rejection retained as
+  defense-in-depth, named for both arrays in §2.3.3/AC-2/AC-7. I2r4
+  floors had no completeness guard → schema: `minItems: 2` + `contains`
+  send + `contains` read-query (family-level); metric-level completeness
+  (every §3.2 tracked metric of a pass-terminal benchmark suite has a
+  floors row) added as a named §2.3.3/AC-7 self-verifier cross-check.
+  I3r4 queue-hooks python/codex combination rule was a clerical trap →
+  resolved MORE mechanically than suggested: split into two catalog ids
+  (`test-queue-hooks-python`, `test-queue-hooks-codex`; 7-id catalog),
+  each independently green — no combined entry, no combination rule to
+  get wrong (§3.4, schema enum). M1r4 §3.3 "one continuous session"
+  unverifiable → cross-referenced to the §2.3.5 wall-clock
+  duration-bounds anomaly check. All schema changes revalidated: both
+  examples VALID (each now carries all seven ci_runs), 5 new negative
+  cases (duplicate suites row, duplicate ci_runs row, 6-of-7 ci_runs,
+  missing read-query floor, empty floors) verified REJECTED.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -120,25 +120,53 @@ just release-readiness <release-tag-candidate>
      manifest never asserts a conclusion that is red at
      release-decision time. Suite evidence on disk is not discarded, but
      per §2.2.2 it is not release evidence without a validated manifest.
+     **Re-launch economics (explicit decision):** an emission-time refusal
+     ends the run; there is no resume path. Re-emitting a manifest after
+     the candidate is green again means re-running the full gate — the
+     accepted cost, because evidence integrity (one continuous gate run
+     per manifest, §2.3.5 duration-bounds anomaly check included) outranks
+     re-run economics. A resume/evidence-caching mechanism is deliberately
+     out of scope; introducing one later is a plan revision, not an
+     implementation choice.
      Ownership: RRG.1 owns the pre-launch check; RRG.4 wires the
      emission-time re-check into §2.3.3 self-verification (AC-11).
    - **Refusal is observable.** Every refusal (pre-launch or
-     emission-time) writes a minimal **refusal record** — a status
-     artifact outside the evidence roots (never under `site/reports/`)
-     naming the candidate (tag + commit SHA), a timestamp, the refusal
-     point (pre-launch | emission), and the exact red/missing run ids.
-     An operator can always distinguish never-launched from
-     refused-N-times, and see why. This record is NOT evidence and is
-     never referenced by a manifest; producing it is an explicit RRG.1
-     acceptance item (§6).
+     emission-time) writes a **refusal record** conforming to the
+     committed schema
+     [release-refusal-record.schema.json](release-refusal-record.schema.json)
+     (worked example:
+     [release-refusal-record.example.json](release-refusal-record.example.json)):
+     candidate (tag + 40-hex commit SHA + branch), `refused_at`
+     timestamp, `refusal_point` (`pre-launch` | `emission`), and the
+     exact red/missing runs (`ci_runs_not_green`, red entries citing the
+     run id, missing entries citing none). An emission-point record MAY
+     additionally list informational `suite_evidence_paths` already
+     produced on disk (never sha256'd, never evidence — the record must
+     not grow into a shadow manifest); a pre-launch record must not.
+     **Path convention:** records are written under
+     `release/refusals/<tag_candidate>/` — outside the evidence roots,
+     never under `site/reports/`. An operator can always distinguish
+     never-launched from refused-N-times, and see why. This record is
+     NOT evidence and is never referenced by a manifest; the writer is
+     built once in RRG.1 (explicit acceptance item, §6) and **reused —
+     not re-implemented — by RRG.4** for the emission point (explicit
+     RRG.4 acceptance item, §6).
    - **Rehearsal carve-out.** For `run_kind: "rehearsal"` (§2.3.4) the
      precondition and the emission-time re-check are **synthesized, not
      fetched**: no GitHub API call is made; the rehearsal harness
      fabricates the seven `ci_runs[]` rows with sentinel run ids
-     (1 through 7) and `commit_sha` = the rehearsal HEAD, `conclusion`
+     (1 through 7) and `commit_sha` set to the actual git HEAD commit SHA
+     of the tree at rehearsal invocation time, `conclusion`
      `success`. This is safe because rehearsal manifests are structurally
      non-evidence (rehearsal root + two-way refusal, §2.3.4), and it keeps
      RRG.4's green-rehearsal acceptance gate independent of live CI state.
+     Accepted residual: beyond `run_kind` and harness discipline, the
+     §2.3.4 two-way direction check (rehearsal output confined to the
+     rehearsal root, release manifests refusing rehearsal-root paths) is
+     the **sole** safeguard distinguishing a sentinel-bearing manifest
+     from release evidence — `run_id` values are not independently
+     validated against GitHub. This is a recorded acceptance, not an
+     oversight.
 
 ### 2.3 First-time-pass enforcement (no clerical QA rounds)
 
@@ -250,17 +278,28 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   manifest is the sole release-evidence pointer (§2.2.1, §2.2.2, §4).
 - AC-3: `READY` requires all suites `pass` or Rand-approved
   `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3);
-  anything else renders `NOT-READY`. A declared-skip of a benchmark family
-  drops that family's `floors[]` requirement (schema-conditional, §4) —
-  the skip never forces a fabricated measurement.
+  anything else renders `NOT-READY`. The `floors[]` requirement for a
+  benchmark family is schema-conditional on that family having **produced
+  a measurement** (§4): required for `pass` or `fail` with a
+  measurement-bearing `fail_reason` (`floor-breach`, `test-failure`,
+  `measurement-anomaly`, `provenance-missing`); NOT required for
+  `declared-skip` or for `fail`/`suite-error` (the suite could not
+  execute, §2.2.5/AC-5) — the schema never forces fabricating a
+  measurement that never ran.
 - AC-4: every executed suite (`pass`/`fail`) carries `host` + in-band
   execution-identity provenance — schema-required, so
   missing provenance ⇒ suite `fail` (`provenance-missing`); a
   `declared-skip` must NOT carry host/identity; never `READY` with a
-  provenance gap (§2.2.4, §4).
+  provenance gap (§2.2.4, §4). For a `fail` row whose suite never ran
+  (`suite-error`), the provenance identifies the **runner process that
+  adjudicated the terminal state** (the orchestrator's own
+  host/identity) — always real, never fabricated, so requiring it for
+  every `fail` does not recreate the fabricate-or-reject class.
 - AC-5: mechanical READY-refusal for absent declared benchmark families
   (suite `fail`/`suite-error`) and unpinned/mismatched testbed tier
-  definitions (§2.2.5).
+  definitions (§2.2.5). A `fail`/`suite-error` benchmark row is
+  schema-valid **without** a `floors[]` row (AC-3/§4): the mandated
+  NOT-READY path never demands a fabricated measurement.
 - AC-6: validate-at-emit in every suite adapter (§2.3.2).
 - AC-7: self-verification covers schema, sha256s, provenance,
   cross-references, reports-index, duplicate-`suite_id` rejection in both
@@ -283,8 +322,10 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   §2.2.6 CI-eligibility precondition: all seven runs verified green
   **before any suite launches** (RRG.1) AND **re-verified at
   manifest-emission time** (RRG.4 self-verification) — a red/missing run
-  at either point refuses with "candidate not CI-eligible" (distinct from
-  INCOMPLETE-by-absence) and writes the §2.2.6 refusal record; never
+  refuses with the point-specific named state ("candidate not CI-eligible"
+  pre-launch; "candidate no longer CI-eligible at emission" at emission —
+  both distinct from INCOMPLETE-by-absence) and writes the §2.2.6 refusal
+  record; never
   `READY`, and never evidence discarded, over a red repo suite — including
   one that went red between launch and emission (§2.2.6, §3.4, §4).
   A refused launch is AC-1's sole carve-out.
@@ -303,7 +344,9 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   become release evidence only when a validated release manifest references
   them.
 - Pass criteria: per-lane pass with no suppressed failures; analyze_logs
-  clean; acceptance per §2.5.
+  clean — both enforced at generation time by the RRG.2 smoke adapter
+  (validate-at-emit, AC-6), same wiring as the other three suites;
+  acceptance per §2.5.
 
 ### 3.2 Benchmarks — full
 
@@ -385,6 +428,11 @@ artifact — [release-evidence-manifest.schema.json](release-evidence-manifest.s
 (a `READY` run with a Rand-approved declared-skip of a benchmark family —
 no floors row for the skipped family, demonstrating the conditional
 floors requirement).
+The §2.2.6 refusal record has its own committed schema and worked
+example — [release-refusal-record.schema.json](release-refusal-record.schema.json)
+and [release-refusal-record.example.json](release-refusal-record.example.json)
+— so RRG.1 and RRG.4 implement one reviewed shape rather than each
+interpreting prose.
 RRG.1 lifts these into their final in-repo home next to the validator; the
 schema content in this plan is the reviewed baseline.
 
@@ -417,14 +465,21 @@ Summary of the committed schema (normative source is the schema file):
   **Convention (schema-enforced): `ratchet_proposal` may be present only
   when `met` is true** — the harness never proposes ratcheting from a
   breached measurement. Family-level completeness is schema-mechanized
-  **conditionally on execution** (root-level `allOf`: a family's suite
-  reaching `pass`/`fail` requires at least one floors row for that
-  family; a Rand-approved `declared-skip` of a benchmark family requires
-  none — the schema never forces fabricating a measurement that never
-  ran, per §2.1/AC-3); metric-level completeness (every §3.2 tracked
+  **conditionally on a produced measurement** (root-level `allOf`: a
+  family's suite reaching `pass`, or `fail` with a measurement-bearing
+  `fail_reason` — `floor-breach`, `test-failure`, `measurement-anomaly`,
+  `provenance-missing` — requires at least one floors row for that
+  family; a Rand-approved `declared-skip` requires none, and neither
+  does `fail`/`suite-error` (the AC-5 absent-family path executed
+  nothing) — the schema never forces fabricating a measurement that
+  never ran, per §2.1/AC-3/AC-5. The measurement-bearing set is a closed
+  whitelist: a future fail_reason defaults to NOT forcing a floors row.
+  Documented probe case: `fail`/`suite-error` with no floors row for
+  that family **validates**; `fail`/`floor-breach` without one is
+  rejected); metric-level completeness (every §3.2 tracked
   metric of a pass-terminal benchmark suite has a floors row) and the
-  forbid direction (no floors row for a non-executed family) are named
-  §2.3.3 self-verifier cross-checks;
+  forbid direction (no floors row for a family that produced no
+  measurement) are named §2.3.3 self-verifier cross-checks;
 - `ci_runs[]` — **closed repo-suite catalog, exactly-once
   schema-mechanized** (§3.4): `suite_id` is the seven-id enum (`just-ci`,
   `test-graft-python`, `test-hermes-graft-bridge`,
@@ -472,15 +527,36 @@ direction.
 - No mid-run team messaging is required; the run is attended only by its
   runner. Findings from a failed gate route through fenix triage as usual.
 
+### 5.1 Release-pipeline placement (trigger and gate point)
+
+- **Trigger (manual, once per candidate):** after the release-candidate
+  tag (`release-candidate-vX.Y.Z`, cut from `develop` via
+  `release-candidate.yml` per the publishing skill's release-state
+  strategy) exists, the operator (§8 Q1) launches
+  `just release-readiness <tag-candidate>` on the evidence host(s).
+  Nothing triggers the gate automatically; the §2.2.6 CI-eligibility
+  precondition is the gate's own first act, not a separate manual step.
+- **Gate point (publisher readiness preflight):** the gate's output — a
+  committed, validated `run_kind: "release"` manifest with
+  `verdict: "READY"` whose `candidate.commit_sha` equals the
+  release-candidate tag commit — becomes a **required input of the
+  publisher's readiness preflight**, i.e. it blocks the `main` merge,
+  before any tag/publish action. No READY manifest for the exact
+  candidate commit ⇒ readiness preflight fails; the final preflight on
+  `main` (exact-commit re-check, candidate-tag ancestry) is unchanged
+  and does not re-run the gate. Wiring the manifest check into the
+  preflight checklist is an RRG.4 documentation deliverable; the
+  publishing skill's preflight remains the enforcement location.
+
 ## 6. Implementation sprints (post-approval, definition→code)
 
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
-| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the non-evidence refusal record (candidate, timestamp, refusal point, red/missing run ids) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
+| RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render, **§2.2.6 CI-eligibility precondition check with the "candidate not CI-eligible" refusal state and the refusal-record writer implementing the committed [release-refusal-record.schema.json](release-refusal-record.schema.json) (path convention `release/refusals/<tag_candidate>/`; built once here, reused by RRG.4) — both explicit acceptance items, AC-11**) + short ADR recording the terminal-state taxonomy, adapter composition model, concurrency model (§5), **and the §2.2.6 CI-eligibility/refusal-state semantics (snapshot-vs-emission verification, refusal observability, INCOMPLETE-vs-refusal boundary)** | — | Cipher |
 | RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
 | RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
 | RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set, duplicate-`suite_id` rejection across both `suites[]` and `ci_runs[]`, the floors cross-check (both directions), and the §2.2.6 emission-time CI re-verification into §2.3.3 whole-set self-verification** (AC-7, AC-11). **Explicit acceptance item: an emission-time refusal invokes the RRG.1 refusal-record writer with `refusal_point: "emission"` — reused, never re-implemented — so the AC-11 emission path cannot silently skip the record.** Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8, using the §2.2 rule 6 rehearsal carve-out — no live GH API dependency) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
 
 RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
 atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
@@ -687,3 +763,54 @@ owns; no sprint-local reinterpretation.
   (send pass without send row; read-query pass without read-query row),
   duplicate rows and 6-of-7 ci_runs still REJECTED; skip-without-floors
   VALID only when the family's suite is declared-skip.
+- **r7 (2026-08-31, addressing quality-mgr r6 FAIL @ 4a6fcb17b, msg
+  01M1DCMPRX5CDQYR98ABDFDFYX; all 6 r5 findings scored FIXED, no
+  regressions; 1B/4I/4M)**: B1r6 `fail`/`suite-error` still forced a
+  fabricated floors row (second instance of the fabricate-or-reject
+  class, probe-confirmed: AC-5's own mandated NOT-READY scenario was
+  schema-unsatisfiable without inventing `observed_p50`) → floors
+  conditionals narrowed to a **produced measurement**: the root `allOf`
+  `if` now fires on `pass` OR `fail` with a measurement-bearing
+  `fail_reason` (`floor-breach`, `test-failure`, `measurement-anomaly`,
+  `provenance-missing` — a closed whitelist, so future fail reasons
+  default to NOT forcing a row); `declared-skip` and `fail`/`suite-error`
+  require none; AC-3/AC-5/§4 updated; documented probe case added
+  (suite-error without floors row validates). Fail-as-single-bucket
+  sweep run over the remaining schema conditionals per quality-mgr's
+  trajectory note: the `pass`/`fail` ⇒ host+execution_identity
+  conditional is intentionally kept (AC-4 note added: for `suite-error`
+  the provenance is the adjudicating runner's own identity — real, not
+  fabricated). I1r6 refusal-state naming contradiction → point-specific
+  names applied consistently ("candidate not CI-eligible" pre-launch,
+  "candidate no longer CI-eligible at emission") at §2.2 rule 6, AC-11,
+  and the schema ci_runs description. I2r6 refusal record had no
+  committed shape → new committed
+  release-refusal-record.schema.json + release-refusal-record.example.json
+  (candidate, refusal_point, refused_at, ci_runs_not_green with
+  red-requires-run_id / missing-forbids-run_id conditionals) and the
+  path convention `release/refusals/<tag_candidate>/`; §2.2 rule 6, §4,
+  and RRG.1 reference the schema instead of prose field lists. I3r6
+  emission path could skip the record → explicit RRG.4 acceptance item:
+  reuse the RRG.1 writer with `refusal_point: "emission"`, never
+  re-implement. I4r6 re-launch economics silent → explicit decision
+  recorded in §2.2 rule 6: no resume path, full re-run accepted
+  (evidence integrity outranks re-run cost); resume/caching is
+  deliberately out of scope and would be a plan revision. M1r6
+  "rehearsal HEAD" → reworded to the actual git HEAD commit SHA at
+  rehearsal invocation time. M2r6 → §3.1 pass criteria explicitly
+  RRG.2-adapter-enforced (validate-at-emit, AC-6). M3r6 → optional
+  informational `suite_evidence_paths` on emission-point refusal records
+  (schema-limited: never on pre-launch records, never sha256'd — the
+  record cannot grow into a shadow manifest). M4r6 → recorded acceptance
+  in §2.2 rule 6: the §2.3.4 two-way direction check is the sole
+  rehearsal/release safeguard; sentinel run_ids are not independently
+  validated. Additionally (Rand question at r7): new §5.1 fixes the
+  gate's release-pipeline placement — manual launch after the
+  release-candidate tag exists; the validated READY manifest for the
+  exact candidate commit is a required input of the publisher's
+  readiness preflight (blocks the `main` merge); final preflight on
+  `main` unchanged. Schema revalidated: all THREE manifest examples +
+  refusal example VALID; new probes — suite-error-without-floors VALID,
+  floor-breach-without-floors REJECTED, pre-launch record with
+  suite_evidence_paths REJECTED, missing-state record with run_id
+  REJECTED; all prior negative cases still REJECTED.

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -88,7 +88,10 @@ just release-readiness <release-tag-candidate>
 5. Mechanical READY-refusal guards (no forbidden path may depend on operator
    discipline):
    - a declared benchmark family absent from the tree (e.g. read/query
-     before PR #1120 merges) ⇒ runner refuses to render `READY`;
+     before PR #1120 merges) ⇒ that family's suite is recorded
+     `fail` with `fail_reason: "suite-error"` (the suite could not
+     execute at all), so the runner mechanically refuses to render
+     `READY`;
    - testbed tier-definition state not pinned and matched — the manifest's
      `testbed_definitions.commit_sha` must identify the tier-definition
      revision actually executed, 1:1 (§3.3) — otherwise the testbed suite is
@@ -114,6 +117,11 @@ The mechanism that makes §1's first-time-pass requirement real:
 3. **Whole-set self-verification.** Before rendering a verdict, the gate
    re-validates the complete evidence set + manifest exactly as QA would:
    schema, sha256s, provenance fields, cross-references, reports-index,
+   duplicate-`suite_id` rejection (the schema's `contains` clauses enforce
+   at-least-once; exactly-once is completed here), **the §2.3.5
+   anomaly-check set** (per-family D7 clean-run criteria, historical p50
+   sanity band, wall-clock duration bounds, evidence-row counts vs declared
+   workload — built in RRG.2, wired into this self-verification in RRG.4),
    **and the testbed evidence-form classes that caused the v1.4.6 churn
    (§7.2/§7.3): every tier row has populated `detail`, version sentinels are
    consistent across prompt files, and executed tiers match the pinned
@@ -178,10 +186,12 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
 - AC-1: one launch (`just release-readiness <tag-candidate>`) drives every
   declared suite to a terminal state without operator input (§2.1, §2.2.1).
 - AC-2: manifest written only after all suites terminal; validates against
-  the committed schema (closed suite catalog present exactly once, verdict
+  the committed schema **and** the §2.3.3 self-verifier (schema enforces
+  every catalog suite at-least-once; the self-verifier completes
+  exactly-once via duplicate-`suite_id` rejection — AC-7); verdict
   `READY`/`NOT-READY` only — an incomplete run writes no manifest,
-  INCOMPLETE-by-absence); is the sole release-evidence pointer (§2.2.1,
-  §2.2.2, §4).
+  INCOMPLETE-by-absence; the manifest is the sole release-evidence pointer
+  (§2.2.1, §2.2.2, §4).
 - AC-3: `READY` requires all suites `pass` or Rand-approved
   `declared-skip`, plus green whole-set self-verification (§2.2.3, §2.3.3);
   anything else renders `NOT-READY`.
@@ -190,17 +200,23 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   missing provenance ⇒ suite `fail` (`provenance-missing`); a
   `declared-skip` must NOT carry host/identity; never `READY` with a
   provenance gap (§2.2.4, §4).
-- AC-5: mechanical READY-refusal for absent declared benchmark families and
-  unpinned/mismatched testbed tier definitions (§2.2.5).
+- AC-5: mechanical READY-refusal for absent declared benchmark families
+  (suite `fail`/`suite-error`) and unpinned/mismatched testbed tier
+  definitions (§2.2.5).
 - AC-6: validate-at-emit in every suite adapter (§2.3.2).
 - AC-7: self-verification covers schema, sha256s, provenance,
-  cross-references, reports-index, tier-row `detail` populated, version
+  cross-references, reports-index, duplicate-`suite_id` rejection
+  (exactly-once catalog completion), the §2.3.5 anomaly-check set
+  (checks built in RRG.2, wired in RRG.4), tier-row `detail` populated
+  and conformant to the RRG.3a tier-row schema (§3.3), version
   sentinels consistent, tiers 1:1 vs pinned definitions (§2.3.3).
 - AC-8: rehearsal mode green, `run_kind` separation enforced both
   directions, rehearsal output confined to the rehearsal root (§2.3.4).
 - AC-9: hosts per §2.4; shared daemon and interactive accounts untouched.
 - AC-10: AT2 unresolved (#1121) ⇒ testbed suite `fail`, unless Rand grants
-  a standing skip (§7.4, §8 Q3).
+  a standing skip (§7.4, §8 Q3); tier-level dispositions (per-tier state
+  incl. declared-skip, skip-vs-1:1 rule) are encoded per the RRG.3a
+  tier-row schema (§3.3).
 
 ## 3. Suite inventory (definition — existing tests only)
 
@@ -249,15 +265,36 @@ This checklist is the one place gate acceptance lives; §3 pass criteria and
   (digest/SHA/CI run id) recorded in-band; version sentinels consistent
   across prompt files; tier definitions pinned by testbed commit SHA in the
   manifest (`testbed_definitions`) and matched 1:1 by the executed set.
-- AT2/AT3 handling per §7.4 and AC-10.
+- **Tier-row evidence schema (RRG.3a acceptance deliverable)**: the
+  per-tier artifact — the exact evidence-form class that caused the v1.4.6
+  churn — gets its own committed schema + worked example, delivered by
+  RRG.3a and referenced from AC-7/AC-10: tier id drawn from the pinned
+  definition set, non-null `detail`, version-sentinel field, per-tier state
+  enum including `declared-skip`, and the explicit rule for how a skipped
+  tier interacts with the 1:1 tier-match check. It is deliberately NOT
+  committed in this plan: the tier-row shape is co-owned by the external
+  testbed repo whose definitions RRG.3b is still reconciling — pinning it
+  now would freeze a premature contract. RRG.3a is not acceptable without
+  it.
+- AT2/AT3 handling per §7.4 and AC-10; the tier-level representation of
+  those dispositions is part of the RRG.3a tier-row schema above.
 
 ### 3.4 Repo test suites (recorded, not re-run)
 
-- `just ci` (lint + test), test-graft-python, test-hermes-graft-bridge,
-  test-hermes-graft-smoke, test-admission-capacity,
-  test-queue-hooks-python(+codex).
+- Closed catalog, manifest `ci_runs[].suite_id` ids in parentheses:
+  `just ci` (lint + test → `just-ci`), test-graft-python
+  (`test-graft-python`), test-hermes-graft-bridge
+  (`test-hermes-graft-bridge`), test-hermes-graft-smoke
+  (`test-hermes-graft-smoke`), test-admission-capacity
+  (`test-admission-capacity`), and test-queue-hooks-python + codex variant
+  (recorded as one entry, `test-queue-hooks`).
 - The gate records the green CI run ids for the exact release-candidate
-  commit in the manifest instead of re-executing them on the evidence host.
+  commit in the manifest instead of re-executing them on the evidence
+  host. The schema requires all six catalog entries with
+  `conclusion: "success"`: a missing or non-green repo suite means no
+  manifest can be emitted for the launch (INCOMPLETE-by-absence) — a
+  partial `ci_runs` set is schema-invalid, never a silently reduced
+  evidence bar.
 
 ## 4. Release evidence manifest
 
@@ -294,9 +331,18 @@ Summary of the committed schema (normative source is the schema file):
   `host`/`execution_identity` (nothing executed — identity must not be
   fabricated);
 - `floors[]` — family (`send` | `read-query`), metric, floor vs observed
-  p50, met flag, optional ratchet proposal (harness-computed, §2.3.5);
-- `ci_runs[]` — run ids + conclusions for the repo suites (§3.4) pinned to
-  the candidate commit;
+  p50, met flag, optional ratchet proposal (harness-computed, §2.3.5).
+  **Convention (schema-enforced): `ratchet_proposal` may be present only
+  when `met` is true** — the harness never proposes ratcheting from a
+  breached measurement;
+- `ci_runs[]` — **closed repo-suite catalog** (§3.4): `suite_id` is the
+  enum `just-ci` / `test-graft-python` / `test-hermes-graft-bridge` /
+  `test-hermes-graft-smoke` / `test-admission-capacity` /
+  `test-queue-hooks` (covering both python and codex variants), all six
+  required present via `contains` clauses, each with run id and
+  `conclusion` fixed to `success` (only green runs are recordable — a
+  missing/non-green repo suite means the gate refuses to emit a manifest),
+  pinned to the candidate commit;
 - `verdict` — `READY` / `NOT-READY` only. `INCOMPLETE` is deliberately
   unrepresentable: an incomplete run writes no manifest at all
   (INCOMPLETE-by-absence, §2.2.1);
@@ -336,10 +382,15 @@ direction.
 | # | Deliverable | must_follow | Assignee (proposed) |
 |---|---|---|---|
 | RRG.1 | Manifest schema (lifted from this plan's committed baseline) + `just release-readiness` orchestrator skeleton (suite registry, terminal-state tracking, fail-closed manifest render) + short ADR recording the terminal-state taxonomy, adapter composition model, and concurrency model (§5) | — | Cipher |
-| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4 | RRG.1 | Cipher |
-| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks) | RRG.1 | Cipher |
-| RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1. Parallel-safe with RRG.3a: disjoint repos (RRG.3b edits only atm-hermes-testbed; RRG.3a edits only atm-core) — their sole coupling is the pin value RRG.3a's manifest records, fixed at RRG.3b merge (or Rand-approved fallback SHA) | Cipher (atm-hermes-testbed PR) |
-| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs. Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+| RRG.2 | Suite adapters: smoke + benchmark families (reuse existing runners; no new harness framework — additive composition only); includes closing §7.8 (send-family execution-identity provenance) so both benchmark families meet AC-4; **builds the §2.3.5 anomaly-check set** (D7 clean-run criteria, sanity band, duration bounds, evidence-row counts) emitting `fail`/`measurement-anomaly` | RRG.1 | Cipher |
+| RRG.3a | atm-core testbed adapter (manifest `testbed_definitions` pinning, AC-5 guard, §2.3.3 tier checks); **owns the tier-row evidence schema + example (§3.3)** and **owns the AC-10/§7.4 AT2/AT3 disposition logic** (fail-closed default, standing-skip encoding) | RRG.1 | Cipher |
+| RRG.3b | Testbed-repo tier definitions: merge testbed PR #2 and add Phase-AV coverage definitions (§7.1). Acceptance: §7.1–§7.3 items resolved (definitions exist for every executed row, AT8 reconciled, detail-population expectations encoded). Fallback if PR #2 stalls (external repo): the gate pins to a Rand-approved testbed commit SHA carrying the reviewed definitions — RRG.3a is not blocked, only the pin value changes | RRG.1; parallel-safe with RRG.3a (see note below) | Cipher (atm-hermes-testbed PR) |
+| RRG.4 | reports-index manifest validation + rehearsal-root exclusion + docs; **wires the RRG.2 anomaly-check set and duplicate-`suite_id` rejection into §2.3.3 whole-set self-verification** (AC-7). Acceptance: **green `--rehearse` run end-to-end** (§2.3.4/AC-8) — the gate is not declared implemented without it | RRG.1–RRG.3a | Cipher |
+
+RRG.3a/RRG.3b parallel-safety rationale: disjoint repos (RRG.3b edits only
+atm-hermes-testbed; RRG.3a edits only atm-core). Their sole coupling is the
+pin value RRG.3a's manifest records, fixed at RRG.3b merge (or the
+Rand-approved fallback SHA).
 
 All sprints are ordinary dev worktrees off develop with quality-mgr QA;
 no test executions beyond each sprint's own new unit tests (rehearsal mode
@@ -445,3 +496,30 @@ owns; no sprint-local reinterpretation.
   defense-in-depth only. M2r2 RRG.3b parallel-safe annotation → §6 cell now
   states disjoint repos + sole coupling (pin value). §2.5 AC-2/AC-3/AC-4
   reconciled with the schema changes.
+- **r4 (2026-09-01, addressing quality-mgr r3 FAIL @ 856efe41c, msg
+  01M1DAASJ032FB3DE85VJ7T3TW; r2 dispositions scored 9/9 truthful)**:
+  B1r3 `ci_runs` had no closed catalog (empty/partial schema-valid; READY
+  example carried 1 of 6) → closed 6-id enum + `contains` clauses +
+  `conclusion` const `success` + minItems 6; §3.4 ids aligned; both
+  examples carry all six. B2r3 (B4r2 residual) AC-2 overclaimed
+  exactly-once as schema-enforced → AC-2 reworded to schema
+  (at-least-once) + self-verifier (duplicate rejection), duplicate
+  rejection added as an explicit §2.3.3/AC-7 item wired in RRG.4. B3r3
+  anomaly-check set claimed "part of §2.3.3" without being named or owned
+  there → named in §2.3.3 and AC-7 with ownership: checks built in RRG.2,
+  wired into self-verification in RRG.4 (§6 cells updated). I1r3 tier-row
+  evidence artifact had no schema/example or tier-level AT2/AT3
+  representation → RRG.3a acceptance deliverable defined in §3.3
+  (tier id enum, non-null detail, sentinel field, per-tier state enum
+  incl. declared-skip, skip-vs-1:1 rule), referenced from AC-7/AC-10;
+  deliberately not committed in-plan (testbed co-ownership, RRG.3b still
+  reconciling). I2r3 no symmetric forbids → schema now forbids
+  fail_reason/skip_reason off their own terminal states (pass forbids
+  both). I3r3 AC-10 disposition logic unowned → RRG.3a cell names it.
+  M1r3 absent-family fail_reason named: `suite-error` (§2.2.5/AC-5).
+  M2r3 ratchet_proposal-only-when-met stated in §4 and schema-enforced.
+  M3r3 example skip row cross-refs AC-10/§7.4. M4r3 RRG.3b rationale
+  moved to a note below the §6 table. All schema changes revalidated:
+  both examples VALID, 6 new negative cases (partial ci_runs, non-green
+  run, fail_reason-on-pass, skip_reason-on-fail, fail_reason-on-skip,
+  ratchet-on-unmet-floor) verified REJECTED.

--- a/docs/plans/release-readiness-gate/release-refusal-record.example.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.example.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "candidate": {
+    "tag_candidate": "v1.5.0-rc1",
+    "commit_sha": "0000000000000000000000000000000000000000",
+    "branch": "develop"
+  },
+  "refusal_point": "emission",
+  "refused_at": "2026-09-17T21:55:00Z",
+  "ci_runs_not_green": [
+    {
+      "suite_id": "test-queue-hooks-codex",
+      "state": "red",
+      "run_id": 123456806
+    },
+    {
+      "suite_id": "test-admission-capacity",
+      "state": "missing"
+    }
+  ],
+  "suite_evidence_paths": [
+    "site/reports/smoke/macos/m5-atmbench/2026-09-17-run.json",
+    "site/reports/send-message-benchmark/2026-09-17-campaign.json"
+  ]
+}

--- a/docs/plans/release-readiness-gate/release-refusal-record.example.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.example.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "candidate": {
-    "tag_candidate": "v1.5.0-rc1",
+    "tag_candidate": "v1.6.0",
     "commit_sha": "0000000000000000000000000000000000000000",
     "branch": "develop"
   },

--- a/docs/plans/release-readiness-gate/release-refusal-record.example.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.example.json
@@ -3,7 +3,8 @@
   "candidate": {
     "tag_candidate": "v1.6.0",
     "commit_sha": "0000000000000000000000000000000000000000",
-    "branch": "develop"
+    "branch": "develop",
+    "workspace_version": "1.5.7"
   },
   "refusal_point": "emission",
   "refused_at": "2026-09-17T21:55:00Z",

--- a/docs/plans/release-readiness-gate/release-refusal-record.schema.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.schema.json
@@ -22,9 +22,18 @@
       "additionalProperties": false,
       "required": ["tag_candidate", "commit_sha", "branch"],
       "properties": {
-        "tag_candidate": { "type": "string", "minLength": 1 },
+        "tag_candidate": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.0$",
+          "description": "Same shape as the manifest's candidate.tag_candidate (§5.1: proposed releases are always vX.Y.0) — the refusal record names the same candidate the gate refused."
+        },
         "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-        "branch": { "type": "string", "minLength": 1 }
+        "branch": { "type": "string", "minLength": 1 },
+        "workspace_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "description": "OPTIONAL: the gated tree's Cargo.toml [workspace.package] version (§5.1 per-attempt patch++). Present when the refusal fired after the gate's first opening act recorded it (AC-13); absent for a pre-launch refusal that fired before the version was read."
+        }
       }
     },
     "refusal_point": {

--- a/docs/plans/release-readiness-gate/release-refusal-record.schema.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "atm-core/release-refusal-record/v1",
+  "title": "Release-readiness refusal record",
+  "description": "Status artifact written on every §2.2.6 CI-eligibility refusal (pre-launch or emission-time). Written under release/refusals/<tag_candidate>/ — outside the evidence roots, never under site/reports/. It is NOT release evidence and is never referenced by a manifest; it exists so an operator can distinguish never-launched from refused-N-times and see exactly why. One writer implementation (RRG.1); RRG.4 reuses it for the emission point.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate",
+    "refusal_point",
+    "refused_at",
+    "ci_runs_not_green"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tag_candidate", "commit_sha", "branch"],
+      "properties": {
+        "tag_candidate": { "type": "string", "minLength": 1 },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "branch": { "type": "string", "minLength": 1 }
+      }
+    },
+    "refusal_point": {
+      "enum": ["pre-launch", "emission"],
+      "description": "pre-launch = the §2.2.6 eligibility check refused before any suite ran ('candidate not CI-eligible'); emission = the TOCTOU re-check refused at manifest-emission time ('candidate no longer CI-eligible at emission')."
+    },
+    "refused_at": { "type": "string", "format": "date-time" },
+    "ci_runs_not_green": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The exact repo-suite runs that failed the eligibility check. state 'red' carries the run_id whose conclusion is not success; state 'missing' means no run for that suite_id exists on the candidate commit (run_id absent).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["suite_id", "state"],
+        "properties": {
+          "suite_id": {
+            "enum": [
+              "just-ci",
+              "test-graft-python",
+              "test-hermes-graft-bridge",
+              "test-hermes-graft-smoke",
+              "test-admission-capacity",
+              "test-queue-hooks-python",
+              "test-queue-hooks-codex"
+            ]
+          },
+          "state": { "enum": ["red", "missing"] },
+          "run_id": { "type": "integer", "minimum": 1 }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "state": { "const": "missing" } }, "required": ["state"] },
+            "then": {
+              "properties": { "run_id": false },
+              "description": "A missing run has no run_id to cite; fabricating one is the clerical class §2.3 bans."
+            }
+          },
+          {
+            "if": { "properties": { "state": { "const": "red" } }, "required": ["state"] },
+            "then": { "required": ["run_id"] }
+          }
+        ]
+      }
+    },
+    "suite_evidence_paths": {
+      "type": "array",
+      "description": "OPTIONAL, emission-point only, informational: paths of suite evidence already produced on disk before the emission-time refusal, to ease operator reconciliation. These are NOT release evidence (per §2.2.2 nothing is release evidence without a validated manifest) and carry no sha256 — this record never grows into a shadow manifest.",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "refusal_point": { "const": "pre-launch" } }, "required": ["refusal_point"] },
+      "then": {
+        "properties": { "suite_evidence_paths": false },
+        "description": "A pre-launch refusal ran no suites — there are no evidence paths to list."
+      }
+    }
+  ]
+}

--- a/docs/plans/release-readiness-gate/release-refusal-record.schema.json
+++ b/docs/plans/release-readiness-gate/release-refusal-record.schema.json
@@ -20,7 +20,7 @@
     "candidate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["tag_candidate", "commit_sha", "branch"],
+      "required": ["tag_candidate", "commit_sha", "branch", "workspace_version"],
       "properties": {
         "tag_candidate": {
           "type": "string",
@@ -32,7 +32,7 @@
         "workspace_version": {
           "type": "string",
           "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
-          "description": "OPTIONAL: the gated tree's Cargo.toml [workspace.package] version (§5.1 per-attempt patch++). Present when the refusal fired after the gate's first opening act recorded it (AC-13); absent for a pre-launch refusal that fired before the version was read."
+          "description": "REQUIRED: the gated tree's Cargo.toml [workspace.package] version (§5.1 per-attempt patch++). Act 1 of the gate's ordered opening acts records this version before the §2.2.6 precondition (Act 2) can fire a pre-launch refusal, so the version is available at every refusal point. A tree whose version cannot be read never reaches a refusal record at all — that is the §2.2 rule 7 named startup failure 'candidate version unreadable', not a refusal."
         }
       }
     },


### PR DESCRIPTION
## Summary

Plan for the `just release-readiness <tag-candidate>` gate: one launch runs full smoke, both benchmark families, and atm-hermes-testbed integration, and emits a single validated evidence manifest (`READY`/`NOT-READY`) as the sole release-evidence pointer.

Key mechanisms (first-time-pass by construction, per Rand's directive that a field-level clerical miss must never cost a QA round):
- Committed JSON Schema (2020-12) + three worked examples (NOT-READY, READY, READY-with-approved-skip); exactly-once suite/ci_runs catalogs schema-mechanized; provenance and fail/skip-reason conditionals; conditional floors (a declared-skip never forces a fabricated measurement)
- Validate-at-emit + whole-set self-verification; bounded plausibility (enumerated anomaly checks only); single QA round by contract
- §2.2.6 CI-eligibility precondition with emission-time re-verification (TOCTOU sealed) and an observable non-evidence refusal record
- Rehearsal mode with structural release/rehearsal separation and no live GH API dependency
- Implementation sprints RRG.1–RRG.4 (Cipher), acceptance = §2.5 checklist

## QA history

Six plan-hardening rounds with quality-mgr (r1–r5 verdicts + dispositions recorded inline in the plan doc). r6 review is in flight @ 4a6fcb17b; merge gate = quality-mgr PASS + Rand approval.

Open questions for Rand: §8 Q1 (launch identity), Q2 (candidate vs integrate builds), Q3 (AT2 standing skip vs fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)