### PR TITLE
fix(peer-tls): fail closed on legacy literal-IP trusted-peer rows with migration path (#972)

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -183,7 +183,7 @@ allowed_dependencies = ["async-trait", "atm-storage", "chrono", "rusqlite", "ser
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/peer-tls/Cargo.toml"
 boundary_record_path = "boundaries/peer-tls/mtls-peer-stream-adapter.toml"
-allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls"]
+allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls", "tracing"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-template-sc-compose/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "tracing",
 ]
 
 [[package]]

--- a/boundaries/peer-tls/mtls-peer-stream-adapter.toml
+++ b/boundaries/peer-tls/mtls-peer-stream-adapter.toml
@@ -22,7 +22,7 @@ io_forbidden = ["http_runtime", "message_delivery", "message_persistence", "rece
 
 [dependencies]
 allowed_dependents = ["atm-daemon-bootstrap"]
-allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls"]
+allowed_dependencies = ["atm-storage", "rcgen", "rustls", "tempfile", "tokio", "tokio-rustls", "tracing"]
 forbidden_edges = ["atm-http-runtime -> peer-tls", "atm -> peer-tls", "atm-graft -> peer-tls", "atm-daemon -> peer-tls"]
 
 [references]

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1883,6 +1883,9 @@ mod tests {
         let reports = legacy_literal_ip_peer_reports(&peers);
         assert_eq!(reports.len(), 2, "the durable hostname row is excluded");
 
+        let enabled_host: HostName = "192.168.128.29".parse().expect("host");
+        let disabled_host: HostName = "10.0.0.5".parse().expect("host");
+
         let enabled = reports
             .iter()
             .find(|report| report.host == "192.168.128.29")
@@ -1890,11 +1893,11 @@ mod tests {
         assert!(enabled.enabled);
         assert_eq!(
             enabled.migrate_command,
-            "atm peer trust migrate --map 192.168.128.29=<hostname> --yes"
+            atm_storage::TrustedPeerCatalogAudit::migrate_command(&enabled_host, "<hostname>")
         );
         assert_eq!(
             enabled.revoke_command,
-            "atm peer trust revoke --host 192.168.128.29 --yes"
+            atm_storage::TrustedPeerCatalogAudit::revoke_command(&enabled_host)
         );
 
         let disabled = reports
@@ -1904,7 +1907,7 @@ mod tests {
         assert!(!disabled.enabled);
         assert_eq!(
             disabled.revoke_command,
-            "atm peer trust revoke --host 10.0.0.5 --yes"
+            atm_storage::TrustedPeerCatalogAudit::revoke_command(&disabled_host)
         );
     }
 

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -30,9 +30,10 @@ pub use report::{
     DoctorEnvironmentVisibility, DoctorExecutionContext, DoctorFinding, DoctorReport,
     DoctorSeverity, DoctorStatus, DoctorSummary, GraftReceiverLeaseDoctorReport,
     GraftReceiversDoctorReport, HerdrBreakerDoctor, HerdrBreakerDoctorReport,
-    HerdrBreakerDoctorState, HerdrQueuePumpDoctorReport, PeerAuthorityDoctorReport,
-    PeerConfigDoctorReport, PeerWireSecurityStatus, PostSendDoctorReport, PostSendHookRuleIndex,
-    PostSendHookRuleReport, RecipientDeliveryPath, RecipientDeliveryPathReport,
+    HerdrBreakerDoctorState, HerdrQueuePumpDoctorReport, LegacyLiteralIpPeerDoctorReport,
+    PeerAuthorityDoctorReport, PeerConfigDoctorReport, PeerWireSecurityStatus,
+    PostSendDoctorReport, PostSendHookRuleIndex, PostSendHookRuleReport, RecipientDeliveryPath,
+    RecipientDeliveryPathReport,
 };
 
 /// Async application port for the live Herdr visibility checks performed by
@@ -289,8 +290,37 @@ fn peer_config_doctor_report_inner(
                 enabled: peer.enabled,
             })
             .collect(),
+        legacy_literal_ip_peers: legacy_literal_ip_peer_reports(&peers),
         validation_failure: None,
     })
+}
+
+/// Projects legacy literal-IP trusted-peer rows (enabled or disabled) with
+/// their exact safe migrate/revoke remediation for `atm doctor` output.
+fn legacy_literal_ip_peer_reports(
+    peers: &[atm_storage::TrustedPeer],
+) -> Vec<LegacyLiteralIpPeerDoctorReport> {
+    let audit = atm_storage::TrustedPeerCatalogAudit::from_peers(peers);
+    audit
+        .legacy_literal_enabled_hosts()
+        .iter()
+        .map(|host| (host, true))
+        .chain(
+            audit
+                .legacy_literal_disabled_hosts()
+                .iter()
+                .map(|host| (host, false)),
+        )
+        .map(|(host, enabled)| LegacyLiteralIpPeerDoctorReport {
+            host: host.to_string(),
+            enabled,
+            migrate_command: atm_storage::TrustedPeerCatalogAudit::migrate_command(
+                host,
+                "<hostname>",
+            ),
+            revoke_command: atm_storage::TrustedPeerCatalogAudit::revoke_command(host),
+        })
+        .collect()
 }
 
 struct DoctorRunContext {
@@ -791,7 +821,9 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use super::{ordered_member_summaries, peer_config_doctor_report};
+    use super::{
+        legacy_literal_ip_peer_reports, ordered_member_summaries, peer_config_doctor_report,
+    };
     use crate::config::AtmConfig;
     use crate::config::types::{HookRecipient, PostSendHookRule};
     use crate::doctor::{
@@ -1827,6 +1859,56 @@ mod tests {
     }
 
     #[test]
+    fn legacy_literal_ip_peer_reports_names_hosts_with_exact_remediation() {
+        let peers = vec![
+            TrustedPeer {
+                host: "rand-m5.local".parse().expect("host"),
+                fingerprint: "sha256:durable".parse().expect("fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(443).expect("port"),
+            },
+            TrustedPeer {
+                host: "192.168.128.29".parse().expect("host"),
+                fingerprint: "sha256:legacy-enabled".parse().expect("fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(443).expect("port"),
+            },
+            TrustedPeer {
+                host: "10.0.0.5".parse().expect("host"),
+                fingerprint: "sha256:legacy-disabled".parse().expect("fingerprint"),
+                enabled: false,
+                https_port: std::num::NonZeroU16::new(443).expect("port"),
+            },
+        ];
+        let reports = legacy_literal_ip_peer_reports(&peers);
+        assert_eq!(reports.len(), 2, "the durable hostname row is excluded");
+
+        let enabled = reports
+            .iter()
+            .find(|report| report.host == "192.168.128.29")
+            .expect("enabled legacy row reported");
+        assert!(enabled.enabled);
+        assert_eq!(
+            enabled.migrate_command,
+            "atm peer trust migrate --map 192.168.128.29=<hostname> --yes"
+        );
+        assert_eq!(
+            enabled.revoke_command,
+            "atm peer trust revoke --host 192.168.128.29 --yes"
+        );
+
+        let disabled = reports
+            .iter()
+            .find(|report| report.host == "10.0.0.5")
+            .expect("disabled legacy row reported");
+        assert!(!disabled.enabled);
+        assert_eq!(
+            disabled.revoke_command,
+            "atm peer trust revoke --host 10.0.0.5 --yes"
+        );
+    }
+
+    #[test]
     fn peer_config_doctor_projection_redacts_private_key_reference_from_store() {
         let (report, findings) = peer_config_doctor_report(&StubPeerConfigStore::healthy());
 
@@ -1840,6 +1922,7 @@ mod tests {
             Some("sha256:local")
         );
         assert!(report.validation_failure.is_none());
+        assert!(report.legacy_literal_ip_peers.is_empty());
 
         let serialized = serde_json::to_string(&report).expect("serialize doctor projection");
         assert!(!serialized.contains("keychain:secret"));

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -147,6 +147,14 @@ pub struct PeerConfigDoctorReport {
     pub enabled_trusted_peer_count: usize,
     #[serde(default)]
     pub trusted_peers: Vec<PeerAuthorityDoctorReport>,
+    /// Legacy literal-IP trusted-peer rows (enabled or disabled) with their
+    /// exact safe migration/retirement remediation. See issue #972: a
+    /// disabled row never blocks startup and an enabled row fails startup
+    /// closed unless the operator opts into the testing/benchmarking-only
+    /// skip; both cases are surfaced here so `atm doctor` reports them
+    /// before/at upgrade rather than only at daemon launch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub legacy_literal_ip_peers: Vec<LegacyLiteralIpPeerDoctorReport>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation_failure: Option<DoctorFinding>,
 }
@@ -157,6 +165,19 @@ pub struct PeerAuthorityDoctorReport {
     pub host: String,
     pub https_port: u16,
     pub enabled: bool,
+}
+
+/// Safe projection of one legacy literal-IP trusted-peer row, carrying the
+/// exact commands that migrate or retire it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LegacyLiteralIpPeerDoctorReport {
+    pub host: String,
+    pub enabled: bool,
+    /// Converts this row to a durable hostname, keeping its fingerprint and
+    /// port. `<hostname>` is a placeholder for the operator's chosen name.
+    pub migrate_command: String,
+    /// Retires this row from the trusted-peer catalog.
+    pub revoke_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -37,7 +37,7 @@ use atm_http_runtime::{
 use atm_runtime::{RuntimeAssembly, RuntimeAssemblyInputs, assemble_runtime};
 use atm_storage::request_budget::SERVER_REQUEST_BUDGET;
 use atm_storage_rusqlite::SqliteStorageFactory;
-use peer_tls::MtlsPeerStreamAdapter;
+use peer_tls::{LEGACY_LITERAL_IP_SKIP_ENV_VAR, LegacyLiteralIpPolicy, MtlsPeerStreamAdapter};
 use tokio::net::TcpStream;
 
 mod atm_temp_config;
@@ -583,13 +583,33 @@ fn bootstrap_peer_stream_adapter(
     assembly: &RuntimeAssembly,
     peer_wire_mode: PeerWireMode,
 ) -> Result<Option<Arc<dyn PeerStreamAdapter>>, AtmError> {
+    let policy = legacy_literal_ip_policy_from_env();
     peer_stream_adapter_for_mode(peer_wire_mode, || {
         Ok(Arc::new(BootstrapMtlsStreamAdapter {
-            adapter: Arc::new(MtlsPeerStreamAdapter::from_peer_config(
+            adapter: Arc::new(MtlsPeerStreamAdapter::from_peer_config_with_policy(
                 assembly.peer_config_store.as_ref(),
+                policy,
             )?),
         }) as Arc<dyn PeerStreamAdapter>)
     })
+}
+
+/// Resolves the legacy literal-IP trusted-peer admission policy from
+/// `ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP`. This is a narrow trust-catalog
+/// admission knob, never a peer-wire-mode selector: ADR-047's
+/// environment-selection prohibition governs `--peer-wire-security` only.
+fn legacy_literal_ip_policy_from_env() -> LegacyLiteralIpPolicy {
+    legacy_literal_ip_policy_from_value(std::env::var(LEGACY_LITERAL_IP_SKIP_ENV_VAR).ok())
+}
+
+/// Only the exact value `"1"` selects the testing/benchmarking-only
+/// skip-with-warning behavior; every other value, and the variable being
+/// unset (`None`), keeps the safe fail-closed default.
+fn legacy_literal_ip_policy_from_value(value: Option<String>) -> LegacyLiteralIpPolicy {
+    match value.as_deref() {
+        Some("1") => LegacyLiteralIpPolicy::SkipWithWarning,
+        _ => LegacyLiteralIpPolicy::FailClosed,
+    }
 }
 
 /// Drain the Axum runtime before releasing outbound peer drivers and the
@@ -818,10 +838,12 @@ mod replacement_runtime_tests {
     use super::{
         DaemonLaunchIdentity, REPLACEMENT_DRAIN_DEADLINE, ReplacementHandlerConfig,
         SelectedPeerAdapterSelection, ShutdownSignal, assemble_host_runtime_with_template_composer,
-        build_replacement_handler, parse_direct_peer_port, parse_peer_wire_mode,
-        peer_stream_adapter_for_mode, replacement_runtime_config_with_direct_peer,
-        start_replacement_runtime, write_ready_signal_if_requested,
+        build_replacement_handler, legacy_literal_ip_policy_from_value, parse_direct_peer_port,
+        parse_peer_wire_mode, peer_stream_adapter_for_mode,
+        replacement_runtime_config_with_direct_peer, start_replacement_runtime,
+        write_ready_signal_if_requested,
     };
+    use peer_tls::LegacyLiteralIpPolicy;
 
     /// Test-owned receiver selection prevents an external tmux/graft action
     /// from obscuring the bootstrap's direct-peer persistence proof.
@@ -843,6 +865,29 @@ mod replacement_runtime_tests {
         let mut output = Vec::new();
         write_ready_signal_if_requested(&mut output, false).expect("disabled marker");
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn legacy_literal_ip_policy_defaults_to_fail_closed() {
+        assert_eq!(
+            legacy_literal_ip_policy_from_value(None),
+            LegacyLiteralIpPolicy::FailClosed
+        );
+        for other in ["0", "true", "yes", "SkipWithWarning", ""] {
+            assert_eq!(
+                legacy_literal_ip_policy_from_value(Some(other.to_string())),
+                LegacyLiteralIpPolicy::FailClosed,
+                "non-exact value {other:?} must not select the skip policy"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_literal_ip_policy_skips_with_warning_only_on_exact_value_one() {
+        assert_eq!(
+            legacy_literal_ip_policy_from_value(Some("1".to_string())),
+            LegacyLiteralIpPolicy::SkipWithWarning
+        );
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/mail_messages_schema.rs
+++ b/crates/atm-storage-rusqlite/src/mail_messages_schema.rs
@@ -8,11 +8,11 @@
 //! self-detecting table rebuild that migrates those databases.
 
 use crate::schema_support::{
-    ensure_columns_match_canonical, merge_restore_failure, table_column_names,
+    TableRebuildPlan, TableRebuildView, rebuild_table, run_within_foreign_keys_toggle,
 };
-use crate::shared_db::{SharedDbTarget, sqlite_error};
+use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
 use atm_storage::error::AtmError;
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::{Transaction, TransactionBehavior};
 use std::time::Instant;
 
 /// Canonical `mail_messages` table DDL, parameterized by its `CREATE` clause.
@@ -123,7 +123,7 @@ const MAIL_MESSAGES_INDEX_DDL: &str = mail_messages_index_ddl!();
 /// rolls the rebuild transaction back, so the legacy table is left untouched
 /// and a later startup retries.
 pub(crate) fn ensure_mail_messages_message_text_nullable(
-    connection: &mut Connection,
+    connection: &mut SqliteConnection,
     target: &SharedDbTarget,
 ) -> Result<(), AtmError> {
     use rusqlite::OptionalExtension;
@@ -146,45 +146,20 @@ pub(crate) fn ensure_mail_messages_message_text_nullable(
         return Ok(());
     }
 
-    // `PRAGMA foreign_keys` is a no-op inside a transaction, so it must be
-    // toggled here: `mail_message_states` has a foreign key onto
-    // `mail_messages`, and the drop/rename below would otherwise cascade the
-    // state rows away. This follows SQLite's documented ALTER TABLE procedure.
-    connection
-        .pragma_update(None, "foreign_keys", "OFF")
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to disable foreign keys for the mail_messages rebuild",
-                error,
-            )
-        })?;
-    let rebuild = rebuild_mail_messages_with_nullable_message_text(connection, target);
-    let restored = connection
-        .pragma_update(None, "foreign_keys", "ON")
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to restore foreign keys after the mail_messages rebuild",
-                error,
-            )
-        });
-    match (rebuild, restored) {
-        (Ok(()), outcome) => outcome,
-        (Err(failure), Ok(())) => Err(failure),
-        // The connection is left with foreign keys disabled; surface that
-        // alongside the rebuild failure instead of dropping it.
-        (Err(failure), Err(restore)) => Err(merge_restore_failure(failure, &restore)),
-    }
+    // `mail_message_states` has a foreign key onto `mail_messages`, and the
+    // rebuild's drop/rename would otherwise cascade the state rows away; see
+    // `run_within_foreign_keys_toggle`.
+    run_within_foreign_keys_toggle(connection, target, "mail_messages", |connection| {
+        rebuild_mail_messages_with_nullable_message_text(connection, target)
+    })
 }
 
 /// Performs the SQLite table rebuild that relaxes `message_text` to nullable.
 ///
-/// The stages below are SQLite's documented ALTER TABLE procedure. Callers
-/// must have disabled `PRAGMA foreign_keys` and must restore it afterwards;
-/// see [`ensure_mail_messages_message_text_nullable`].
+/// Callers must have disabled `PRAGMA foreign_keys` and must restore it
+/// afterwards; see [`ensure_mail_messages_message_text_nullable`].
 fn rebuild_mail_messages_with_nullable_message_text(
-    connection: &mut Connection,
+    connection: &mut SqliteConnection,
     target: &SharedDbTarget,
 ) -> Result<(), AtmError> {
     let started = Instant::now();
@@ -198,12 +173,21 @@ fn rebuild_mail_messages_with_nullable_message_text(
             )
         })?;
 
-    drop_catalog_view(&transaction, target)?;
-    let columns = create_staging_table(&transaction, target)?;
-    let copied = copy_rows_into_staging_table(&transaction, target, &columns)?;
-    swap_in_staging_table(&transaction, target)?;
-    restore_indexes_and_catalog_view(&transaction, target)?;
-    reject_foreign_key_violations(&transaction, target)?;
+    let copied = rebuild_table(
+        &transaction,
+        target,
+        &TableRebuildPlan {
+            table: "mail_messages",
+            staging_table: MAIL_MESSAGES_REBUILD_TABLE,
+            staging_table_ddl: MAIL_MESSAGES_REBUILD_TABLE_DDL,
+            index_ddl: MAIL_MESSAGES_INDEX_DDL,
+            view: Some(TableRebuildView {
+                name: "decomposed_messages",
+                restore: restore_decomposed_messages_view,
+            }),
+            check_foreign_keys: true,
+        },
+    )?;
 
     transaction.commit().map_err(|error| {
         sqlite_error(
@@ -222,150 +206,23 @@ fn rebuild_mail_messages_with_nullable_message_text(
     Ok(())
 }
 
-/// Drops the catalog view so the later rename cannot fail schema validation.
+/// Recreates the `decomposed_messages` catalog view, along with whatever
+/// template-catalog migrations it depends on, after the rebuild swap.
 ///
-/// SQLite validates view bodies during `ALTER TABLE ... RENAME`, and
-/// `decomposed_messages` selects from `mail_messages`. The view is recreated
-/// verbatim from its owning module by [`restore_indexes_and_catalog_view`].
-fn drop_catalog_view(
+/// `decomposed_messages` selects from `mail_messages`, so it must have been
+/// dropped before the swap's `ALTER TABLE ... RENAME`; this restores it
+/// verbatim from its owning module.
+fn restore_decomposed_messages_view(
     transaction: &Transaction<'_>,
     target: &SharedDbTarget,
 ) -> Result<(), AtmError> {
-    transaction
-        .execute_batch("DROP VIEW IF EXISTS decomposed_messages;")
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to drop the decomposed_messages view for the mail_messages rebuild",
-                error,
-            )
-        })
-}
-
-/// Creates the staging table and returns its canonical column list.
-///
-/// The staging table has the canonical shape by construction, so its columns
-/// are the authority the legacy table is checked against; a legacy table with
-/// an unknown or missing column is rejected rather than silently truncated.
-fn create_staging_table(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<Vec<String>, AtmError> {
-    transaction
-        .execute_batch(MAIL_MESSAGES_REBUILD_TABLE_DDL)
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to create the rebuilt mail_messages table",
-                error,
-            )
-        })?;
-    let columns = table_column_names(transaction, target, MAIL_MESSAGES_REBUILD_TABLE)?;
-    ensure_columns_match_canonical(
-        transaction,
-        target,
-        "mail_messages",
-        &columns.iter().map(String::as_str).collect::<Vec<_>>(),
-    )?;
-    Ok(columns)
-}
-
-/// Copies every legacy row into the staging table, returning the row count.
-fn copy_rows_into_staging_table(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-    columns: &[String],
-) -> Result<usize, AtmError> {
-    let column_list = columns
-        .iter()
-        .map(|column| format!("\"{column}\""))
-        .collect::<Vec<_>>()
-        .join(", ");
-    transaction
-        .execute(
-            &format!(
-                "INSERT INTO {MAIL_MESSAGES_REBUILD_TABLE} ({column_list}) SELECT {column_list} FROM mail_messages;"
-            ),
-            [],
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to copy rows into the rebuilt mail_messages table",
-                error,
-            )
-        })
-}
-
-/// Drops the legacy table and renames the staging table into its place.
-fn swap_in_staging_table(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    transaction
-        .execute_batch(&format!(
-            "DROP TABLE mail_messages;
-             ALTER TABLE {MAIL_MESSAGES_REBUILD_TABLE} RENAME TO mail_messages;"
-        ))
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to swap in the rebuilt mail_messages table",
-                error,
-            )
-        })
-}
-
-/// Replays the mailbox indexes and recreates the catalog view after the swap.
-///
-/// Dropping the legacy table also dropped its indexes, so both are rebuilt
-/// from the definitions a fresh database uses.
-fn restore_indexes_and_catalog_view(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    transaction
-        .execute_batch(MAIL_MESSAGES_INDEX_DDL)
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to recreate mail_messages indexes after the rebuild",
-                error,
-            )
-        })?;
     crate::template_catalog_schema::ensure_schema(transaction, target)
-}
-
-/// Fails the transaction when the rebuild left a dangling foreign key.
-fn reject_foreign_key_violations(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    let violations = transaction
-        .query_row(
-            "SELECT COUNT(1) FROM pragma_foreign_key_check;",
-            [],
-            |row| row.get::<_, i64>(0),
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to run the foreign-key check after the mail_messages rebuild",
-                error,
-            )
-        })?;
-    if violations > 0 {
-        return Err(AtmError::mailbox_write(format!(
-            "mail_messages rebuild on {} left {violations} foreign key violation(s); rolling back",
-            target.display()
-        )));
-    }
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema_support::table_column_names;
     use crate::shared_db::{NEXT_IN_MEMORY_DB_ID, ensure_schema, open_connection_for_target};
     use std::sync::atomic::Ordering;
 
@@ -451,7 +308,7 @@ INSERT INTO mail_message_states(
         }
     }
 
-    fn legacy_mail_messages_connection(label: &str) -> (SharedDbTarget, Connection) {
+    fn legacy_mail_messages_connection(label: &str) -> (SharedDbTarget, SqliteConnection) {
         let target = in_memory_target(label);
         let connection = open_connection_for_target(&target).expect("open connection");
         connection
@@ -460,14 +317,14 @@ INSERT INTO mail_message_states(
         (target, connection)
     }
 
-    fn fresh_schema_connection(label: &str) -> (SharedDbTarget, Connection) {
+    fn fresh_schema_connection(label: &str) -> (SharedDbTarget, SqliteConnection) {
         let target = in_memory_target(label);
         let mut connection = open_connection_for_target(&target).expect("open connection");
         ensure_schema(&mut connection, &target).expect("fresh schema");
         (target, connection)
     }
 
-    fn message_text_notnull(connection: &Connection) -> i64 {
+    fn message_text_notnull(connection: &SqliteConnection) -> i64 {
         connection
             .query_row(
                 r#"SELECT "notnull" FROM pragma_table_info('mail_messages') WHERE name = 'message_text';"#,
@@ -477,13 +334,13 @@ INSERT INTO mail_message_states(
             .expect("probe message_text nullability")
     }
 
-    fn foreign_keys_enabled(connection: &Connection) -> i64 {
+    fn foreign_keys_enabled(connection: &SqliteConnection) -> i64 {
         connection
             .query_row("PRAGMA foreign_keys;", [], |row| row.get(0))
             .expect("read foreign_keys pragma")
     }
 
-    fn foreign_key_violations(connection: &Connection) -> i64 {
+    fn foreign_key_violations(connection: &SqliteConnection) -> i64 {
         connection
             .query_row(
                 "SELECT COUNT(1) FROM pragma_foreign_key_check;",
@@ -493,7 +350,7 @@ INSERT INTO mail_message_states(
             .expect("run foreign key check")
     }
 
-    fn schema_objects(connection: &Connection, object_type: &str) -> Vec<(String, String)> {
+    fn schema_objects(connection: &SqliteConnection, object_type: &str) -> Vec<(String, String)> {
         connection
             .prepare(
                 "SELECT name, sql FROM sqlite_master
@@ -509,7 +366,7 @@ INSERT INTO mail_message_states(
             .expect("decode sqlite_master rows")
     }
 
-    fn decomposed_view_sql(connection: &Connection) -> String {
+    fn decomposed_view_sql(connection: &SqliteConnection) -> String {
         connection
             .query_row(
                 "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'decomposed_messages';",
@@ -519,7 +376,7 @@ INSERT INTO mail_message_states(
             .expect("read decomposed_messages view sql")
     }
 
-    fn mail_messages_rootpage(connection: &Connection) -> i64 {
+    fn mail_messages_rootpage(connection: &SqliteConnection) -> i64 {
         connection
             .query_row(
                 "SELECT rootpage FROM sqlite_master WHERE type = 'table' AND name = 'mail_messages';",
@@ -529,7 +386,7 @@ INSERT INTO mail_message_states(
             .expect("read mail_messages rootpage")
     }
 
-    fn legacy_rows(connection: &Connection) -> Vec<LegacyRow> {
+    fn legacy_rows(connection: &SqliteConnection) -> Vec<LegacyRow> {
         connection
             .prepare(
                 "SELECT team, agent, message_key, envelope_json, from_agent,

--- a/crates/atm-storage-rusqlite/src/schema_support.rs
+++ b/crates/atm-storage-rusqlite/src/schema_support.rs
@@ -3,12 +3,17 @@
 //! SQLite cannot relax a `NOT NULL` constraint or widen a `CHECK` constraint in
 //! place, so [`crate::mail_messages_schema`] and [`crate::team_roster_schema`]
 //! both recreate their table with the documented rename/create/copy/drop
-//! procedure. The helpers here own the parts those rebuilds must agree on:
-//! column introspection, the guard that refuses to silently drop an unknown
-//! legacy column, and compound failure reporting when cleanup itself fails.
+//! procedure. The helpers here own every stage of that procedure -- column
+//! introspection, the guard that refuses to silently drop an unknown legacy
+//! column, the drop-staging-copy-swap-restore rebuild itself, the optional
+//! post-rebuild foreign-key check, and the `PRAGMA foreign_keys` toggle
+//! around a rebuild -- so the two callers cannot let the procedure itself
+//! drift apart, and only their table-specific shape (DDL, index DDL, and an
+//! optional dependent view) varies.
 
 use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
 use atm_storage::error::AtmError;
+use rusqlite::Transaction;
 
 /// Reads the declared column names of `table` in their declaration order.
 ///
@@ -93,6 +98,277 @@ pub(crate) fn ensure_columns_match_canonical(
         )));
     }
     Ok(())
+}
+
+/// A dependent view that must be dropped before a table rebuild and
+/// recreated afterward.
+///
+/// The restore is a callback rather than raw DDL because recreating a view
+/// can require running other schema-owning migrations first (see
+/// `mail_messages_schema`'s `decomposed_messages`, whose columns depend on
+/// the template-catalog migrations in `template_catalog_schema::ensure_schema`).
+pub(crate) struct TableRebuildView<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) restore: fn(&Transaction<'_>, &SharedDbTarget) -> Result<(), AtmError>,
+}
+
+/// Table-specific shape for one legacy-table rebuild.
+///
+/// [`rebuild_table`] performs the documented drop-view/create-staging/copy/
+/// swap/restore-indexes/restore-view/check-foreign-keys procedure; this plan
+/// supplies only what varies per table.
+pub(crate) struct TableRebuildPlan<'a> {
+    /// The live table being rebuilt. Also names the table in error text.
+    pub(crate) table: &'a str,
+    /// Name of the staging table created under the canonical DDL.
+    pub(crate) staging_table: &'a str,
+    /// `CREATE TABLE <staging_table> (...)` statement for the canonical shape.
+    pub(crate) staging_table_ddl: &'a str,
+    /// Index DDL replayed on `table` after the swap.
+    pub(crate) index_ddl: &'a str,
+    /// The table's dependent view, if any, to drop before and restore after.
+    pub(crate) view: Option<TableRebuildView<'a>>,
+    /// Whether to reject the rebuild when it leaves a dangling foreign key.
+    pub(crate) check_foreign_keys: bool,
+}
+
+/// Rebuilds `plan.table` under the SQLite-documented ALTER TABLE procedure:
+/// drop its dependent view (if any), create a staging table under the
+/// canonical DDL, copy every legacy row into it (refusing an unknown or
+/// missing column), swap the staging table into place, replay its indexes,
+/// restore its dependent view (if any), and optionally reject a dangling
+/// foreign key left by the swap. Returns the number of rows copied.
+///
+/// # Errors
+/// Returns an error naming the failing stage; the caller's transaction is
+/// left uncommitted so it rolls back on drop.
+pub(crate) fn rebuild_table(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    plan: &TableRebuildPlan<'_>,
+) -> Result<usize, AtmError> {
+    if let Some(view) = &plan.view {
+        drop_rebuild_view(transaction, target, plan.table, view.name)?;
+    }
+    let columns = create_staging_table(
+        transaction,
+        target,
+        plan.table,
+        plan.staging_table,
+        plan.staging_table_ddl,
+    )?;
+    let copied = copy_rows_into_staging_table(
+        transaction,
+        target,
+        plan.table,
+        plan.staging_table,
+        &columns,
+    )?;
+    swap_in_staging_table(transaction, target, plan.table, plan.staging_table)?;
+    restore_table_indexes(transaction, target, plan.table, plan.index_ddl)?;
+    if let Some(view) = &plan.view {
+        (view.restore)(transaction, target)?;
+    }
+    if plan.check_foreign_keys {
+        reject_foreign_key_violations(transaction, target, plan.table)?;
+    }
+    Ok(copied)
+}
+
+/// Drops `view` so a later `ALTER TABLE ... RENAME` on `table` cannot fail
+/// schema validation against a view body that selects from it.
+fn drop_rebuild_view(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+    view: &str,
+) -> Result<(), AtmError> {
+    transaction
+        .execute_batch(&format!("DROP VIEW IF EXISTS {view};"))
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to drop the {view} view for the {table} rebuild"),
+                error,
+            )
+        })
+}
+
+/// Creates the staging table and returns its canonical column list.
+///
+/// The staging table has the canonical shape by construction, so its columns
+/// are the authority `table`'s live columns are checked against; a legacy
+/// table with an unknown or missing column is rejected rather than silently
+/// truncated.
+fn create_staging_table(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+    staging_table: &str,
+    staging_table_ddl: &str,
+) -> Result<Vec<String>, AtmError> {
+    transaction
+        .execute_batch(staging_table_ddl)
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to create the rebuilt {table} table"),
+                error,
+            )
+        })?;
+    let columns = table_column_names(transaction, target, staging_table)?;
+    ensure_columns_match_canonical(
+        transaction,
+        target,
+        table,
+        &columns.iter().map(String::as_str).collect::<Vec<_>>(),
+    )?;
+    Ok(columns)
+}
+
+/// Copies every live row of `table` into `staging_table`, returning the row
+/// count.
+fn copy_rows_into_staging_table(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+    staging_table: &str,
+    columns: &[String],
+) -> Result<usize, AtmError> {
+    let column_list = columns
+        .iter()
+        .map(|column| format!("\"{column}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    transaction
+        .execute(
+            &format!(
+                "INSERT INTO {staging_table} ({column_list}) SELECT {column_list} FROM {table};"
+            ),
+            [],
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to copy rows into the rebuilt {table} table"),
+                error,
+            )
+        })
+}
+
+/// Drops the live table and renames the staging table into its place.
+fn swap_in_staging_table(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+    staging_table: &str,
+) -> Result<(), AtmError> {
+    transaction
+        .execute_batch(&format!(
+            "DROP TABLE {table};
+             ALTER TABLE {staging_table} RENAME TO {table};"
+        ))
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to swap in the rebuilt {table} table"),
+                error,
+            )
+        })
+}
+
+/// Replays `index_ddl` on `table` after the swap dropped its indexes.
+fn restore_table_indexes(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+    index_ddl: &str,
+) -> Result<(), AtmError> {
+    transaction.execute_batch(index_ddl).map_err(|error| {
+        sqlite_error(
+            target,
+            format!("failed to recreate {table} indexes after the rebuild"),
+            error,
+        )
+    })
+}
+
+/// Fails the transaction when the rebuild left a dangling foreign key.
+fn reject_foreign_key_violations(
+    transaction: &Transaction<'_>,
+    target: &SharedDbTarget,
+    table: &str,
+) -> Result<(), AtmError> {
+    let violations = transaction
+        .query_row(
+            "SELECT COUNT(1) FROM pragma_foreign_key_check;",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to run the foreign-key check after the {table} rebuild"),
+                error,
+            )
+        })?;
+    if violations > 0 {
+        return Err(AtmError::mailbox_write(format!(
+            "{table} rebuild on {} left {violations} foreign key violation(s); rolling back",
+            target.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Runs `work` with `PRAGMA foreign_keys` disabled, then restores it.
+///
+/// A rebuild that drops and recreates `table` would otherwise cascade away
+/// any row referencing it via a foreign key (`PRAGMA foreign_keys` is a
+/// no-op inside a transaction, so it must be toggled around one, per
+/// SQLite's documented ALTER TABLE procedure). `work`'s success or failure
+/// always takes priority in the returned error over a restore failure; a
+/// restore failure is folded into a successful `work`'s failure via
+/// [`merge_restore_failure`], and reported alone when `work` itself
+/// succeeded.
+///
+/// # Errors
+/// Returns `work`'s error (augmented with any restore failure), or the
+/// restore failure alone when `work` succeeded but the pragma could not be
+/// restored.
+pub(crate) fn run_within_foreign_keys_toggle<T>(
+    connection: &mut SqliteConnection,
+    target: &SharedDbTarget,
+    table: &str,
+    work: impl FnOnce(&mut SqliteConnection) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    connection
+        .pragma_update(None, "foreign_keys", "OFF")
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to disable foreign keys for the {table} rebuild"),
+                error,
+            )
+        })?;
+    let outcome = work(connection);
+    let restored = connection
+        .pragma_update(None, "foreign_keys", "ON")
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to restore foreign keys after the {table} rebuild"),
+                error,
+            )
+        });
+    match (outcome, restored) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_value), Err(restore_failure)) => Err(restore_failure),
+        (Err(failure), Ok(())) => Err(failure),
+        // The connection is left with foreign keys disabled; surface that
+        // alongside the original failure instead of dropping it.
+        (Err(failure), Err(restore)) => Err(merge_restore_failure(failure, &restore)),
+    }
 }
 
 /// Folds a failed connection-state restore into the error that preceded it.

--- a/crates/atm-storage-rusqlite/src/team_roster_schema.rs
+++ b/crates/atm-storage-rusqlite/src/team_roster_schema.rs
@@ -120,7 +120,7 @@ mod tests {
                 CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);
                 INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, updated_at
-                ) VALUES ('hermes', 'skillrx', 'permanent', 'claude-code', 'now');",
+                ) VALUES ('test-team', 'test-agent', 'permanent', 'claude-code', 'now');",
             )
             .expect("create legacy roster table");
 
@@ -129,14 +129,14 @@ mod tests {
             .execute(
                 "INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, updated_at
-                ) VALUES ('hermes', 'python-worker', 'permanent', 'python-graft', 'now');",
+                ) VALUES ('test-team', 'python-worker', 'permanent', 'python-graft', 'now');",
                 [],
             )
             .expect("new harness should satisfy migrated check constraint");
         let harnesses: Vec<String> = connection
             .prepare(
                 "SELECT harness FROM team_roster
-                 WHERE team_name = 'hermes' ORDER BY agent_name;",
+                 WHERE team_name = 'test-team' ORDER BY agent_name;",
             )
             .expect("prepare harness query")
             .query_map([], |row| row.get(0))
@@ -173,7 +173,7 @@ mod tests {
                 );
                 INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, operator_annotation, updated_at
-                ) VALUES ('hermes', 'skillrx', 'permanent', 'claude-code', 'keep me', 'now');",
+                ) VALUES ('test-team', 'test-agent', 'permanent', 'claude-code', 'keep me', 'now');",
             )
             .expect("create legacy roster table with an unknown column");
 
@@ -187,7 +187,7 @@ mod tests {
 
         let annotation: String = connection
             .query_row(
-                "SELECT operator_annotation FROM team_roster WHERE agent_name = 'skillrx';",
+                "SELECT operator_annotation FROM team_roster WHERE agent_name = 'test-agent';",
                 [],
                 |row| row.get(0),
             )

--- a/crates/atm-storage-rusqlite/src/team_roster_schema.rs
+++ b/crates/atm-storage-rusqlite/src/team_roster_schema.rs
@@ -6,30 +6,38 @@
 //! constraint, following the same procedure as
 //! [`crate::mail_messages_schema`].
 
-use crate::schema_support::ensure_columns_match_canonical;
-use crate::shared_db::{SharedDbTarget, sqlite_error};
+use crate::schema_support::{TableRebuildPlan, rebuild_table};
+use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
 use atm_storage::error::AtmError;
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::TransactionBehavior;
 
-/// Every column the rebuilt `team_roster` table defines, in declaration order.
-///
-/// The rebuild copies rows by explicit column list, so a legacy roster column
-/// outside this set would be dropped silently; the shared guard rejects that.
-const TEAM_ROSTER_CANONICAL_COLUMNS: &[&str] = &[
-    "team_name",
-    "agent_name",
-    "member_kind",
-    "harness",
-    "agent_type",
-    "model",
-    "metadata_json",
-    "source",
-    "recipient_pane_id",
-    "updated_at",
-];
+/// Staging table name used by the harness `CHECK` constraint rebuild.
+const TEAM_ROSTER_REBUILD_TABLE: &str = "team_roster_harness_rebuild";
+
+/// `CREATE TABLE` for the rebuild staging table, carrying the current
+/// harness `CHECK` constraint.
+const TEAM_ROSTER_REBUILD_TABLE_DDL: &str = r#"
+CREATE TABLE team_roster_harness_rebuild (
+    team_name TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
+    harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode', 'hermes', 'python-graft')),
+    agent_type TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    source TEXT,
+    recipient_pane_id TEXT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (team_name, agent_name)
+);
+"#;
+
+/// Index DDL replayed after the rebuild swaps the tables.
+const TEAM_ROSTER_INDEX_DDL: &str =
+    "CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);";
 
 pub(crate) fn ensure_team_roster_harness_values(
-    connection: &mut Connection,
+    connection: &mut SqliteConnection,
     target: &SharedDbTarget,
 ) -> Result<(), AtmError> {
     let table_sql = connection
@@ -48,12 +56,6 @@ pub(crate) fn ensure_team_roster_harness_values(
     if table_sql.contains("'hermes'") && table_sql.contains("'python-graft'") {
         return Ok(());
     }
-    ensure_columns_match_canonical(
-        connection,
-        target,
-        "team_roster",
-        TEAM_ROSTER_CANONICAL_COLUMNS,
-    )?;
 
     let transaction = connection
         .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -64,7 +66,18 @@ pub(crate) fn ensure_team_roster_harness_values(
                 error,
             )
         })?;
-    rebuild_team_roster_with_current_harness_values(&transaction, target)?;
+    rebuild_table(
+        &transaction,
+        target,
+        &TableRebuildPlan {
+            table: "team_roster",
+            staging_table: TEAM_ROSTER_REBUILD_TABLE,
+            staging_table_ddl: TEAM_ROSTER_REBUILD_TABLE_DDL,
+            index_ddl: TEAM_ROSTER_INDEX_DDL,
+            view: None,
+            check_foreign_keys: false,
+        },
+    )?;
     transaction.commit().map_err(|error| {
         sqlite_error(
             target,
@@ -72,54 +85,6 @@ pub(crate) fn ensure_team_roster_harness_values(
             error,
         )
     })
-}
-
-/// Recreates `team_roster` with the current harness `CHECK` constraint.
-///
-/// The copied column list is derived from [`TEAM_ROSTER_CANONICAL_COLUMNS`]
-/// rather than spelled out again, and the recreated table is checked back
-/// against that same list so the `CREATE TABLE` body below cannot drift away
-/// from what the copy assumes.
-fn rebuild_team_roster_with_current_harness_values(
-    transaction: &Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    let column_list = TEAM_ROSTER_CANONICAL_COLUMNS.join(", ");
-    transaction
-        .execute_batch(&format!(
-            "DROP INDEX IF EXISTS idx_team_roster_team_name;
-             ALTER TABLE team_roster RENAME TO team_roster_legacy_harness;
-             CREATE TABLE team_roster (
-                 team_name TEXT NOT NULL,
-                 agent_name TEXT NOT NULL,
-                 member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
-                 harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode', 'hermes', 'python-graft')),
-                 agent_type TEXT NOT NULL DEFAULT '',
-                 model TEXT NOT NULL DEFAULT '',
-                 metadata_json TEXT NOT NULL DEFAULT '{{}}',
-                 source TEXT,
-                 recipient_pane_id TEXT NULL,
-                 updated_at TEXT NOT NULL,
-                 PRIMARY KEY (team_name, agent_name)
-             );
-             INSERT INTO team_roster({column_list})
-             SELECT {column_list} FROM team_roster_legacy_harness;
-             DROP TABLE team_roster_legacy_harness;
-             CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);"
-        ))
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to migrate team_roster harness constraint",
-                error,
-            )
-        })?;
-    ensure_columns_match_canonical(
-        transaction,
-        target,
-        "team_roster",
-        TEAM_ROSTER_CANONICAL_COLUMNS,
-    )
 }
 
 #[cfg(test)]

--- a/crates/atm-storage-rusqlite/src/team_roster_schema.rs
+++ b/crates/atm-storage-rusqlite/src/team_roster_schema.rs
@@ -93,6 +93,11 @@ mod tests {
     use crate::shared_db::{NEXT_IN_MEMORY_DB_ID, open_connection_for_target};
     use std::sync::atomic::Ordering;
 
+    /// Neutral fixture identifiers: the subject under test is the harness
+    /// CHECK constraint, not any particular team or agent.
+    const TEST_TEAM: &str = "test-team";
+    const TEST_AGENT: &str = "test-agent";
+
     #[test]
     fn ensure_team_roster_harness_values_migrates_legacy_check_constraint() {
         let target = SharedDbTarget::InMemory {
@@ -104,14 +109,14 @@ mod tests {
         let mut connection = open_connection_for_target(&target).expect("open connection");
         connection
             .execute_batch(
-                "CREATE TABLE team_roster (
+                &format!("CREATE TABLE team_roster (
                     team_name TEXT NOT NULL,
                     agent_name TEXT NOT NULL,
                     member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
                     harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode')),
                     agent_type TEXT NOT NULL DEFAULT '',
                     model TEXT NOT NULL DEFAULT '',
-                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    metadata_json TEXT NOT NULL DEFAULT '{{}}',
                     source TEXT,
                     recipient_pane_id TEXT NULL,
                     updated_at TEXT NOT NULL,
@@ -120,24 +125,28 @@ mod tests {
                 CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);
                 INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, updated_at
-                ) VALUES ('test-team', 'test-agent', 'permanent', 'claude-code', 'now');",
+                ) VALUES ('{team}', '{agent}', 'permanent', 'claude-code', 'now');", team = TEST_TEAM, agent = TEST_AGENT),
             )
             .expect("create legacy roster table");
 
         ensure_team_roster_harness_values(&mut connection, &target).expect("migrate roster");
         connection
             .execute(
-                "INSERT INTO team_roster(
+                &format!(
+                    "INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, updated_at
-                ) VALUES ('test-team', 'python-worker', 'permanent', 'python-graft', 'now');",
+                ) VALUES ('{team}', 'python-worker', 'permanent', 'python-graft', 'now');",
+                    team = TEST_TEAM
+                ),
                 [],
             )
             .expect("new harness should satisfy migrated check constraint");
         let harnesses: Vec<String> = connection
-            .prepare(
+            .prepare(&format!(
                 "SELECT harness FROM team_roster
-                 WHERE team_name = 'test-team' ORDER BY agent_name;",
-            )
+                 WHERE team_name = '{team}' ORDER BY agent_name;",
+                team = TEST_TEAM
+            ))
             .expect("prepare harness query")
             .query_map([], |row| row.get(0))
             .expect("query harnesses")
@@ -157,14 +166,14 @@ mod tests {
         let mut connection = open_connection_for_target(&target).expect("open connection");
         connection
             .execute_batch(
-                "CREATE TABLE team_roster (
+                &format!("CREATE TABLE team_roster (
                     team_name TEXT NOT NULL,
                     agent_name TEXT NOT NULL,
                     member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
                     harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode')),
                     agent_type TEXT NOT NULL DEFAULT '',
                     model TEXT NOT NULL DEFAULT '',
-                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    metadata_json TEXT NOT NULL DEFAULT '{{}}',
                     source TEXT,
                     recipient_pane_id TEXT NULL,
                     operator_annotation TEXT NULL,
@@ -173,7 +182,7 @@ mod tests {
                 );
                 INSERT INTO team_roster(
                     team_name, agent_name, member_kind, harness, operator_annotation, updated_at
-                ) VALUES ('test-team', 'test-agent', 'permanent', 'claude-code', 'keep me', 'now');",
+                ) VALUES ('{team}', '{agent}', 'permanent', 'claude-code', 'keep me', 'now');", team = TEST_TEAM, agent = TEST_AGENT),
             )
             .expect("create legacy roster table with an unknown column");
 
@@ -187,7 +196,10 @@ mod tests {
 
         let annotation: String = connection
             .query_row(
-                "SELECT operator_annotation FROM team_roster WHERE agent_name = 'test-agent';",
+                &format!(
+                    "SELECT operator_annotation FROM team_roster WHERE agent_name = '{agent}';",
+                    agent = TEST_AGENT
+                ),
                 [],
                 |row| row.get(0),
             )

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 mod error_catalog;
 pub mod error_codes;
 pub mod factory;
+pub mod peer_catalog_audit;
 pub mod request_budget;
 pub mod schema;
 pub mod search;
@@ -44,6 +45,7 @@ pub use contract::{
 pub use error::AtmError;
 pub use error_codes::AtmErrorCode;
 pub use factory::{StorageFactory, StorageHandleParts, StorageHandles};
+pub use peer_catalog_audit::TrustedPeerCatalogAudit;
 pub use roles::ROLE_WORKER;
 pub use schema::{AlertKind, AtmMessageId, InboxMessage, MessageEnvelope, PendingAck, ThreadMode};
 pub use search::{

--- a/crates/atm-storage/src/peer_catalog_audit.rs
+++ b/crates/atm-storage/src/peer_catalog_audit.rs
@@ -1,0 +1,183 @@
+//! Pure audit of a trusted-peer catalog against durable-hostname enforcement.
+//!
+//! This module owns only the read-only classification of trusted-peer rows.
+//! It performs no storage I/O, TLS work, or CLI mutation; callers use the
+//! resulting audit to decide startup policy or render operator remediation.
+
+use crate::contract::TrustedPeer;
+use crate::types::HostName;
+
+/// Partitions a trusted-peer catalog by durable-hostname status and
+/// enablement, isolating legacy literal-IP authority rows that predate
+/// [`HostName::is_durable_hostname`] enforcement.
+///
+/// # Examples
+/// ```
+/// use atm_storage::TrustedPeerCatalogAudit;
+///
+/// let audit = TrustedPeerCatalogAudit::from_peers(&[]);
+/// assert!(!audit.has_legacy_literal_ip_rows());
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TrustedPeerCatalogAudit {
+    durable_enabled: Vec<HostName>,
+    durable_disabled: Vec<HostName>,
+    legacy_literal_enabled: Vec<HostName>,
+    legacy_literal_disabled: Vec<HostName>,
+}
+
+impl TrustedPeerCatalogAudit {
+    /// Classifies every row in `peers` without mutating or reordering them.
+    #[must_use]
+    pub fn from_peers(peers: &[TrustedPeer]) -> Self {
+        let mut audit = Self::default();
+        for peer in peers {
+            let durable = peer.host.is_durable_hostname();
+            let bucket = match (durable, peer.enabled) {
+                (true, true) => &mut audit.durable_enabled,
+                (true, false) => &mut audit.durable_disabled,
+                (false, true) => &mut audit.legacy_literal_enabled,
+                (false, false) => &mut audit.legacy_literal_disabled,
+            };
+            bucket.push(peer.host.clone());
+        }
+        audit
+    }
+
+    /// Durable-hostname peers currently enabled for outbound/inbound mTLS.
+    #[must_use]
+    pub fn durable_enabled_hosts(&self) -> &[HostName] {
+        &self.durable_enabled
+    }
+
+    /// Legacy literal-IP rows that are enabled and would otherwise be used
+    /// as a live mTLS peer authority.
+    #[must_use]
+    pub fn legacy_literal_enabled_hosts(&self) -> &[HostName] {
+        &self.legacy_literal_enabled
+    }
+
+    /// Legacy literal-IP rows that are disabled and therefore historical
+    /// only; they must never block an otherwise-valid configuration.
+    #[must_use]
+    pub fn legacy_literal_disabled_hosts(&self) -> &[HostName] {
+        &self.legacy_literal_disabled
+    }
+
+    /// True when the catalog contains any legacy literal-IP row, enabled or
+    /// disabled.
+    #[must_use]
+    pub fn has_legacy_literal_ip_rows(&self) -> bool {
+        !self.legacy_literal_enabled.is_empty() || !self.legacy_literal_disabled.is_empty()
+    }
+
+    /// The exact, safe command that converts `host` (a legacy literal-IP
+    /// authority) to a durable `target_hostname`, preserving its fingerprint
+    /// and port. `target_hostname` may be a literal placeholder such as
+    /// `<hostname>` when rendering guidance rather than an executable command.
+    #[must_use]
+    pub fn migrate_command(host: &HostName, target_hostname: &str) -> String {
+        format!("atm peer trust migrate --map {host}={target_hostname} --yes")
+    }
+
+    /// The exact, safe command that retires `host` from the trusted-peer
+    /// catalog without touching any other row.
+    #[must_use]
+    pub fn revoke_command(host: &HostName) -> String {
+        format!("atm peer trust revoke --host {host} --yes")
+    }
+
+    /// Renders one remediation line per legacy literal-IP row (enabled and
+    /// disabled), naming the host and its exact safe migrate/revoke commands.
+    /// Returns an empty string when no legacy literal-IP rows are present.
+    #[must_use]
+    pub fn remediation_text(&self) -> String {
+        let mut lines = Vec::new();
+        for host in &self.legacy_literal_enabled {
+            lines.push(format!(
+                "{host} (enabled): migrate with `{}` or retire with `{}`",
+                Self::migrate_command(host, "<hostname>"),
+                Self::revoke_command(host)
+            ));
+        }
+        for host in &self.legacy_literal_disabled {
+            lines.push(format!(
+                "{host} (disabled): safe to prune with `{}`",
+                Self::revoke_command(host)
+            ));
+        }
+        lines.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU16;
+
+    fn peer(host: &str, enabled: bool) -> TrustedPeer {
+        TrustedPeer {
+            host: host.parse().expect("host"),
+            fingerprint: "sha256:test".parse().expect("fingerprint"),
+            enabled,
+            https_port: NonZeroU16::new(443).expect("port"),
+        }
+    }
+
+    #[test]
+    fn empty_catalog_has_no_legacy_rows() {
+        let audit = TrustedPeerCatalogAudit::from_peers(&[]);
+        assert!(!audit.has_legacy_literal_ip_rows());
+        assert_eq!(audit.remediation_text(), "");
+    }
+
+    #[test]
+    fn mixed_catalog_partitions_every_bucket() {
+        let peers = vec![
+            peer("rand-m5.local", true),
+            peer("rand-m4.local", false),
+            peer("192.168.128.29", true),
+            peer("10.0.0.5", false),
+        ];
+        let audit = TrustedPeerCatalogAudit::from_peers(&peers);
+        assert_eq!(
+            audit.durable_enabled_hosts(),
+            &["rand-m5.local".parse::<HostName>().expect("host")]
+        );
+        assert_eq!(audit.durable_disabled.len(), 1);
+        assert_eq!(
+            audit.legacy_literal_enabled_hosts(),
+            &["192.168.128.29".parse::<HostName>().expect("host")]
+        );
+        assert_eq!(
+            audit.legacy_literal_disabled_hosts(),
+            &["10.0.0.5".parse::<HostName>().expect("host")]
+        );
+        assert!(audit.has_legacy_literal_ip_rows());
+    }
+
+    #[test]
+    fn remediation_text_names_every_offending_host_with_exact_commands() {
+        let peers = vec![peer("192.168.128.29", true), peer("10.0.0.5", false)];
+        let audit = TrustedPeerCatalogAudit::from_peers(&peers);
+        let text = audit.remediation_text();
+        assert!(text.contains("192.168.128.29"));
+        assert!(text.contains("atm peer trust migrate --map 192.168.128.29=<hostname> --yes"));
+        assert!(text.contains("atm peer trust revoke --host 192.168.128.29 --yes"));
+        assert!(text.contains("10.0.0.5"));
+        assert!(text.contains("atm peer trust revoke --host 10.0.0.5 --yes"));
+    }
+
+    #[test]
+    fn migrate_and_revoke_commands_render_exact_cli_invocations() {
+        let host: HostName = "192.168.128.29".parse().expect("host");
+        assert_eq!(
+            TrustedPeerCatalogAudit::migrate_command(&host, "rand-m5.local"),
+            "atm peer trust migrate --map 192.168.128.29=rand-m5.local --yes"
+        );
+        assert_eq!(
+            TrustedPeerCatalogAudit::revoke_command(&host),
+            "atm peer trust revoke --host 192.168.128.29 --yes"
+        );
+    }
+}

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -132,7 +132,7 @@ enum TrustSubcommand {
 
 /// One legacy literal-IP row and the migration action it will receive.
 struct MigrationPlanEntry {
-    legacy: TrustedPeer,
+    literal_ip_row: TrustedPeer,
     action: MigrationAction,
 }
 
@@ -351,14 +351,17 @@ fn build_migration_plan(
     }
     Ok(legacy_peers
         .into_iter()
-        .map(|legacy| {
+        .map(|literal_ip_row| {
             let action = map
                 .iter()
-                .find(|(source, _)| *source == legacy.host)
+                .find(|(source, _)| *source == literal_ip_row.host)
                 .map_or(MigrationAction::Revoke, |(_, target)| {
                     MigrationAction::Convert(target.clone())
                 });
-            MigrationPlanEntry { legacy, action }
+            MigrationPlanEntry {
+                literal_ip_row,
+                action,
+            }
         })
         .collect())
 }
@@ -370,7 +373,7 @@ fn print_migration_plan(plan: &[MigrationPlanEntry]) {
         return;
     }
     for entry in plan {
-        let status = if entry.legacy.enabled {
+        let status = if entry.literal_ip_row.enabled {
             "enabled"
         } else {
             "disabled"
@@ -383,7 +386,9 @@ fn print_migration_plan(plan: &[MigrationPlanEntry]) {
         };
         println!(
             "[{status}] {} (fingerprint {}, port {}): {action}",
-            entry.legacy.host, entry.legacy.fingerprint, entry.legacy.https_port
+            entry.literal_ip_row.host,
+            entry.literal_ip_row.fingerprint,
+            entry.literal_ip_row.https_port
         );
     }
 }
@@ -398,14 +403,14 @@ fn apply_migration_plan(
     for entry in plan {
         match entry.action {
             MigrationAction::Convert(target) => {
-                apply_migration_convert(store, &entry.legacy, &target)?;
+                apply_migration_convert(store, &entry.literal_ip_row, &target)?;
                 changed = true;
             }
             MigrationAction::Revoke => {
-                store.remove_trusted_peer(&entry.legacy.host)?;
+                store.remove_trusted_peer(&entry.literal_ip_row.host)?;
                 println!(
                     "revoked legacy literal-IP trusted peer {}",
-                    entry.legacy.host
+                    entry.literal_ip_row.host
                 );
                 changed = true;
             }
@@ -416,27 +421,27 @@ fn apply_migration_plan(
 
 fn apply_migration_convert(
     store: &(dyn PeerConfigStore + Send + Sync),
-    legacy: &TrustedPeer,
+    literal_ip_peer: &TrustedPeer,
     target: &HostName,
 ) -> std::result::Result<(), AtmError> {
     if let Some(existing) = store.trusted_peer(target)? {
-        if existing.fingerprint != legacy.fingerprint {
+        if existing.fingerprint != literal_ip_peer.fingerprint {
             return Err(AtmError::peer_config_validation(format!(
                 "trusted peer '{target}' already exists with a different fingerprint; \
                  resolve manually before migrating '{}'",
-                legacy.host
+                literal_ip_peer.host
             )));
         }
     } else {
         store.save_trusted_peer(&TrustedPeer {
             host: target.clone(),
-            fingerprint: legacy.fingerprint.clone(),
-            enabled: legacy.enabled,
-            https_port: legacy.https_port,
+            fingerprint: literal_ip_peer.fingerprint.clone(),
+            enabled: literal_ip_peer.enabled,
+            https_port: literal_ip_peer.https_port,
         })?;
     }
-    store.remove_trusted_peer(&legacy.host)?;
-    println!("migrated trusted peer {} to {target}", legacy.host);
+    store.remove_trusted_peer(&literal_ip_peer.host)?;
+    println!("migrated trusted peer {} to {target}", literal_ip_peer.host);
     Ok(())
 }
 
@@ -515,11 +520,16 @@ fn render_output<T: Serialize>(value: &T, json: bool) -> Result<String, AtmError
 
 #[cfg(test)]
 mod tests {
-    use super::{certificate, render_output, require_confirmation};
+    use super::{
+        PeerSubcommand, TrustCommand, TrustSubcommand, certificate, render_output,
+        require_confirmation,
+    };
+    use crate::commands::{Cli, Command};
     use std::sync::Mutex;
 
     use atm_storage::{
         AtmErrorCode, HostName, HttpsInterface, LocalCertificate, PeerConfigStore, TrustedPeer,
+        TrustedPeerCatalogAudit,
     };
     use clap::Parser;
 
@@ -1018,5 +1028,48 @@ mod tests {
                 .is_none()
         );
         assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    /// RBQA-F002 drift guard: the migrate/revoke remediation strings rendered
+    /// by `TrustedPeerCatalogAudit` are the single source of truth for the
+    /// exact command text; this test parses them through the real top-level
+    /// `atm` clap `Cli` and asserts they resolve to the expected subcommand
+    /// and arguments, so a clap definition change that breaks the rendered
+    /// text is caught here instead of drifting silently.
+    #[test]
+    fn remediation_commands_parse_through_the_real_cli() {
+        let host: HostName = "192.168.128.29".parse().expect("host");
+
+        let migrate_command = TrustedPeerCatalogAudit::migrate_command(&host, "rand-m5.local");
+        let arguments: Vec<&str> = migrate_command.split_whitespace().collect();
+        let cli = Cli::try_parse_from(arguments).expect("migrate remediation command parses");
+        match cli.command {
+            Command::Peer(super::PeerCommand {
+                command:
+                    PeerSubcommand::Trust(TrustCommand {
+                        command: TrustSubcommand::Migrate { map, yes },
+                    }),
+            }) => {
+                assert_eq!(map, vec!["192.168.128.29=rand-m5.local".to_string()]);
+                assert!(yes);
+            }
+            other => panic!("expected `atm peer trust migrate`, got {other:?}"),
+        }
+
+        let revoke_command = TrustedPeerCatalogAudit::revoke_command(&host);
+        let arguments: Vec<&str> = revoke_command.split_whitespace().collect();
+        let cli = Cli::try_parse_from(arguments).expect("revoke remediation command parses");
+        match cli.command {
+            Command::Peer(super::PeerCommand {
+                command:
+                    PeerSubcommand::Trust(TrustCommand {
+                        command: TrustSubcommand::Revoke { host, yes },
+                    }),
+            }) => {
+                assert_eq!(host, "192.168.128.29");
+                assert!(yes);
+            }
+            other => panic!("expected `atm peer trust revoke`, got {other:?}"),
+        }
     }
 }

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -113,6 +113,32 @@ enum TrustSubcommand {
         #[arg(long)]
         yes: bool,
     },
+    /// Migrate or retire legacy literal-IP trusted-peer entries.
+    ///
+    /// Without `--yes`, prints the migration plan (one line per legacy
+    /// literal-IP row: enabled/disabled, fingerprint, port, and the action)
+    /// and makes no changes. With `--yes`, applies the plan: rows named by
+    /// `--map IP=HOSTNAME` convert to the durable hostname, preserving their
+    /// fingerprint and port; every other legacy literal-IP row is revoked.
+    Migrate {
+        /// Convert the legacy literal-IP entry `IP` to durable hostname
+        /// `HOSTNAME`, keeping its fingerprint and port. May be repeated.
+        #[arg(long = "map", value_name = "IP=HOSTNAME")]
+        map: Vec<String>,
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+/// One legacy literal-IP row and the migration action it will receive.
+struct MigrationPlanEntry {
+    legacy: TrustedPeer,
+    action: MigrationAction,
+}
+
+enum MigrationAction {
+    Convert(HostName),
+    Revoke,
 }
 
 impl PeerCommand {
@@ -275,8 +301,143 @@ impl TrustCommand {
                 );
                 Ok(removed)
             }
+            TrustSubcommand::Migrate { map, yes } => {
+                let map = parse_migration_map(&map)?;
+                let plan = build_migration_plan(store, &map)?;
+                if !yes {
+                    print_migration_plan(&plan);
+                    return Ok(false);
+                }
+                apply_migration_plan(store, plan)
+            }
         }
     }
+}
+
+/// Parses repeated `--map IP=HOSTNAME` arguments. `HOSTNAME` must pass the
+/// same durable-hostname validation as `atm peer trust add`.
+fn parse_migration_map(map: &[String]) -> std::result::Result<Vec<(HostName, HostName)>, AtmError> {
+    map.iter()
+        .map(|entry| {
+            let (source, target) = entry.split_once('=').ok_or_else(|| {
+                AtmError::peer_config_validation("--map must be formatted as IP=HOSTNAME")
+            })?;
+            let source: HostName = source
+                .parse()
+                .map_err(|_source| AtmError::peer_config_validation("invalid --map source IP"))?;
+            Ok((source, trusted_peer_host(target)?))
+        })
+        .collect()
+}
+
+/// Builds the full migration plan: every legacy literal-IP row in the
+/// catalog, paired with its `--map` conversion target or a revoke action.
+/// Fails when a `--map` source does not name an actual legacy row.
+fn build_migration_plan(
+    store: &(dyn PeerConfigStore + Send + Sync),
+    map: &[(HostName, HostName)],
+) -> std::result::Result<Vec<MigrationPlanEntry>, AtmError> {
+    let legacy_peers: Vec<TrustedPeer> = store
+        .list_trusted_peers()?
+        .into_iter()
+        .filter(|peer| !peer.host.is_durable_hostname())
+        .collect();
+    for (source, _) in map {
+        if !legacy_peers.iter().any(|peer| &peer.host == source) {
+            return Err(AtmError::peer_config_validation(format!(
+                "--map source '{source}' is not a legacy literal-IP trusted peer entry"
+            )));
+        }
+    }
+    Ok(legacy_peers
+        .into_iter()
+        .map(|legacy| {
+            let action = map
+                .iter()
+                .find(|(source, _)| *source == legacy.host)
+                .map_or(MigrationAction::Revoke, |(_, target)| {
+                    MigrationAction::Convert(target.clone())
+                });
+            MigrationPlanEntry { legacy, action }
+        })
+        .collect())
+}
+
+/// Renders the migration plan without applying any change.
+fn print_migration_plan(plan: &[MigrationPlanEntry]) {
+    if plan.is_empty() {
+        println!("no legacy literal-IP trusted peer entries found; nothing to migrate");
+        return;
+    }
+    for entry in plan {
+        let status = if entry.legacy.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        let action = match &entry.action {
+            MigrationAction::Convert(target) => {
+                format!("convert to {target} (keep fingerprint/port)")
+            }
+            MigrationAction::Revoke => "revoke (no --map target)".to_string(),
+        };
+        println!(
+            "[{status}] {} (fingerprint {}, port {}): {action}",
+            entry.legacy.host, entry.legacy.fingerprint, entry.legacy.https_port
+        );
+    }
+}
+
+/// Applies the migration plan. Converting to an existing target hostname
+/// with a mismatched fingerprint is refused rather than clobbering it.
+fn apply_migration_plan(
+    store: &(dyn PeerConfigStore + Send + Sync),
+    plan: Vec<MigrationPlanEntry>,
+) -> std::result::Result<bool, AtmError> {
+    let mut changed = false;
+    for entry in plan {
+        match entry.action {
+            MigrationAction::Convert(target) => {
+                apply_migration_convert(store, &entry.legacy, &target)?;
+                changed = true;
+            }
+            MigrationAction::Revoke => {
+                store.remove_trusted_peer(&entry.legacy.host)?;
+                println!(
+                    "revoked legacy literal-IP trusted peer {}",
+                    entry.legacy.host
+                );
+                changed = true;
+            }
+        }
+    }
+    Ok(changed)
+}
+
+fn apply_migration_convert(
+    store: &(dyn PeerConfigStore + Send + Sync),
+    legacy: &TrustedPeer,
+    target: &HostName,
+) -> std::result::Result<(), AtmError> {
+    if let Some(existing) = store.trusted_peer(target)? {
+        if existing.fingerprint != legacy.fingerprint {
+            return Err(AtmError::peer_config_validation(format!(
+                "trusted peer '{target}' already exists with a different fingerprint; \
+                 resolve manually before migrating '{}'",
+                legacy.host
+            )));
+        }
+    } else {
+        store.save_trusted_peer(&TrustedPeer {
+            host: target.clone(),
+            fingerprint: legacy.fingerprint.clone(),
+            enabled: legacy.enabled,
+            https_port: legacy.https_port,
+        })?;
+    }
+    store.remove_trusted_peer(&legacy.host)?;
+    println!("migrated trusted peer {} to {target}", legacy.host);
+    Ok(())
 }
 
 fn peer(
@@ -522,6 +683,14 @@ mod tests {
                 "--yes",
             ],
             vec!["atm", "trust", "revoke", "--host", "peer.example", "--yes"],
+            vec![
+                "atm",
+                "trust",
+                "migrate",
+                "--map",
+                "192.168.128.29=peer.example",
+                "--yes",
+            ],
         ];
 
         for command in commands {
@@ -687,6 +856,117 @@ mod tests {
         )
         .expect("legacy peer should remain revocable");
         assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    fn seed_legacy_peer(
+        store: &InMemoryPeerConfigStore,
+        host: &str,
+        fingerprint: &str,
+        enabled: bool,
+    ) {
+        store
+            .save_trusted_peer(&TrustedPeer {
+                host: host.parse().expect("legacy host syntax"),
+                fingerprint: fingerprint.parse().expect("fingerprint"),
+                enabled,
+                https_port: std::num::NonZeroU16::new(443).expect("non-zero port"),
+            })
+            .expect("seed legacy peer");
+    }
+
+    #[test]
+    fn migrate_dry_run_reports_plan_without_mutating_the_store() {
+        let store = InMemoryPeerConfigStore::default();
+        seed_legacy_peer(&store, "192.168.128.29", "sha256:legacy-a", true);
+        seed_legacy_peer(&store, "10.0.0.5", "sha256:legacy-b", false);
+
+        run_peer(&store, &["atm", "trust", "migrate"]).expect("dry run succeeds");
+        let peers = store.list_trusted_peers().expect("list peers");
+        assert_eq!(peers.len(), 2, "dry run must not change the catalog");
+    }
+
+    #[test]
+    fn migrate_with_map_converts_and_preserves_fingerprint_and_port() {
+        let store = InMemoryPeerConfigStore::default();
+        seed_legacy_peer(&store, "192.168.128.29", "sha256:legacy-a", true);
+
+        run_peer(
+            &store,
+            &[
+                "atm",
+                "trust",
+                "migrate",
+                "--map",
+                "192.168.128.29=rand-m5.local",
+                "--yes",
+            ],
+        )
+        .expect("migrate converts the legacy row");
+
+        let peers = store.list_trusted_peers().expect("list peers");
+        assert_eq!(peers.len(), 1);
+        let migrated = &peers[0];
+        assert_eq!(migrated.host, "rand-m5.local".parse().expect("host"));
+        assert_eq!(migrated.fingerprint.as_str(), "sha256:legacy-a");
+        assert!(migrated.enabled);
+        assert_eq!(migrated.https_port.get(), 443);
+    }
+
+    #[test]
+    fn migrate_without_map_revokes_remaining_legacy_rows() {
+        let store = InMemoryPeerConfigStore::default();
+        seed_legacy_peer(&store, "192.168.128.29", "sha256:legacy-a", true);
+        seed_legacy_peer(&store, "10.0.0.5", "sha256:legacy-b", false);
+
+        run_peer(&store, &["atm", "trust", "migrate", "--yes"]).expect("migrate revokes rows");
+        assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    #[test]
+    fn migrate_rejects_a_map_source_absent_from_the_catalog() {
+        let store = InMemoryPeerConfigStore::default();
+        let error = run_peer(
+            &store,
+            &[
+                "atm",
+                "trust",
+                "migrate",
+                "--map",
+                "192.168.128.29=rand-m5.local",
+                "--yes",
+            ],
+        )
+        .expect_err("unknown --map source must fail");
+        assert!(error.message().contains("192.168.128.29"));
+    }
+
+    #[test]
+    fn migrate_refuses_to_clobber_an_existing_target_with_a_different_fingerprint() {
+        let store = InMemoryPeerConfigStore::default();
+        seed_legacy_peer(&store, "192.168.128.29", "sha256:legacy-a", true);
+        store
+            .save_trusted_peer(&TrustedPeer {
+                host: "rand-m5.local".parse().expect("host"),
+                fingerprint: "sha256:existing".parse().expect("fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(443).expect("port"),
+            })
+            .expect("seed existing durable peer");
+
+        let error = run_peer(
+            &store,
+            &[
+                "atm",
+                "trust",
+                "migrate",
+                "--map",
+                "192.168.128.29=rand-m5.local",
+                "--yes",
+            ],
+        )
+        .expect_err("mismatched fingerprint must not be clobbered");
+        assert!(error.message().contains("different fingerprint"));
+        assert_eq!(store.list_trusted_peers().expect("list peers").len(), 2);
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -1026,6 +1026,7 @@ mod tests {
                 enabled: true,
             }],
             validation_failure: None,
+            legacy_literal_ip_peers: Vec::new(),
         });
 
         assert!(rendered.contains("sha256:public-fingerprint"));

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -330,6 +330,19 @@ fn render_doctor_peer_config(peer_config: &atm_core::doctor::PeerConfigDoctorRep
             if peer.enabled { "enabled" } else { "disabled" }
         ));
     }
+    for legacy_peer in &peer_config.legacy_literal_ip_peers {
+        rendered.push_str(&format!(
+            "\n  legacy literal-IP peer {} ({}): migrate with `{}` or retire with `{}`",
+            legacy_peer.host,
+            if legacy_peer.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            legacy_peer.migrate_command,
+            legacy_peer.revoke_command
+        ));
+    }
     rendered
 }
 
@@ -1033,5 +1046,47 @@ mod tests {
         assert!(rendered.contains("peer.example.test:43101 (enabled)"));
         assert!(!rendered.contains("private_key_ref"));
         assert!(!rendered.contains("keychain:secret"));
+    }
+
+    /// ATM-QA-001 / RBQA-F001: the human-readable `atm doctor` text must
+    /// surface every legacy literal-IP trusted-peer row and its exact
+    /// remediation commands, not just the `--json` output.
+    #[test]
+    fn doctor_peer_text_surfaces_legacy_literal_ip_peers_and_remediation() {
+        let rendered = render_doctor_peer_config(&PeerConfigDoctorReport {
+            configured_interface_count: 1,
+            enabled_interface_count: 1,
+            certificate_fingerprint: Some("sha256:public-fingerprint".to_string()),
+            trusted_peer_count: 2,
+            enabled_trusted_peer_count: 1,
+            trusted_peers: Vec::new(),
+            validation_failure: None,
+            legacy_literal_ip_peers: vec![
+                atm_core::doctor::LegacyLiteralIpPeerDoctorReport {
+                    host: "192.168.128.29".to_string(),
+                    enabled: true,
+                    migrate_command: "atm peer trust migrate --map 192.168.128.29=<hostname> --yes"
+                        .to_string(),
+                    revoke_command: "atm peer trust revoke --host 192.168.128.29 --yes".to_string(),
+                },
+                atm_core::doctor::LegacyLiteralIpPeerDoctorReport {
+                    host: "10.0.0.5".to_string(),
+                    enabled: false,
+                    migrate_command: "atm peer trust migrate --map 10.0.0.5=<hostname> --yes"
+                        .to_string(),
+                    revoke_command: "atm peer trust revoke --host 10.0.0.5 --yes".to_string(),
+                },
+            ],
+        });
+
+        assert!(rendered.contains("192.168.128.29"));
+        assert!(rendered.contains("(enabled)"));
+        assert!(rendered.contains("atm peer trust migrate --map 192.168.128.29=<hostname> --yes"));
+        assert!(rendered.contains("atm peer trust revoke --host 192.168.128.29 --yes"));
+
+        assert!(rendered.contains("10.0.0.5"));
+        assert!(rendered.contains("(disabled)"));
+        assert!(rendered.contains("atm peer trust migrate --map 10.0.0.5=<hostname> --yes"));
+        assert!(rendered.contains("atm peer trust revoke --host 10.0.0.5 --yes"));
     }
 }

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -1503,6 +1503,45 @@
               "args": [
                 {
                   "has_default": false,
+                  "id": "map",
+                  "long": "map",
+                  "num_args": {
+                    "max": 1,
+                    "min": 1
+                  },
+                  "required": false,
+                  "short": null
+                },
+                {
+                  "has_default": true,
+                  "id": "stderr_logs",
+                  "long": "stderr-logs",
+                  "num_args": {
+                    "max": 0,
+                    "min": 0
+                  },
+                  "required": false,
+                  "short": null
+                },
+                {
+                  "has_default": true,
+                  "id": "yes",
+                  "long": "yes",
+                  "num_args": {
+                    "max": 0,
+                    "min": 0
+                  },
+                  "required": false,
+                  "short": null
+                }
+              ],
+              "name": "migrate",
+              "subcommands": []
+            },
+            {
+              "args": [
+                {
+                  "has_default": false,
                   "id": "fingerprint",
                   "long": "fingerprint",
                   "num_args": {

--- a/crates/peer-tls/Cargo.toml
+++ b/crates/peer-tls/Cargo.toml
@@ -14,6 +14,7 @@ atm-storage.workspace = true
 rustls.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 rcgen = "0.13"

--- a/crates/peer-tls/src/lib.rs
+++ b/crates/peer-tls/src/lib.rs
@@ -8,7 +8,8 @@ use std::{fmt, sync::Arc, time::Duration};
 
 use atm_storage::{
     AtmError, HostName, PeerConfigStore, PinnedClientVerifier, TlsIdentity, TrustedPeer,
-    certificate_fingerprint, certificate_valid_now, install_tls_provider, normalize_fingerprint,
+    TrustedPeerCatalogAudit, certificate_fingerprint, certificate_valid_now, install_tls_provider,
+    normalize_fingerprint,
 };
 use rustls::{
     CertificateError, ClientConfig, DigitallySignedStruct, Error, ServerConfig, SignatureScheme,
@@ -23,6 +24,32 @@ use tokio::{
 use tokio_rustls::{TlsAcceptor, TlsConnector, TlsStream};
 
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Name of the explicit, testing/benchmarking-only opt-out that downgrades a
+/// legacy literal-IP enabled trusted-peer row from a fail-closed startup
+/// error to a skipped-with-warning row. Exact value `"1"` selects
+/// [`LegacyLiteralIpPolicy::SkipWithWarning`]; any other value, or the
+/// variable being unset, keeps the default
+/// [`LegacyLiteralIpPolicy::FailClosed`]. This must never be treated as a
+/// wire-mode selector: it narrows only which trusted-peer rows are admitted
+/// into an already-selected mTLS configuration.
+pub const LEGACY_LITERAL_IP_SKIP_ENV_VAR: &str = "ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP";
+
+/// Startup policy for legacy literal-IP trusted-peer rows discovered while
+/// composing an mTLS adapter. The default is fail-closed: a live literal-IP
+/// authority blocks daemon startup with exact migration guidance rather than
+/// silently trusting or silently dropping it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LegacyLiteralIpPolicy {
+    /// Refuse to start when any enabled trusted peer uses a literal-IP
+    /// authority. This is the safe default for every normal daemon launch.
+    #[default]
+    FailClosed,
+    /// Skip enabled literal-IP rows (emitting a `tracing::warn!` naming each
+    /// host and this opt-out) instead of failing startup. Scoped to
+    /// testing/benchmarking; never enabled implicitly.
+    SkipWithWarning,
+}
 
 /// Concrete mTLS facade assembled only after the daemon has selected mTLS.
 ///
@@ -49,8 +76,28 @@ impl fmt::Debug for MtlsPeerStreamAdapter {
 }
 
 impl MtlsPeerStreamAdapter {
-    /// Snapshot valid mTLS configuration from the storage-neutral control plane.
+    /// Snapshot valid mTLS configuration from the storage-neutral control
+    /// plane, failing closed on any legacy literal-IP enabled trusted peer.
+    /// This is the convenience default used by every normal daemon launch;
+    /// see [`Self::from_peer_config_with_policy`] for the explicit,
+    /// testing/benchmarking-only skip opt-out.
     pub fn from_peer_config(store: &(dyn PeerConfigStore + Send + Sync)) -> Result<Self, AtmError> {
+        Self::from_peer_config_with_policy(store, LegacyLiteralIpPolicy::FailClosed)
+    }
+
+    /// Snapshot valid mTLS configuration from the storage-neutral control
+    /// plane under an explicit legacy literal-IP admission `policy`.
+    ///
+    /// # Errors
+    /// Returns [`AtmError`] when the daemon has no enabled peer interface, no
+    /// valid local identity, or (under [`LegacyLiteralIpPolicy::FailClosed`])
+    /// any enabled trusted peer uses a literal-IP authority. The error names
+    /// every offending host and carries the exact `atm peer trust migrate`
+    /// or `atm peer trust revoke` remediation commands.
+    pub fn from_peer_config_with_policy(
+        store: &(dyn PeerConfigStore + Send + Sync),
+        policy: LegacyLiteralIpPolicy,
+    ) -> Result<Self, AtmError> {
         let has_enabled_interface = store
             .list_interfaces()?
             .into_iter()
@@ -67,7 +114,7 @@ impl MtlsPeerStreamAdapter {
             AtmError::certificate_operation("configured mTLS identity is invalid")
                 .with_cause(error.detail())
         })?;
-        let trusted_peers = store.list_trusted_peers()?;
+        let trusted_peers = Self::admit_trusted_peers(store.list_trusted_peers()?, policy)?;
         install_tls_provider();
         let client_configs = trusted_peers
             .iter()
@@ -90,6 +137,32 @@ impl MtlsPeerStreamAdapter {
             server_config,
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
         })
+    }
+
+    /// Applies the legacy literal-IP admission `policy` to `trusted_peers`,
+    /// warning about (but never blocking on) disabled legacy rows and either
+    /// failing closed on, or skipping with a warning, enabled legacy rows.
+    /// [`PinnedServerVerifier::new`] retains its own durable-hostname check
+    /// as a defence-in-depth backstop after this admission step.
+    fn admit_trusted_peers(
+        trusted_peers: Vec<TrustedPeer>,
+        policy: LegacyLiteralIpPolicy,
+    ) -> Result<Vec<TrustedPeer>, AtmError> {
+        let audit = TrustedPeerCatalogAudit::from_peers(&trusted_peers);
+        warn_disabled_legacy_literal_ip_rows(&audit);
+        if audit.legacy_literal_enabled_hosts().is_empty() {
+            return Ok(trusted_peers);
+        }
+        match policy {
+            LegacyLiteralIpPolicy::FailClosed => Err(legacy_literal_ip_fail_closed_error(&audit)),
+            LegacyLiteralIpPolicy::SkipWithWarning => {
+                warn_skipped_legacy_literal_ip_rows(&audit);
+                Ok(trusted_peers
+                    .into_iter()
+                    .filter(|peer| peer.host.is_durable_hostname() || !peer.enabled)
+                    .collect())
+            }
+        }
     }
 
     /// Narrow test/operations hook for a bounded handshake deadline.
@@ -198,6 +271,63 @@ impl MtlsPeerStreamAdapter {
                 .with_cause(source)
             })
     }
+}
+
+/// Builds the fail-closed startup error for one or more enabled legacy
+/// literal-IP trusted-peer rows. The message names every offending host and
+/// the cause carries the exact migrate/revoke remediation commands, so an
+/// operator never needs a manual SQLite edit to recover.
+fn legacy_literal_ip_fail_closed_error(audit: &TrustedPeerCatalogAudit) -> AtmError {
+    let hosts = audit
+        .legacy_literal_enabled_hosts()
+        .iter()
+        .map(HostName::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    AtmError::peer_config_validation(format!(
+        "mTLS peer authority must use a durable hostname rather than a literal IP; \
+         enabled legacy literal-IP trusted peer(s) block startup: {hosts}. Migrate or \
+         revoke each row (see cause), or set {LEGACY_LITERAL_IP_SKIP_ENV_VAR}=1 to skip \
+         them for testing/benchmarking only."
+    ))
+    .with_cause(audit.remediation_text())
+}
+
+/// Emits one `tracing::warn!` naming every disabled legacy literal-IP row.
+/// Disabled rows are historical only and must never block startup, but an
+/// operator should still be told they exist and how to prune them.
+fn warn_disabled_legacy_literal_ip_rows(audit: &TrustedPeerCatalogAudit) {
+    if audit.legacy_literal_disabled_hosts().is_empty() {
+        return;
+    }
+    let hosts = audit
+        .legacy_literal_disabled_hosts()
+        .iter()
+        .map(HostName::to_string)
+        .collect::<Vec<_>>();
+    tracing::warn!(
+        hosts = ?hosts,
+        remediation = %audit.remediation_text(),
+        "disabled legacy literal-IP trusted peer row(s) present; they do not block mTLS \
+         startup but should be pruned"
+    );
+}
+
+/// Emits one `tracing::warn!` naming every enabled legacy literal-IP row
+/// skipped under the explicit testing/benchmarking opt-out.
+fn warn_skipped_legacy_literal_ip_rows(audit: &TrustedPeerCatalogAudit) {
+    let hosts = audit
+        .legacy_literal_enabled_hosts()
+        .iter()
+        .map(HostName::to_string)
+        .collect::<Vec<_>>();
+    tracing::warn!(
+        hosts = ?hosts,
+        env_var = LEGACY_LITERAL_IP_SKIP_ENV_VAR,
+        remediation = %audit.remediation_text(),
+        "skipping enabled legacy literal-IP trusted peer row(s) for outbound/inbound mTLS \
+         due to explicit testing/benchmarking opt-out; these rows are not authenticated"
+    );
 }
 
 fn outbound_handshake_error(source: std::io::Error) -> AtmError {
@@ -398,8 +528,12 @@ mod tests {
     }
 
     fn peer(certificate: &LocalCertificate, enabled: bool) -> TrustedPeer {
+        peer_with_host(certificate, "localhost", enabled)
+    }
+
+    fn peer_with_host(certificate: &LocalCertificate, host: &str, enabled: bool) -> TrustedPeer {
         TrustedPeer {
-            host: "localhost".parse().expect("host"),
+            host: host.parse().expect("host"),
             fingerprint: certificate.fingerprint.clone(),
             enabled,
             https_port: NonZeroU16::new(443).expect("port"),
@@ -729,5 +863,77 @@ mod tests {
         };
         assert_eq!(error.code().as_str(), "ATM_TRANSPORT_PROTOCOL_FAILED");
         raw_client.await.expect("raw client");
+    }
+
+    #[test]
+    fn mixed_catalog_enabled_literal_ip_fails_closed_and_names_the_host() {
+        let directory = tempfile::tempdir().expect("directory");
+        let local = identity(&directory, "local");
+        let durable = identity(&directory, "durable-peer");
+        let legacy = identity(&directory, "legacy-peer");
+        let error = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(local),
+            peers: vec![
+                peer_with_host(&durable, "rand-m5.local", true),
+                peer_with_host(&legacy, "192.168.128.29", true),
+            ],
+        })
+        .expect_err("enabled legacy literal-IP peer must fail closed");
+        assert_eq!(error.code().as_str(), "ATM_PEER_CONFIG_VALIDATION_FAILED");
+        assert!(error.message().contains("192.168.128.29"));
+        assert!(
+            error
+                .cause()
+                .is_some_and(|cause| cause.contains("192.168.128.29"))
+        );
+    }
+
+    #[test]
+    fn mixed_catalog_disabled_literal_ip_never_blocks_a_valid_hostname_configuration() {
+        let directory = tempfile::tempdir().expect("directory");
+        let local = identity(&directory, "local");
+        let durable = identity(&directory, "durable-peer");
+        let legacy = identity(&directory, "legacy-peer");
+        let adapter = MtlsPeerStreamAdapter::from_peer_config(&TestStore {
+            interfaces: vec![interface()],
+            certificate: Some(local),
+            peers: vec![
+                peer_with_host(&durable, "rand-m5.local", true),
+                peer_with_host(&legacy, "192.168.128.29", false),
+            ],
+        })
+        .expect("disabled legacy literal-IP row must not block startup");
+        assert_eq!(adapter.client_configs.len(), 1);
+        let hostname: HostName = "rand-m5.local".parse().expect("host");
+        assert!(adapter.client_config_for(&hostname).is_ok());
+    }
+
+    #[test]
+    fn skip_with_warning_policy_admits_the_hostname_peer_without_trusting_the_ip() {
+        let directory = tempfile::tempdir().expect("directory");
+        let local = identity(&directory, "local");
+        let durable = identity(&directory, "durable-peer");
+        let legacy = identity(&directory, "legacy-peer");
+        let adapter = MtlsPeerStreamAdapter::from_peer_config_with_policy(
+            &TestStore {
+                interfaces: vec![interface()],
+                certificate: Some(local),
+                peers: vec![
+                    peer_with_host(&durable, "rand-m5.local", true),
+                    peer_with_host(&legacy, "192.168.128.29", true),
+                ],
+            },
+            LegacyLiteralIpPolicy::SkipWithWarning,
+        )
+        .expect("skip policy must not fail closed");
+        assert_eq!(adapter.client_configs.len(), 1);
+        let hostname: HostName = "rand-m5.local".parse().expect("host");
+        assert!(adapter.client_config_for(&hostname).is_ok());
+        let literal_ip: HostName = "192.168.128.29".parse().expect("host");
+        let error = adapter
+            .client_config_for(&literal_ip)
+            .expect_err("skipped literal-IP row must not be an authority");
+        assert_eq!(error.code().as_str(), "ATM_PEER_AUTHENTICATION_FAILED");
     }
 }

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -111,7 +111,7 @@ under a typed `peer_tls::LegacyLiteralIpPolicy`:
   authenticated, in either direction) and a `tracing::warn!` names each
   skipped host.
 
-Operators can also pre-empt the fail-closed path entirely, at any time, with
+Operators can also preempt the fail-closed path entirely, at any time, with
 `atm peer trust migrate` (issue #972): `--map IP=HOSTNAME` converts a legacy
 literal-IP row to the durable hostname while preserving its fingerprint and
 port, and a bare `--yes` (no `--map`) revokes every remaining legacy

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -80,3 +80,26 @@ host only after the client certificate/pin verification completes before HTTP
 decode. Startup writes the selected public mode to the retained observability
 port and daemon doctor context; neither includes key material, certificate
 contents, pins, or raw trust records.
+
+## Legacy literal-IP trusted-peer admission (issue #972)
+
+Once mTLS is selected, `peer-tls` fails closed at startup when any *enabled*
+trusted-peer row predates durable-hostname enforcement and still uses a
+literal IP authority (`HostName::is_durable_hostname() == false`). The
+resulting `ATM_PEER_CONFIG_VALIDATION_FAILED` error names every offending
+host and carries the exact `atm peer trust migrate --map <ip>=<hostname>
+--yes` / `atm peer trust revoke --host <ip> --yes` remediation, so recovery
+never requires a manual SQLite edit. A *disabled* legacy literal-IP row is
+historical only: it is reported with a `tracing::warn!` but never blocks
+startup.
+
+`ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP` (exact value `"1"`) downgrades
+enabled legacy literal-IP rows from fail-closed to skip-with-warning: they
+are dropped from the trust catalog (never authenticated, in either
+direction) and a `tracing::warn!` names each skipped host. This variable is
+an explicit, narrowly-scoped testing/benchmarking opt-out for a mixed
+old-IP/new-hostname catalog during migration; it does not exist outside that
+scope and must never be treated as a general trust bypass. It is a
+trust-catalog admission knob only — it cannot select, or fall back to, a
+different peer-wire mode, so it does not conflict with this ADR's
+environment-selection prohibition for `--peer-wire-security`.

--- a/docs/adr/ADR-047-layered-peer-wire-security.md
+++ b/docs/adr/ADR-047-layered-peer-wire-security.md
@@ -60,6 +60,12 @@ Doctor, retained diagnostics, smoke JSON/XHTML, and benchmark evidence must
 record the active peer-wire mode. Plaintext-test evidence cannot satisfy any
 mTLS or peer-allowlist acceptance criterion.
 
+Legacy literal-IP trusted-peer rows are a fail-closed admission concern
+layered on top of the selected mTLS mode, not a peer-wire mode of their own;
+see [Legacy literal-IP trusted-peer admission (issue
+#972)](#legacy-literal-ip-trusted-peer-admission-issue-972) below for the
+`LegacyLiteralIpPolicy` default and its narrowly-scoped opt-out.
+
 ## AO.3 implementation evidence
 
 AO.3 implements the launch seam in `atm-daemon-bootstrap`. It parses
@@ -83,23 +89,41 @@ contents, pins, or raw trust records.
 
 ## Legacy literal-IP trusted-peer admission (issue #972)
 
-Once mTLS is selected, `peer-tls` fails closed at startup when any *enabled*
-trusted-peer row predates durable-hostname enforcement and still uses a
-literal IP authority (`HostName::is_durable_hostname() == false`). The
-resulting `ATM_PEER_CONFIG_VALIDATION_FAILED` error names every offending
-host and carries the exact `atm peer trust migrate --map <ip>=<hostname>
---yes` / `atm peer trust revoke --host <ip> --yes` remediation, so recovery
-never requires a manual SQLite edit. A *disabled* legacy literal-IP row is
-historical only: it is reported with a `tracing::warn!` but never blocks
-startup.
+Once mTLS is selected, `peer-tls` classifies every trusted-peer row with
+`atm_storage::TrustedPeerCatalogAudit::from_peers` (durable-hostname vs.
+legacy literal-IP, each split by enabled/disabled) and admits the catalog
+under a typed `peer_tls::LegacyLiteralIpPolicy`:
 
-`ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP` (exact value `"1"`) downgrades
-enabled legacy literal-IP rows from fail-closed to skip-with-warning: they
-are dropped from the trust catalog (never authenticated, in either
-direction) and a `tracing::warn!` names each skipped host. This variable is
-an explicit, narrowly-scoped testing/benchmarking opt-out for a mixed
-old-IP/new-hostname catalog during migration; it does not exist outside that
-scope and must never be treated as a general trust bypass. It is a
-trust-catalog admission knob only — it cannot select, or fall back to, a
-different peer-wire mode, so it does not conflict with this ADR's
-environment-selection prohibition for `--peer-wire-security`.
+- `LegacyLiteralIpPolicy::FailClosed` — the default. Any *enabled*
+  trusted-peer row that predates durable-hostname enforcement and still uses
+  a literal IP authority (`HostName::is_durable_hostname() == false`) fails
+  startup closed with `ATM_PEER_CONFIG_VALIDATION_FAILED`. The error names
+  every offending host and carries the exact `atm peer trust migrate --map
+  <ip>=<hostname> --yes` / `atm peer trust revoke --host <ip> --yes`
+  remediation (rendered by `TrustedPeerCatalogAudit::migrate_command` /
+  `::revoke_command`, the single source of truth for that command text), so
+  recovery never requires a manual SQLite edit. A *disabled* legacy
+  literal-IP row is historical only under either policy: it is reported
+  with a `tracing::warn!` but never blocks startup.
+- `LegacyLiteralIpPolicy::SkipWithWarning` — selected only via
+  `ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP` (exact value `"1"`; see below).
+  Enabled legacy literal-IP rows are dropped from the trust catalog (never
+  authenticated, in either direction) and a `tracing::warn!` names each
+  skipped host.
+
+Operators can also pre-empt the fail-closed path entirely, at any time, with
+`atm peer trust migrate` (issue #972): `--map IP=HOSTNAME` converts a legacy
+literal-IP row to the durable hostname while preserving its fingerprint and
+port, and a bare `--yes` (no `--map`) revokes every remaining legacy
+literal-IP row. `atm doctor` (both `--json` and human-readable text) reports
+every legacy literal-IP row up front, before daemon launch, using the same
+`TrustedPeerCatalogAudit` projection so its remediation text can never drift
+from what `peer-tls` actually enforces.
+
+`ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP` is an explicit, narrowly-scoped
+testing/benchmarking opt-out for a mixed old-IP/new-hostname catalog during
+migration; it does not exist outside that scope and must never be treated
+as a general trust bypass. It is a trust-catalog admission knob only — it
+cannot select, or fall back to, a different peer-wire mode, so it does not
+conflict with this ADR's environment-selection prohibition for
+`--peer-wire-security`.


### PR DESCRIPTION
## Summary

Closes #972. AO2 mTLS startup now detects legacy literal-IP `peer_trusted_peers` rows before the peer adapter is built and reports exact, safe remediation instead of an anonymous `ATM_PEER_AUTHENTICATION_FAILED`.

- **Catalog audit** (`atm-storage::peer_catalog_audit::TrustedPeerCatalogAudit`): pure partition of the trusted-peer catalog into hostname peers, enabled literal-IP rows, and disabled literal-IP rows, with remediation text naming every offending host.
- **Fail-closed by default** (`peer-tls::LegacyLiteralIpPolicy`): an enabled literal-IP row aborts startup with `ATM_PEER_CONFIG_VALIDATION_FAILED` listing each host and the exact `atm peer trust migrate --map <ip>=<hostname> --yes` / `atm peer trust revoke --host <ip> --yes` commands. Disabled or historical literal-IP rows never block a valid hostname-only configuration and are never trusted.
- **Explicit opt-out, testing/benchmarking only**: `ATM_PEER_TRUST_SKIP_LEGACY_LITERAL_IP=1` (exact value) switches to skip-with-warning; the IP rows are still not trusted, only the abort is suppressed. Documented in ADR-047.
- **Migration CLI**: `atm peer trust migrate [--map IP=HOSTNAME]... [--yes]`. Dry-run by default; `--map` converts a legacy row keeping fingerprint and https_port; remaining legacy rows are revoked; refuses to clobber an existing hostname row with a different fingerprint. No manual SQLite edits.
- **Doctor**: `PeerConfigDoctorReport.legacy_literal_ip_peers` lists hosts with remediation.
- **Tests**: mixed old-IP + hostname catalog coverage in atm-storage, peer-tls, daemon bootstrap (policy env parsing), CLI migrate (dry-run, map, revoke, missing source, fingerprint clash), and doctor.
- Boundary allowlist: `tracing` added for `peer-tls` (`.just/lint-config.toml`).

No legacy synchronous daemon code touched. `PinnedServerVerifier`'s own durable-hostname check is kept as defence in depth.

Branch was stacked on PR #1135 (merged to develop as 2dceed0b0) and now targets develop directly.

## Gates

`cargo test` (atm-storage, peer-tls, atm-daemon-bootstrap, agent-team-mail, agent-team-mail-core) green; `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, function-length and boundary lints clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK