### PR TITLE
fix(smoke): configure direct-peer port

### DIFF
--- a/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
+++ b/docs/plans/phase-al/sprint-AL13-m5-direct-crosshost-smoke.md
@@ -153,6 +153,8 @@ export ATM_SMOKE_REMOTE_IDENTITY=m5-test
 export ATM_SMOKE_REMOTE_TEAM=atm-dev
 export ATM_SMOKE_REMOTE_ATM=/opt/homebrew/bin/atm
 export ATM_SMOKE_REPETITIONS=10
+# Optional for an account-local loopback fixture; defaults to 43101.
+# export ATM_SMOKE_DIRECT_PEER_PORT=43111
 ```
 
 Run, in this exact order, from the M5 AL.13 home worktree:

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -6,6 +6,9 @@ Run one progressively stronger smoke feature against the selected daemon.
 The runner never starts, stops, switches, or configures a daemon.  Use the
 daemon-switch skill before invoking ``just smoke``.  Local identity comes from the normal
 CLI environment: ``ATM_IDENTITY`` and ``ATM_TEAM``.
+
+The direct-peer smoke port defaults to 43101.  Account-local loopback
+fixtures can override it with ``ATM_SMOKE_DIRECT_PEER_PORT`` (1-65535).
 """
 from __future__ import annotations
 
@@ -57,6 +60,19 @@ CROSSHOST_CURL_MTLS = "crosshost-curl-tls"
 ADMISSION_CAPACITY = "admission-capacity"
 DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team":null,"caller_identity":null}'
 DEFAULT_LIVE_REPETITIONS = 10
+DEFAULT_DIRECT_PEER_PORT = 43101
+
+
+def direct_peer_port() -> int:
+    """Return the configured direct-peer port for the live smoke harness."""
+    value = os.environ.get("ATM_SMOKE_DIRECT_PEER_PORT", str(DEFAULT_DIRECT_PEER_PORT)).strip()
+    try:
+        port = int(value)
+    except ValueError as error:
+        raise SmokeError("ATM_SMOKE_DIRECT_PEER_PORT must be an integer between 1 and 65535") from error
+    if not 1 <= port <= 65535:
+        raise SmokeError("ATM_SMOKE_DIRECT_PEER_PORT must be between 1 and 65535")
+    return port
 
 
 def require_environment() -> tuple[str, str, str]:
@@ -267,7 +283,7 @@ def certificate_authority(pem: Path) -> str:
 def resolve_dns_addresses(host: str) -> list[str]:
     """Return every address the local resolver provides for a peer hostname."""
     try:
-        records = socket.getaddrinfo(host, 43101, type=socket.SOCK_STREAM)
+        records = socket.getaddrinfo(host, direct_peer_port(), type=socket.SOCK_STREAM)
     except OSError as error:
         raise SmokeError(f"DNS resolution for {host} failed: {error}") from error
     return sorted({record[4][0] for record in records})
@@ -275,9 +291,10 @@ def resolve_dns_addresses(host: str) -> list[str]:
 
 def remote_resolve_dns_addresses(peer: str, host: str) -> list[str]:
     """Resolve a hostname through the remote computer's normal resolver."""
+    port = direct_peer_port()
     script = (
         "import json, socket; "
-        f"print(json.dumps(sorted({{item[4][0] for item in socket.getaddrinfo({host!r}, 43101, type=socket.SOCK_STREAM)}})))"
+        f"print(json.dumps(sorted({{item[4][0] for item in socket.getaddrinfo({host!r}, {port}, type=socket.SOCK_STREAM)}})))"
     )
     result = remote_shell(peer, f"python3 -c {shlex.quote(script)}")
     try:
@@ -373,20 +390,21 @@ def curl_doctor(
                 local_authority = certificate_authority(local_public)
                 remote_authority = certificate_authority(remote_public)
                 scheme = "http" if plaintext else "https"
-                local_url = f"{scheme}://{local_authority}:43101/v1/atm/doctor"
-                remote_url = f"{scheme}://{remote_authority}:43101/v1/atm/doctor"
+                port = direct_peer_port()
+                local_url = f"{scheme}://{local_authority}:{port}/v1/atm/doctor"
+                remote_url = f"{scheme}://{remote_authority}:{port}/v1/atm/doctor"
                 headers = ["-H", "Content-Type: application/json"]
                 remote_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
                 if not plaintext:
                     remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
-                remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
+                remote_curl.extend(["--resolve", f"{local_authority}:{port}:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
                 remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
                 remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
                 add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready", origin=peer, destination=platform.node())
                 local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
                 if not plaintext:
                     local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
-                local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
+                local_curl.extend(["--resolve", f"{remote_authority}:{port}:{remote_host}", "--data", DOCTOR_BODY, remote_url])
                 local_result = command(local_curl)
                 local_report = parse_json(local_result, f"curl doctor to {peer}")
                 add_case(cases, f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready", origin=platform.node(), destination=peer)
@@ -398,7 +416,7 @@ def curl_doctor(
                     remote_negative = [
                         "curl", "--silent", "--show-error", "--connect-timeout", "2", "--max-time", "5",
                         "--write-out", "%{http_code}", "-X", "GET", *headers, "--cacert", remote_local_ca,
-                        "--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url,
+                        "--resolve", f"{local_authority}:{port}:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url,
                     ]
                     remote_negative_result = remote_shell(
                         peer, " ".join(shlex.quote(value) for value in remote_negative)
@@ -413,7 +431,7 @@ def curl_doctor(
                     local_negative = [
                         "curl", "--silent", "--show-error", "--connect-timeout", "2", "--max-time", "5",
                         "--write-out", "%{http_code}", "-X", "GET", *headers, "--cacert", str(remote_public),
-                        "--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url,
+                        "--resolve", f"{remote_authority}:{port}:{remote_host}", "--data", DOCTOR_BODY, remote_url,
                     ]
                     local_negative_result = command(local_negative)
                     add_mtls_rejection_case(

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -471,6 +471,19 @@ class FeatureSmokeTests(unittest.TestCase):
         ):
             self.assertEqual(RUNNER.resolve_dns_addresses("peer.example"), ["192.0.2.10", "2001:db8::10"])
 
+    def test_direct_peer_port_defaults_to_43101(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(RUNNER.direct_peer_port(), 43101)
+
+    def test_direct_peer_port_override_is_used_by_dns_resolution(self):
+        with mock.patch.dict(os.environ, {"ATM_SMOKE_DIRECT_PEER_PORT": "43111"}, clear=False), mock.patch.object(
+            RUNNER.socket,
+            "getaddrinfo",
+            return_value=[(2, 1, 6, "", ("192.0.2.10", 43111))],
+        ) as getaddrinfo:
+            self.assertEqual(RUNNER.resolve_dns_addresses("peer.example"), ["192.0.2.10"])
+        self.assertEqual(getaddrinfo.call_args.args[:2], ("peer.example", 43111))
+
     def test_dns_case_requires_the_advertised_ip(self):
         cases = []
         RUNNER.add_dns_case(
@@ -531,7 +544,9 @@ class FeatureSmokeTests(unittest.TestCase):
                 return rejected
             return result
 
-        with mock.patch.object(RUNNER, "certificate_bundle", return_value="/tmp/local-bundle.pem"), mock.patch.object(
+        with mock.patch.dict(os.environ, {"ATM_SMOKE_DIRECT_PEER_PORT": "43111"}, clear=False), mock.patch.object(
+            RUNNER, "certificate_bundle", return_value="/tmp/local-bundle.pem"
+        ), mock.patch.object(
             RUNNER,
             "remote_command",
             return_value={
@@ -567,7 +582,8 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertNotIn("--cert", curl_calls[1])
         self.assertIn("--write-out", curl_calls[1])
         self.assertNotIn("--resolve", curl_calls[2])
-        self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[2])
+        self.assertIn("https://remote.example.test:43111/v1/atm/doctor", curl_calls[2])
+        self.assertIn("remote.example.test:43111:192.0.2.20", curl_calls[0])
         local_ca_path = curl_calls[0][curl_calls[0].index("--cacert") + 1]
         self.assertEqual(Path(local_ca_path).name, "remote-public.pem")
         self.assertTrue(any("unauthenticated mTLS" in case["name"] for case in cases))
@@ -576,6 +592,13 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertIn("local-public.pem", cleanup_script)
         self.assertIn("peer-public.pem", cleanup_script)
         self.assertIn("rmdir", cleanup_script)
+
+    def test_direct_peer_port_rejects_non_numeric_and_out_of_range_values(self):
+        for value in ("not-a-port", "0", "65536"):
+            with self.subTest(value=value), mock.patch.dict(
+                os.environ, {"ATM_SMOKE_DIRECT_PEER_PORT": value}, clear=False
+            ), self.assertRaisesRegex(RUNNER.SmokeError, "ATM_SMOKE_DIRECT_PEER_PORT"):
+                RUNNER.direct_peer_port()
 
     def test_mtls_rejection_requires_nonzero_curl_exit_and_no_http_status(self):
         self.assertTrue(RUNNER.mtls_rejected_before_http({"exit_code": 35, "stdout": "000", "stderr": ""}))


### PR DESCRIPTION
## Summary
- add validated ATM_SMOKE_DIRECT_PEER_PORT override with the existing 43101 default
- apply the override to DNS probes, doctor URLs, and curl resolve mappings
- document the fixture override and add default/override/validation tests

Finding: RRG-SMOKE-LOCALHOST-PORT-001

## Verification
- just fmt
- just lint (35 checks)
- .just/run_pytests.py (1003 tests, 21 skipped)