### PR TITLE
ci: run PR checks for evidence/* and triage/* base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*", "docs/*", "plan/*"]
+    branches: [develop, main, "integrate/*", "fix/*", "feature/*", "sprint/*", "docs/*", "plan/*", "evidence/*", "triage/*"]
   push:
     branches: [develop, main]
 


### PR DESCRIPTION
Stack #1163's middle layers (#1160, #1161) have zero CI runs because their base branches are `evidence/*`, which the `pull_request` branch filter in ci.yml does not include. This adds `evidence/*` and `triage/*` to the filter so every stacked layer gets its own run.

One-line workflow change, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK