### PR TITLE
evidence(readiness): land 1.4.10 atmbench report artifacts from origin/evidence/readiness-1.4.10-atmbench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*", "docs/*", "plan/*"]
+    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*", "docs/*", "plan/*", "evidence/*", "triage/*"]
   push:
     branches: [develop, main]
 

--- a/site/reports/send-message-benchmark/20260903T185218Z-m5-atmbench-sqlite.json
+++ b/site/reports/send-message-benchmark/20260903T185218Z-m5-atmbench-sqlite.json
@@ -1,0 +1,71 @@
+{
+  "baseline": {
+    "p50_floor": 35000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "8a5496ff70985a7914da729f0f623d818315de80063122c532ba7f9df3e64827",
+    "atm-daemon": "1df23708fb7862c956d489d97e2d42818ac46de3573de588bc2829862375de4b"
+  },
+  "campaign_id": "20260903T185218Z-m5-atmbench",
+  "direct_sqlite_message_write": {
+    "accepted_count": 886000,
+    "admissions_per_second": 44283.71881400479,
+    "elapsed_seconds": 20.007353125,
+    "kind": "async_storage_admission",
+    "requested_count": 886000,
+    "worker_count": 512
+  },
+  "durability_after_restart": {
+    "expected_accepted_count": 886000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 886000,
+    "passed": true
+  },
+  "frames_per_connection": 0,
+  "generated_at": "2026-09-03T18:52:30.882046Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 886000,
+  "messages_durable": 886000,
+  "messages_requested": 886000,
+  "metrics": {
+    "accepted_count": 886000,
+    "admissions_per_second": {
+      "max": 53371.165662016734,
+      "min": 12181.770285312286,
+      "p50": 43893.4612340499,
+      "p95": 51292.57283545343,
+      "p99": 52012.22287237501
+    },
+    "application_wire_bytes": null,
+    "application_wire_bytes_per_second": null,
+    "connection_count": null,
+    "connections_per_second": null,
+    "first_failure": null,
+    "interval_count": 886,
+    "interval_latency_ms": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "passed_interval_count": 886,
+    "request_frames_per_second": null,
+    "requested_count": 886000,
+    "response_count": 886000,
+    "time_to_send_1k_s": {
+      "max": 0.082089875,
+      "min": 0.018736709,
+      "p50": 0.0227824375,
+      "p95": 0.026957708,
+      "p99": 0.03917375
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "1a0623e668725e8baa27243b1aa0b703d13ef0b4",
+  "status": "PASS",
+  "target": "sqlite"
+}

--- a/site/reports/send-message-benchmark/20260904-161450.219123-windows-x64-01-tcp-f16.json
+++ b/site/reports/send-message-benchmark/20260904-161450.219123-windows-x64-01-tcp-f16.json
@@ -1,0 +1,94 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "benchmark_target": "tcp",
+  "campaign_id": null,
+  "cleanup_failure": null,
+  "command": "just benchmark --target tcp",
+  "daemon_version": "atm 1.4.13",
+  "direct_sqlite_message_write": null,
+  "doctor_after_restart_status": "passed",
+  "doctor_status": "passed",
+  "durability_after_restart": {
+    "expected_accepted_count": 157000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 157000,
+    "passed": true
+  },
+  "execution_daemon": "shipped_atm_daemon",
+  "failure": null,
+  "frames_per_connection": 16,
+  "generated_at": "2026-09-04T16:14:50.219123Z",
+  "hook_mode": "active",
+  "host_arch": "amd64",
+  "host_label": "windows-x64-01",
+  "host_os": "windows",
+  "host_state_isolation": "dedicated_benchmark_os_account",
+  "messages_per_connection": 16,
+  "metrics": {
+    "accepted_count": 157000,
+    "admissions_per_second": {
+      "max": 9008.010823151837,
+      "min": 5507.014286860427,
+      "p50": 7928.893686424027,
+      "p95": 8509.41439444321,
+      "p99": 8894.359909657383
+    },
+    "application_wire_bytes": {
+      "request": 125125435,
+      "response": 64446819,
+      "total": 189572254
+    },
+    "application_wire_bytes_per_second": {
+      "max": 10833592.312593434,
+      "min": 6646316.416554687,
+      "p50": 9579797.111831566,
+      "p95": 10252840.234405525,
+      "p99": 10716654.156667806
+    },
+    "connection_count": 9891,
+    "connections_per_second": {
+      "max": 567.5046818585657,
+      "min": 346.9419000722069,
+      "p50": 499.52030224471366,
+      "p95": 536.0931068499223,
+      "p99": 560.3446743084152
+    },
+    "first_failure": null,
+    "interval_count": 157,
+    "interval_latency_ms": {
+      "max": 122.06389987841249,
+      "min": 1.9669998437166214,
+      "p50": 29.853749903850257,
+      "p95": 66.18209998123348,
+      "p99": 105.00239999964833
+    },
+    "passed_interval_count": 157,
+    "request_frames_per_second": {
+      "max": 9008.010823151837,
+      "min": 5507.014286860427,
+      "p50": 7928.893686424027,
+      "p95": 8509.41439444321,
+      "p99": 8894.359909657383
+    },
+    "requested_count": 157000,
+    "response_count": 157000,
+    "time_to_send_1k_s": {
+      "max": 0.18158659990876913,
+      "min": 0.11101230001077056,
+      "p50": 0.12612099992111325,
+      "p95": 0.14224529988132417,
+      "p99": 0.17382879997603595
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "peer_wire_security": "plaintext-test",
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.000026098219678,
+  "sample_count": 157,
+  "schema_version": 3,
+  "source_revision": "8b04d89d76218f210e4cd2e77ddd66b8d41096bc",
+  "target_duration_s": 20.0,
+  "transport": "tcp",
+  "worker_limit": 64
+}

--- a/site/reports/send-message-benchmark/20260904-windows-tcp-floor-root-cause-progress.md
+++ b/site/reports/send-message-benchmark/20260904-windows-tcp-floor-root-cause-progress.md
@@ -1,0 +1,46 @@
+# Windows TCP Floor Root-Cause Progress
+
+## Scope
+
+This report compares retained Windows benchmark evidence only. It does not
+build or run a historical revision, and it does not change `baselines.json`.
+
+## Comparable TCP Evidence
+
+All rows below use Windows `tcp`, 16 frames per connection, and the historical
+64-worker runner shape.
+
+| Timestamp (UTC) | Revision | p50 msg/s | Interpretation |
+| --- | --- | ---: | --- |
+| 2026-08-01 21:13 | `2973fe2f936c` | 8,793.91 | Last recorded PASS and source of the current floor. |
+| 2026-08-01 22:48 | `fd8dd58e04a8` | 8,636.26 | Already below the seeded floor. |
+| 2026-08-21 02:52 | `78ec6008c03d` | 6,581.30 | Latest retained pre-candidate comparable evidence. |
+| 2026-09-04 16:14 | `f39c2236477a` | 7,928.89 | 1.4.13 candidate control, retained in the adjacent JSON artifact. |
+
+The candidate remains 9.8% below the historical seed, but is 20.5% above the
+latest comparable pre-candidate record. The retained evidence therefore does
+not support attributing the remaining floor miss to the 1.4.13 candidate.
+
+## Known Pipeline Regression And Current State
+
+Canonical finding `RRG-INGRESS-ADMIT-001` records an earlier, independently
+root-caused throughput regression after the historical seed:
+
+1. AQ graft endpoint delivery added a blocking control-path SQLite borrow to
+   each local write (`334e5ca89` / `1c74392a8`).
+2. Bare-CLI queue-pull handling then cleared a marker for each Immediate write,
+   adding another control-path transaction and SQLite WAL contention.
+3. The candidate contains the repairs: `39327974c` caches graft receiver lease
+   resolution off the write path, and `40b00b236` limits marker clearing to
+   `NudgeKind::Queue`.
+
+The current source confirms the Immediate-write guard remains present in
+`crates/atm-daemon-bootstrap/src/received_hook_selector.rs`.
+
+## Remaining Work
+
+The cause of the residual 9.8% difference from the one historical PASS has
+not been isolated. The next valid discriminator is performance profiling of
+the current TCP/f16/64 path on the Windows benchmark account, correlated with
+the retained evidence. No runtime change is justified from the evidence in
+this report alone.

--- a/site/reports/send-message-benchmark/20260904-windows-tcp-write-pipeline-review.md
+++ b/site/reports/send-message-benchmark/20260904-windows-tcp-write-pipeline-review.md
@@ -1,0 +1,40 @@
+# Windows TCP Write-Pipeline Review
+
+## Method
+
+Three independent read-only Luna reviews compared the local write pipeline from
+the last recorded Windows TCP/f16/64 PASS, `2973fe2f936c`, to the 1.4.13
+candidate, `f39c2236477a`. No build, benchmark run, or source modification was
+performed for this review.
+
+The capacity benchmark adds a sender and recipient with no pane or Herdr
+metadata and no Graft receiver lease. The delivery classifier therefore selects
+`BareCli`; the request's default `Immediate` nudge mode selects a `Steer`
+queue-pull dispatch. Plain TCP benchmark ingress is non-peer ingress, so the
+router awaits the received-hook future before returning the response.
+
+## Ranked Findings
+
+| Rank | Change | Introduced | Benchmark-path evidence | Windows concern | Status |
+| --- | --- | --- | --- | --- | --- |
+| P1 | Bare-CLI hook schedules `spawn_blocking`, waits for it, then appends to a process-wide mutex-protected FIFO. | `2517d84f6` | Every newly persisted capacity write is `BareCli` + `Immediate`, selecting `PullPendingReceivedHook`; the local response awaits it. | Thread-pool scheduling and global mutex contention occur on every TCP response. The 32-entry FIFO reaches its drop path during sustained traffic. | High-confidence suspect; needs an A/B measurement. |
+| P1 | Search projection and FTS trigger work occur in every unique-message writer transaction. | `1135ef7ce`, changed by `5929160a2` | Each benchmark message is unique and durable. The writer updates the message row, state row, projection, and FTS index in the same transaction. | Longer SQLite WAL transactions and NTFS page writes can increase single-writer occupancy. | Medium-high regression risk; not isolated as the cause. |
+| P2 | Local ingress awaits received-hook completion after persistence. | Present after `e2100f0389`; current branch at `storage_and_nudge_router.rs` | TCP smoke ingress is not `Peer`; the await is live. The FIFO dispatch makes it non-empty for the capacity roster. | Couples post-commit work to response latency. | This is the response-path mechanism that exposes P1. |
+| P2 | Lease cache synchronization remains on each write. | `1c74392a8`, repaired by `39327974c` | The delivery policy queries the short-lived cache for every write. | Mutex/condition-variable overhead, with an occasional SQLite refresh. | Low-to-medium residual suspect; the previous per-write SQLite lookup is repaired. |
+| P3 | HTTP listener retains completed connection tasks until shutdown; each request also reconstructs/parses request data. | `ebca2d6884`, `c1e521aa4`, `f28ee24e8b` and follow-ups | The f16 control creates 9,891 connections and every request copies/parses payload data. | Task bookkeeping and allocator pressure can be more visible on Windows. | Plausible, unproven. |
+
+## Confirmed Repairs Not To Revert
+
+- `39327974c` keeps Graft receiver lease SQLite lookups out of the ordinary
+  local write hot path through a short-lived, coalescing cache.
+- `40b00b236` keeps queue-marker clearing restricted to `NudgeKind::Queue`.
+  Capacity `Immediate` writes are `Steer` and do not perform that transaction.
+
+## Next Discriminator
+
+Do not change the daemon or lower the floor based on this code review. The
+first controlled measurement should compare the current TCP/f16/64 path with
+the capacity recipient's received-hook dispatch disabled or detached while
+retaining durable persistence and response semantics. If throughput materially
+recovers, profile the `spawn_blocking` FIFO handoff and its mutex. If it does
+not, measure writer transaction time and FTS/WAL work next.

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-sqlite.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-sqlite.json
@@ -1,0 +1,71 @@
+{
+  "baseline": {
+    "p50_floor": 35000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": {
+    "accepted_count": 924000,
+    "admissions_per_second": 46165.61719404162,
+    "elapsed_seconds": 20.014895417,
+    "kind": "async_storage_admission",
+    "requested_count": 924000,
+    "worker_count": 512
+  },
+  "durability_after_restart": {
+    "expected_accepted_count": 924000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 924000,
+    "passed": true
+  },
+  "frames_per_connection": 0,
+  "generated_at": "2026-09-04T03:33:32.260385Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 924000,
+  "messages_durable": 924000,
+  "messages_requested": 924000,
+  "metrics": {
+    "accepted_count": 924000,
+    "admissions_per_second": {
+      "max": 56266.04566957382,
+      "min": 8304.587350244932,
+      "p50": 48238.356270617536,
+      "p95": 52882.42254377673,
+      "p99": 54370.726800690514
+    },
+    "application_wire_bytes": null,
+    "application_wire_bytes_per_second": null,
+    "connection_count": null,
+    "connections_per_second": null,
+    "first_failure": null,
+    "interval_count": 924,
+    "interval_latency_ms": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "passed_interval_count": 924,
+    "request_frames_per_second": null,
+    "requested_count": 924000,
+    "response_count": 924000,
+    "time_to_send_1k_s": {
+      "max": 0.120415375,
+      "min": 0.017772708,
+      "p50": 0.020730395999999998,
+      "p95": 0.024233916,
+      "p99": 0.036262125
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "PASS",
+  "target": "sqlite"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp-tls.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp-tls.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 13500.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 145000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 145000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:34:38.955698Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 145000,
+  "messages_durable": 145000,
+  "messages_requested": 145000,
+  "metrics": {
+    "accepted_count": 145000,
+    "admissions_per_second": {
+      "max": 8645.688888144656,
+      "min": 5423.745963625802,
+      "p50": 7371.041364720723,
+      "p95": 8262.818167659458,
+      "p99": 8615.348361981883
+    },
+    "application_wire_bytes": {
+      "request": 123048265,
+      "response": 59683265,
+      "total": 182731530
+    },
+    "application_wire_bytes_per_second": {
+      "max": 10891406.576840231,
+      "min": 6809675.769711102,
+      "p50": 9285669.359206932,
+      "p95": 10409085.186709002,
+      "p99": 10853185.099006677
+    },
+    "connection_count": 18125,
+    "connections_per_second": {
+      "max": 1080.711111018082,
+      "min": 677.9682454532252,
+      "p50": 921.3801705900904,
+      "p95": 1032.8522709574322,
+      "p99": 1076.9185452477354
+    },
+    "first_failure": null,
+    "interval_count": 145,
+    "interval_latency_ms": {
+      "max": 171.25529199984157,
+      "min": 0.7638750003025052,
+      "p50": 54.04295850030394,
+      "p95": 137.7836669998942,
+      "p99": 159.47079200032022
+    },
+    "passed_interval_count": 145,
+    "request_frames_per_second": {
+      "max": 8645.688888144656,
+      "min": 5423.745963625802,
+      "p50": 7371.041364720723,
+      "p95": 8262.818167659458,
+      "p99": 8615.348361981883
+    },
+    "requested_count": 145000,
+    "response_count": 145000,
+    "time_to_send_1k_s": {
+      "max": 0.18437441700007184,
+      "min": 0.11566458300058002,
+      "p50": 0.13566604100014956,
+      "p95": 0.165563167000073,
+      "p99": 0.1812683329999345
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "tcp-tls"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 17000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 108000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 108000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:34:17.903026Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 108000,
+  "messages_durable": 108000,
+  "messages_requested": 108000,
+  "metrics": {
+    "accepted_count": 108000,
+    "admissions_per_second": {
+      "max": 7282.633826271768,
+      "min": 2467.9079420994776,
+      "p50": 5523.51910074255,
+      "p95": 6583.652297586379,
+      "p99": 7280.488697235234
+    },
+    "application_wire_bytes": {
+      "request": 88813390,
+      "response": 44425390,
+      "total": 133238780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 8984949.483162794,
+      "min": 3039845.6076810313,
+      "p50": 6819352.18672782,
+      "p95": 8122581.022147195,
+      "p99": 8967741.9528195
+    },
+    "connection_count": 13500,
+    "connections_per_second": {
+      "max": 910.329228283971,
+      "min": 308.4884927624347,
+      "p50": 690.4398875928188,
+      "p95": 822.9565371982974,
+      "p99": 910.0610871544043
+    },
+    "first_failure": null,
+    "interval_count": 108,
+    "interval_latency_ms": {
+      "max": 396.5555000004315,
+      "min": 1.1190000004717149,
+      "p50": 52.50959375007369,
+      "p95": 132.67479200021626,
+      "p99": 226.79004100064049
+    },
+    "passed_interval_count": 108,
+    "request_frames_per_second": {
+      "max": 7282.633826271768,
+      "min": 2467.9079420994776,
+      "p50": 5523.51910074255,
+      "p95": 6583.652297586379,
+      "p99": 7280.488697235234
+    },
+    "requested_count": 108000,
+    "response_count": 108000,
+    "time_to_send_1k_s": {
+      "max": 0.4052014999997482,
+      "min": 0.1373129590001554,
+      "p50": 0.1810443959998338,
+      "p95": 0.23894383300012123,
+      "p99": 0.2950137910002013
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "tcp"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-uds.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-uds.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 18000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 117000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 117000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:33:53.788641Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 117000,
+  "messages_durable": 117000,
+  "messages_requested": 117000,
+  "metrics": {
+    "accepted_count": 117000,
+    "admissions_per_second": {
+      "max": 7617.782805920316,
+      "min": 3167.4019505215656,
+      "p50": 6105.663078835529,
+      "p95": 7144.7836827287,
+      "p99": 7417.980337197933
+    },
+    "application_wire_bytes": {
+      "request": 84055765,
+      "response": 48136765,
+      "total": 132192530
+    },
+    "application_wire_bytes_per_second": {
+      "max": 8606190.124988476,
+      "min": 3578372.353601739,
+      "p50": 6910084.18947211,
+      "p95": 8071819.365562749,
+      "p99": 8395299.246623762
+    },
+    "connection_count": 14625,
+    "connections_per_second": {
+      "max": 952.2228507400395,
+      "min": 395.9252438151957,
+      "p50": 763.2078848544411,
+      "p95": 893.0979603410875,
+      "p99": 927.2475421497417
+    },
+    "first_failure": null,
+    "interval_count": 117,
+    "interval_latency_ms": {
+      "max": 309.06824999965465,
+      "min": 1.1858749994644313,
+      "p50": 49.617958499766246,
+      "p95": 122.06116700053826,
+      "p99": 215.18474999993487
+    },
+    "passed_interval_count": 117,
+    "request_frames_per_second": {
+      "max": 7617.782805920316,
+      "min": 3167.4019505215656,
+      "p50": 6105.663078835529,
+      "p95": 7144.7836827287,
+      "p99": 7417.980337197933
+    },
+    "requested_count": 117000,
+    "response_count": 117000,
+    "time_to_send_1k_s": {
+      "max": 0.3157161660001293,
+      "min": 0.13127179200000683,
+      "p50": 0.16378237499975512,
+      "p95": 0.2458509590005633,
+      "p99": 0.30405079100000876
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "uds"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench.campaign.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench.campaign.json
@@ -1,0 +1,342 @@
+{
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "completed_at": "2026-09-04T03:35:00.490991Z",
+  "host_label": "m5-atmbench",
+  "os": "macos",
+  "phase": "ao2",
+  "results": [
+    {
+      "baseline": {
+        "p50_floor": 35000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": {
+        "accepted_count": 924000,
+        "admissions_per_second": 46165.61719404162,
+        "elapsed_seconds": 20.014895417,
+        "kind": "async_storage_admission",
+        "requested_count": 924000,
+        "worker_count": 512
+      },
+      "durability_after_restart": {
+        "expected_accepted_count": 924000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 924000,
+        "passed": true
+      },
+      "frames_per_connection": 0,
+      "generated_at": "2026-09-04T03:33:32.260385Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 924000,
+      "messages_durable": 924000,
+      "messages_requested": 924000,
+      "metrics": {
+        "accepted_count": 924000,
+        "admissions_per_second": {
+          "max": 56266.04566957382,
+          "min": 8304.587350244932,
+          "p50": 48238.356270617536,
+          "p95": 52882.42254377673,
+          "p99": 54370.726800690514
+        },
+        "application_wire_bytes": null,
+        "application_wire_bytes_per_second": null,
+        "connection_count": null,
+        "connections_per_second": null,
+        "first_failure": null,
+        "interval_count": 924,
+        "interval_latency_ms": {
+          "max": 0.0,
+          "min": 0.0,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0
+        },
+        "passed_interval_count": 924,
+        "request_frames_per_second": null,
+        "requested_count": 924000,
+        "response_count": 924000,
+        "time_to_send_1k_s": {
+          "max": 0.120415375,
+          "min": 0.017772708,
+          "p50": 0.020730395999999998,
+          "p95": 0.024233916,
+          "p99": 0.036262125
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "PASS",
+      "target": "sqlite"
+    },
+    {
+      "baseline": {
+        "p50_floor": 18000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 117000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 117000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:33:53.788641Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 117000,
+      "messages_durable": 117000,
+      "messages_requested": 117000,
+      "metrics": {
+        "accepted_count": 117000,
+        "admissions_per_second": {
+          "max": 7617.782805920316,
+          "min": 3167.4019505215656,
+          "p50": 6105.663078835529,
+          "p95": 7144.7836827287,
+          "p99": 7417.980337197933
+        },
+        "application_wire_bytes": {
+          "request": 84055765,
+          "response": 48136765,
+          "total": 132192530
+        },
+        "application_wire_bytes_per_second": {
+          "max": 8606190.124988476,
+          "min": 3578372.353601739,
+          "p50": 6910084.18947211,
+          "p95": 8071819.365562749,
+          "p99": 8395299.246623762
+        },
+        "connection_count": 14625,
+        "connections_per_second": {
+          "max": 952.2228507400395,
+          "min": 395.9252438151957,
+          "p50": 763.2078848544411,
+          "p95": 893.0979603410875,
+          "p99": 927.2475421497417
+        },
+        "first_failure": null,
+        "interval_count": 117,
+        "interval_latency_ms": {
+          "max": 309.06824999965465,
+          "min": 1.1858749994644313,
+          "p50": 49.617958499766246,
+          "p95": 122.06116700053826,
+          "p99": 215.18474999993487
+        },
+        "passed_interval_count": 117,
+        "request_frames_per_second": {
+          "max": 7617.782805920316,
+          "min": 3167.4019505215656,
+          "p50": 6105.663078835529,
+          "p95": 7144.7836827287,
+          "p99": 7417.980337197933
+        },
+        "requested_count": 117000,
+        "response_count": 117000,
+        "time_to_send_1k_s": {
+          "max": 0.3157161660001293,
+          "min": 0.13127179200000683,
+          "p50": 0.16378237499975512,
+          "p95": 0.2458509590005633,
+          "p99": 0.30405079100000876
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "uds"
+    },
+    {
+      "baseline": {
+        "p50_floor": 17000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 108000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 108000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:34:17.903026Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 108000,
+      "messages_durable": 108000,
+      "messages_requested": 108000,
+      "metrics": {
+        "accepted_count": 108000,
+        "admissions_per_second": {
+          "max": 7282.633826271768,
+          "min": 2467.9079420994776,
+          "p50": 5523.51910074255,
+          "p95": 6583.652297586379,
+          "p99": 7280.488697235234
+        },
+        "application_wire_bytes": {
+          "request": 88813390,
+          "response": 44425390,
+          "total": 133238780
+        },
+        "application_wire_bytes_per_second": {
+          "max": 8984949.483162794,
+          "min": 3039845.6076810313,
+          "p50": 6819352.18672782,
+          "p95": 8122581.022147195,
+          "p99": 8967741.9528195
+        },
+        "connection_count": 13500,
+        "connections_per_second": {
+          "max": 910.329228283971,
+          "min": 308.4884927624347,
+          "p50": 690.4398875928188,
+          "p95": 822.9565371982974,
+          "p99": 910.0610871544043
+        },
+        "first_failure": null,
+        "interval_count": 108,
+        "interval_latency_ms": {
+          "max": 396.5555000004315,
+          "min": 1.1190000004717149,
+          "p50": 52.50959375007369,
+          "p95": 132.67479200021626,
+          "p99": 226.79004100064049
+        },
+        "passed_interval_count": 108,
+        "request_frames_per_second": {
+          "max": 7282.633826271768,
+          "min": 2467.9079420994776,
+          "p50": 5523.51910074255,
+          "p95": 6583.652297586379,
+          "p99": 7280.488697235234
+        },
+        "requested_count": 108000,
+        "response_count": 108000,
+        "time_to_send_1k_s": {
+          "max": 0.4052014999997482,
+          "min": 0.1373129590001554,
+          "p50": 0.1810443959998338,
+          "p95": 0.23894383300012123,
+          "p99": 0.2950137910002013
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "tcp"
+    },
+    {
+      "baseline": {
+        "p50_floor": 13500.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 145000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 145000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:34:38.955698Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 145000,
+      "messages_durable": 145000,
+      "messages_requested": 145000,
+      "metrics": {
+        "accepted_count": 145000,
+        "admissions_per_second": {
+          "max": 8645.688888144656,
+          "min": 5423.745963625802,
+          "p50": 7371.041364720723,
+          "p95": 8262.818167659458,
+          "p99": 8615.348361981883
+        },
+        "application_wire_bytes": {
+          "request": 123048265,
+          "response": 59683265,
+          "total": 182731530
+        },
+        "application_wire_bytes_per_second": {
+          "max": 10891406.576840231,
+          "min": 6809675.769711102,
+          "p50": 9285669.359206932,
+          "p95": 10409085.186709002,
+          "p99": 10853185.099006677
+        },
+        "connection_count": 18125,
+        "connections_per_second": {
+          "max": 1080.711111018082,
+          "min": 677.9682454532252,
+          "p50": 921.3801705900904,
+          "p95": 1032.8522709574322,
+          "p99": 1076.9185452477354
+        },
+        "first_failure": null,
+        "interval_count": 145,
+        "interval_latency_ms": {
+          "max": 171.25529199984157,
+          "min": 0.7638750003025052,
+          "p50": 54.04295850030394,
+          "p95": 137.7836669998942,
+          "p99": 159.47079200032022
+        },
+        "passed_interval_count": 145,
+        "request_frames_per_second": {
+          "max": 8645.688888144656,
+          "min": 5423.745963625802,
+          "p50": 7371.041364720723,
+          "p95": 8262.818167659458,
+          "p99": 8615.348361981883
+        },
+        "requested_count": 145000,
+        "response_count": 145000,
+        "time_to_send_1k_s": {
+          "max": 0.18437441700007184,
+          "min": 0.11566458300058002,
+          "p50": 0.13566604100014956,
+          "p95": 0.165563167000073,
+          "p99": 0.1812683329999345
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "tcp-tls"
+    }
+  ],
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "started_at": "2026-09-04T03:33:20.951042Z",
+  "status": "FAIL"
+}

--- a/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-sqlite.json
+++ b/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-sqlite.json
@@ -1,0 +1,71 @@
+{
+  "baseline": {
+    "p50_floor": 16035.345045815106,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+    "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+  },
+  "campaign_id": "20260904T152523Z-windows-x64-01",
+  "direct_sqlite_message_write": {
+    "accepted_count": 493000,
+    "admissions_per_second": 24617.936122917345,
+    "elapsed_seconds": 20.0260492,
+    "kind": "async_storage_admission",
+    "requested_count": 493000,
+    "worker_count": 512
+  },
+  "durability_after_restart": {
+    "expected_accepted_count": 493000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 493000,
+    "passed": true
+  },
+  "frames_per_connection": 0,
+  "generated_at": "2026-09-04T15:25:44.184195Z",
+  "host_label": "windows-x64-01",
+  "incomplete_reason": null,
+  "messages_admitted": 493000,
+  "messages_durable": 493000,
+  "messages_requested": 493000,
+  "metrics": {
+    "accepted_count": 493000,
+    "admissions_per_second": {
+      "max": 31721.05770694818,
+      "min": 5627.272011074471,
+      "p50": 26976.646317283128,
+      "p95": 30358.687897509073,
+      "p99": 31083.79881322056
+    },
+    "application_wire_bytes": null,
+    "application_wire_bytes_per_second": null,
+    "connection_count": null,
+    "connections_per_second": null,
+    "first_failure": null,
+    "interval_count": 493,
+    "interval_latency_ms": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "passed_interval_count": 493,
+    "request_frames_per_second": null,
+    "requested_count": 493000,
+    "response_count": 493000,
+    "time_to_send_1k_s": {
+      "max": 0.177706,
+      "min": 0.0315248,
+      "p50": 0.0370691,
+      "p95": 0.0501609,
+      "p99": 0.0866413
+    }
+  },
+  "os": "windows",
+  "schema_version": 4,
+  "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+  "status": "PASS",
+  "target": "sqlite"
+}

--- a/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-tcp-tls.json
+++ b/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-tcp-tls.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 6891.680319866575,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+    "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+  },
+  "campaign_id": "20260904T152523Z-windows-x64-01",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 139000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 139000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T15:26:34.301058Z",
+  "host_label": "windows-x64-01",
+  "incomplete_reason": null,
+  "messages_admitted": 139000,
+  "messages_durable": 139000,
+  "messages_requested": 139000,
+  "metrics": {
+    "accepted_count": 139000,
+    "admissions_per_second": {
+      "max": 9562.871568955548,
+      "min": 767.2802248176689,
+      "p50": 7381.778966109825,
+      "p95": 9026.59054796292,
+      "p99": 9471.903498145048
+    },
+    "application_wire_bytes": {
+      "request": 114755015,
+      "response": 57209015,
+      "total": 171964030
+    },
+    "application_wire_bytes_per_second": {
+      "max": 11807755.669767862,
+      "min": 950468.3784928874,
+      "p50": 9131775.48432573,
+      "p95": 11163635.860193143,
+      "p99": 11695432.844334597
+    },
+    "connection_count": 17375,
+    "connections_per_second": {
+      "max": 1195.3589461194435,
+      "min": 95.91002810220861,
+      "p50": 922.7223707637281,
+      "p95": 1128.323818495365,
+      "p99": 1183.987937268131
+    },
+    "first_failure": null,
+    "interval_count": 139,
+    "interval_latency_ms": {
+      "max": 1274.411000078544,
+      "min": 1.7226999625563622,
+      "p50": 48.42950007878244,
+      "p95": 116.43510009162128,
+      "p99": 208.9464000891894
+    },
+    "passed_interval_count": 139,
+    "request_frames_per_second": {
+      "max": 9562.871568955548,
+      "min": 767.2802248176689,
+      "p50": 7381.778966109825,
+      "p95": 9026.59054796292,
+      "p99": 9471.903498145048
+    },
+    "requested_count": 139000,
+    "response_count": 139000,
+    "time_to_send_1k_s": {
+      "max": 1.3033048000652343,
+      "min": 0.10457110009156168,
+      "p50": 0.1354686999693513,
+      "p95": 0.15653859986923635,
+      "p99": 0.22740580001845956
+    }
+  },
+  "os": "windows",
+  "schema_version": 4,
+  "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+  "status": "PASS",
+  "target": "tcp-tls"
+}

--- a/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-tcp.json
+++ b/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01-tcp.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 8793.914612253,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+    "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+  },
+  "campaign_id": "20260904T152523Z-windows-x64-01",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 154000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 154000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T15:26:08.824506Z",
+  "host_label": "windows-x64-01",
+  "incomplete_reason": null,
+  "messages_admitted": 154000,
+  "messages_durable": 154000,
+  "messages_requested": 154000,
+  "metrics": {
+    "accepted_count": 154000,
+    "admissions_per_second": {
+      "max": 10432.739599860946,
+      "min": 5645.453127681611,
+      "p50": 7564.123162565458,
+      "p95": 9490.151119091119,
+      "p99": 10120.986262580594
+    },
+    "application_wire_bytes": {
+      "request": 122684640,
+      "response": 63394640,
+      "total": 186079280
+    },
+    "application_wire_bytes_per_second": {
+      "max": 12579275.772532336,
+      "min": 6829586.921212829,
+      "p50": 9143130.91182633,
+      "p95": 11444737.319180781,
+      "p99": 12203379.186106551
+    },
+    "connection_count": 19250,
+    "connections_per_second": {
+      "max": 1304.0924499826183,
+      "min": 705.6816409602013,
+      "p50": 945.5153953206823,
+      "p95": 1186.2688898863898,
+      "p99": 1265.1232828225743
+    },
+    "first_failure": null,
+    "interval_count": 154,
+    "interval_latency_ms": {
+      "max": 159.27869989536703,
+      "min": 1.9133000168949366,
+      "p50": 57.55485006375238,
+      "p95": 124.29790012538433,
+      "p99": 145.6946001853794
+    },
+    "passed_interval_count": 154,
+    "request_frames_per_second": {
+      "max": 10432.739599860946,
+      "min": 5645.453127681611,
+      "p50": 7564.123162565458,
+      "p95": 9490.151119091119,
+      "p99": 10120.986262580594
+    },
+    "requested_count": 154000,
+    "response_count": 154000,
+    "time_to_send_1k_s": {
+      "max": 0.17713369987905025,
+      "min": 0.09585210005752742,
+      "p50": 0.13220305007416755,
+      "p95": 0.15124940010719,
+      "p99": 0.16294860001653433
+    }
+  },
+  "os": "windows",
+  "schema_version": 4,
+  "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+  "status": "FAIL",
+  "target": "tcp"
+}

--- a/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01.campaign.json
+++ b/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01.campaign.json
@@ -1,0 +1,256 @@
+{
+  "campaign_id": "20260904T152523Z-windows-x64-01",
+  "completed_at": "2026-09-04T15:27:00.094199Z",
+  "host_label": "windows-x64-01",
+  "os": "windows",
+  "phase": "ao2",
+  "results": [
+    {
+      "baseline": {
+        "p50_floor": 16035.345045815106,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+        "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+      },
+      "campaign_id": "20260904T152523Z-windows-x64-01",
+      "direct_sqlite_message_write": {
+        "accepted_count": 493000,
+        "admissions_per_second": 24617.936122917345,
+        "elapsed_seconds": 20.0260492,
+        "kind": "async_storage_admission",
+        "requested_count": 493000,
+        "worker_count": 512
+      },
+      "durability_after_restart": {
+        "expected_accepted_count": 493000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 493000,
+        "passed": true
+      },
+      "frames_per_connection": 0,
+      "generated_at": "2026-09-04T15:25:44.184195Z",
+      "host_label": "windows-x64-01",
+      "incomplete_reason": null,
+      "messages_admitted": 493000,
+      "messages_durable": 493000,
+      "messages_requested": 493000,
+      "metrics": {
+        "accepted_count": 493000,
+        "admissions_per_second": {
+          "max": 31721.05770694818,
+          "min": 5627.272011074471,
+          "p50": 26976.646317283128,
+          "p95": 30358.687897509073,
+          "p99": 31083.79881322056
+        },
+        "application_wire_bytes": null,
+        "application_wire_bytes_per_second": null,
+        "connection_count": null,
+        "connections_per_second": null,
+        "first_failure": null,
+        "interval_count": 493,
+        "interval_latency_ms": {
+          "max": 0.0,
+          "min": 0.0,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0
+        },
+        "passed_interval_count": 493,
+        "request_frames_per_second": null,
+        "requested_count": 493000,
+        "response_count": 493000,
+        "time_to_send_1k_s": {
+          "max": 0.177706,
+          "min": 0.0315248,
+          "p50": 0.0370691,
+          "p95": 0.0501609,
+          "p99": 0.0866413
+        }
+      },
+      "os": "windows",
+      "schema_version": 4,
+      "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+      "status": "PASS",
+      "target": "sqlite"
+    },
+    {
+      "baseline": {
+        "p50_floor": 8793.914612253,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+        "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+      },
+      "campaign_id": "20260904T152523Z-windows-x64-01",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 154000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 154000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T15:26:08.824506Z",
+      "host_label": "windows-x64-01",
+      "incomplete_reason": null,
+      "messages_admitted": 154000,
+      "messages_durable": 154000,
+      "messages_requested": 154000,
+      "metrics": {
+        "accepted_count": 154000,
+        "admissions_per_second": {
+          "max": 10432.739599860946,
+          "min": 5645.453127681611,
+          "p50": 7564.123162565458,
+          "p95": 9490.151119091119,
+          "p99": 10120.986262580594
+        },
+        "application_wire_bytes": {
+          "request": 122684640,
+          "response": 63394640,
+          "total": 186079280
+        },
+        "application_wire_bytes_per_second": {
+          "max": 12579275.772532336,
+          "min": 6829586.921212829,
+          "p50": 9143130.91182633,
+          "p95": 11444737.319180781,
+          "p99": 12203379.186106551
+        },
+        "connection_count": 19250,
+        "connections_per_second": {
+          "max": 1304.0924499826183,
+          "min": 705.6816409602013,
+          "p50": 945.5153953206823,
+          "p95": 1186.2688898863898,
+          "p99": 1265.1232828225743
+        },
+        "first_failure": null,
+        "interval_count": 154,
+        "interval_latency_ms": {
+          "max": 159.27869989536703,
+          "min": 1.9133000168949366,
+          "p50": 57.55485006375238,
+          "p95": 124.29790012538433,
+          "p99": 145.6946001853794
+        },
+        "passed_interval_count": 154,
+        "request_frames_per_second": {
+          "max": 10432.739599860946,
+          "min": 5645.453127681611,
+          "p50": 7564.123162565458,
+          "p95": 9490.151119091119,
+          "p99": 10120.986262580594
+        },
+        "requested_count": 154000,
+        "response_count": 154000,
+        "time_to_send_1k_s": {
+          "max": 0.17713369987905025,
+          "min": 0.09585210005752742,
+          "p50": 0.13220305007416755,
+          "p95": 0.15124940010719,
+          "p99": 0.16294860001653433
+        }
+      },
+      "os": "windows",
+      "schema_version": 4,
+      "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+      "status": "FAIL",
+      "target": "tcp"
+    },
+    {
+      "baseline": {
+        "p50_floor": 6891.680319866575,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "8991b7d0522786d597ad99d0ed974c99d07334c36e4994464810f8f33af950eb",
+        "atm-daemon": "57fb6a879239d7777be24d32d24a5cbf44c7de952ae7f1ec43be2dd461fe6f3d"
+      },
+      "campaign_id": "20260904T152523Z-windows-x64-01",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 139000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 139000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T15:26:34.301058Z",
+      "host_label": "windows-x64-01",
+      "incomplete_reason": null,
+      "messages_admitted": 139000,
+      "messages_durable": 139000,
+      "messages_requested": 139000,
+      "metrics": {
+        "accepted_count": 139000,
+        "admissions_per_second": {
+          "max": 9562.871568955548,
+          "min": 767.2802248176689,
+          "p50": 7381.778966109825,
+          "p95": 9026.59054796292,
+          "p99": 9471.903498145048
+        },
+        "application_wire_bytes": {
+          "request": 114755015,
+          "response": 57209015,
+          "total": 171964030
+        },
+        "application_wire_bytes_per_second": {
+          "max": 11807755.669767862,
+          "min": 950468.3784928874,
+          "p50": 9131775.48432573,
+          "p95": 11163635.860193143,
+          "p99": 11695432.844334597
+        },
+        "connection_count": 17375,
+        "connections_per_second": {
+          "max": 1195.3589461194435,
+          "min": 95.91002810220861,
+          "p50": 922.7223707637281,
+          "p95": 1128.323818495365,
+          "p99": 1183.987937268131
+        },
+        "first_failure": null,
+        "interval_count": 139,
+        "interval_latency_ms": {
+          "max": 1274.411000078544,
+          "min": 1.7226999625563622,
+          "p50": 48.42950007878244,
+          "p95": 116.43510009162128,
+          "p99": 208.9464000891894
+        },
+        "passed_interval_count": 139,
+        "request_frames_per_second": {
+          "max": 9562.871568955548,
+          "min": 767.2802248176689,
+          "p50": 7381.778966109825,
+          "p95": 9026.59054796292,
+          "p99": 9471.903498145048
+        },
+        "requested_count": 139000,
+        "response_count": 139000,
+        "time_to_send_1k_s": {
+          "max": 1.3033048000652343,
+          "min": 0.10457110009156168,
+          "p50": 0.1354686999693513,
+          "p95": 0.15653859986923635,
+          "p99": 0.22740580001845956
+        }
+      },
+      "os": "windows",
+      "schema_version": 4,
+      "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+      "status": "PASS",
+      "target": "tcp-tls"
+    }
+  ],
+  "schema_version": 4,
+  "source_revision": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+  "started_at": "2026-09-04T15:25:23.739111Z",
+  "status": "FAIL"
+}

--- a/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01.xhtml
+++ b/site/reports/send-message-benchmark/20260904T152523Z-windows-x64-01.xhtml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <title>ATM benchmark campaign — 20260904T152523Z-windows-x64-01</title>
+  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+  <style type="text/css">
+    body { font-family: sans-serif; color: #1f2937; margin: 2rem auto; max-width: 75rem; padding: 0 1rem; }
+    table { border-collapse: collapse; margin: 1rem 0; width: 100%; } th, td { border: 1px solid #cbd5e1; padding: .55rem; text-align: left; }
+    th { background: #f1f5f9; } .PASS { color: #065f46; font-weight: bold; } .FAIL { color: #991b1b; font-weight: bold; } .INCOMPLETE { color: #92400e; font-weight: bold; }
+    .meta { color: #475569; } code { font-family: ui-monospace, monospace; } .incomplete { margin-top: 2rem; border: 2px solid #f59e0b; padding: 1rem; background: #fffbeb; }
+  </style>
+</head>
+<body>
+  <h1>ATM benchmark campaign — 20260904T152523Z-windows-x64-01</h1>
+  <p class="meta"><code>20260904T152523Z-windows-x64-01</code> · windows-x64-01 · phase ao2 · source <code>f39c2236477a891abf5c8b99f1611a9b453bc714</code></p>
+  <p>Status: <strong class="FAIL">FAIL</strong> · started <time datetime="2026-09-04T15:25:23.739111Z">Sep 4, 2026 · 08:25 PDT</time> · completed <time datetime="2026-09-04T15:27:00.094199Z">Sep 4, 2026 · 08:27 PDT</time></p>
+  <table>
+    <thead><tr><th>Test</th><th>p50 msg/sec</th><th>p95</th><th>p99</th><th>Durable write proof</th><th>Baseline floor</th><th>Margin</th><th>Verdict</th></tr></thead>
+    <tbody>
+      <tr data-target="tcp"><td>TCP</td><td>7564.12</td><td>9490.15</td><td>10120.99</td><td>154000 / 154000 after restart</td><td>8793.91</td><td>-1229.79</td><td class="FAIL">FAIL</td></tr>
+      <tr data-target="tcp-tls"><td>TCP + TLS</td><td>7381.78</td><td>9026.59</td><td>9471.90</td><td>139000 / 139000 after restart</td><td>6891.68</td><td>+490.10</td><td class="PASS">PASS</td></tr>
+      <tr data-target="uds"><td>UDS</td><td>n/a</td><td>n/a</td><td>n/a</td><td>not captured</td><td>n/a</td><td>n/a</td><td class="INCOMPLETE">INCOMPLETE</td></tr>
+      <tr data-target="sqlite"><td>SQLite</td><td>26976.65</td><td>30358.69</td><td>31083.80</td><td>493000 / 493000 after restart</td><td>16035.35</td><td>+10941.30</td><td class="PASS">PASS</td></tr>
+    </tbody>
+  </table>
+  <script type="application/ecmascript"><![CDATA[
+(() => { const f = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short", hourCycle: "h23", timeZoneName: "short" }); document.querySelectorAll("time[datetime]").forEach((node) => { node.textContent = f.format(new Date(node.dateTime)); }); })();
+  ]]></script>
+</body>
+</html>

--- a/site/reports/smoke/windows/FastPC4/20260904T152428093245Z-pid50856-smoke-thorough/smoke-thorough.json
+++ b/site/reports/smoke/windows/FastPC4/20260904T152428093245Z-pid50856-smoke-thorough/smoke-thorough.json
@@ -1,0 +1,206 @@
+{
+  "level": "thorough",
+  "timestamp": "2026-09-04T15:24:27.835586+00:00",
+  "binary_sha": "f39c2236477a891abf5c8b99f1611a9b453bc714",
+  "duration_secs": 90.569,
+  "status": "passed",
+  "rows": [
+    {
+      "id": "AD11-CMD-SEND-001",
+      "flow": "send command preserves caller-context ownership across environment and explicit override paths",
+      "verdict": "PASS",
+      "notes": "send stays bound to the shared caller-context contract across environment and explicit override paths"
+    },
+    {
+      "id": "AD11-CMD-READ-001",
+      "flow": "read command preserves caller-context ownership across environment and explicit override paths",
+      "verdict": "PASS",
+      "notes": "read stays bound to the shared caller-context contract across environment and explicit override paths"
+    },
+    {
+      "id": "AD11-CMD-ACK-001",
+      "flow": "ack command preserves caller-context ownership across environment and explicit override paths",
+      "verdict": "PASS",
+      "notes": "ack stays bound to the shared caller-context contract across environment and explicit override paths"
+    },
+    {
+      "id": "AD11-CMD-LIST-001",
+      "flow": "list command preserves retained filters while keeping caller-context ownership explicit",
+      "verdict": "PASS",
+      "notes": "list preserves retained filters while staying bound to explicit caller-context ownership"
+    },
+    {
+      "id": "AD11-CMD-CLEAR-001",
+      "flow": "clear command preserves caller-context ownership across environment and explicit override paths",
+      "verdict": "PASS",
+      "notes": "clear stays bound to the shared caller-context contract across environment and explicit override paths"
+    },
+    {
+      "id": "AD11-CMD-LOG-001",
+      "flow": "log command remains daemon-independent with caller-context enforcement at the CLI boundary",
+      "verdict": "PASS",
+      "notes": "log remains daemon-independent and still fails locally when caller context is unavailable"
+    },
+    {
+      "id": "AD11-CMD-MEMBERS-001",
+      "flow": "members command remains daemon-independent while preserving explicit team override handling",
+      "verdict": "PASS",
+      "notes": "members remains daemon-independent while preserving retained caller-team semantics"
+    },
+    {
+      "id": "AD11-CMD-TEAMS-001",
+      "flow": "teams list command remains daemon-independent on the retained CLI surface",
+      "verdict": "PASS",
+      "notes": "teams list remains daemon-independent on the retained CLI surface"
+    },
+    {
+      "id": "AD11-CMD-TEAMS-ADD-MEMBER-001",
+      "flow": "teams add-member preserves the retained home-dir payload contract",
+      "verdict": "PASS",
+      "notes": "teams add-member preserves the retained home-dir payload contract"
+    },
+    {
+      "id": "AD11-CMD-TEAMS-UPDATE-MEMBER-001",
+      "flow": "teams update-member preserves caller context and fails locally when mandatory caller context is missing",
+      "verdict": "PASS",
+      "notes": "teams update-member preserves caller context and still fails locally when mandatory caller context is missing"
+    },
+    {
+      "id": "AD11-CMD-TEAMS-BACKUP-001",
+      "flow": "teams backup preserves retained team scoping and remains daemon-independent in dry-run execution",
+      "verdict": "PASS",
+      "notes": "teams backup preserves retained team scoping and remains daemon-independent in dry-run execution"
+    },
+    {
+      "id": "AD11-CMD-TEAMS-RESTORE-001",
+      "flow": "teams restore preserves retained path and dry-run behavior without requiring the daemon",
+      "verdict": "PASS",
+      "notes": "teams restore preserves retained path and dry-run behavior without requiring the daemon"
+    },
+    {
+      "id": "AD11-CMD-DOCTOR-001",
+      "flow": "doctor remains identity-free while preserving optional team scoping and the direct local path",
+      "verdict": "PASS",
+      "notes": "doctor remains identity-free while preserving optional team scoping and the direct local path"
+    },
+    {
+      "id": "AD11-POSTSEND-LOCAL-TMUX-001",
+      "flow": "local tmux post-send requires and uses authoritative pane metadata",
+      "verdict": "PASS",
+      "notes": "local tmux post-send remains bound to authoritative roster pane metadata"
+    },
+    {
+      "id": "AD11-POSTSEND-WARNING-001",
+      "flow": "sender-visible warning fallback survives failed post-send emission",
+      "verdict": "PASS",
+      "notes": "failed post-send emission still degrades into a sender-visible warning after durable send success"
+    },
+    {
+      "id": "AD11-ROSTER-REPAIR-001",
+      "flow": "fixture evidence preserves repaired pane metadata through team-admin and doctor projections",
+      "verdict": "PASS",
+      "notes": "fixture-backed smoke evidence proves pane repair survives the accepted team-admin and doctor projection paths"
+    },
+    {
+      "id": "AD11-XREPO-001",
+      "flow": "sender roster home_dir governs post-send config lookup across repos",
+      "verdict": "PASS",
+      "notes": "post-send config discovery remains anchored to sender roster metadata rather than ambient caller cwd, preserving cross-repo local-send behavior"
+    },
+    {
+      "id": "AD11-GRAFT-001",
+      "flow": "graft-backed post-send uses a direct same-host receiver socket with typed warning fallback",
+      "verdict": "PASS",
+      "notes": "the graft-backed emission seam performs one bounded same-host receiver delivery attempt and still surfaces typed sender warnings when the receiver path is unavailable"
+    },
+    {
+      "id": "AD11-AUTH-001",
+      "flow": "update-member auth checks and infallible add-member projection are closed",
+      "verdict": "PASS",
+      "notes": "the promoted AD.9 auth and infallible findings are closed: update-member consumes caller context materially, and add-member projection no longer pretends to fail"
+    },
+    {
+      "id": "AD11-READINESS-001",
+      "flow": "phase-ad readiness and boundary artifacts fail closed",
+      "verdict": "PASS",
+      "notes": "Phase AD readiness records, smoke artifacts, and MessageReceivedHookEmitter boundary inventory are all present and wired into the retained validation gate"
+    },
+    {
+      "id": "AD17-ULID-001",
+      "flow": "retained ATM message identity stays ULID-only on the accepted line",
+      "verdict": "PASS",
+      "notes": "ULID-only message identity remains enforced in the retained SQLite mailbox state"
+    },
+    {
+      "id": "AD17-READ-001",
+      "flow": "read mutation and contains filtering stay self-consistent on the durable store-backed path",
+      "verdict": "PASS",
+      "notes": "read mutation still reports the post-mutation state and contains filtering still sees the durable full-body projection"
+    },
+    {
+      "id": "AD17-CI-001",
+      "flow": "CI exercises the replacement runtime without restoring the frozen daemon lane",
+      "verdict": "PASS",
+      "notes": "the replacement-runtime CI lane remains present and no frozen atm-daemon test lane is restored"
+    },
+    {
+      "id": "AD18-RUNTIME-ROOT-001",
+      "flow": "raw CLI runtime ownership stays anchored to the accepted ATM_HOME root",
+      "verdict": "PASS",
+      "notes": "raw CLI bootstrap, socket ownership, and daemon lock state all stay rooted under the accepted ATM_HOME runtime subtree"
+    },
+    {
+      "id": "AD18-RUNTIME-ROOT-002",
+      "flow": "sibling worktrees with one ATM_HOME keep one canonical runtime root while preserving invocation-directory reporting",
+      "verdict": "PASS",
+      "notes": "sibling-worktree regression coverage proves one ATM_HOME stays canonical while command-local invocation directories remain distinct and explicit"
+    },
+    {
+      "id": "AD19-READ-OUTPUT-001",
+      "flow": "read mutation returns the message it actually mutated together with post-mutation bucket counts",
+      "verdict": "PASS",
+      "notes": "read returns the durable message it actually mutated, reports post-mutation unread counts, and leaves ack mutation semantics intact"
+    },
+    {
+      "id": "AD20-READ-CONTAINS-001",
+      "flow": "metadata-backed contains stays full-body correct while keeping durable-body reload bounded",
+      "verdict": "PASS",
+      "notes": "metadata-backed contains stays full-body correct and only reloads durable body for surviving summary-miss candidates"
+    },
+    {
+      "id": "AD29-POSTSEND-EXTERNAL-001",
+      "flow": "external post-send hook success suppresses built-in fallback while preserving durable send success",
+      "verdict": "PASS",
+      "notes": "external post-send hook success keeps the built-in nudge path inactive while durable send success remains intact"
+    },
+    {
+      "id": "AD29-POSTSEND-PARTIAL-001",
+      "flow": "mixed post-send hook outcomes preserve durable delivery while surfacing sender-visible warnings",
+      "verdict": "PASS",
+      "notes": "mixed hook accounting preserves durable delivery success and retains a sender-visible warning for failed matches"
+    },
+    {
+      "id": "AD29-POSTSEND-BUILTIN-001",
+      "flow": "built-in fallback covers both tmux and graft recipients when no external hook matches",
+      "verdict": "PASS",
+      "notes": "built-in fallback stays honest for both tmux-backed and graft-backed recipients when no external hook matches"
+    },
+    {
+      "id": "AD29-POSTSEND-RESET-001",
+      "flow": "deleting a prior override row restores the built-in default template path",
+      "verdict": "PASS",
+      "notes": "removing a stored override row re-exposes the built-in default template instead of leaving an implicit disabled state behind"
+    },
+    {
+      "id": "AD29-POSTSEND-DISABLE-001",
+      "flow": "explicitly disabled built-in template state skips local post-send delivery cleanly",
+      "verdict": "PASS",
+      "notes": "the explicit disabled-template state becomes a documented no-delivery path instead of an accidental empty-string side effect"
+    }
+  ],
+  "summary": {
+    "pass": 32,
+    "fail": 0,
+    "skip": 0
+  }
+}

--- a/site/reports/smoke/windows/FastPC4/20260904T152428093245Z-pid50856-smoke-thorough/smoke-thorough.md
+++ b/site/reports/smoke/windows/FastPC4/20260904T152428093245Z-pid50856-smoke-thorough/smoke-thorough.md
@@ -1,0 +1,45 @@
+# Smoke Thorough
+
+- status: `passed`
+- timestamp: `2026-09-04T15:24:27.835586+00:00`
+- binary SHA: `f39c2236477a891abf5c8b99f1611a9b453bc714`
+- duration secs: `90.569`
+- summary: `pass=32`, `fail=0`, `skip=0`
+- row semantics: `PASS` means every command in the row exited `0`; `FAIL`
+  records the first failing command only and does not claim sibling commands in
+  that row were executed after the failure
+
+| Row | Flow | Verdict | Notes |
+| --- | --- | --- | --- |
+| `AD11-CMD-SEND-001` | send command preserves caller-context ownership across environment and explicit override paths | `PASS` | send stays bound to the shared caller-context contract across environment and explicit override paths |
+| `AD11-CMD-READ-001` | read command preserves caller-context ownership across environment and explicit override paths | `PASS` | read stays bound to the shared caller-context contract across environment and explicit override paths |
+| `AD11-CMD-ACK-001` | ack command preserves caller-context ownership across environment and explicit override paths | `PASS` | ack stays bound to the shared caller-context contract across environment and explicit override paths |
+| `AD11-CMD-LIST-001` | list command preserves retained filters while keeping caller-context ownership explicit | `PASS` | list preserves retained filters while staying bound to explicit caller-context ownership |
+| `AD11-CMD-CLEAR-001` | clear command preserves caller-context ownership across environment and explicit override paths | `PASS` | clear stays bound to the shared caller-context contract across environment and explicit override paths |
+| `AD11-CMD-LOG-001` | log command remains daemon-independent with caller-context enforcement at the CLI boundary | `PASS` | log remains daemon-independent and still fails locally when caller context is unavailable |
+| `AD11-CMD-MEMBERS-001` | members command remains daemon-independent while preserving explicit team override handling | `PASS` | members remains daemon-independent while preserving retained caller-team semantics |
+| `AD11-CMD-TEAMS-001` | teams list command remains daemon-independent on the retained CLI surface | `PASS` | teams list remains daemon-independent on the retained CLI surface |
+| `AD11-CMD-TEAMS-ADD-MEMBER-001` | teams add-member preserves the retained home-dir payload contract | `PASS` | teams add-member preserves the retained home-dir payload contract |
+| `AD11-CMD-TEAMS-UPDATE-MEMBER-001` | teams update-member preserves caller context and fails locally when mandatory caller context is missing | `PASS` | teams update-member preserves caller context and still fails locally when mandatory caller context is missing |
+| `AD11-CMD-TEAMS-BACKUP-001` | teams backup preserves retained team scoping and remains daemon-independent in dry-run execution | `PASS` | teams backup preserves retained team scoping and remains daemon-independent in dry-run execution |
+| `AD11-CMD-TEAMS-RESTORE-001` | teams restore preserves retained path and dry-run behavior without requiring the daemon | `PASS` | teams restore preserves retained path and dry-run behavior without requiring the daemon |
+| `AD11-CMD-DOCTOR-001` | doctor remains identity-free while preserving optional team scoping and the direct local path | `PASS` | doctor remains identity-free while preserving optional team scoping and the direct local path |
+| `AD11-POSTSEND-LOCAL-TMUX-001` | local tmux post-send requires and uses authoritative pane metadata | `PASS` | local tmux post-send remains bound to authoritative roster pane metadata |
+| `AD11-POSTSEND-WARNING-001` | sender-visible warning fallback survives failed post-send emission | `PASS` | failed post-send emission still degrades into a sender-visible warning after durable send success |
+| `AD11-ROSTER-REPAIR-001` | fixture evidence preserves repaired pane metadata through team-admin and doctor projections | `PASS` | fixture-backed smoke evidence proves pane repair survives the accepted team-admin and doctor projection paths |
+| `AD11-XREPO-001` | sender roster home_dir governs post-send config lookup across repos | `PASS` | post-send config discovery remains anchored to sender roster metadata rather than ambient caller cwd, preserving cross-repo local-send behavior |
+| `AD11-GRAFT-001` | graft-backed post-send uses a direct same-host receiver socket with typed warning fallback | `PASS` | the graft-backed emission seam performs one bounded same-host receiver delivery attempt and still surfaces typed sender warnings when the receiver path is unavailable |
+| `AD11-AUTH-001` | update-member auth checks and infallible add-member projection are closed | `PASS` | the promoted AD.9 auth and infallible findings are closed: update-member consumes caller context materially, and add-member projection no longer pretends to fail |
+| `AD11-READINESS-001` | phase-ad readiness and boundary artifacts fail closed | `PASS` | Phase AD readiness records, smoke artifacts, and MessageReceivedHookEmitter boundary inventory are all present and wired into the retained validation gate |
+| `AD17-ULID-001` | retained ATM message identity stays ULID-only on the accepted line | `PASS` | ULID-only message identity remains enforced in the retained SQLite mailbox state |
+| `AD17-READ-001` | read mutation and contains filtering stay self-consistent on the durable store-backed path | `PASS` | read mutation still reports the post-mutation state and contains filtering still sees the durable full-body projection |
+| `AD17-CI-001` | CI exercises the replacement runtime without restoring the frozen daemon lane | `PASS` | the replacement-runtime CI lane remains present and no frozen atm-daemon test lane is restored |
+| `AD18-RUNTIME-ROOT-001` | raw CLI runtime ownership stays anchored to the accepted ATM_HOME root | `PASS` | raw CLI bootstrap, socket ownership, and daemon lock state all stay rooted under the accepted ATM_HOME runtime subtree |
+| `AD18-RUNTIME-ROOT-002` | sibling worktrees with one ATM_HOME keep one canonical runtime root while preserving invocation-directory reporting | `PASS` | sibling-worktree regression coverage proves one ATM_HOME stays canonical while command-local invocation directories remain distinct and explicit |
+| `AD19-READ-OUTPUT-001` | read mutation returns the message it actually mutated together with post-mutation bucket counts | `PASS` | read returns the durable message it actually mutated, reports post-mutation unread counts, and leaves ack mutation semantics intact |
+| `AD20-READ-CONTAINS-001` | metadata-backed contains stays full-body correct while keeping durable-body reload bounded | `PASS` | metadata-backed contains stays full-body correct and only reloads durable body for surviving summary-miss candidates |
+| `AD29-POSTSEND-EXTERNAL-001` | external post-send hook success suppresses built-in fallback while preserving durable send success | `PASS` | external post-send hook success keeps the built-in nudge path inactive while durable send success remains intact |
+| `AD29-POSTSEND-PARTIAL-001` | mixed post-send hook outcomes preserve durable delivery while surfacing sender-visible warnings | `PASS` | mixed hook accounting preserves durable delivery success and retains a sender-visible warning for failed matches |
+| `AD29-POSTSEND-BUILTIN-001` | built-in fallback covers both tmux and graft recipients when no external hook matches | `PASS` | built-in fallback stays honest for both tmux-backed and graft-backed recipients when no external hook matches |
+| `AD29-POSTSEND-RESET-001` | deleting a prior override row restores the built-in default template path | `PASS` | removing a stored override row re-exposes the built-in default template instead of leaving an implicit disabled state behind |
+| `AD29-POSTSEND-DISABLE-001` | explicitly disabled built-in template state skips local post-send delivery cleanly | `PASS` | the explicit disabled-template state becomes a documented no-delivery path instead of an accidental empty-string side effect |


### PR DESCRIPTION
Reports-only re-land from the stale evidence branch: benchmark/smoke artifacts and the regenerated reports index. Version bumps, harness edits and superseded triage records are dropped. Part of the readiness-1.4 evidence-ledger stack (every attempt lands on develop, PASS or FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK