### PR TITLE
evidence(readiness): land 1.4.11 atmbench report artifacts from origin/evidence/readiness-1.4.11-atmbench

### DIFF
--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-sqlite.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-sqlite.json
@@ -1,0 +1,71 @@
+{
+  "baseline": {
+    "p50_floor": 35000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": {
+    "accepted_count": 924000,
+    "admissions_per_second": 46165.61719404162,
+    "elapsed_seconds": 20.014895417,
+    "kind": "async_storage_admission",
+    "requested_count": 924000,
+    "worker_count": 512
+  },
+  "durability_after_restart": {
+    "expected_accepted_count": 924000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 924000,
+    "passed": true
+  },
+  "frames_per_connection": 0,
+  "generated_at": "2026-09-04T03:33:32.260385Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 924000,
+  "messages_durable": 924000,
+  "messages_requested": 924000,
+  "metrics": {
+    "accepted_count": 924000,
+    "admissions_per_second": {
+      "max": 56266.04566957382,
+      "min": 8304.587350244932,
+      "p50": 48238.356270617536,
+      "p95": 52882.42254377673,
+      "p99": 54370.726800690514
+    },
+    "application_wire_bytes": null,
+    "application_wire_bytes_per_second": null,
+    "connection_count": null,
+    "connections_per_second": null,
+    "first_failure": null,
+    "interval_count": 924,
+    "interval_latency_ms": {
+      "max": 0.0,
+      "min": 0.0,
+      "p50": 0.0,
+      "p95": 0.0,
+      "p99": 0.0
+    },
+    "passed_interval_count": 924,
+    "request_frames_per_second": null,
+    "requested_count": 924000,
+    "response_count": 924000,
+    "time_to_send_1k_s": {
+      "max": 0.120415375,
+      "min": 0.017772708,
+      "p50": 0.020730395999999998,
+      "p95": 0.024233916,
+      "p99": 0.036262125
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "PASS",
+  "target": "sqlite"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp-tls.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp-tls.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 13500.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 145000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 145000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:34:38.955698Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 145000,
+  "messages_durable": 145000,
+  "messages_requested": 145000,
+  "metrics": {
+    "accepted_count": 145000,
+    "admissions_per_second": {
+      "max": 8645.688888144656,
+      "min": 5423.745963625802,
+      "p50": 7371.041364720723,
+      "p95": 8262.818167659458,
+      "p99": 8615.348361981883
+    },
+    "application_wire_bytes": {
+      "request": 123048265,
+      "response": 59683265,
+      "total": 182731530
+    },
+    "application_wire_bytes_per_second": {
+      "max": 10891406.576840231,
+      "min": 6809675.769711102,
+      "p50": 9285669.359206932,
+      "p95": 10409085.186709002,
+      "p99": 10853185.099006677
+    },
+    "connection_count": 18125,
+    "connections_per_second": {
+      "max": 1080.711111018082,
+      "min": 677.9682454532252,
+      "p50": 921.3801705900904,
+      "p95": 1032.8522709574322,
+      "p99": 1076.9185452477354
+    },
+    "first_failure": null,
+    "interval_count": 145,
+    "interval_latency_ms": {
+      "max": 171.25529199984157,
+      "min": 0.7638750003025052,
+      "p50": 54.04295850030394,
+      "p95": 137.7836669998942,
+      "p99": 159.47079200032022
+    },
+    "passed_interval_count": 145,
+    "request_frames_per_second": {
+      "max": 8645.688888144656,
+      "min": 5423.745963625802,
+      "p50": 7371.041364720723,
+      "p95": 8262.818167659458,
+      "p99": 8615.348361981883
+    },
+    "requested_count": 145000,
+    "response_count": 145000,
+    "time_to_send_1k_s": {
+      "max": 0.18437441700007184,
+      "min": 0.11566458300058002,
+      "p50": 0.13566604100014956,
+      "p95": 0.165563167000073,
+      "p99": 0.1812683329999345
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "tcp-tls"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-tcp.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 17000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 108000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 108000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:34:17.903026Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 108000,
+  "messages_durable": 108000,
+  "messages_requested": 108000,
+  "metrics": {
+    "accepted_count": 108000,
+    "admissions_per_second": {
+      "max": 7282.633826271768,
+      "min": 2467.9079420994776,
+      "p50": 5523.51910074255,
+      "p95": 6583.652297586379,
+      "p99": 7280.488697235234
+    },
+    "application_wire_bytes": {
+      "request": 88813390,
+      "response": 44425390,
+      "total": 133238780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 8984949.483162794,
+      "min": 3039845.6076810313,
+      "p50": 6819352.18672782,
+      "p95": 8122581.022147195,
+      "p99": 8967741.9528195
+    },
+    "connection_count": 13500,
+    "connections_per_second": {
+      "max": 910.329228283971,
+      "min": 308.4884927624347,
+      "p50": 690.4398875928188,
+      "p95": 822.9565371982974,
+      "p99": 910.0610871544043
+    },
+    "first_failure": null,
+    "interval_count": 108,
+    "interval_latency_ms": {
+      "max": 396.5555000004315,
+      "min": 1.1190000004717149,
+      "p50": 52.50959375007369,
+      "p95": 132.67479200021626,
+      "p99": 226.79004100064049
+    },
+    "passed_interval_count": 108,
+    "request_frames_per_second": {
+      "max": 7282.633826271768,
+      "min": 2467.9079420994776,
+      "p50": 5523.51910074255,
+      "p95": 6583.652297586379,
+      "p99": 7280.488697235234
+    },
+    "requested_count": 108000,
+    "response_count": 108000,
+    "time_to_send_1k_s": {
+      "max": 0.4052014999997482,
+      "min": 0.1373129590001554,
+      "p50": 0.1810443959998338,
+      "p95": 0.23894383300012123,
+      "p99": 0.2950137910002013
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "tcp"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-uds.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench-uds.json
@@ -1,0 +1,86 @@
+{
+  "baseline": {
+    "p50_floor": 18000.0,
+    "revision": 1
+  },
+  "binary_hashes": {
+    "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+    "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+  },
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "direct_sqlite_message_write": null,
+  "durability_after_restart": {
+    "expected_accepted_count": 117000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 117000,
+    "passed": true
+  },
+  "frames_per_connection": 8,
+  "generated_at": "2026-09-04T03:33:53.788641Z",
+  "host_label": "m5-atmbench",
+  "incomplete_reason": null,
+  "messages_admitted": 117000,
+  "messages_durable": 117000,
+  "messages_requested": 117000,
+  "metrics": {
+    "accepted_count": 117000,
+    "admissions_per_second": {
+      "max": 7617.782805920316,
+      "min": 3167.4019505215656,
+      "p50": 6105.663078835529,
+      "p95": 7144.7836827287,
+      "p99": 7417.980337197933
+    },
+    "application_wire_bytes": {
+      "request": 84055765,
+      "response": 48136765,
+      "total": 132192530
+    },
+    "application_wire_bytes_per_second": {
+      "max": 8606190.124988476,
+      "min": 3578372.353601739,
+      "p50": 6910084.18947211,
+      "p95": 8071819.365562749,
+      "p99": 8395299.246623762
+    },
+    "connection_count": 14625,
+    "connections_per_second": {
+      "max": 952.2228507400395,
+      "min": 395.9252438151957,
+      "p50": 763.2078848544411,
+      "p95": 893.0979603410875,
+      "p99": 927.2475421497417
+    },
+    "first_failure": null,
+    "interval_count": 117,
+    "interval_latency_ms": {
+      "max": 309.06824999965465,
+      "min": 1.1858749994644313,
+      "p50": 49.617958499766246,
+      "p95": 122.06116700053826,
+      "p99": 215.18474999993487
+    },
+    "passed_interval_count": 117,
+    "request_frames_per_second": {
+      "max": 7617.782805920316,
+      "min": 3167.4019505215656,
+      "p50": 6105.663078835529,
+      "p95": 7144.7836827287,
+      "p99": 7417.980337197933
+    },
+    "requested_count": 117000,
+    "response_count": 117000,
+    "time_to_send_1k_s": {
+      "max": 0.3157161660001293,
+      "min": 0.13127179200000683,
+      "p50": 0.16378237499975512,
+      "p95": 0.2458509590005633,
+      "p99": 0.30405079100000876
+    }
+  },
+  "os": "macos",
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "status": "FAIL",
+  "target": "uds"
+}

--- a/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench.campaign.json
+++ b/site/reports/send-message-benchmark/20260904T033320Z-m5-atmbench.campaign.json
@@ -1,0 +1,342 @@
+{
+  "campaign_id": "20260904T033320Z-m5-atmbench",
+  "completed_at": "2026-09-04T03:35:00.490991Z",
+  "host_label": "m5-atmbench",
+  "os": "macos",
+  "phase": "ao2",
+  "results": [
+    {
+      "baseline": {
+        "p50_floor": 35000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": {
+        "accepted_count": 924000,
+        "admissions_per_second": 46165.61719404162,
+        "elapsed_seconds": 20.014895417,
+        "kind": "async_storage_admission",
+        "requested_count": 924000,
+        "worker_count": 512
+      },
+      "durability_after_restart": {
+        "expected_accepted_count": 924000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 924000,
+        "passed": true
+      },
+      "frames_per_connection": 0,
+      "generated_at": "2026-09-04T03:33:32.260385Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 924000,
+      "messages_durable": 924000,
+      "messages_requested": 924000,
+      "metrics": {
+        "accepted_count": 924000,
+        "admissions_per_second": {
+          "max": 56266.04566957382,
+          "min": 8304.587350244932,
+          "p50": 48238.356270617536,
+          "p95": 52882.42254377673,
+          "p99": 54370.726800690514
+        },
+        "application_wire_bytes": null,
+        "application_wire_bytes_per_second": null,
+        "connection_count": null,
+        "connections_per_second": null,
+        "first_failure": null,
+        "interval_count": 924,
+        "interval_latency_ms": {
+          "max": 0.0,
+          "min": 0.0,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0
+        },
+        "passed_interval_count": 924,
+        "request_frames_per_second": null,
+        "requested_count": 924000,
+        "response_count": 924000,
+        "time_to_send_1k_s": {
+          "max": 0.120415375,
+          "min": 0.017772708,
+          "p50": 0.020730395999999998,
+          "p95": 0.024233916,
+          "p99": 0.036262125
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "PASS",
+      "target": "sqlite"
+    },
+    {
+      "baseline": {
+        "p50_floor": 18000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 117000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 117000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:33:53.788641Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 117000,
+      "messages_durable": 117000,
+      "messages_requested": 117000,
+      "metrics": {
+        "accepted_count": 117000,
+        "admissions_per_second": {
+          "max": 7617.782805920316,
+          "min": 3167.4019505215656,
+          "p50": 6105.663078835529,
+          "p95": 7144.7836827287,
+          "p99": 7417.980337197933
+        },
+        "application_wire_bytes": {
+          "request": 84055765,
+          "response": 48136765,
+          "total": 132192530
+        },
+        "application_wire_bytes_per_second": {
+          "max": 8606190.124988476,
+          "min": 3578372.353601739,
+          "p50": 6910084.18947211,
+          "p95": 8071819.365562749,
+          "p99": 8395299.246623762
+        },
+        "connection_count": 14625,
+        "connections_per_second": {
+          "max": 952.2228507400395,
+          "min": 395.9252438151957,
+          "p50": 763.2078848544411,
+          "p95": 893.0979603410875,
+          "p99": 927.2475421497417
+        },
+        "first_failure": null,
+        "interval_count": 117,
+        "interval_latency_ms": {
+          "max": 309.06824999965465,
+          "min": 1.1858749994644313,
+          "p50": 49.617958499766246,
+          "p95": 122.06116700053826,
+          "p99": 215.18474999993487
+        },
+        "passed_interval_count": 117,
+        "request_frames_per_second": {
+          "max": 7617.782805920316,
+          "min": 3167.4019505215656,
+          "p50": 6105.663078835529,
+          "p95": 7144.7836827287,
+          "p99": 7417.980337197933
+        },
+        "requested_count": 117000,
+        "response_count": 117000,
+        "time_to_send_1k_s": {
+          "max": 0.3157161660001293,
+          "min": 0.13127179200000683,
+          "p50": 0.16378237499975512,
+          "p95": 0.2458509590005633,
+          "p99": 0.30405079100000876
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "uds"
+    },
+    {
+      "baseline": {
+        "p50_floor": 17000.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 108000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 108000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:34:17.903026Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 108000,
+      "messages_durable": 108000,
+      "messages_requested": 108000,
+      "metrics": {
+        "accepted_count": 108000,
+        "admissions_per_second": {
+          "max": 7282.633826271768,
+          "min": 2467.9079420994776,
+          "p50": 5523.51910074255,
+          "p95": 6583.652297586379,
+          "p99": 7280.488697235234
+        },
+        "application_wire_bytes": {
+          "request": 88813390,
+          "response": 44425390,
+          "total": 133238780
+        },
+        "application_wire_bytes_per_second": {
+          "max": 8984949.483162794,
+          "min": 3039845.6076810313,
+          "p50": 6819352.18672782,
+          "p95": 8122581.022147195,
+          "p99": 8967741.9528195
+        },
+        "connection_count": 13500,
+        "connections_per_second": {
+          "max": 910.329228283971,
+          "min": 308.4884927624347,
+          "p50": 690.4398875928188,
+          "p95": 822.9565371982974,
+          "p99": 910.0610871544043
+        },
+        "first_failure": null,
+        "interval_count": 108,
+        "interval_latency_ms": {
+          "max": 396.5555000004315,
+          "min": 1.1190000004717149,
+          "p50": 52.50959375007369,
+          "p95": 132.67479200021626,
+          "p99": 226.79004100064049
+        },
+        "passed_interval_count": 108,
+        "request_frames_per_second": {
+          "max": 7282.633826271768,
+          "min": 2467.9079420994776,
+          "p50": 5523.51910074255,
+          "p95": 6583.652297586379,
+          "p99": 7280.488697235234
+        },
+        "requested_count": 108000,
+        "response_count": 108000,
+        "time_to_send_1k_s": {
+          "max": 0.4052014999997482,
+          "min": 0.1373129590001554,
+          "p50": 0.1810443959998338,
+          "p95": 0.23894383300012123,
+          "p99": 0.2950137910002013
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "tcp"
+    },
+    {
+      "baseline": {
+        "p50_floor": 13500.0,
+        "revision": 1
+      },
+      "binary_hashes": {
+        "atm": "5377652741470a7c61da4a8aaa73d46e35b1e1843a8e4c6aa30dc494f55c1692",
+        "atm-daemon": "2dfb88dc19f3a71591b5cec27c51ae5ab0fee611058714dadb4d92f9f25a5fae"
+      },
+      "campaign_id": "20260904T033320Z-m5-atmbench",
+      "direct_sqlite_message_write": null,
+      "durability_after_restart": {
+        "expected_accepted_count": 145000,
+        "method": "isolated_sqlite_exact_count_after_restart",
+        "observed_mailbox_count": 145000,
+        "passed": true
+      },
+      "frames_per_connection": 8,
+      "generated_at": "2026-09-04T03:34:38.955698Z",
+      "host_label": "m5-atmbench",
+      "incomplete_reason": null,
+      "messages_admitted": 145000,
+      "messages_durable": 145000,
+      "messages_requested": 145000,
+      "metrics": {
+        "accepted_count": 145000,
+        "admissions_per_second": {
+          "max": 8645.688888144656,
+          "min": 5423.745963625802,
+          "p50": 7371.041364720723,
+          "p95": 8262.818167659458,
+          "p99": 8615.348361981883
+        },
+        "application_wire_bytes": {
+          "request": 123048265,
+          "response": 59683265,
+          "total": 182731530
+        },
+        "application_wire_bytes_per_second": {
+          "max": 10891406.576840231,
+          "min": 6809675.769711102,
+          "p50": 9285669.359206932,
+          "p95": 10409085.186709002,
+          "p99": 10853185.099006677
+        },
+        "connection_count": 18125,
+        "connections_per_second": {
+          "max": 1080.711111018082,
+          "min": 677.9682454532252,
+          "p50": 921.3801705900904,
+          "p95": 1032.8522709574322,
+          "p99": 1076.9185452477354
+        },
+        "first_failure": null,
+        "interval_count": 145,
+        "interval_latency_ms": {
+          "max": 171.25529199984157,
+          "min": 0.7638750003025052,
+          "p50": 54.04295850030394,
+          "p95": 137.7836669998942,
+          "p99": 159.47079200032022
+        },
+        "passed_interval_count": 145,
+        "request_frames_per_second": {
+          "max": 8645.688888144656,
+          "min": 5423.745963625802,
+          "p50": 7371.041364720723,
+          "p95": 8262.818167659458,
+          "p99": 8615.348361981883
+        },
+        "requested_count": 145000,
+        "response_count": 145000,
+        "time_to_send_1k_s": {
+          "max": 0.18437441700007184,
+          "min": 0.11566458300058002,
+          "p50": 0.13566604100014956,
+          "p95": 0.165563167000073,
+          "p99": 0.1812683329999345
+        }
+      },
+      "os": "macos",
+      "schema_version": 4,
+      "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+      "status": "FAIL",
+      "target": "tcp-tls"
+    }
+  ],
+  "schema_version": 4,
+  "source_revision": "f5de135513ed2607fadc3f69a9188b1fdad5f043",
+  "started_at": "2026-09-04T03:33:20.951042Z",
+  "status": "FAIL"
+}


### PR DESCRIPTION
Reports-only re-land of the artifacts on the stale evidence branch; version
bumps, harness edits and superseded triage records are dropped. Reports
index regenerated. Every attempt lands on develop, PASS or FAIL.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>