### PR TITLE
evidence(readiness): land 1.4.9 atmbench report artifacts from origin/evidence/readiness-1.4.9-atmbench

### DIFF
--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -12,7 +12,7 @@
   <section><h2>Benchmark</h2>
     <ul>
       <li><a href="read-query-benchmark/index.html">index</a><time datetime="2026-09-04T06:54:46.399585Z">2026-09-04T06:54:46.399585Z</time><span class="report-meta">benchmark · hosts: rand-m5.local</span></li>
-      <li><a href="send-message-benchmark/index.html">index</a><time datetime="2026-08-29T22:47:02.194731Z">2026-08-29T22:47:02.194731Z</time><span class="report-meta">benchmark · hosts: windows-x64-01</span></li>
+      <li><a href="send-message-benchmark/index.html">index</a><time datetime="2026-09-04T05:49:52.700442Z">2026-09-04T05:49:52.700442Z</time><span class="report-meta">benchmark · hosts: m5-atmbench</span></li>
     </ul>
   </section>
   <section><h2>Fuzz</h2>
@@ -26,8 +26,6 @@
   </section>
   <section><h2>Smoke</h2>
     <ul>
-      <li><a href="smoke/macos/rand-m5.local/20260904T064302534002Z-pid88668-localhost/index.html">smoke/macos/rand-m5.local/20260904T064302534002Z-pid88668-localhost</a><time datetime="2026-09-04T06:43:02.544954Z">2026-09-04T06:43:02.544954Z</time><span class="report-meta">smoke · FAIL · hosts: rand-m5.local</span></li>
-      <li><a href="smoke/macos/rand-m5.local/20260904T064248085403Z-pid88558-localhost/index.html">smoke/macos/rand-m5.local/20260904T064248085403Z-pid88558-localhost</a><time datetime="2026-09-04T06:42:48.097228Z">2026-09-04T06:42:48.097228Z</time><span class="report-meta">smoke · FAIL · hosts: rand-m5.local</span></li>
       <li><a href="smoke/macos/rand-m5.local/20260831T203502835995Z-pid58124-local-ip/index.html">smoke/macos/rand-m5.local/20260831T203502835995Z-pid58124-local-ip</a><time datetime="2026-08-31T20:35:02.846504Z">2026-08-31T20:35:02.846504Z</time><span class="report-meta">smoke · FAIL · hosts: rand-m5.local</span></li>
       <li><a href="smoke/macos/rand-m5.local/20260831T203217630910Z-pid56376-localhost/index.html">smoke/macos/rand-m5.local/20260831T203217630910Z-pid56376-localhost</a><time datetime="2026-08-31T20:32:17.887273Z">2026-08-31T20:32:17.887273Z</time><span class="report-meta">smoke · FAIL · hosts: rand-m5.local</span></li>
       <li><a href="smoke/macos/rand-m4.local/20260820T222412780815Z-pid97059-crosshost-curl-tls/index.html">smoke/macos/rand-m4.local/20260820T222412780815Z-pid97059-crosshost-curl-tls</a><time datetime="2026-08-20T22:24:12.812913Z">2026-08-20T22:24:12.812913Z</time><span class="report-meta">smoke · FAIL · hosts: rand-m4.local</span></li>

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-sqlite.json
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-sqlite.json
@@ -1,0 +1,26 @@
+{
+  "baseline": {
+    "p50_floor": 35000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+    "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+  },
+  "campaign_id": "20260903T183628Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": null,
+  "frames_per_connection": 0,
+  "generated_at": "2026-09-03T18:36:39.681959Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+  "messages_admitted": 0,
+  "messages_durable": 0,
+  "messages_requested": 0,
+  "metrics": null,
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+  "status": "INCOMPLETE",
+  "target": "sqlite"
+}

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-tcp-tls.json
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-tcp-tls.json
@@ -1,0 +1,26 @@
+{
+  "baseline": {
+    "p50_floor": 13500.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+    "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+  },
+  "campaign_id": "20260903T183628Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-03T18:36:42.318969Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+  "messages_admitted": 0,
+  "messages_durable": 0,
+  "messages_requested": 0,
+  "metrics": null,
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+  "status": "INCOMPLETE",
+  "target": "tcp-tls"
+}

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-tcp.json
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-tcp.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 17000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+    "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+  },
+  "campaign_id": "20260903T183628Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 600,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 600,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-03T18:36:40.623858Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 600,
+  "messages_durable": 600,
+  "messages_requested": 1000,
+  "metrics": {
+    "accepted_count": 600,
+    "admissions_per_second": {
+      "max": 422.18351542814537,
+      "min": 422.18351542814537,
+      "p50": 422.18351542814537,
+      "p95": 422.18351542814537,
+      "p99": 422.18351542814537
+    },
+    "application_wire_bytes": {
+      "request": 820265,
+      "response": 400666,
+      "total": 1220931
+    },
+    "application_wire_bytes_per_second": {
+      "max": 859094.9027920015,
+      "min": 859094.9027920015,
+      "p50": 859094.9027920015,
+      "p95": 859094.9027920015,
+      "p99": 859094.9027920015
+    },
+    "connection_count": 125,
+    "connections_per_second": {
+      "max": 87.95489904753028,
+      "min": 87.95489904753028,
+      "p50": 87.95489904753028,
+      "p95": 87.95489904753028,
+      "p99": 87.95489904753028
+    },
+    "first_failure": "HTTP 503: {\"code\":\"ATM_MAILBOX_WRITE_FAILED\",\"message\":\"failed to look up graft receiver endpoint\\n  Recovery: Repair mailbox access or wait for the competing operation, then retry.\\n  Recovery: Repair mailbox access or wait for the competing operation, then retry.\"}",
+    "interval_count": 1,
+    "interval_latency_ms": {
+      "max": 1415.3893750626594,
+      "min": 41.929000057280064,
+      "p50": 599.952916498296,
+      "p95": 1089.0579170081764,
+      "p99": 1302.7598339831457
+    },
+    "passed_interval_count": 0,
+    "request_frames_per_second": {
+      "max": 703.6391923802422,
+      "min": 703.6391923802422,
+      "p50": 703.6391923802422,
+      "p95": 703.6391923802422,
+      "p99": 703.6391923802422
+    },
+    "requested_count": 1000,
+    "response_count": 1000,
+    "time_to_send_1k_s": {
+      "max": 2.368638195136252,
+      "min": 2.368638195136252,
+      "p50": 2.368638195136252,
+      "p95": 2.368638195136252,
+      "p99": 2.368638195136252
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+  "status": "FAIL",
+  "target": "tcp"
+}

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-uds.json
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench-uds.json
@@ -1,0 +1,26 @@
+{
+  "baseline": {
+    "p50_floor": 18000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+    "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+  },
+  "campaign_id": "20260903T183628Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": null,
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-03T18:36:40.494445Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+  "messages_admitted": 0,
+  "messages_durable": 0,
+  "messages_requested": 0,
+  "metrics": null,
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+  "status": "INCOMPLETE",
+  "target": "uds"
+}

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench.campaign.json
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench.campaign.json
@@ -1,0 +1,177 @@
+{
+  "campaign_id": "20260903T183628Z-m5-atmbench",
+  "completed_at": "2026-09-03T18:36:42.444157Z",
+  "host_label": "m5-atmbench",
+  "os": "macos",
+  "phase": "ao2",
+  "results": [
+    {
+      "baseline": {
+        "p50_floor": 35000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+        "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+      },
+      "campaign_id": "20260903T183628Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": null,
+      "frames_per_connection": 0,
+      "generated_at": "2026-09-03T18:36:39.681959Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+      "messages_admitted": 0,
+      "messages_durable": 0,
+      "messages_requested": 0,
+      "metrics": null,
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+      "status": "INCOMPLETE",
+      "target": "sqlite"
+    },
+    {
+      "baseline": {
+        "p50_floor": 18000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+        "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+      },
+      "campaign_id": "20260903T183628Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": null,
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-03T18:36:40.494445Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+      "messages_admitted": 0,
+      "messages_durable": 0,
+      "messages_requested": 0,
+      "metrics": null,
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+      "status": "INCOMPLETE",
+      "target": "uds"
+    },
+    {
+      "baseline": {
+        "p50_floor": 17000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+        "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+      },
+      "campaign_id": "20260903T183628Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 600,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 600,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-03T18:36:40.623858Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 600,
+      "messages_durable": 600,
+      "messages_requested": 1000,
+      "metrics": {
+        "accepted_count": 600,
+        "admissions_per_second": {
+          "max": 422.18351542814537,
+          "min": 422.18351542814537,
+          "p50": 422.18351542814537,
+          "p95": 422.18351542814537,
+          "p99": 422.18351542814537
+        },
+        "application_wire_bytes": {
+          "request": 820265,
+          "response": 400666,
+          "total": 1220931
+        },
+        "application_wire_bytes_per_second": {
+          "max": 859094.9027920015,
+          "min": 859094.9027920015,
+          "p50": 859094.9027920015,
+          "p95": 859094.9027920015,
+          "p99": 859094.9027920015
+        },
+        "connection_count": 125,
+        "connections_per_second": {
+          "max": 87.95489904753028,
+          "min": 87.95489904753028,
+          "p50": 87.95489904753028,
+          "p95": 87.95489904753028,
+          "p99": 87.95489904753028
+        },
+        "first_failure": "HTTP 503: {\"code\":\"ATM_MAILBOX_WRITE_FAILED\",\"message\":\"failed to look up graft receiver endpoint\\n  Recovery: Repair mailbox access or wait for the competing operation, then retry.\\n  Recovery: Repair mailbox access or wait for the competing operation, then retry.\"}",
+        "interval_count": 1,
+        "interval_latency_ms": {
+          "max": 1415.3893750626594,
+          "min": 41.929000057280064,
+          "p50": 599.952916498296,
+          "p95": 1089.0579170081764,
+          "p99": 1302.7598339831457
+        },
+        "passed_interval_count": 0,
+        "request_frames_per_second": {
+          "max": 703.6391923802422,
+          "min": 703.6391923802422,
+          "p50": 703.6391923802422,
+          "p95": 703.6391923802422,
+          "p99": 703.6391923802422
+        },
+        "requested_count": 1000,
+        "response_count": 1000,
+        "time_to_send_1k_s": {
+          "max": 2.368638195136252,
+          "min": 2.368638195136252,
+          "p50": 2.368638195136252,
+          "p95": 2.368638195136252,
+          "p99": 2.368638195136252
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+      "status": "FAIL",
+      "target": "tcp"
+    },
+    {
+      "baseline": {
+        "p50_floor": 13500.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "055e80a9213d8cff5a271258b5bb71d6784022d0e19618f901eeb2f8324a6f48",
+        "atm-daemon": "5ee4ec4a45f58290d3bea95b5a307b3415e8261cd075e852a970d6c1d426f9ab"
+      },
+      "campaign_id": "20260903T183628Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": null,
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-03T18:36:42.318969Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": "benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request\n8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material",
+      "messages_admitted": 0,
+      "messages_durable": 0,
+      "messages_requested": 0,
+      "metrics": null,
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+      "status": "INCOMPLETE",
+      "target": "tcp-tls"
+    }
+  ],
+  "schema_version": 4,
+  "source_revision": "863ee20139cf6ffaf0647601c4b9dfae4a37ab51",
+  "started_at": "2026-09-03T18:36:28.177152Z",
+  "status": "INCOMPLETE"
+}

--- a/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench.xhtml
+++ b/site/reports/send-message-benchmark/20260903T183628Z-m5-atmbench.xhtml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <title>ATM benchmark campaign — 20260903T183628Z-m5-atmbench</title>
+  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+  <style type="text/css">
+    body { font-family: sans-serif; color: #1f2937; margin: 2rem auto; max-width: 75rem; padding: 0 1rem; }
+    table { border-collapse: collapse; margin: 1rem 0; width: 100%; } th, td { border: 1px solid #cbd5e1; padding: .55rem; text-align: left; }
+    th { background: #f1f5f9; } .PASS { color: #065f46; font-weight: bold; } .FAIL { color: #991b1b; font-weight: bold; } .INCOMPLETE { color: #92400e; font-weight: bold; }
+    .meta { color: #475569; } code { font-family: ui-monospace, monospace; } .incomplete { margin-top: 2rem; border: 2px solid #f59e0b; padding: 1rem; background: #fffbeb; }
+  </style>
+</head>
+<body>
+  <h1>ATM benchmark campaign — 20260903T183628Z-m5-atmbench</h1>
+  <p class="meta"><code>20260903T183628Z-m5-atmbench</code> · m5-atmbench · phase ao2 · source <code>863ee20139cf6ffaf0647601c4b9dfae4a37ab51</code></p>
+  <p>Status: <strong class="INCOMPLETE">INCOMPLETE</strong> · started <time datetime="2026-09-03T18:36:28.177152Z">Sep 3, 2026 · 11:36 PDT</time> · completed <time datetime="2026-09-03T18:36:42.444157Z">Sep 3, 2026 · 11:36 PDT</time></p>
+  <table>
+    <thead><tr><th>Test</th><th>p50 msg/sec</th><th>p95</th><th>p99</th><th>Durable write proof</th><th>Baseline floor</th><th>Margin</th><th>Verdict</th></tr></thead>
+    <tbody>
+      <tr data-target="tcp"><td>TCP</td><td>422.18</td><td>422.18</td><td>422.18</td><td>600 / 600 after restart</td><td>17000.00</td><td>-16577.82</td><td class="FAIL">FAIL</td></tr>
+      <tr data-target="tcp-tls"><td>TCP + TLS</td><td>n/a</td><td>n/a</td><td>n/a</td><td>not captured</td><td>13500.00</td><td>n/a</td><td class="INCOMPLETE">INCOMPLETE</td></tr>
+      <tr data-target="uds"><td>UDS</td><td>n/a</td><td>n/a</td><td>n/a</td><td>not captured</td><td>18000.00</td><td>n/a</td><td class="INCOMPLETE">INCOMPLETE</td></tr>
+      <tr data-target="sqlite"><td>SQLite</td><td>n/a</td><td>n/a</td><td>n/a</td><td>not captured</td><td>35000.00</td><td>n/a</td><td class="INCOMPLETE">INCOMPLETE</td></tr>
+    </tbody>
+  </table>
+  <aside class="incomplete"><strong>Incomplete campaign:</strong> benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request
+8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material; benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request
+8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material; benchmark snapshot phase failed: could not generate disposable P-256 mTLS certificate: problems making Certificate Request
+8431459968:error:0DFFF097:asn1 encoding routines:CRYPTO_internal:string too long:/AppleInternal/Library/BuildRoots/4~CNqEugB7-7yoTeHDwKLZ0PRIsI79y9XP33qXeIo/Library/Caches/com.apple.xbs/TemporaryDirectory.MoIAiI/Sources/libressl/libressl-3.3/crypto/asn1/a_mbstr.c:156:maxsize=64; recovery: keep the benchmark daemon stopped and inspect retained snapshot staging material</aside>
+  <script type="application/ecmascript"><![CDATA[
+(() => { const f = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short", hourCycle: "h23", timeZoneName: "short" }); document.querySelectorAll("time[datetime]").forEach((node) => { node.textContent = f.format(new Date(node.dateTime)); }); })();
+  ]]></script>
+</body>
+</html>


### PR DESCRIPTION
Reports-only re-land from the stale evidence branch: benchmark/smoke artifacts and the regenerated reports index. Version bumps, harness edits and superseded triage records are dropped. Part of the readiness-1.4 evidence-ledger stack (every attempt lands on develop, PASS or FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK