### PR TITLE
triage(readiness): record Rand's post-release deferral on the direct-peer records

### DIFF
--- a/.triage/readiness-1.4/findings/RRG-CLI-DIRECT-PEER-DIAL-PORT-001.ttl
+++ b/.triage/readiness-1.4/findings/RRG-CLI-DIRECT-PEER-DIAL-PORT-001.ttl
@@ -22,7 +22,8 @@
   triage:foundAt "2026-09-04T07:33:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-CLI-DIRECT-PEER-DIAL-PORT-001/DEV-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-CLI-DIRECT-PEER-DIAL-PORT-001/DEV-2> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" ;
+  triage:releaseDecision "Rand decision 2026-09-04 (team-lead ruling 01M1NX1PDN9W25WGCB6B2D4Y91): deferred to post-release. The 1.4.13 release ships without this fix; tracked as a known follow-up. Status and dispatchReady unchanged (already open, no pre-release dispatch); arch-ctm idle on this item. Companion records: RRG-DIRECT-PEER-BIND-ADDR-001, RRG-CLI-DIRECT-PEER-DIAL-PORT-001, RRG-TRUST-KEY-LOOPBACK-001." .
 
 <urn:atm:triage:occurrence/RRG-CLI-DIRECT-PEER-DIAL-PORT-001/DEV-1>
   a triage:Occurrence ;

--- a/.triage/readiness-1.4/findings/RRG-DIRECT-PEER-BIND-ADDR-001.ttl
+++ b/.triage/readiness-1.4/findings/RRG-DIRECT-PEER-BIND-ADDR-001.ttl
@@ -22,7 +22,8 @@
   triage:foundAt "2026-09-04T06:37:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-DIRECT-PEER-BIND-ADDR-001/DEV-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-DIRECT-PEER-BIND-ADDR-001/DEV-2> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" ;
+  triage:releaseDecision "Rand decision 2026-09-04 (team-lead ruling 01M1NX1PDN9W25WGCB6B2D4Y91): deferred to post-release. The 1.4.13 release ships without this fix; tracked as a known follow-up. Status and dispatchReady unchanged (already open, no pre-release dispatch); arch-ctm idle on this item. Companion records: RRG-DIRECT-PEER-BIND-ADDR-001, RRG-CLI-DIRECT-PEER-DIAL-PORT-001, RRG-TRUST-KEY-LOOPBACK-001." .
 
 <urn:atm:triage:occurrence/RRG-DIRECT-PEER-BIND-ADDR-001/DEV-1>
   a triage:Occurrence ;

--- a/.triage/readiness-1.4/findings/RRG-TRUST-KEY-LOOPBACK-001.ttl
+++ b/.triage/readiness-1.4/findings/RRG-TRUST-KEY-LOOPBACK-001.ttl
@@ -22,7 +22,8 @@
   triage:foundAt "2026-09-03T20:55:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-TRUST-KEY-LOOPBACK-001/CAND-1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RRG-TRUST-KEY-LOOPBACK-001/CAND-2> ;
-  triage:triageRecordVersion "2" .
+  triage:triageRecordVersion "3" ;
+  triage:releaseDecision "Rand decision 2026-09-04 (team-lead ruling 01M1NX1PDN9W25WGCB6B2D4Y91): deferred to post-release. The 1.4.13 release ships without this fix; tracked as a known follow-up. Status and dispatchReady unchanged (already open, no pre-release dispatch); arch-ctm idle on this item. Companion records: RRG-DIRECT-PEER-BIND-ADDR-001, RRG-CLI-DIRECT-PEER-DIAL-PORT-001, RRG-TRUST-KEY-LOOPBACK-001." .
 
 <urn:atm:triage:occurrence/RRG-TRUST-KEY-LOOPBACK-001/CAND-1>
   a triage:Occurrence ;


### PR DESCRIPTION
Triage-only. Appends a `triage:releaseDecision` note (record version bumped) to RRG-DIRECT-PEER-BIND-ADDR-001, RRG-CLI-DIRECT-PEER-DIAL-PORT-001 and RRG-TRUST-KEY-LOOPBACK-001 citing team-lead ruling 01M1NX1PDN9W25WGCB6B2D4Y91: 1.4.13 ships without these fixes, tracked as known post-release follow-ups. No status or dispatchReady changes. Requested by quality-mgr for the release ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK