### PR TITLE
fix: retain OS causes for retained-log startup failures

### DIFF
--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -675,10 +675,10 @@ fn build_logger(
 }
 
 fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(), AtmError> {
-    fs::create_dir_all(log_dir).map_err(|_source| {
+    fs::create_dir_all(log_dir).map_err(|source| {
         AtmError::observability_bootstrap(format!(
-            "failed to create retained log directory {}",
-            log_dir.display()
+            "failed to create retained log directory {}: {source}",
+            log_dir.display(),
         ))
 
     })?;
@@ -687,10 +687,10 @@ fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(
         .append(true)
         .open(active_log_path)
         .map(|_| ())
-        .map_err(|_source| {
+        .map_err(|source| {
             AtmError::observability_bootstrap(format!(
-                "failed to open retained log file {} during startup",
-                active_log_path.display()
+                "failed to open retained log file {} during startup: {source}",
+                active_log_path.display(),
             ))
 
         })
@@ -1190,6 +1190,9 @@ mod tests {
         let blocked_parent = tempdir.path().join("blocked-parent");
         std::fs::write(&blocked_parent, "not a directory").expect("blocked parent");
         let blocked_log_dir = blocked_parent.join("logs");
+        let expected = std::fs::create_dir_all(&blocked_log_dir)
+            .expect_err("child of a regular file must not be a directory")
+            .to_string();
         let _env = EnvGuard::set_many([
             (
                 "ATM_LOG_DIR",
@@ -1208,6 +1211,7 @@ mod tests {
                 .message()
                 .contains(&blocked_log_dir.display().to_string())
         );
+        assert!(error.message().contains(&expected), "{error}");
     }
 
     #[test]
@@ -1218,6 +1222,13 @@ mod tests {
         std::fs::create_dir_all(&blocked_log_dir).expect("blocked log dir");
         std::fs::create_dir(blocked_log_dir.join("atm.log.jsonl"))
             .expect("non-appendable log path");
+        let active_log_path = blocked_log_dir.join("atm.log.jsonl");
+        let expected = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&active_log_path)
+            .expect_err("directory must not be appendable")
+            .to_string();
         let _env = EnvGuard::set_many([
             (
                 "ATM_LOG_DIR",
@@ -1235,8 +1246,9 @@ mod tests {
         assert!(
             error
                 .message()
-                .contains(&blocked_log_dir.join("atm.log.jsonl").display().to_string())
+                .contains(&active_log_path.display().to_string())
         );
+        assert!(error.message().contains(&expected), "{error}");
     }
 
     #[test]

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -321,10 +321,10 @@ pub(crate) fn build_logger(
 }
 
 fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(), AtmError> {
-    fs::create_dir_all(log_dir).map_err(|_source| {
+    fs::create_dir_all(log_dir).map_err(|source| {
         AtmError::observability_bootstrap(format!(
-            "failed to create retained log directory {}",
-            log_dir.display()
+            "failed to create retained log directory {}: {source}",
+            log_dir.display(),
         ))
     })?;
     OpenOptions::new()
@@ -332,10 +332,10 @@ fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(
         .append(true)
         .open(active_log_path)
         .map(|_| ())
-        .map_err(|_source| {
+        .map_err(|source| {
             AtmError::observability_bootstrap(format!(
-                "failed to open retained log file {} during startup",
-                active_log_path.display()
+                "failed to open retained log file {} during startup: {source}",
+                active_log_path.display(),
             ))
         })
 }
@@ -1018,8 +1018,8 @@ mod adapter_tests {
     use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
 
     use super::{
-        ATM_LOG_LEVEL_ENV, exit_code_for_atm_error, exit_code_for_error, init_observability,
-        level_for_outcome, logger_level_override, tracing_level_filter,
+        ATM_LOG_LEVEL_ENV, ensure_retained_log_ready, exit_code_for_atm_error, exit_code_for_error,
+        init_observability, level_for_outcome, logger_level_override, tracing_level_filter,
     };
 
     fn with_env_var<R>(key: &'static str, value: Option<&str>, f: impl FnOnce() -> R) -> R {
@@ -1118,6 +1118,50 @@ mod adapter_tests {
         let error = init_observability(false).expect_err("invalid ATM_LOG_DIR should fail closed");
         assert!(error.is_config());
         assert!(error.message().contains("absolute path"));
+    }
+
+    #[test]
+    fn retained_log_open_failure_preserves_the_os_error() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let log_dir = tempdir.path().join("logs");
+        std::fs::create_dir_all(&log_dir).expect("log dir");
+        let active_log_path = log_dir.join("atm.log.jsonl");
+        std::fs::create_dir(&active_log_path).expect("non-appendable log path");
+        let expected = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&active_log_path)
+            .expect_err("directory must not be appendable")
+            .to_string();
+
+        let error = ensure_retained_log_ready(&log_dir, &active_log_path)
+            .expect_err("retained log open must fail closed");
+
+        assert!(error.is_observability_bootstrap());
+        assert!(
+            error
+                .message()
+                .contains(&active_log_path.display().to_string())
+        );
+        assert!(error.message().contains(&expected), "{error}");
+    }
+
+    #[test]
+    fn retained_log_directory_failure_preserves_the_os_error() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let blocked_parent = tempdir.path().join("blocked-parent");
+        std::fs::write(&blocked_parent, "not a directory").expect("blocked parent");
+        let log_dir = blocked_parent.join("logs");
+        let expected = std::fs::create_dir_all(&log_dir)
+            .expect_err("child of a regular file must not be a directory")
+            .to_string();
+
+        let error = ensure_retained_log_ready(&log_dir, &log_dir.join("atm.log.jsonl"))
+            .expect_err("retained log directory creation must fail closed");
+
+        assert!(error.is_observability_bootstrap());
+        assert!(error.message().contains(&log_dir.display().to_string()));
+        assert!(error.message().contains(&expected), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1130

Summary:
- Preserve the underlying standard-library I/O error when retained-log directory creation or append-open fails.
- Apply the same diagnostic contract to ATM CLI and daemon startup.
- Keep the existing fail-closed observability-bootstrap error category and resolved path.
- Add focused CLI and daemon tests that compare the surfaced diagnostic with the actual OS error from the failing operation.

Verification:
- cargo fmt --check
- focused CLI and daemon retained-log error tests
- just lint (32 checks passed)
- just test (916 Python tests, 21 skipped, plus the full workspace Rust suite)

No team, mailbox, database, daemon, or log files were modified by this change.