### PR TITLE
docs(release-readiness): Local Network permission precondition per host (#1140)

### DIFF
--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -70,25 +70,31 @@ macOS host precondition for steps 1 and 2 (Rand, 2026-09-03, primary
 blocker seen on the first cross-host ping; step 3 is Windows and has no
 equivalent prompt): macOS shows a blocking Local Network permission prompt
 the first time a freshly built or re-signed atm daemon or CLI touches the
-local network. While the prompt is unanswered the daemon process is
-blocked, so the symptom is not limited to `.local` peer dials: local
-`atm doctor` calls time out and even a pure loopback `atm send` to
-`localhost:43101` fails with `RemoteDeliveryUnconfirmed` ("could not
-confirm acceptance by direct peer"), which is exactly the false-positive
-pattern in the rand-m5 localhost smoke of 2026-08-31
+local network. While the prompt is unanswered the daemon's network path
+is blocked, so the symptom is not limited to `.local` peer dials: a pure
+loopback `atm send` to `localhost:43101` fails with
+`RemoteDeliveryUnconfirmed` ("could not confirm acceptance by direct
+peer") even though the daemon is running and answers `atm doctor`. That
+is exactly the pattern in the rand-m5 localhost smoke of 2026-08-31
 (`site/reports/smoke/macos/rand-m5.local/20260831T203217630910Z-pid56376-localhost/localhost.json`:
-every `doctor` case failed and every localhost send returned that error).
-The prompt is the suspected cause of that run; #1140 owns confirming it
-(the committed evidence shows the symptom, not the dialog). Before smoke,
-each macOS runner grants Local Network access to the candidate's atm
-binaries on their host (System Settings → Privacy & Security → Local
-Network), confirms `atm doctor --json` returns promptly, and confirms one
-cross-host `atm send` round-trips. A rebuilt or re-signed binary can
-re-trigger the prompt, so in step 2 the grant and the doctor check are
-re-confirmed after the `/daemon-switch` rebuild and again after the
-restore. A smoke or benchmark failure with these signatures on a host
-whose grant was not confirmed is a precondition miss, not product
-evidence: fix the grant and re-run. Operator-facing steps are in
+all 10 `doctor` cases PASS, all 20 send and ack-send cases FAIL with that
+error). The prompt is the suspected cause of that run; #1140 owns
+confirming it (the committed evidence shows the symptom, not the dialog).
+Because doctor passed in that run, a passing doctor does not prove the
+grant is in place; the discriminating check is a loopback send.
+Separately observed hardware-smoke `atm doctor` timeouts are also
+attributed to permission dialogs blocking the daemon, but that file is
+not evidence of them. Before smoke, each macOS runner grants Local Network
+access to the candidate's atm binaries on their host (System Settings →
+Privacy & Security → Local Network), confirms `atm doctor --json` returns
+promptly, confirms one loopback `atm send` to `localhost:43101` is
+accepted, and confirms one cross-host `atm send` round-trips. A rebuilt
+or re-signed binary can re-trigger the prompt, so in step 2 the grant,
+the doctor check, and the loopback send are re-confirmed after the
+`/daemon-switch` rebuild and again after the restore. A smoke or
+benchmark failure with these signatures on a host whose grant was not
+confirmed is a precondition miss, not product evidence: fix the grant
+and re-run. Operator-facing steps are in
 `docs/user-documents/troubleshooting.md` (Daemon Startup Or Connect
 Failure); see §5 item 7 (#1140).
 Repo suites (`just ci`, test-graft-python, test-hermes-graft-bridge,
@@ -142,9 +148,10 @@ candidate commit are cited by run id.
 6. Send-family benchmark reports do not capture the executing account
    in-band the way the read family does after AV-PROD-001R.
 7. macOS Local Network permission prompt blocks the daemon per freshly
-   built binary until answered, failing local doctor and loopback sends as
-   well as cross-host traffic (see §2 precondition; suspected, not yet
-   confirmed, cause of the 2026-08-31 rand-m5 localhost smoke failure);
+   built binary until answered, failing loopback and cross-host sends
+   while `atm doctor` can still pass (see §2 precondition; suspected, not
+   yet confirmed, cause of the 2026-08-31 rand-m5 localhost smoke run:
+   10/10 doctor PASS, 20/20 sends FAIL);
    tracked as atm-core #1140 (confirm the cause; whether stable code
    signing or a launch-time probe can keep grants across builds), not
    fixed here.
@@ -604,6 +611,18 @@ candidate commit are cited by run id.
   the step 2 `/daemon-switch` rebuild → added (after rebuild and after
   restore). Minor: no troubleshooting cross-link → operator steps added
   to `docs/user-documents/troubleshooting.md` and linked from §2.
+- **PR #1141 r2 (2026-09-03, quality-mgr FAIL @ 2cf5ad2f1, PR comment
+  5529669549)**: Blocking (ATM-QA-002 regressed): r1 text claimed the
+  2026-08-31 localhost.json showed every `doctor` case failing; the file
+  shows all 10 doctor cases PASS and only the 20 send/ack-send cases
+  failing → §2 and §5 item 7 corrected to the file's actual data, the
+  doctor check demoted from discriminating signal to health check, and a
+  loopback-send check added as the discriminating precondition.
+  Important (ATM-QA-003): troubleshooting.md symptom line implied the
+  evidence showed a doctor failure → reworded so doctor timeouts are a
+  separately reported symptom and a passing doctor does not prove the
+  grant. #1140's description reviewed: it attributes doctor timeouts to
+  earlier hardware smoke, not to this file, so it needs no correction.
 - **Rand review (2026-09-03)**: smoke and benchmarks are two separate
   tests on both atmbench and cwin, smoke first, benchmarks skipped on
   smoke failure; AT3 cross-host leg (rand-m5 host daemon ↔ Colima daemon)

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -66,15 +66,31 @@ report.
 
 Steps 2 and 3 run concurrently; step 1 runs whenever atmbench is free.
 
-Host precondition for every step (Rand, 2026-09-03, primary blocker seen
-on the first cross-host ping): macOS shows a blocking Local Network
-permission prompt the first time the atm daemon or CLI reaches a `.local`
-peer, and the peer send fails (`RemoteDeliveryUnconfirmed`, "could not
-connect to direct peer") until it is answered. Before smoke, each runner
-grants Local Network access to the candidate's atm binaries on their host
-(System Settings → Privacy & Security → Local Network) and confirms one
+macOS host precondition for steps 1 and 2 (Rand, 2026-09-03, primary
+blocker seen on the first cross-host ping; step 3 is Windows and has no
+equivalent prompt): macOS shows a blocking Local Network permission prompt
+the first time a freshly built or re-signed atm daemon or CLI touches the
+local network. While the prompt is unanswered the daemon process is
+blocked, so the symptom is not limited to `.local` peer dials: local
+`atm doctor` calls time out and even a pure loopback `atm send` to
+`localhost:43101` fails with `RemoteDeliveryUnconfirmed` ("could not
+confirm acceptance by direct peer"), which is exactly the false-positive
+pattern in the rand-m5 localhost smoke of 2026-08-31
+(`site/reports/smoke/macos/rand-m5.local/20260831T203217630910Z-pid56376-localhost/localhost.json`:
+every `doctor` case failed and every localhost send returned that error).
+The prompt is the suspected cause of that run; #1140 owns confirming it
+(the committed evidence shows the symptom, not the dialog). Before smoke,
+each macOS runner grants Local Network access to the candidate's atm
+binaries on their host (System Settings → Privacy & Security → Local
+Network), confirms `atm doctor --json` returns promptly, and confirms one
 cross-host `atm send` round-trips. A rebuilt or re-signed binary can
-re-trigger the prompt; see §5 item 7 (#1140).
+re-trigger the prompt, so in step 2 the grant and the doctor check are
+re-confirmed after the `/daemon-switch` rebuild and again after the
+restore. A smoke or benchmark failure with these signatures on a host
+whose grant was not confirmed is a precondition miss, not product
+evidence: fix the grant and re-run. Operator-facing steps are in
+`docs/user-documents/troubleshooting.md` (Daemon Startup Or Connect
+Failure); see §5 item 7 (#1140).
 Repo suites (`just ci`, test-graft-python, test-hermes-graft-bridge,
 test-hermes-graft-smoke, test-admission-capacity, test-queue-hooks-python,
 test-queue-hooks-python-codex) are not re-run; their green CI runs on the
@@ -125,10 +141,13 @@ candidate commit are cited by run id.
 5. No isolated Windows benchmark account; cwin results are informational.
 6. Send-family benchmark reports do not capture the executing account
    in-band the way the read family does after AV-PROD-001R.
-7. macOS Local Network permission prompt blocks first cross-host peer
-   traffic per binary (see §2 precondition); tracked as atm-core #1140
-   (whether stable code signing or a launch-time probe can keep grants
-   across builds), not fixed here.
+7. macOS Local Network permission prompt blocks the daemon per freshly
+   built binary until answered, failing local doctor and loopback sends as
+   well as cross-host traffic (see §2 precondition; suspected, not yet
+   confirmed, cause of the 2026-08-31 rand-m5 localhost smoke failure);
+   tracked as atm-core #1140 (confirm the cause; whether stable code
+   signing or a launch-time probe can keep grants across builds), not
+   fixed here.
 
 ## 6. Open questions for Rand
 
@@ -573,6 +592,18 @@ candidate commit are cited by run id.
   → precondition in §2 step 1 and §5 item 7; step-3 sender of record
   unstated → §3 names Rand. Minor: `test-queue-hooks-codex` →
   `test-queue-hooks-python-codex`.
+- **PR #1141 r1 (2026-09-03, quality-mgr FAIL @ 00de73ee6, PR comment
+  5529605562)**: Important: "for every step" unsupported → narrowed to
+  the macOS runners (steps 1 and 2), step 3 excluded. Important: causal
+  attribution to the prompt not reconciled with the committed
+  2026-08-31 localhost.json (pure `localhost:43101` sends and doctor
+  cases failing) → precondition now cites that file, describes the
+  daemon-blocked symptom set, and marks the prompt as the suspected cause
+  for #1140 to confirm. Important: local doctor hang omitted → added as
+  a named symptom and a required check. Minor: no re-confirmation after
+  the step 2 `/daemon-switch` rebuild → added (after rebuild and after
+  restore). Minor: no troubleshooting cross-link → operator steps added
+  to `docs/user-documents/troubleshooting.md` and linked from §2.
 - **Rand review (2026-09-03)**: smoke and benchmarks are two separate
   tests on both atmbench and cwin, smoke first, benchmarks skipped on
   smoke failure; AT3 cross-host leg (rand-m5 host daemon ↔ Colima daemon)

--- a/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
+++ b/docs/plans/release-readiness-gate/release-readiness-gate-plan.md
@@ -65,6 +65,16 @@ report.
    gated on parity.
 
 Steps 2 and 3 run concurrently; step 1 runs whenever atmbench is free.
+
+Host precondition for every step (Rand, 2026-09-03, primary blocker seen
+on the first cross-host ping): macOS shows a blocking Local Network
+permission prompt the first time the atm daemon or CLI reaches a `.local`
+peer, and the peer send fails (`RemoteDeliveryUnconfirmed`, "could not
+connect to direct peer") until it is answered. Before smoke, each runner
+grants Local Network access to the candidate's atm binaries on their host
+(System Settings → Privacy & Security → Local Network) and confirms one
+cross-host `atm send` round-trips. A rebuilt or re-signed binary can
+re-trigger the prompt; see §5 item 7 (#1140).
 Repo suites (`just ci`, test-graft-python, test-hermes-graft-bridge,
 test-hermes-graft-smoke, test-admission-capacity, test-queue-hooks-python,
 test-queue-hooks-python-codex) are not re-run; their green CI runs on the
@@ -115,6 +125,10 @@ candidate commit are cited by run id.
 5. No isolated Windows benchmark account; cwin results are informational.
 6. Send-family benchmark reports do not capture the executing account
    in-band the way the read family does after AV-PROD-001R.
+7. macOS Local Network permission prompt blocks first cross-host peer
+   traffic per binary (see §2 precondition); tracked as atm-core #1140
+   (whether stable code signing or a launch-time probe can keep grants
+   across builds), not fixed here.
 
 ## 6. Open questions for Rand
 

--- a/docs/user-documents/troubleshooting.md
+++ b/docs/user-documents/troubleshooting.md
@@ -64,6 +64,21 @@ atm log filter --level error
 Use doctor and retained logs first. Those are the supported operator-facing
 surfaces for daemon/runtime recovery.
 
+### macOS Local Network Permission Prompt
+
+On macOS, the first time a freshly built or re-signed `atm` daemon or CLI
+touches the local network the system shows a Local Network permission
+prompt. Until it is answered the daemon is blocked, so `atm doctor` times
+out, a loopback `atm send` can fail with `RemoteDeliveryUnconfirmed`, and
+cross-host sends report "could not connect to direct peer". If those
+symptoms appear right after a build:
+
+1. Answer the prompt, or grant access under System Settings → Privacy &
+   Security → Local Network for the `atm` and `atm-daemon` binaries.
+2. Confirm `atm doctor --json` returns promptly.
+3. Re-check after every rebuild or re-sign; the grant is per binary and a
+   new build can trigger the prompt again (tracked as atm-core #1140).
+
 ## Post-Send Warning Surface
 
 Symptoms:

--- a/docs/user-documents/troubleshooting.md
+++ b/docs/user-documents/troubleshooting.md
@@ -68,14 +68,18 @@ surfaces for daemon/runtime recovery.
 
 On macOS, the first time a freshly built or re-signed `atm` daemon or CLI
 touches the local network the system shows a Local Network permission
-prompt. Until it is answered the daemon is blocked, so `atm doctor` times
-out, a loopback `atm send` can fail with `RemoteDeliveryUnconfirmed`, and
-cross-host sends report "could not connect to direct peer". If those
-symptoms appear right after a build:
+prompt. Until it is answered the daemon's network path is blocked: a
+loopback `atm send` fails with `RemoteDeliveryUnconfirmed` and cross-host
+sends report "could not connect to direct peer", while `atm doctor` can
+still pass. Hardware-smoke runs have also reported `atm doctor` timing
+out while a permission dialog was pending. If those symptoms appear
+right after a build:
 
 1. Answer the prompt, or grant access under System Settings → Privacy &
    Security → Local Network for the `atm` and `atm-daemon` binaries.
-2. Confirm `atm doctor --json` returns promptly.
+2. Confirm `atm doctor --json` returns promptly and one loopback
+   `atm send` to yourself is accepted; a passing doctor alone does not
+   prove the grant is in place.
 3. Re-check after every rebuild or re-sign; the grant is per binary and a
    new build can trigger the prompt again (tracked as atm-core #1140).
 


### PR DESCRIPTION
Follow-up to #1139 (merged). Adds the macOS Local Network permission prompt as a per-host precondition before smoke, and records it as known gap item 7 pointing at #1140. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK