### PR TITLE
fix(release): block published crates whose workspace deps are missing from the publish manifest

### DIFF
--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -338,3 +338,138 @@ class ValidateReleaseContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ManifestDependencyCoverageTests(unittest.TestCase):
+    """Consumer-owned check: published crates must not depend on unpublished workspace crates."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        (self.root / "release").mkdir()
+        (self.root / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """
+                [workspace]
+                members = ["crates/*"]
+                resolver = "2"
+
+                [workspace.package]
+                version = "1.5.0"
+
+                [workspace.dependencies]
+                atm-leaf = { path = "crates/atm-leaf", version = "1.5.0" }
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        self.write_crate("atm-leaf", "")
+        self.write_crate("atm-mid", 'atm-leaf = { workspace = true }\n')
+        self.write_crate(
+            "atm-top",
+            'atm-mid = { path = "../atm-mid", version = "1.5.0" }\nserde = "1"\n',
+            build_dependencies='atm-leaf = { workspace = true }\n',
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_crate(
+        self,
+        name: str,
+        dependencies: str,
+        *,
+        build_dependencies: str = "",
+        publish: str = "",
+    ) -> None:
+        crate_dir = self.root / "crates" / name
+        crate_dir.mkdir(parents=True, exist_ok=True)
+        (crate_dir / "Cargo.toml").write_text(
+            f'[package]\nname = "{name}"\nversion.workspace = true\n{publish}\n'
+            f"[dependencies]\n{dependencies}\n[build-dependencies]\n{build_dependencies}",
+            encoding="utf-8",
+        )
+
+    def write_manifest(self, *packages: str, unpublished: tuple[str, ...] = ()) -> None:
+        blocks = []
+        for order, package in enumerate((*packages, *unpublished), start=1):
+            blocks.append(
+                textwrap.dedent(
+                    f"""
+                    [[crates]]
+                    artifact = "{package}"
+                    package = "{package}"
+                    cargo_toml = "crates/{package}/Cargo.toml"
+                    publish = {"false" if package in unpublished else "true"}
+                    publish_order = {order}
+                    """
+                ).strip()
+            )
+        (self.root / "release" / "publish-artifacts.toml").write_text(
+            "schema_version = 1\n\n" + "\n\n".join(blocks) + "\n",
+            encoding="utf-8",
+        )
+
+    def coverage_findings(self) -> list[VALIDATE_RELEASE.Finding]:
+        findings: list[VALIDATE_RELEASE.Finding] = []
+        VALIDATE_RELEASE.validate_manifest_dependency_coverage(self.root, findings)
+        return findings
+
+    def test_complete_manifest_passes(self) -> None:
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top")
+
+        self.assertEqual(self.coverage_findings(), [])
+
+    def test_transitive_and_build_dependencies_missing_from_manifest_block(self) -> None:
+        self.write_manifest("atm-top")
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].check, "manifest-dependency-coverage")
+        self.assertTrue(findings[0].blocks)
+        self.assertEqual(
+            findings[0].detail.splitlines(),
+            [
+                "atm-top depends on workspace crate atm-leaf which the manifest does not publish",
+                "atm-top depends on workspace crate atm-mid which the manifest does not publish",
+            ],
+        )
+
+    def test_manifest_entry_with_publish_false_still_blocks(self) -> None:
+        self.write_manifest("atm-mid", "atm-top", unpublished=("atm-leaf",))
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("atm-leaf which the manifest does not publish", findings[0].detail)
+
+    def test_dependency_whose_cargo_toml_opts_out_of_publishing_blocks(self) -> None:
+        self.write_crate("atm-leaf", "", publish="publish = false\n")
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top")
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(
+            findings[0].detail.splitlines(),
+            [
+                "atm-mid depends on workspace crate atm-leaf which sets publish = false",
+                "atm-top depends on workspace crate atm-leaf which sets publish = false",
+            ],
+        )
+
+    def test_unpublished_crates_outside_the_manifest_are_ignored(self) -> None:
+        self.write_crate("atm-tool", 'atm-leaf = { workspace = true }\n', publish="publish = false\n")
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top")
+
+        self.assertEqual(self.coverage_findings(), [])
+
+    def test_missing_cargo_toml_is_reported(self) -> None:
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top", "atm-ghost")
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("atm-ghost: cargo_toml", findings[0].detail)

--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -336,8 +336,6 @@ class ValidateReleaseContractTests(unittest.TestCase):
         self.assertTrue(any(finding.check == "cargo-package-published-crate" and finding.blocks for finding in findings))
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class ManifestDependencyCoverageTests(unittest.TestCase):
@@ -473,3 +471,36 @@ class ManifestDependencyCoverageTests(unittest.TestCase):
 
         self.assertEqual(len(findings), 1)
         self.assertIn("atm-ghost: cargo_toml", findings[0].detail)
+
+    def test_unresolvable_workspace_members_fail_closed(self) -> None:
+        (self.root / "Cargo.toml").write_text(
+            '[workspace]\nresolver = "2"\n\n[workspace.package]\nversion = "1.5.0"\n',
+            encoding="utf-8",
+        )
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top")
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].blocks)
+        self.assertIn("[workspace].members resolved to no crates", findings[0].detail)
+        self.assertIn("atm-top: not a resolvable [workspace].members crate", findings[0].detail)
+
+    def test_published_crate_outside_the_member_list_fails_closed(self) -> None:
+        (self.root / "Cargo.toml").write_text(
+            (self.root / "Cargo.toml").read_text(encoding="utf-8").replace('members = ["crates/*"]', 'members = ["crates/atm-leaf", "crates/atm-mid"]'),
+            encoding="utf-8",
+        )
+        self.write_manifest("atm-leaf", "atm-mid", "atm-top")
+
+        findings = self.coverage_findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(
+            findings[0].detail.splitlines(),
+            ["atm-top: not a resolvable [workspace].members crate at crates/atm-top/Cargo.toml"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -398,6 +398,9 @@ def workspace_dependency_names(crate_toml: Path, root: Path, members: dict[str, 
 def validate_manifest_dependency_coverage(root: Path, findings: list[Finding]) -> None:
     """Every workspace dependency of a published crate must itself be published by the manifest.
 
+    Fails closed: if the workspace member list cannot be resolved, or a published crate is not
+    itself a resolvable member, the check reports an error instead of evaluating nothing.
+
     Consumer-owned check absent from the kit CLI (upstream sc-publish gap): the kit's
     ``validate-publish-order`` silently ignores dependencies missing from the manifest,
     which let the 1.5.0 readiness preflight run without ``atm-herdr`` and
@@ -409,11 +412,16 @@ def validate_manifest_dependency_coverage(root: Path, findings: list[Finding]) -
     published = {crate.get("package") for crate in crates}
     members = workspace_member_manifests(root)
     problems: list[str] = []
+    if crates and not members:
+        problems.append("Cargo.toml [workspace].members resolved to no crates; dependency coverage cannot be evaluated")
     for crate in crates:
         package = crate.get("package")
         crate_toml = root / str(crate.get("cargo_toml", ""))
         if not crate_toml.is_file():
             problems.append(f"{package}: cargo_toml {crate.get('cargo_toml')!r} does not exist")
+            continue
+        if members.get(package) != crate_toml:
+            problems.append(f"{package}: not a resolvable [workspace].members crate at {crate.get('cargo_toml')}")
             continue
         for dependency in sorted(workspace_dependency_names(crate_toml, root, members)):
             dependency_toml = members.get(dependency)

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -346,6 +346,96 @@ def validate_cli_surface(root: Path, findings: list[Finding]) -> None:
     )
 
 
+def workspace_member_manifests(root: Path) -> dict[str, Path]:
+    """Map every workspace member package name to its Cargo.toml."""
+
+    cargo = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    members = cargo.get("workspace", {}).get("members", [])
+    manifests: dict[str, Path] = {}
+    for member in members if isinstance(members, list) else []:
+        for member_dir in sorted(root.glob(member)) if isinstance(member, str) else []:
+            crate_toml = member_dir / "Cargo.toml"
+            if not crate_toml.is_file():
+                continue
+            name = tomllib.loads(crate_toml.read_text(encoding="utf-8")).get("package", {}).get("name")
+            if isinstance(name, str):
+                manifests[name] = crate_toml
+    return manifests
+
+
+def crate_is_publishable(crate_toml: Path) -> bool:
+    publish = tomllib.loads(crate_toml.read_text(encoding="utf-8")).get("package", {}).get("publish")
+    return not (publish is False or (isinstance(publish, list) and not publish))
+
+
+def workspace_dependency_names(crate_toml: Path, root: Path, members: dict[str, Path]) -> set[str]:
+    """Workspace crates this crate needs published first (runtime, build, target deps)."""
+
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    workspace_deps = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8")).get("workspace", {}).get(
+        "dependencies", {}
+    )
+
+    def resolve(dep_name: str, spec: object) -> str | None:
+        if isinstance(spec, dict) and spec.get("workspace") is True:
+            spec = workspace_deps.get(dep_name, {})
+        if isinstance(spec, dict):
+            package = spec.get("package", dep_name)
+            return package if isinstance(package, str) and ("path" in spec or package in members) else None
+        return dep_name if dep_name in members else None
+
+    tables = [data.get("dependencies", {}), data.get("build-dependencies", {})]
+    for target in data.get("target", {}).values():
+        if isinstance(target, dict):
+            tables.extend((target.get("dependencies", {}), target.get("build-dependencies", {})))
+    names: set[str] = set()
+    for table in tables:
+        if isinstance(table, dict):
+            names.update(package for dep, spec in table.items() if (package := resolve(dep, spec)))
+    return names
+
+
+def validate_manifest_dependency_coverage(root: Path, findings: list[Finding]) -> None:
+    """Every workspace dependency of a published crate must itself be published by the manifest.
+
+    Consumer-owned check absent from the kit CLI (upstream sc-publish gap): the kit's
+    ``validate-publish-order`` silently ignores dependencies missing from the manifest,
+    which let the 1.5.0 readiness preflight run without ``atm-herdr`` and
+    ``atm-observability`` declared until ``cargo package`` failed.
+    """
+
+    contract = load_release_contract(root)
+    crates = [crate for crate in contract.get("crates", []) if isinstance(crate, dict) and crate.get("publish")]
+    published = {crate.get("package") for crate in crates}
+    members = workspace_member_manifests(root)
+    problems: list[str] = []
+    for crate in crates:
+        package = crate.get("package")
+        crate_toml = root / str(crate.get("cargo_toml", ""))
+        if not crate_toml.is_file():
+            problems.append(f"{package}: cargo_toml {crate.get('cargo_toml')!r} does not exist")
+            continue
+        for dependency in sorted(workspace_dependency_names(crate_toml, root, members)):
+            dependency_toml = members.get(dependency)
+            if dependency_toml is None:
+                continue
+            if not crate_is_publishable(dependency_toml):
+                problems.append(f"{package} depends on workspace crate {dependency} which sets publish = false")
+            elif dependency not in published:
+                problems.append(f"{package} depends on workspace crate {dependency} which the manifest does not publish")
+    if problems:
+        findings.append(
+            Finding(
+                check="manifest-dependency-coverage",
+                severity="error",
+                summary="published crates depend on workspace crates the manifest does not publish",
+                detail="\n".join(problems),
+            )
+        )
+        return
+    print("ok: every workspace dependency of a published crate is published by the manifest")
+
+
 def validate_manifest(
     root: Path,
     findings: list[Finding],
@@ -377,6 +467,7 @@ def validate_manifest(
     for check, cmd, summary in commands:
         completed = run_capture(cmd, cwd=root)
         append_completed_findings(findings, check, completed, f"{check} passed", summary)
+    validate_manifest_dependency_coverage(root, findings)
     validate_preflight_contract(root, findings)
 
 


### PR DESCRIPTION
## Summary

Post-release follow-up from the 1.5.0 readiness preflight (Rand-approved 2026-09-04).

The kit's `validate-publish-order` only checks ordering among crates already in the manifest, so a published crate whose workspace dependency is absent from `release/publish-artifacts.toml` passes silently. That let the 1.5.0 preflight run without `atm-herdr` and `atm-observability` declared until `cargo package` failed.

This adds a consumer-owned, in-process check to `scripts/validate_release.py` (`manifest-dependency-coverage`, part of the `manifest` target): every runtime, build, and target workspace dependency of a published manifest crate must itself be published by the manifest and must not set `package.publish = false`. Workspace-inherited deps, renamed `package =` deps, and glob members are resolved.

No kit files are edited; the upstream gap is filed against sc-publish separately.

## Verification

- Against the real workspace: passes.
- With the `atm-herdr` block removed from a copy of the manifest: reports `atm-http-runtime` and `atm-daemon-bootstrap` depending on an unpublished crate.
- 6 new unit tests in `.just/tests/test_validate_release.py` over a synthetic workspace (transitive + build deps, `publish = false` manifest entry, `package.publish = false`, unrelated unpublished crates ignored, missing `cargo_toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
