### PR TITLE
triage(readiness): closure QA on read-lanes + ratchet-state findings

### DIFF
--- a/.triage/readiness-1.4/findings/RRG-READ-DOCTOR-LANES-001.ttl
+++ b/.triage/readiness-1.4/findings/RRG-READ-DOCTOR-LANES-001.ttl
@@ -15,15 +15,17 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-04T06:12:00Z"^^xsd:dateTime ;
   triage:foundIn triage:RRG-S1 ;
   triage:foundAt "2026-09-04T05:58:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-READ-DOCTOR-LANES-001/CAND-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-READ-DOCTOR-LANES-001/CAND-2> ;
-  triage:triageRecordVersion "2" ;
-  triage:qa10Note "QA-10 (quality-mgr, 2026-09-04): code fix for both occurrences verified by req-qa/arch-qa/ruthless-boundary-qa/rust-qa-agent at commit 56cfd142b (PR #1143 branch, arch-ctm). Both occurrences marked fixed below. Finding-level status intentionally left 'open': per fenix's QA-10 dispatch, closure of this finding requires the atmbench read-campaign benchmark-read evidence (tracked separately, PR #1150), not just the code fix." .
+  triage:triageRecordVersion "3" ;
+  triage:qa10Note "QA-10 (quality-mgr, 2026-09-04): code fix for both occurrences verified by req-qa/arch-qa/ruthless-boundary-qa/rust-qa-agent at commit 56cfd142b (PR #1143 branch, arch-ctm). Both occurrences marked fixed below. Finding-level status intentionally left 'open': per fenix's QA-10 dispatch, closure of this finding requires the atmbench read-campaign benchmark-read evidence (tracked separately, PR #1150), not just the code fix." ;
+  triage:closureNote "quality-mgr closure (2026-09-04, qa-readiness-read-evidence-r11): official read campaign 20260904T065446Z-rand-m5.local-read landed on PR #1150 (commit ceda87608a), executed against 1.4.13 content merged to develop (5ca0fedce, includes the 56cfd142b doctor-lanes fix). Doctor report published effective reader_lanes end to end (mailbox pool_size 4/queue_depth 16, search pool_size 2/queue_depth 8) and the benchmark preflight accepted it — all three families (read-fanout, query-fts, read-under-write-load) status PASS, success_rate 1.0, observed p50 throughput well above the current floors (798.8 vs 754.8; 799.1 vs 753.1; 790.7 vs 739.2). Independently re-verified the raw campaign JSON directly (not just arch-ctm's summary) before closing. Finding-level status flipped to fixed/closed: both the code fix and the required read-campaign evidence are now in hand." .
 
 <urn:atm:triage:occurrence/RRG-READ-DOCTOR-LANES-001/CAND-1>
   a triage:Occurrence ;

--- a/.triage/readiness-1.4/findings/RRG-READ-RATCHET-STATE-001.ttl
+++ b/.triage/readiness-1.4/findings/RRG-READ-RATCHET-STATE-001.ttl
@@ -15,37 +15,39 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-04T06:50:00Z"^^xsd:dateTime ;
   triage:foundIn triage:RRG-S1 ;
   triage:foundAt "2026-09-04T06:38:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-READ-RATCHET-STATE-001/CAND-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-READ-RATCHET-STATE-001/CAND-2> ;
-  triage:triageRecordVersion "2" ;
-  triage:qmgrRuling "quality-mgr ruling 2026-09-04: approved path (a) -- reviewed process commit, no harness code change: baselines.previous.json set equal to the current revision-1 baselines.json verbatim, baselines.json bumped to revision 2 with floors/provenance/source-campaigns unchanged plus a rationale line ('ratchet state seeded, floors unchanged'). Path (b) (harness special-case for revision-1) rejected: unnecessary code-path complexity for a one-time bootstrap that a data commit fully resolves, and it would leave the fail-closed rule with an exception to reason about on every future revision-1 scenario. Fail-closed semantics preserved for all future revisions; floor values not moved. Dispatch this as a dedicated process commit on chore/readiness-candidate-1.4.7 (or a follow-up branch merging there), then re-run just benchmark-read officially -- the pre-seed diagnostic numbers (query-fts ~802/s, read-under-write ~777/s, fanout PASS) are informative but do NOT themselves constitute official evidence, since they ran with diagnostic_only=true and bypassed the previous-baseline load entirely. RRG-READ-DOCTOR-LANES-001's finding-level closure and the release-readiness read stage both require the official post-seed campaign artifact, not just these diagnostics." .
+  triage:triageRecordVersion "3" ;
+  triage:qmgrRuling "quality-mgr ruling 2026-09-04: approved path (a) -- reviewed process commit, no harness code change: baselines.previous.json set equal to the current revision-1 baselines.json verbatim, baselines.json bumped to revision 2 with floors/provenance/source-campaigns unchanged plus a rationale line ('ratchet state seeded, floors unchanged'). Path (b) (harness special-case for revision-1) rejected: unnecessary code-path complexity for a one-time bootstrap that a data commit fully resolves, and it would leave the fail-closed rule with an exception to reason about on every future revision-1 scenario. Fail-closed semantics preserved for all future revisions; floor values not moved. Dispatch this as a dedicated process commit on chore/readiness-candidate-1.4.7 (or a follow-up branch merging there), then re-run just benchmark-read officially -- the pre-seed diagnostic numbers (query-fts ~802/s, read-under-write ~777/s, fanout PASS) are informative but do NOT themselves constitute official evidence, since they ran with diagnostic_only=true and bypassed the previous-baseline load entirely. RRG-READ-DOCTOR-LANES-001's finding-level closure and the release-readiness read stage both require the official post-seed campaign artifact, not just these diagnostics." ;
+  triage:closureNote "quality-mgr closure (2026-09-04, qa-readiness-read-evidence-r11): seed commit e1a6639f9 (baselines.json revision 2, baselines.previous.json = verbatim revision-1 copy, floors unchanged) landed on chore/readiness-candidate-1.4.7, merged to develop via PR #1143 (5ca0fedce), independently verified byte-for-byte at the time. The official post-seed campaign then ran clean: 20260904T065446Z-rand-m5.local-read (PR #1150, commit ceda87608a) reports ratchet.previous_revision 1, ratchet.current_revision 2, ratchet.engaged true, all three families PASS -- confirming the fail-closed requirement this finding described is resolved end to end (seed + successful official run), not just the seed alone. Finding-level status flipped to fixed/closed. Ruling on the campaign's floor-raise proposal (candidate_floor ~758.9/759.2/751.2, all above current revision-2 floors): NOT approved as a new committed floor from this round. The original AV.4 floors were seeded from three concordant campaigns (quorum); a single post-seed campaign is insufficient evidence to raise floors, and floors must never ratchet on a single run's variance. The proposal stays recorded in the campaign artifact only, no baselines.json edit. If a floor raise is wanted, it needs its own multi-campaign reviewed-floor-commit process, separate from this closure." .
 
 <urn:atm:triage:occurrence/RRG-READ-RATCHET-STATE-001/CAND-1>
   a triage:Occurrence ;
   triage:file "scripts/smoke/read_benchmark.py" ;
   triage:line 849 ;
-  triage:snippet "previous = None if diagnostic_only else load_previous_baselines(previous_path)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "previous = None if diagnostic_only else load_previous_baselines(previous_path) -- fixed at e1a6639f9: baselines.previous.json now exists (verbatim revision-1 copy), so load_previous_baselines succeeds for official runs; confirmed by the official campaign ceda87608a which recorded ratchet.previous_revision 1 / current_revision 2." ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "chore/readiness-candidate-1.4.7" ;
-  triage:headSha "7517ab486" ;
-  triage:occursIn <urn:atm:triage:worktree/CAND/7517ab486> .
+  triage:headSha "e1a6639f9" ;
+  triage:occursIn <urn:atm:triage:worktree/CAND/e1a6639f9-ratchet-seed> .
 
 <urn:atm:triage:occurrence/RRG-READ-RATCHET-STATE-001/CAND-2>
   a triage:Occurrence ;
   triage:file "site/reports/read-query-benchmark/baselines.json" ;
   triage:line 3 ;
-  triage:snippet "\"revision\": 1," ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "\"revision\": 1, -- fixed at e1a6639f9: revision bumped to 2 (floors/provenance/source-campaigns unchanged, rationale line added); official campaign ceda87608a ran against this revision-2 baseline and PASSed all three families." ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "chore/readiness-candidate-1.4.7" ;
-  triage:headSha "7517ab486" ;
-  triage:occursIn <urn:atm:triage:worktree/CAND/7517ab486> .
+  triage:headSha "e1a6639f9" ;
+  triage:occursIn <urn:atm:triage:worktree/CAND/e1a6639f9-ratchet-seed> .
 
 <urn:atm:triage:worktree/CAND/7517ab486>
   a triage:WorktreeSnapshot ;
@@ -53,3 +55,10 @@
   triage:branch "chore/readiness-candidate-1.4.7" ;
   triage:headSha "7517ab486" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/CAND/e1a6639f9-ratchet-seed>
+  a triage:WorktreeSnapshot ;
+  triage:path "atm-core-worktrees/chore/readiness-candidate-1.4.7" ;
+  triage:branch "chore/readiness-candidate-1.4.7" ;
+  triage:headSha "e1a6639f9" ;
+  triage:orderIndex 2 .


### PR DESCRIPTION
## Summary
- Finding-level closure of `RRG-READ-DOCTOR-LANES-001` and `RRG-READ-RATCHET-STATE-001`, per quality-mgr's `qa-readiness-read-evidence-r11` task from fenix.
- Independently re-verified the official read-campaign artifact `20260904T065446Z-rand-m5.local-read` (commit `ceda87608a`, PR #1150) directly against the raw JSON, not just the reported summary: all three families (read-fanout, query-fts, read-under-write-load) status PASS, success_rate 1.0, throughput comfortably above the current floors (798.8 vs 754.8; 799.1 vs 753.1; 790.7 vs 739.2). Ratchet state `previous_revision 1 → current_revision 2`, `engaged: true`.
- Ruling on the campaign's floor-raise proposal: not approved this round. A single post-seed campaign is insufficient evidence to move floors that were originally seeded from three concordant campaigns; the proposal stays recorded in the campaign artifact only.

## Files changed
- `.triage/readiness-1.4/findings/RRG-READ-DOCTOR-LANES-001.ttl` — finding-level `status`/`closed` flipped to fixed/true, `closureNote` added.
- `.triage/readiness-1.4/findings/RRG-READ-RATCHET-STATE-001.ttl` — finding-level and occurrence-level `status`/`closed` flipped to fixed/true, `closureNote` added.

## Test plan
- N/A — Turtle data-record edits only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRTztdpYFQmSMYbNwHdNtL