### PR TITLE
fix: support pinned self-signed daemon-dev identity

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -21,12 +21,14 @@ worktree binary directly.
 6. When peer-interface or trust configuration changes, use `restart` to reload
    the one selected daemon; never launch an extra process.
 7. On macOS, `switch` and `restart` fail closed unless both selected `atm` and
-   `atm-daemon` strictly verify with the stable Apple Development identifiers
-   and the configured Apple team identifier. Build with `just build` (or
-   explicitly run `python3 .just/sign_daemon_dev.py`) before switching. This
-   enforces a matched, signed local build; it is separate from macOS Local
-   Network Privacy authorization. Windows currently warns and skips signing;
-   other platforms are no-ops.
+   `atm-daemon` strictly verify with the configured signing identity. Apple
+   Development identities continue to require their configured team
+   identifier. A configured self-signed identity instead pins the certificate
+   leaf fingerprint and common name. Build with `just build` (or explicitly
+   run `python3 .just/sign_daemon_dev.py`) before switching. This enforces a
+   matched, signed local build; it is separate from macOS Local Network
+   Privacy authorization. Windows currently warns and skips signing; other
+   platforms are no-ops.
 
 ## Commands
 
@@ -71,6 +73,22 @@ python3 .claude/skills/daemon-switch/scripts/daemon-switch.py quiesce --yes \
 
 On systems without Homebrew, provide `--default-cli` and `--default-daemon` to
 `restore`. Use `--dry-run` before the first switch on an unfamiliar host.
+
+## Self-signed development identity
+
+The signing resolver accepts the synced `atm-daemon-dev` self-signed identity
+when it is explicitly selected once with `ATM_SIGNING_IDENTITY=atm-daemon-dev`
+(or its 40-character SHA-1 fingerprint). The resolver records the selected
+certificate's `fingerprint` and `common_name` in
+`~/.config/atm/signing-identity.json` with user-only permissions. Later
+`just build`, `sign_daemon_dev.py`, and daemon-switch invocations load that
+file, so the identity remains selected across sessions and synced hosts.
+
+Self-signed binaries are verified with a strict `codesign` designated
+requirement pinning the certificate leaf fingerprint, as well as the expected
+binary identifier and certificate common name. A changed or mismatched leaf
+fails closed. Apple-issued `Apple Development` identities continue to use the
+team-identifier verification path.
 
 ## Windows selector provisioning
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -30,9 +30,10 @@ if str(DAEMON_SWITCH_SCRIPTS_DIRECTORY) not in sys.path:
 from macos_development_signing import (  # noqa: E402
     CLI_IDENTIFIER,
     DAEMON_IDENTIFIER,
+    SigningIdentity,
     SigningIdentityError,
     resolve_apple_development_identity,
-    verify_apple_signature,
+    verify_signing_identity,
 )
 from temporary_launch import (  # noqa: E402
     CapturedLaunchSpec,
@@ -201,22 +202,11 @@ def macos_development_signing_identity_available() -> bool:
 def macos_binary_has_development_signature(
     binary: Path,
     identifier: str,
-    team_identifier: str,
-    *,
-    leaf_fingerprint: str | None = None,
-    common_name: str | None = None,
+    identity: SigningIdentity,
 ) -> bool:
     """Prove one managed binary carries its selected stable signing identity."""
     try:
-        if leaf_fingerprint is None:
-            return verify_apple_signature(str(binary), identifier, team_identifier)
-        return verify_apple_signature(
-            str(binary),
-            identifier,
-            team_identifier,
-            expected_leaf_fingerprint=leaf_fingerprint,
-            expected_common_name=common_name,
-        )
+        return verify_signing_identity(str(binary), identifier, identity)
     except (OSError, subprocess.SubprocessError):
         return False
 
@@ -237,17 +227,7 @@ def require_macos_development_signatures(cli: Path, daemon: Path) -> None:
         ("CLI", cli, CLI_IDENTIFIER),
         ("daemon", daemon, DAEMON_IDENTIFIER),
     ):
-        if identity.team_identifier:
-            signed = macos_binary_has_development_signature(binary, identifier, identity.team_identifier)
-        else:
-            signed = macos_binary_has_development_signature(
-                binary,
-                identifier,
-                identity.team_identifier,
-                leaf_fingerprint=identity.fingerprint,
-                common_name=identity.common_name,
-            )
-        if not signed:
+        if not macos_binary_has_development_signature(binary, identifier, identity):
             raise SwitchError(
                 f"{label} target is not strictly signed by the required signing identity: "
                 f"{binary}. "

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -199,11 +199,24 @@ def macos_development_signing_identity_available() -> bool:
 
 
 def macos_binary_has_development_signature(
-    binary: Path, identifier: str, team_identifier: str
+    binary: Path,
+    identifier: str,
+    team_identifier: str,
+    *,
+    leaf_fingerprint: str | None = None,
+    common_name: str | None = None,
 ) -> bool:
-    """Prove one managed binary carries its stable Apple Development signature."""
+    """Prove one managed binary carries its selected stable signing identity."""
     try:
-        return verify_apple_signature(str(binary), identifier, team_identifier)
+        if leaf_fingerprint is None:
+            return verify_apple_signature(str(binary), identifier, team_identifier)
+        return verify_apple_signature(
+            str(binary),
+            identifier,
+            team_identifier,
+            expected_leaf_fingerprint=leaf_fingerprint,
+            expected_common_name=common_name,
+        )
     except (OSError, subprocess.SubprocessError):
         return False
 
@@ -224,9 +237,19 @@ def require_macos_development_signatures(cli: Path, daemon: Path) -> None:
         ("CLI", cli, CLI_IDENTIFIER),
         ("daemon", daemon, DAEMON_IDENTIFIER),
     ):
-        if not macos_binary_has_development_signature(binary, identifier, identity.team_identifier):
+        if identity.team_identifier:
+            signed = macos_binary_has_development_signature(binary, identifier, identity.team_identifier)
+        else:
+            signed = macos_binary_has_development_signature(
+                binary,
+                identifier,
+                identity.team_identifier,
+                leaf_fingerprint=identity.fingerprint,
+                common_name=identity.common_name,
+            )
+        if not signed:
             raise SwitchError(
-                f"{label} target is not strictly signed by the required Apple Development identity: "
+                f"{label} target is not strictly signed by the required signing identity: "
                 f"{binary}. "
                 "Build with `just build` or run `python3 .just/sign_daemon_dev.py` before daemon-switch."
             )

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -181,8 +181,8 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         self.assertEqual(
             signed.call_args_list,
             [
-                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity.team_identifier),
-                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity.team_identifier),
+                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity),
+                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity),
             ],
         )
 
@@ -199,8 +199,8 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         self.assertEqual(
             signed.call_args_list,
             [
-                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity.team_identifier),
-                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity.team_identifier),
+                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity),
+                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity),
             ],
         )
 
@@ -221,20 +221,8 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
         self.assertEqual(
             signed.call_args_list,
             [
-                mock.call(
-                    cli,
-                    DAEMON_SWITCH.CLI_IDENTIFIER,
-                    "",
-                    leaf_fingerprint="A" * 40,
-                    common_name="atm-daemon-dev",
-                ),
-                mock.call(
-                    daemon,
-                    DAEMON_SWITCH.DAEMON_IDENTIFIER,
-                    "",
-                    leaf_fingerprint="A" * 40,
-                    common_name="atm-daemon-dev",
-                ),
+                mock.call(cli, DAEMON_SWITCH.CLI_IDENTIFIER, identity),
+                mock.call(daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity),
             ],
         )
 
@@ -424,14 +412,15 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
     def test_signature_check_uses_shared_stable_identifier_verifier(self) -> None:
         daemon = Path("/candidate/atm-daemon")
         with (
-            mock.patch.object(DAEMON_SWITCH, "verify_apple_signature", return_value=True) as verify,
+            mock.patch.object(DAEMON_SWITCH, "verify_signing_identity", return_value=True) as verify,
         ):
+            identity = DAEMON_SWITCH.SigningIdentity("A" * 40, "Apple Development: test", "4869P2ZYC6")
             self.assertTrue(
                 DAEMON_SWITCH.macos_binary_has_development_signature(
-                    daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, "4869P2ZYC6"
+                    daemon, DAEMON_SWITCH.DAEMON_IDENTIFIER, identity
                 )
             )
-        verify.assert_called_once_with(str(daemon), DAEMON_SWITCH.DAEMON_IDENTIFIER, "4869P2ZYC6")
+        verify.assert_called_once_with(str(daemon), DAEMON_SWITCH.DAEMON_IDENTIFIER, identity)
 
     def test_windows_warns_and_skips_the_unimplemented_signature_gate(self) -> None:
         stderr = io.StringIO()

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -204,6 +204,40 @@ class MacosDevelopmentSigningTests(unittest.TestCase):
             ],
         )
 
+    def test_self_signed_identity_uses_leaf_and_common_name_pins(self) -> None:
+        cli = Path("/candidate/atm")
+        daemon = Path("/candidate/atm-daemon")
+        identity = mock.Mock(team_identifier="", fingerprint="A" * 40, common_name="atm-daemon-dev")
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Darwin"),
+            mock.patch.object(DAEMON_SWITCH, "resolve_apple_development_identity", return_value=identity),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "macos_binary_has_development_signature",
+                return_value=True,
+            ) as signed,
+        ):
+            DAEMON_SWITCH.require_macos_development_signatures(cli, daemon)
+        self.assertEqual(
+            signed.call_args_list,
+            [
+                mock.call(
+                    cli,
+                    DAEMON_SWITCH.CLI_IDENTIFIER,
+                    "",
+                    leaf_fingerprint="A" * 40,
+                    common_name="atm-daemon-dev",
+                ),
+                mock.call(
+                    daemon,
+                    DAEMON_SWITCH.DAEMON_IDENTIFIER,
+                    "",
+                    leaf_fingerprint="A" * 40,
+                    common_name="atm-daemon-dev",
+                ),
+            ],
+        )
+
     def test_restore_accepts_homebrew_pair_without_development_identity(self) -> None:
         cli = Path("/opt/homebrew/opt/atm/bin/atm")
         daemon = Path("/opt/homebrew/opt/atm/bin/atm-daemon")

--- a/.just/sign_daemon_dev.py
+++ b/.just/sign_daemon_dev.py
@@ -20,7 +20,7 @@ from macos_development_signing import (  # noqa: E402
     SigningIdentity,
     SigningIdentityError,
     resolve_apple_development_identity,
-    verify_apple_signature,
+    verify_signing_identity,
 )
 
 
@@ -95,15 +95,7 @@ def sign_and_verify_binary(binary: Path, identifier: str, identity: SigningIdent
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    verification_kwargs = {}
-    if not identity.team_identifier:
-        verification_kwargs = {
-            "expected_leaf_fingerprint": identity.fingerprint,
-            "expected_common_name": identity.common_name,
-        }
-    if not verify_apple_signature(
-        str(binary), identifier, identity.team_identifier, **verification_kwargs
-    ):
+    if not verify_signing_identity(str(binary), identifier, identity):
         raise SigningIdentityError(
             f"post-sign verification failed for {binary}; expected {identifier} "
             "and the configured signing identity."

--- a/.just/sign_daemon_dev.py
+++ b/.just/sign_daemon_dev.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Strictly sign managed local ATM binaries with Apple Development on macOS."""
+"""Strictly sign managed local ATM binaries with the configured identity."""
 
 from __future__ import annotations
 
@@ -95,10 +95,18 @@ def sign_and_verify_binary(binary: Path, identifier: str, identity: SigningIdent
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    if not verify_apple_signature(str(binary), identifier, identity.team_identifier):
+    verification_kwargs = {}
+    if not identity.team_identifier:
+        verification_kwargs = {
+            "expected_leaf_fingerprint": identity.fingerprint,
+            "expected_common_name": identity.common_name,
+        }
+    if not verify_apple_signature(
+        str(binary), identifier, identity.team_identifier, **verification_kwargs
+    ):
         raise SigningIdentityError(
             f"post-sign verification failed for {binary}; expected {identifier} "
-            "and the configured Apple Development team."
+            "and the configured signing identity."
         )
 
 
@@ -113,7 +121,7 @@ def main() -> int:
         unlock_login_keychain()
         identity = resolve_apple_development_identity()
     except (OSError, subprocess.SubprocessError, SigningIdentityError) as error:
-        print(f"error: unable to resolve Apple Development signing identity: {error}", file=sys.stderr)
+        print(f"error: unable to resolve configured signing identity: {error}", file=sys.stderr)
         return 1
     for binary, identifier in MANAGED_TARGETS:
         try:

--- a/.just/tests/test_macos_development_signing.py
+++ b/.just/tests/test_macos_development_signing.py
@@ -143,6 +143,24 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform == "darwin", "self-signed signing is macOS-only")
 class MacosSigningIdentityTests(unittest.TestCase):
+    def assert_configured_identity_error(
+        self,
+        config_text: str,
+        identities: tuple[signing.SigningIdentity, ...],
+        message: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "atm" / "signing-identity.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(config_text, encoding="utf-8")
+            with mock.patch.dict(
+                signing.os.environ,
+                {"XDG_CONFIG_HOME": temporary_directory},
+                clear=True,
+            ):
+                with self.assertRaisesRegex(signing.SigningIdentityError, message):
+                    signing._configured_identity(identities)
+
     def test_apple_identity_still_uses_team_identifier_verification(self) -> None:
         verified = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
         details = subprocess.CompletedProcess(
@@ -187,6 +205,56 @@ class MacosSigningIdentityTests(unittest.TestCase):
                     clear=True,
                 ):
                     self.assertEqual(signing.resolve_apple_development_identity(), identity)
+
+    def test_configured_identity_rejects_malformed_json(self) -> None:
+        self.assert_configured_identity_error(
+            "{not-json",
+            (),
+            "unable to read signing identity configuration",
+        )
+
+    def test_configured_identity_rejects_missing_fingerprint(self) -> None:
+        self.assert_configured_identity_error(
+            '{"common_name":"atm-daemon-dev"}',
+            (),
+            "40-character fingerprint",
+        )
+
+    def test_configured_identity_rejects_invalid_fingerprint(self) -> None:
+        self.assert_configured_identity_error(
+            '{"common_name":"atm-daemon-dev","fingerprint":"wrong"}',
+            (),
+            "40-character fingerprint",
+        )
+
+    def test_configured_identity_rejects_missing_common_name(self) -> None:
+        self.assert_configured_identity_error(
+            '{"fingerprint":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}',
+            (),
+            "common_name",
+        )
+
+    def test_configured_identity_rejects_invalid_common_name(self) -> None:
+        self.assert_configured_identity_error(
+            '{"common_name":"","fingerprint":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}',
+            (),
+            "common_name",
+        )
+
+    def test_configured_identity_rejects_identity_missing_from_keychain(self) -> None:
+        self.assert_configured_identity_error(
+            '{"common_name":"atm-daemon-dev","fingerprint":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}',
+            (signing.SigningIdentity("B" * 40, "atm-daemon-dev"),),
+            "not installed exactly once",
+        )
+
+    def test_configured_identity_rejects_duplicate_keychain_identity(self) -> None:
+        identity = signing.SigningIdentity("A" * 40, "atm-daemon-dev")
+        self.assert_configured_identity_error(
+            '{"common_name":"atm-daemon-dev","fingerprint":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}',
+            (identity, identity),
+            "not installed exactly once",
+        )
 
     def test_self_signed_identity_verifies_with_matching_leaf_pin(self) -> None:
         fingerprint = "B" * 40

--- a/.just/tests/test_macos_development_signing.py
+++ b/.just/tests/test_macos_development_signing.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 from unittest import mock
 import unittest
 
@@ -137,6 +139,105 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
         )
         with mock.patch.object(signing, "_run", side_effect=[verified, details]):
             self.assertTrue(signing.verify_apple_signature("/candidate/atm", signing.CLI_IDENTIFIER))
+
+
+@unittest.skipUnless(sys.platform == "darwin", "self-signed signing is macOS-only")
+class MacosSigningIdentityTests(unittest.TestCase):
+    def test_apple_identity_still_uses_team_identifier_verification(self) -> None:
+        verified = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        details = subprocess.CompletedProcess(
+            ["codesign"],
+            0,
+            stdout="",
+            stderr=(
+                f"Identifier={signing.CLI_IDENTIFIER}\n"
+                f"TeamIdentifier={signing.DEFAULT_TEAM_IDENTIFIER}\n"
+            ),
+        )
+        with mock.patch.object(signing, "_run", side_effect=[verified, details]) as run:
+            self.assertTrue(signing.verify_apple_signature("/candidate/atm", signing.CLI_IDENTIFIER))
+        self.assertEqual(run.call_args_list, [
+            mock.call(["codesign", "--verify", "--strict", "/candidate/atm"]),
+            mock.call(["codesign", "-dvv", "/candidate/atm"]),
+        ])
+
+    def test_self_signed_identity_persists_and_reloads_from_file(self) -> None:
+        identity = signing.SigningIdentity("A" * 40, "atm-daemon-dev")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with (
+                mock.patch.object(signing, "_valid_identities", return_value=(identity,)),
+                mock.patch.dict(
+                    signing.os.environ,
+                    {
+                        "ATM_SIGNING_IDENTITY": "atm-daemon-dev",
+                        "XDG_CONFIG_HOME": temporary_directory,
+                    },
+                    clear=True,
+                ),
+            ):
+                self.assertEqual(signing.resolve_apple_development_identity(), identity)
+                config_path = Path(temporary_directory) / "atm" / "signing-identity.json"
+                self.assertEqual(
+                    json.loads(config_path.read_text(encoding="utf-8")),
+                    {"common_name": "atm-daemon-dev", "fingerprint": "A" * 40},
+                )
+                with mock.patch.dict(
+                    signing.os.environ,
+                    {"XDG_CONFIG_HOME": temporary_directory},
+                    clear=True,
+                ):
+                    self.assertEqual(signing.resolve_apple_development_identity(), identity)
+
+    def test_self_signed_identity_verifies_with_matching_leaf_pin(self) -> None:
+        fingerprint = "B" * 40
+        verified = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        details = subprocess.CompletedProcess(
+            ["codesign"],
+            0,
+            stdout="",
+            stderr=f"Identifier={signing.DAEMON_IDENTIFIER}\nAuthority=atm-daemon-dev\n",
+        )
+        pinned = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        with mock.patch.object(signing, "_run", side_effect=[verified, details, pinned]) as run:
+            self.assertTrue(
+                signing.verify_apple_signature(
+                    "/candidate/atm-daemon",
+                    signing.DAEMON_IDENTIFIER,
+                    "",
+                    expected_leaf_fingerprint=fingerprint,
+                    expected_common_name="atm-daemon-dev",
+                )
+            )
+        self.assertEqual(
+            run.call_args_list[-1],
+            mock.call([
+                "codesign",
+                "--verify",
+                "--strict",
+                f'-R=certificate leaf = H"{fingerprint}"',
+                "/candidate/atm-daemon",
+            ]),
+        )
+
+    def test_self_signed_identity_rejects_wrong_leaf_pin(self) -> None:
+        verified = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        details = subprocess.CompletedProcess(
+            ["codesign"],
+            0,
+            stdout="",
+            stderr=f"Identifier={signing.DAEMON_IDENTIFIER}\nAuthority=atm-daemon-dev\n",
+        )
+        pinned = subprocess.CompletedProcess(["codesign"], 1, stdout="", stderr="wrong leaf")
+        with mock.patch.object(signing, "_run", side_effect=[verified, details, pinned]):
+            self.assertFalse(
+                signing.verify_apple_signature(
+                    "/candidate/atm-daemon",
+                    signing.DAEMON_IDENTIFIER,
+                    "",
+                    expected_leaf_fingerprint="C" * 40,
+                    expected_common_name="atm-daemon-dev",
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_macos_development_signing.py
+++ b/.just/tests/test_macos_development_signing.py
@@ -47,6 +47,7 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
                 "_certificate_team_identifier",
                 side_effect=[signing.DEFAULT_TEAM_IDENTIFIER, "OTHERTEAM"],
             ),
+            mock.patch.object(signing, "_load_configured_identity", return_value=None),
             mock.patch.dict(signing.os.environ, {}, clear=True),
         ):
             self.assertEqual(signing.resolve_apple_development_identity(), selected)
@@ -59,6 +60,7 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
         with (
             mock.patch.object(signing, "_valid_identities", return_value=identities),
             mock.patch.object(signing, "_certificate_team_identifier", return_value=signing.DEFAULT_TEAM_IDENTIFIER),
+            mock.patch.object(signing, "_load_configured_identity", return_value=None),
             mock.patch.dict(signing.os.environ, {}, clear=True),
         ):
             with self.assertRaisesRegex(signing.SigningIdentityError, "exactly one"):
@@ -73,6 +75,7 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
                 "_certificate_team_identifier",
                 return_value=signing.DEFAULT_TEAM_IDENTIFIER,
             ),
+            mock.patch.object(signing, "_load_configured_identity", return_value=None),
             mock.patch.dict(signing.os.environ, {}, clear=True),
         ):
             self.assertEqual(
@@ -121,6 +124,7 @@ class AppleDevelopmentSigningTests(unittest.TestCase):
         with (
             mock.patch.object(signing, "_valid_identities", return_value=()),
             mock.patch.object(signing, "_identity_exists_but_is_not_valid", return_value=True),
+            mock.patch.object(signing, "_load_configured_identity", return_value=None),
             mock.patch.dict(signing.os.environ, {}, clear=True),
         ):
             with self.assertRaisesRegex(signing.SigningIdentityError, "WWDR G3"):

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -77,6 +77,24 @@ class SignDaemonDevTests(unittest.TestCase):
             self.assertEqual(sign_daemon_dev.main(), 1)
         self.assertIn("missing Apple identity", stderr.getvalue())
 
+    def test_self_signed_identity_uses_leaf_pin_verification(self) -> None:
+        identity = sign_daemon_dev.SigningIdentity("A" * 40, "atm-daemon-dev")
+        completed = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
+        with (
+            mock.patch.object(sign_daemon_dev.subprocess, "run", return_value=completed),
+            mock.patch.object(sign_daemon_dev, "verify_apple_signature", return_value=True) as verify,
+        ):
+            sign_daemon_dev.sign_and_verify_binary(
+                Path("/candidate/atm-daemon"), sign_daemon_dev.DAEMON_IDENTIFIER, identity
+            )
+        verify.assert_called_once_with(
+            "/candidate/atm-daemon",
+            sign_daemon_dev.DAEMON_IDENTIFIER,
+            "",
+            expected_leaf_fingerprint="A" * 40,
+            expected_common_name="atm-daemon-dev",
+        )
+
     def test_account_secret_unlocks_only_the_current_login_keychain(self) -> None:
         completed = subprocess.CompletedProcess(["security"], 0, stdout="", stderr="")
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -79,16 +79,17 @@ class SignDaemonDevTests(unittest.TestCase):
 
     def test_self_signed_identity_uses_leaf_pin_verification(self) -> None:
         identity = sign_daemon_dev.SigningIdentity("A" * 40, "atm-daemon-dev")
+        candidate = Path("/candidate/atm-daemon")
         completed = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
         with (
             mock.patch.object(sign_daemon_dev.subprocess, "run", return_value=completed),
             mock.patch.object(sign_daemon_dev, "verify_signing_identity", return_value=True) as verify,
         ):
             sign_daemon_dev.sign_and_verify_binary(
-                Path("/candidate/atm-daemon"), sign_daemon_dev.DAEMON_IDENTIFIER, identity
+                candidate, sign_daemon_dev.DAEMON_IDENTIFIER, identity
             )
         verify.assert_called_once_with(
-            "/candidate/atm-daemon",
+            str(candidate),
             sign_daemon_dev.DAEMON_IDENTIFIER,
             identity,
         )

--- a/.just/tests/test_sign_daemon_dev.py
+++ b/.just/tests/test_sign_daemon_dev.py
@@ -45,7 +45,7 @@ class SignDaemonDevTests(unittest.TestCase):
             mock.patch.object(sign_daemon_dev, "unlock_login_keychain") as unlock,
             mock.patch.object(sign_daemon_dev, "resolve_apple_development_identity", return_value=identity),
             mock.patch.object(sign_daemon_dev.subprocess, "run", return_value=completed) as run,
-            mock.patch.object(sign_daemon_dev, "verify_apple_signature", return_value=True),
+            mock.patch.object(sign_daemon_dev, "verify_signing_identity", return_value=True),
             mock.patch.object(sign_daemon_dev.Path, "is_file", side_effect=[True] * len(sign_daemon_dev.MANAGED_TARGETS)),
         ):
             self.assertEqual(sign_daemon_dev.main(), 0)
@@ -82,7 +82,7 @@ class SignDaemonDevTests(unittest.TestCase):
         completed = subprocess.CompletedProcess(["codesign"], 0, stdout="", stderr="")
         with (
             mock.patch.object(sign_daemon_dev.subprocess, "run", return_value=completed),
-            mock.patch.object(sign_daemon_dev, "verify_apple_signature", return_value=True) as verify,
+            mock.patch.object(sign_daemon_dev, "verify_signing_identity", return_value=True) as verify,
         ):
             sign_daemon_dev.sign_and_verify_binary(
                 Path("/candidate/atm-daemon"), sign_daemon_dev.DAEMON_IDENTIFIER, identity
@@ -90,9 +90,7 @@ class SignDaemonDevTests(unittest.TestCase):
         verify.assert_called_once_with(
             "/candidate/atm-daemon",
             sign_daemon_dev.DAEMON_IDENTIFIER,
-            "",
-            expected_leaf_fingerprint="A" * 40,
-            expected_common_name="atm-daemon-dev",
+            identity,
         )
 
     def test_account_secret_unlocks_only_the_current_login_keychain(self) -> None:

--- a/scripts/macos_development_signing.py
+++ b/scripts/macos_development_signing.py
@@ -184,20 +184,6 @@ def _configured_identity(identities: Sequence[SigningIdentity]) -> SigningIdenti
     return resolved
 
 
-def _distinct_fingerprints(identities: Sequence[SigningIdentity]) -> tuple[SigningIdentity, ...]:
-    """Return identities once per certificate fingerprint, preserving keychain order.
-
-    ``security find-identity`` may emit the same certificate once for every
-    keychain in the active search list.  Those rows are aliases for one signing
-    identity, not an ambiguous choice.  Different fingerprints deliberately
-    remain distinct so the caller continues to fail closed.
-    """
-    selected: dict[str, SigningIdentity] = {}
-    for identity in identities:
-        selected.setdefault(identity.fingerprint, identity)
-    return tuple(selected.values())
-
-
 def _identity_exists_but_is_not_valid() -> bool:
     result = _run(["security", "find-identity", "-p", "codesigning"])
     return result.returncode == 0 and any(
@@ -212,7 +198,7 @@ def resolve_apple_development_identity() -> SigningIdentity:
     valid_identities = _valid_identities()
     if override:
         override_fingerprint = _validated_fingerprint(override)
-        candidates = _distinct_fingerprints(tuple(
+        candidates = unique_identities(tuple(
             resolved
             for identity in valid_identities
             if (
@@ -234,7 +220,7 @@ def resolve_apple_development_identity() -> SigningIdentity:
     if configured is not None:
         return configured
 
-    candidates = _distinct_fingerprints(tuple(
+    candidates = unique_identities(tuple(
         resolved
         for identity in valid_identities
         if identity.common_name.startswith(APPLE_DEVELOPMENT_PREFIX)
@@ -279,3 +265,16 @@ def verify_apple_signature(
         pinned = _run(["codesign", "--verify", "--strict", f"-R={requirement}", binary])
         return pinned.returncode == 0
     return f"TeamIdentifier={expected_team_identifier}" in output.splitlines()
+
+
+def verify_signing_identity(binary: str, expected_identifier: str, identity: SigningIdentity) -> bool:
+    """Verify a binary using the selected identity's appropriate authority mode."""
+    if identity.team_identifier:
+        return verify_apple_signature(binary, expected_identifier, identity.team_identifier)
+    return verify_apple_signature(
+        binary,
+        expected_identifier,
+        identity.team_identifier,
+        expected_leaf_fingerprint=identity.fingerprint,
+        expected_common_name=identity.common_name,
+    )

--- a/scripts/macos_development_signing.py
+++ b/scripts/macos_development_signing.py
@@ -1,9 +1,11 @@
-"""Shared Apple Development signing rules for local ATM binaries."""
+"""Shared development signing rules for local ATM binaries."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
+from pathlib import Path
 import re
 import subprocess
 from typing import Sequence
@@ -12,6 +14,7 @@ from typing import Sequence
 APPLE_DEVELOPMENT_PREFIX = "Apple Development"
 DEFAULT_TEAM_IDENTIFIER = "4869P2ZYC6"
 SIGNING_IDENTITY_ENVIRONMENT_VARIABLE = "ATM_SIGNING_IDENTITY"
+SIGNING_IDENTITY_CONFIG_FILENAME = "signing-identity.json"
 CLI_IDENTIFIER = "com.synapticcanvas.atm.cli"
 DAEMON_IDENTIFIER = "com.synapticcanvas.atm.daemon"
 WWDR_G3_INSTRUCTION = (
@@ -34,6 +37,11 @@ class SigningIdentity:
     fingerprint: str
     common_name: str
     team_identifier: str = ""
+
+    @property
+    def is_apple_issued(self) -> bool:
+        """Return whether this is the Apple Development identity path."""
+        return self.common_name.startswith(APPLE_DEVELOPMENT_PREFIX)
 
 
 def _run(command: Sequence[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -98,6 +106,84 @@ def _identity_with_team_identifier(identity: SigningIdentity) -> SigningIdentity
     return SigningIdentity(identity.fingerprint, identity.common_name, team_identifier)
 
 
+def signing_identity_config_path() -> Path:
+    """Return the durable per-user signing identity configuration path."""
+    root = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return root / "atm" / SIGNING_IDENTITY_CONFIG_FILENAME
+
+
+def _validated_fingerprint(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    fingerprint = value.strip().upper()
+    return fingerprint if re.fullmatch(r"[0-9A-F]{40}", fingerprint) else None
+
+
+def _load_configured_identity() -> tuple[str, str] | None:
+    path = signing_identity_config_path()
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SigningIdentityError(f"unable to read signing identity configuration {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise SigningIdentityError(f"signing identity configuration must be an object: {path}")
+    fingerprint = _validated_fingerprint(data.get("fingerprint"))
+    common_name = data.get("common_name")
+    if fingerprint is None or not isinstance(common_name, str) or not common_name.strip():
+        raise SigningIdentityError(
+            f"signing identity configuration must contain a 40-character fingerprint and common_name: {path}"
+        )
+    return fingerprint, common_name.strip()
+
+
+def save_signing_identity(identity: SigningIdentity) -> None:
+    """Persist the selected certificate pin for later builds and host sessions."""
+    path = signing_identity_config_path()
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"common_name": identity.common_name, "fingerprint": identity.fingerprint.upper()},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    os.chmod(path, 0o600)
+
+
+def _resolve_explicit_identity(identity: SigningIdentity) -> SigningIdentity | None:
+    """Resolve either an Apple-issued or explicitly selected self-signed identity."""
+    if not identity.is_apple_issued:
+        return SigningIdentity(identity.fingerprint.upper(), identity.common_name)
+    return _identity_with_team_identifier(identity)
+
+
+def _configured_identity(identities: Sequence[SigningIdentity]) -> SigningIdentity | None:
+    configured = _load_configured_identity()
+    if configured is None:
+        return None
+    fingerprint, common_name = configured
+    candidates = tuple(
+        identity
+        for identity in identities
+        if identity.fingerprint.upper() == fingerprint and identity.common_name == common_name
+    )
+    if len(candidates) != 1:
+        raise SigningIdentityError(
+            "configured signing identity is not installed exactly once: "
+            f"{common_name} ({fingerprint})"
+        )
+    resolved = _resolve_explicit_identity(candidates[0])
+    if resolved is None:
+        raise SigningIdentityError(
+            f"configured Apple Development identity is missing its team identifier: {common_name}"
+        )
+    return resolved
+
+
 def _distinct_fingerprints(identities: Sequence[SigningIdentity]) -> tuple[SigningIdentity, ...]:
     """Return identities once per certificate fingerprint, preserving keychain order.
 
@@ -121,21 +207,32 @@ def _identity_exists_but_is_not_valid() -> bool:
 
 
 def resolve_apple_development_identity() -> SigningIdentity:
-    """Resolve one valid Apple Development identity, or fail with recovery."""
+    """Resolve one configured or valid signing identity, or fail with recovery."""
     override = os.environ.get(SIGNING_IDENTITY_ENVIRONMENT_VARIABLE, "").strip()
     valid_identities = _valid_identities()
     if override:
+        override_fingerprint = _validated_fingerprint(override)
         candidates = _distinct_fingerprints(tuple(
             resolved
             for identity in valid_identities
-            if override in {identity.fingerprint, identity.common_name}
-            if (resolved := _identity_with_team_identifier(identity)) is not None
+            if (
+                (override_fingerprint is not None and identity.fingerprint.upper() == override_fingerprint)
+                or override == identity.common_name
+            )
+            if (resolved := _resolve_explicit_identity(identity)) is not None
         ))
         if len(candidates) == 1:
-            return candidates[0]
+            selected = candidates[0]
+            if not selected.is_apple_issued:
+                save_signing_identity(selected)
+            return selected
         raise SigningIdentityError(
             f"{SIGNING_IDENTITY_ENVIRONMENT_VARIABLE} must identify exactly one valid signing identity."
         )
+
+    configured = _configured_identity(valid_identities)
+    if configured is not None:
+        return configured
 
     candidates = _distinct_fingerprints(tuple(
         resolved
@@ -157,18 +254,28 @@ def resolve_apple_development_identity() -> SigningIdentity:
 
 
 def verify_apple_signature(
-    binary: str, expected_identifier: str, expected_team_identifier: str = DEFAULT_TEAM_IDENTIFIER
+    binary: str,
+    expected_identifier: str,
+    expected_team_identifier: str = DEFAULT_TEAM_IDENTIFIER,
+    *,
+    expected_leaf_fingerprint: str | None = None,
+    expected_common_name: str | None = None,
 ) -> bool:
-    """Return whether one binary has the stable Apple Development signature."""
+    """Return whether one binary has its stable Apple or pinned self-signed signature."""
     verification = _run(["codesign", "--verify", "--strict", binary])
     if verification.returncode != 0:
         return False
     details = _run(["codesign", "-dvv", binary])
     output = f"{details.stdout}\n{details.stderr}"
-    return details.returncode == 0 and all(
-        line in output.splitlines()
-        for line in (
-            f"Identifier={expected_identifier}",
-            f"TeamIdentifier={expected_team_identifier}",
-        )
-    )
+    if details.returncode != 0 or f"Identifier={expected_identifier}" not in output.splitlines():
+        return False
+    if expected_leaf_fingerprint is not None:
+        if expected_common_name is not None and f"Authority={expected_common_name}" not in output.splitlines():
+            return False
+        fingerprint = _validated_fingerprint(expected_leaf_fingerprint)
+        if fingerprint is None:
+            return False
+        requirement = f'certificate leaf = H"{fingerprint}"'
+        pinned = _run(["codesign", "--verify", "--strict", f"-R={requirement}", binary])
+        return pinned.returncode == 0
+    return f"TeamIdentifier={expected_team_identifier}" in output.splitlines()


### PR DESCRIPTION
Fix signing-self-signed-atm-daemon-dev for Phase AS.

- accept an explicitly selected non-Apple identity and persist its fingerprint/common name in ~/.config/atm/signing-identity.json;
- verify self-signed binaries with a strict certificate-leaf designated requirement;
- retain Apple Development TeamIdentifier verification unchanged;
- update signer, daemon-switch skill/script, and macOS-gated tests.

No Rust or workflow changes.

Validation: just lint (32 checks) PASS; focused macOS signing tests PASS; full Python collector 921 tests PASS.