### PR TITLE
fix(benchmark): bind Windows account state to token profile

### DIFF
--- a/scripts/smoke/benchmark_account.py
+++ b/scripts/smoke/benchmark_account.py
@@ -43,13 +43,39 @@ class BenchmarkAccount:
 def account_home() -> Path:
     """Return the account home from OS identity, never a shell HOME override."""
     if os.name == "nt":
-        profile = os.environ.get("USERPROFILE", "").strip()
-        if not profile:
-            raise BenchmarkAccountError("could not resolve the Windows benchmark-account profile")
-        return Path(profile).resolve()
+        return _windows_profile_home()
     import pwd
 
     return Path(pwd.getpwuid(os.geteuid()).pw_dir).resolve()
+
+
+def _windows_profile_home() -> Path:
+    """Resolve the active token's profile, not a caller-controlled environment variable."""
+    import ctypes
+    from ctypes import wintypes
+
+    token = wintypes.HANDLE()
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    userenv = ctypes.WinDLL("userenv", use_last_error=True)
+    open_process_token = advapi32.OpenProcessToken
+    open_process_token.argtypes = [wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
+    open_process_token.restype = wintypes.BOOL
+    if not open_process_token(kernel32.GetCurrentProcess(), 0x0008, ctypes.byref(token)):
+        raise BenchmarkAccountError(f"could not resolve the Windows benchmark-account token: {ctypes.WinError()}")
+    try:
+        size = wintypes.DWORD()
+        get_profile = userenv.GetUserProfileDirectoryW
+        get_profile.argtypes = [wintypes.HANDLE, wintypes.LPWSTR, ctypes.POINTER(wintypes.DWORD)]
+        get_profile.restype = wintypes.BOOL
+        if get_profile(token, None, ctypes.byref(size)) or ctypes.get_last_error() != 122 or not size.value:
+            raise BenchmarkAccountError(f"could not resolve the Windows benchmark-account profile: {ctypes.WinError()}")
+        profile = ctypes.create_unicode_buffer(size.value)
+        if not get_profile(token, profile, ctypes.byref(size)):
+            raise BenchmarkAccountError(f"could not resolve the Windows benchmark-account profile: {ctypes.WinError()}")
+        return Path(profile.value).resolve()
+    finally:
+        kernel32.CloseHandle(token)
 
 
 def canonical_durable_state_root(home: Path | None = None) -> Path:

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -59,6 +59,7 @@ from scripts.smoke.benchmark_policy import classify_status, profile_median_admis
 from scripts.smoke.benchmark_account import (
     BenchmarkAccount,
     BenchmarkAccountError,
+    account_home,
     bootstrap_benchmark_account,
     require_benchmark_account,
 )
@@ -72,9 +73,6 @@ from scripts.smoke.benchmark_snapshot import (
     restore_verified_snapshot,
     verify_active_snapshot,
 )
-
-if os.name != "nt":
-    import pwd
 
 try:
     import resource
@@ -827,13 +825,17 @@ def run_lifecycle_phase(
 
 
 def os_account_home() -> Path:
-    """Match ADR-026's OS-account root instead of trusting a shell HOME override."""
-    if os.name == "nt":
-        profile = os.environ.get("USERPROFILE", "").strip()
-        if not profile:
-            raise SmokeError("could not resolve the Windows OS-user profile for capacity smoke")
-        return Path(profile)
-    return Path(pwd.getpwuid(os.geteuid()).pw_dir)
+    """Match ADR-026's OS-account root instead of trusting a shell HOME override.
+
+    Delegates to ``benchmark_account.account_home`` so Windows resolves the
+    executing token's profile directory rather than a caller-controlled
+    ``USERPROFILE`` value; the durable-root safety check must key on the same
+    identity the benchmark-account manifest is bound to.
+    """
+    try:
+        return account_home()
+    except BenchmarkAccountError as error:
+        raise SmokeError(f"could not resolve the OS-account home for capacity smoke: {error}") from error
 
 
 def validate_capacity_home(path: Path) -> Path:

--- a/scripts/smoke/test_benchmark_account.py
+++ b/scripts/smoke/test_benchmark_account.py
@@ -11,6 +11,21 @@ from scripts.smoke import benchmark_account as ACCOUNT
 
 
 class BenchmarkAccountTests(unittest.TestCase):
+    @unittest.skipUnless(os.name == "nt", "Windows profile resolution only")
+    def test_windows_account_home_ignores_userprofile_override(self):
+        actual_profile = Path("C:/token-owned-profile")
+        with (
+            mock.patch.dict(os.environ, {"USERPROFILE": "C:/spoofed-profile"}),
+            mock.patch.object(ACCOUNT, "_windows_profile_home", return_value=actual_profile),
+        ):
+            self.assertEqual(ACCOUNT.account_home(), actual_profile)
+
+    @unittest.skipUnless(os.name == "nt", "Windows profile resolution only")
+    def test_windows_token_profile_home_is_an_existing_absolute_directory(self):
+        profile = ACCOUNT._windows_profile_home()
+        self.assertTrue(profile.is_absolute())
+        self.assertTrue(profile.is_dir())
+
     def _bootstrap(self, home: Path) -> ACCOUNT.BenchmarkAccount:
         with (
             mock.patch.object(ACCOUNT, "account_home", return_value=home),

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -104,6 +104,21 @@ def healthy_managed_status() -> dict[str, object]:
 
 
 class AdmissionCapacityTests(unittest.TestCase):
+    def test_os_account_home_uses_token_bound_account_home(self):
+        """The durable-root safety check resolves the OS account like benchmark_account, never USERPROFILE."""
+        token_home = Path("C:/token-owned-profile") if os.name == "nt" else Path("/home/token-owned")
+        with (
+            mock.patch.dict(os.environ, {"USERPROFILE": "C:/spoofed-profile", "HOME": "/spoofed-home"}),
+            mock.patch.object(RUNNER, "account_home", return_value=token_home),
+        ):
+            self.assertEqual(RUNNER.os_account_home(), token_home)
+
+    def test_os_account_home_reports_account_resolution_failure(self):
+        with mock.patch.object(RUNNER, "account_home", side_effect=RUNNER.BenchmarkAccountError("no token")):
+            with self.assertRaises(RUNNER.SmokeError) as raised:
+                RUNNER.os_account_home()
+        self.assertIn("no token", str(raised.exception))
+
     def test_default_workers_match_the_reviewed_f8_load_shape(self):
         self.assertEqual(RUNNER.DEFAULT_WORKERS, 512)
 


### PR DESCRIPTION
## Windows benchmark-account root fix

### Root cause
`benchmark_account.account_home()` trusted `USERPROFILE` on Windows. That variable can be overridden to a disposable path, but the daemon resolves its durable runtime scope from the executing Windows token. The harness could therefore validate/snapshot `<override>\.atm\db` while the daemon wrote `%USERPROFILE%\.atm\db` for the token-owned profile, causing the pre-measurement error `benchmark snapshot durable state root is missing`.

### Resolution
- Resolve the Windows benchmark account home through `GetUserProfileDirectoryW` for the current process token.
- Retain the existing Unix `pwd` path unchanged.
- Add Windows regressions for ignoring a `USERPROFILE` override and for resolving an existing absolute token profile.

### Verification
- Focused: `python -m unittest scripts.smoke.test_benchmark_account scripts.smoke.test_run_admission_capacity` -> 126 passed, 9 skipped.
- Live Windows TCP lifecycle against the fresh token-owned account -> PASS: daemon start/doctor, snapshot, profile, restart/durability, restore, cleanup.
- `just test` passed before the final helper change; the final focused suite passes.
- `just lint` has an independent intermittent Python 3.14 Windows interpreter failure in boundary tests (`0xC0000005` / corrupted locals). Direct scanner and the exact test with `-X faulthandler` pass; this PR does not alter that unrelated scanner or daemon/runtime code.

No daemon source, macOS/Linux path, or transport behavior changed.