### PR TITLE
fix(bootstrap): select pinned Python on Windows

### DIFF
--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -286,6 +286,10 @@ class BootstrapTests(unittest.TestCase):
         self.assertIn('PATH=\\"$PATH:/opt/homebrew/bin\\" python3.14', justfile)
         self.assertNotIn("PATH=/opt/homebrew/bin:$PATH python3.14", justfile)
 
+    def test_windows_seed_python_selects_the_pinned_major_minor(self) -> None:
+        justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
+        self.assertIn('if os_family() == "windows" { "py -3.14" }', justfile)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,9 @@ set windows-shell := ["pwsh", "-NoLogo", "-Command"]
 # standard location as a developer-account fallback, never ahead of the
 # interpreter selected by CI (for example actions/setup-python's 3.14.7).
 # The bootstrap script verifies the exact patch release before doing any work.
-seed_python_cmd := if os_family() == "windows" { "python" } else { "env PATH=\"$PATH:/opt/homebrew/bin\" python3.14" }
+# Windows PATH can prefer an unrelated system Python. Use the launcher to
+# select the pinned major/minor line; bootstrap verifies the exact patch.
+seed_python_cmd := if os_family() == "windows" { "py -3.14" } else { "env PATH=\"$PATH:/opt/homebrew/bin\" python3.14" }
 # Keep the bootstrap venv first in PATH as well as executing its Python
 # directly. The path is absolute so helpers remain pinned after changing cwd;
 # PyO3 additionally receives its interpreter explicitly.


### PR DESCRIPTION
## Windows Bootstrap Fix

Windows `Justfile` bootstrap selected PATH's `python.exe`. On this host that is Python 3.12.10, while the repository contract requires Python 3.14.7. A fresh `just bootstrap` therefore failed before creating the compatible tool environment.

### Change

- On Windows only, use `py -3.14` as the seed command.
- Bootstrap still verifies the exact required patch release.
- macOS and Linux command paths are unchanged.
- Add a regression test asserting the Windows selector.

### Verification

- `just bootstrap` advanced through creation of a Python 3.14.7 venv; it then encountered a separate shared tool-contract issue: `cargo-shear 1.13.3` requires Rust 1.95 while the repository pins Rust 1.94.1. That is outside this Windows selector change.
- `just lint pytests`: PASS, 1004 tests / 49 skipped under Python 3.14.7.
- Full `just lint` was launched; the terminal wrapper timed out at 124 seconds, but every emitted gate log, including `pytests` and `boundaries`, exited 0.

The previously observed aggregate `TypeError` / process crash did not reproduce in a fresh Python 3.14.7 venv. This PR fixes the concrete Windows bootstrap mismatch that made that environment non-deterministic to establish; it does not claim an unverified interpreter crash fix.