### PR TITLE
feat(ax1): queue template class and default template fixes (AX.1)

### DIFF
--- a/.claude/skills/restore-team-communications/SKILL.md
+++ b/.claude/skills/restore-team-communications/SKILL.md
@@ -73,7 +73,7 @@ action, not just a passive unread-mail announcement. Preferred structured
 nudge payload:
 
 ```text
-<atm><action>read atm</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
+<atm><action>atm read --message-id {{message_id}}</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
 ```
 
 If the task is queued behind active work, use a nudge about the deferred task

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -131,7 +131,7 @@ allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstr
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "tokio", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-error/Cargo.toml"

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -131,7 +131,7 @@ allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstr
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"
-allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
+allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", "atm-storage", "base64", "chrono", "fs4", "interprocess", "libc", "parking_lot", "sc-lint-attributes", "semver", "serde", "serde_json", "serial_test", "tempfile", "tokio", "toml", "tracing", "tracing-subscriber", "ulid", "windows-sys"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-error/Cargo.toml"

--- a/.just/prerelease_tag.py
+++ b/.just/prerelease_tag.py
@@ -252,6 +252,11 @@ def copy_tracked_files(repo_root: Path, destination: Path) -> None:
         source = repo_root / relative_path
         target = destination / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
+        if not source.exists() and not source.is_symlink():
+            # A candidate may be prepared from a worktree with staged or
+            # unstaged deletions. Those paths are absent from the candidate by
+            # design and will likewise be absent after the deletion commits.
+            continue
         if source.is_symlink():
             target.symlink_to(os.readlink(source))
         else:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -43,7 +43,6 @@ atm-storage = { workspace = true, features = ["test-utils"] }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true
-tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -43,6 +43,7 @@ atm-storage = { workspace = true, features = ["test-utils"] }
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber.workspace = true
+tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -480,7 +480,7 @@ fn graft_receiver_runtime_wiring_and_unconfigured_defaults_are_explicit() {
 
 /// Minimal executor: with in-memory stores the admission future never pends,
 /// so a noop-waker poll loop is sufficient and atm-core keeps its zero
-/// tokio dev-dependency footprint.
+/// a production Tokio dependency footprint.
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
     let waker = std::task::Waker::noop();
     let mut context = std::task::Context::from_waker(waker);

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -479,8 +479,8 @@ fn graft_receiver_runtime_wiring_and_unconfigured_defaults_are_explicit() {
 }
 
 /// Minimal executor: with in-memory stores the admission future never pends,
-/// so a noop-waker poll loop is sufficient and atm-core keeps its zero
-/// a production Tokio dependency footprint.
+/// so a noop-waker poll loop is sufficient and atm-core keeps its
+/// runtime-neutral production dependency footprint.
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
     let waker = std::task::Waker::noop();
     let mut context = std::task::Context::from_waker(waker);

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -134,14 +134,22 @@ impl PostSendHookEvent {
 
 pub fn built_in_nudge_template_kind_from_post_send_event(
     event: &PostSendHookEvent,
+    delivery_kind: NudgeKind,
 ) -> BuiltInNudgeTemplateKind {
-    match (event.is_ack, event.task_id.is_some(), event.requires_ack) {
-        (true, true, _) => BuiltInNudgeTemplateKind::AcknowledgeTask,
-        (true, false, _) => BuiltInNudgeTemplateKind::Acknowledge,
-        (false, true, true) => BuiltInNudgeTemplateKind::DeliveryTaskAck,
-        (false, true, false) => BuiltInNudgeTemplateKind::DeliveryTask,
-        (false, false, true) => BuiltInNudgeTemplateKind::DeliveryAck,
-        (false, false, false) => BuiltInNudgeTemplateKind::Delivery,
+    use BuiltInNudgeTemplateKind as K;
+    match (
+        event.is_ack,
+        event.task_id.is_some(),
+        event.requires_ack,
+        delivery_kind,
+    ) {
+        (true, true, _, _) => K::AcknowledgeTask,
+        (true, false, _, _) => K::Acknowledge,
+        (false, true, _, _) => K::Task,
+        (false, false, false, NudgeKind::Steer) => K::Delivery,
+        (false, false, true, NudgeKind::Steer) => K::DeliveryAck,
+        (false, false, false, NudgeKind::Queue) => K::Queue,
+        (false, false, true, NudgeKind::Queue) => K::QueueAck,
     }
 }
 

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -32,7 +32,7 @@ where
             .recipient_pane_id
             .clone()
             .or_else(|| delivery_snapshot.recipient_pane_id.as_ref().cloned())?;
-        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event)?;
+        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event, kind)?;
         return Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Tmux(
@@ -54,7 +54,7 @@ where
         });
     }
     if delivery_snapshot.graft_post_send {
-        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event)?;
+        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event, kind)?;
         return Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::Graft(GraftNudgeTarget {
@@ -96,11 +96,15 @@ const fn nudge_kind_for_mode(nudge_mode: NudgeMode) -> NudgeKind {
 
 /// Render the database-resolved built-in nudge once for every first-party
 /// delivery sink. Tmux and graft therefore receive identical XML text.
-fn render_built_in_nudge_for_dispatch<R>(runtime: &R, event: &PostSendHookEvent) -> Option<String>
+fn render_built_in_nudge_for_dispatch<R>(
+    runtime: &R,
+    event: &PostSendHookEvent,
+    delivery_kind: NudgeKind,
+) -> Option<String>
 where
     R: RetainedServiceRuntime + ?Sized,
 {
-    let kind = built_in_nudge_template_kind_from_post_send_event(event);
+    let kind = built_in_nudge_template_kind_from_post_send_event(event, delivery_kind);
     let override_row = match runtime.load_nudge_template_override(&event.recipient_team, kind) {
         Ok(row) => row,
         Err(error) => {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -302,6 +302,17 @@ pub(crate) fn request_requires_ack(request: &SendRequest, task_id: &Option<TaskI
         )
 }
 
+pub(crate) fn send_mode_for_task_request(
+    request: &SendRequest,
+    task_id: &Option<TaskId>,
+) -> NudgeMode {
+    if task_id.is_some() {
+        NudgeMode::Deferred
+    } else {
+        request.nudge_mode
+    }
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "Y.6 closeout keeps the explicit send outcome pieces visible at the sprint seam."
@@ -632,7 +643,11 @@ pub(crate) mod tests;
 
 #[cfg(test)]
 mod path_body_tests {
-    use super::looks_like_path_only_body;
+    use super::{
+        NudgeMode, SendMessageSource, WriteRequest, looks_like_path_only_body,
+        send_mode_for_task_request,
+    };
+    use crate::types::TeamName;
 
     #[test]
     fn detects_existing_relative_and_absolute_files() {
@@ -683,5 +698,50 @@ mod path_body_tests {
             root.path(),
             home.path()
         ));
+    }
+
+    #[test]
+    fn task_request_forces_deferred_mode_while_ordinary_request_is_unchanged() {
+        let home_dir = tempfile::tempdir().expect("temporary home");
+        let team: TeamName = "test-team".parse().expect("team");
+        let task_request = WriteRequest::new(
+            home_dir.path().to_path_buf(),
+            home_dir.path().to_path_buf(),
+            "sender".parse().expect("sender"),
+            "recipient@test-team",
+            team.clone(),
+            SendMessageSource::Inline("task".to_owned()),
+            None,
+            false,
+            Some("task-1".parse().expect("task id")),
+            false,
+        )
+        .expect("task request")
+        .with_nudge_mode(NudgeMode::Immediate);
+        let task_id = task_request.task_id.clone();
+        assert_eq!(
+            send_mode_for_task_request(&task_request, &task_id),
+            NudgeMode::Deferred
+        );
+
+        let ordinary_request = WriteRequest::new(
+            home_dir.path().to_path_buf(),
+            home_dir.path().to_path_buf(),
+            "sender".parse().expect("sender"),
+            "recipient@test-team",
+            team,
+            SendMessageSource::Inline("ordinary".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("ordinary request")
+        .with_nudge_mode(NudgeMode::Immediate);
+        let task_id = ordinary_request.task_id.clone();
+        assert_eq!(
+            send_mode_for_task_request(&ordinary_request, &task_id),
+            NudgeMode::Immediate
+        );
     }
 }

--- a/crates/atm-core/src/send/nudge_template.rs
+++ b/crates/atm-core/src/send/nudge_template.rs
@@ -65,16 +65,19 @@ fn render_values(event: &PostSendHookEvent) -> BTreeMap<&'static str, String> {
 pub fn default_template(kind: BuiltInNudgeTemplateKind) -> &'static str {
     match kind {
         BuiltInNudgeTemplateKind::Delivery => {
-            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>atm read --message-id {{message_id}}</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
         }
         BuiltInNudgeTemplateKind::DeliveryAck => {
-            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>atm read --message-id {{message_id}}</action>\n  <action>ack the message</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
         }
-        BuiltInNudgeTemplateKind::DeliveryTask => {
-            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        BuiltInNudgeTemplateKind::Queue => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>atm read --message-id {{message_id}}</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
         }
-        BuiltInNudgeTemplateKind::DeliveryTaskAck => {
-            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        BuiltInNudgeTemplateKind::QueueAck => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>atm read --message-id {{message_id}}</action>\n  <action>ack the message</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::Task => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>atm read --message-id {{message_id}}</action>\n  <action>ack the message</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
         }
         BuiltInNudgeTemplateKind::Acknowledge => {
             "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
@@ -205,10 +208,46 @@ mod tests {
     fn render_built_in_nudge_populates_placeholders() {
         let rendered = render_built_in_nudge(
             &base_event(),
-            default_template(BuiltInNudgeTemplateKind::DeliveryTaskAck),
+            default_template(BuiltInNudgeTemplateKind::Task),
         )
         .expect("rendered template");
         assert!(rendered.contains(&format!("{TEST_LEAD}@{TEST_TEAM}")));
         assert!(rendered.contains("01KX1TEST00000000000000000"));
+    }
+
+    #[test]
+    fn all_default_templates_render_and_match_their_delivery_contract() {
+        let kinds = [
+            BuiltInNudgeTemplateKind::Delivery,
+            BuiltInNudgeTemplateKind::DeliveryAck,
+            BuiltInNudgeTemplateKind::Queue,
+            BuiltInNudgeTemplateKind::QueueAck,
+            BuiltInNudgeTemplateKind::Task,
+            BuiltInNudgeTemplateKind::Acknowledge,
+            BuiltInNudgeTemplateKind::AcknowledgeTask,
+        ];
+        for kind in kinds {
+            let body = default_template(kind);
+            assert!(!body.contains("read atm "), "legacy read action in {kind}");
+            render_built_in_nudge(&base_event(), body).expect("default template renders");
+            if matches!(
+                kind,
+                BuiltInNudgeTemplateKind::Delivery | BuiltInNudgeTemplateKind::DeliveryAck
+            ) {
+                assert!(body.contains("<when idle=\"immediate\""));
+            } else if !matches!(
+                kind,
+                BuiltInNudgeTemplateKind::Acknowledge | BuiltInNudgeTemplateKind::AcknowledgeTask
+            ) {
+                assert!(!body.contains("<when "));
+            }
+            if !matches!(
+                kind,
+                BuiltInNudgeTemplateKind::Acknowledge | BuiltInNudgeTemplateKind::AcknowledgeTask
+            ) {
+                assert!(body.contains("execute the assigned task"));
+                assert!(body.contains("atm read --message-id"));
+            }
+        }
     }
 }

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1721,6 +1721,32 @@ mod tests {
     }
 
     #[test]
+    fn set_nudge_template_override_round_trips_queue_ack_kind() {
+        let override_store = RecordingNudgeTemplateOverrideStore::default();
+        let outcome = set_nudge_template_override_with_store(
+            &override_store,
+            SetNudgeTemplateOverrideRequest::new(
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                "queue_ack",
+                "<atm/>".to_string(),
+            )
+            .expect("request"),
+        )
+        .expect("save");
+
+        assert_eq!(outcome.kind, BuiltInNudgeTemplateKind::QueueAck);
+        let saved = override_store
+            .load_template_override(
+                &TEST_TEAM.parse().expect("team"),
+                BuiltInNudgeTemplateKind::QueueAck,
+            )
+            .expect("load")
+            .expect("saved row");
+        assert_eq!(saved.template_body(), Some("<atm/>"));
+    }
+
+    #[test]
     fn disable_nudge_template_override_saves_disabled_row_through_boundary() {
         let override_store = RecordingNudgeTemplateOverrideStore::default();
         let outcome = disable_nudge_template_override_with_store(

--- a/crates/atm-core/src/write/pipeline.rs
+++ b/crates/atm-core/src/write/pipeline.rs
@@ -98,7 +98,13 @@ impl PreparedWrite {
         observability: &dyn ObservabilityPort,
     ) -> Result<WriteOutcome, AtmError> {
         let outcome = self.finish(runtime, observability)?;
-        let _ = self.mark_pending_if_deferred(runtime);
+        if let Err(error) = self.mark_pending_if_deferred(runtime) {
+            tracing::warn!(
+                message_id = %self.persisted_message_id(),
+                %error,
+                "synchronous deferred-write queue marker failed after durable write"
+            );
+        }
         Ok(outcome)
     }
 

--- a/crates/atm-core/src/write/pipeline.rs
+++ b/crates/atm-core/src/write/pipeline.rs
@@ -2,7 +2,7 @@
 //! entry family, and persisted-write preparation.
 
 use super::*;
-use crate::send::NudgeMode;
+use crate::send::{NudgeMode, send_mode_for_task_request};
 
 /// Result of the one canonical write operation.
 ///
@@ -523,6 +523,7 @@ fn prepare_persisted_write<
 ) -> Result<PreparedWrite, AtmError> {
     let mut context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
+    request.nudge_mode = send_mode_for_task_request(&request, &task_id);
     let requires_ack = request_requires_ack(&request, &task_id);
     let body = resolve_message_body(
         &request.message_source,
@@ -591,6 +592,7 @@ async fn prepare_persisted_write_async(
 ) -> Result<PreparedWrite, AtmError> {
     let mut context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
+    request.nudge_mode = send_mode_for_task_request(&request, &task_id);
     let requires_ack = request_requires_ack(&request, &task_id);
     let verified_template =
         crate::send::async_persistence::verify_template_request(runtime, &request)?;

--- a/crates/atm-core/tests/nudge_mode.rs
+++ b/crates/atm-core/tests/nudge_mode.rs
@@ -18,6 +18,56 @@ use atm_core::send::{
 };
 use atm_core::types::{AgentName, IsoTimestamp, ModelName, PaneId, TaskId, TeamName};
 
+#[derive(Default)]
+struct InMemoryAsyncStore;
+
+impl atm_storage::contract::sealed::Sealed for InMemoryAsyncStore {}
+
+impl atm_storage::MessageStore for InMemoryAsyncStore {
+    fn save_message(&self, _message: &atm_storage::Message) -> Result<(), AtmError> {
+        Ok(())
+    }
+
+    fn save_messages_atomically(&self, _messages: &[atm_storage::Message]) -> Result<(), AtmError> {
+        Ok(())
+    }
+
+    fn load_message(
+        &self,
+        _key: &atm_storage::MessageKey,
+    ) -> Result<Option<atm_storage::Message>, AtmError> {
+        Ok(None)
+    }
+
+    fn list_messages(
+        &self,
+        _query: &atm_storage::MessageQuery,
+    ) -> Result<Vec<atm_storage::Message>, AtmError> {
+        Ok(Vec::new())
+    }
+
+    fn delete_message(&self, _key: &atm_storage::MessageKey) -> Result<(), AtmError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl atm_storage::AsyncMessageStore for InMemoryAsyncStore {}
+
+/// Minimal executor matching the core's async admission tests. This fixture's
+/// in-memory async store never yields, so no Tokio runtime is needed.
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    let waker = std::task::Waker::noop();
+    let mut context = std::task::Context::from_waker(waker);
+    let mut future = std::pin::pin!(future);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            std::task::Poll::Ready(output) => return output,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
 /// Records every `mark_pending` call; every other method is a trivial no-op
 /// since this suite never exercises the durable claim/requeue lifecycle.
 #[derive(Default)]
@@ -109,12 +159,14 @@ fn setup_with_store(
     let root = tempfile::tempdir().expect("temp root");
     let assembly = atm_runtime_test_support::open_isolated_sqlite_boundary(root.path())
         .expect("sqlite runtime");
+    let async_store = Arc::new(InMemoryAsyncStore);
     let recording_store = Arc::new(RecordingPendingNudgeStore {
         fail_mark_pending,
         ..RecordingPendingNudgeStore::default()
     });
     let runtime = assembly
         .service_runtime
+        .with_async_message_store(async_store)
         .with_pending_nudge_store(recording_store.clone());
     let team: TeamName = "test-team".parse().expect("team");
     runtime
@@ -475,8 +527,8 @@ fn task_tagged_sync_prepare_forces_deferred_mode() {
     );
 }
 
-#[tokio::test]
-async fn task_tagged_async_prepare_forces_deferred_mode() {
+#[test]
+fn task_tagged_async_prepare_forces_deferred_mode() {
     let (root, runtime, _recording_store, team) = setup();
     let home_dir = root.path().join("home");
     std::fs::create_dir_all(&home_dir).expect("home dir");
@@ -488,10 +540,12 @@ async fn task_tagged_async_prepare_forces_deferred_mode() {
         IsoTimestamp::now(),
     );
 
-    let prepared =
-        atm_core::send::prepare_write_with_async_runtime(request, &NullObservability, &runtime)
-            .await
-            .expect("prepare async write");
+    let prepared = block_on(atm_core::send::prepare_write_with_async_runtime(
+        request,
+        &NullObservability,
+        &runtime,
+    ))
+    .expect("prepare async write");
     assert_eq!(
         prepared.outbound_request().nudge_mode,
         NudgeMode::Deferred,

--- a/crates/atm-core/tests/nudge_mode.rs
+++ b/crates/atm-core/tests/nudge_mode.rs
@@ -7,10 +7,11 @@
 use std::sync::{Arc, Mutex};
 
 use atm_core::boundary::{
-    MemberKey, NudgeClaim, NudgeKind, PendingNudgeStore, PostSendBuiltInTarget, PostSendHookEvent,
-    RosterHarness, RosterMemberKind, built_in_nudge_template_kind_from_post_send_event,
+    MemberKey, NudgeClaim, NudgeKind, PendingNudgeStore, PostSendBuiltInTarget, RosterHarness,
+    RosterMemberKind, built_in_nudge_template_kind_from_post_send_event,
 };
 use atm_core::error::AtmError;
+use atm_core::nudge_dispatch::rebuild_received_hook_dispatch;
 use atm_core::observability::NullObservability;
 use atm_core::schema::AtmMessageId;
 use atm_core::send::{
@@ -156,6 +157,31 @@ fn setup_with_store(
     Arc<RecordingPendingNudgeStore>,
     TeamName,
 ) {
+    let team: TeamName = "test-team".parse().expect("team");
+    setup_with_roster(
+        fail_mark_pending,
+        vec![
+            roster_member(&team, "sender", None),
+            roster_member(
+                &team,
+                "recipient",
+                Some(PaneId::from_cli("%9").expect("pane")),
+            ),
+        ],
+        false,
+    )
+}
+
+fn setup_with_roster(
+    fail_mark_pending: bool,
+    members: Vec<atm_core::boundary::RosterEntry>,
+    register_graft: bool,
+) -> (
+    tempfile::TempDir,
+    atm_core::LocalServiceRuntime,
+    Arc<RecordingPendingNudgeStore>,
+    TeamName,
+) {
     let root = tempfile::tempdir().expect("temp root");
     let assembly = atm_runtime_test_support::open_isolated_sqlite_boundary(root.path())
         .expect("sqlite runtime");
@@ -164,23 +190,39 @@ fn setup_with_store(
         fail_mark_pending,
         ..RecordingPendingNudgeStore::default()
     });
-    let runtime = assembly
+    let mut runtime = assembly
         .service_runtime
         .with_async_message_store(async_store)
         .with_pending_nudge_store(recording_store.clone());
     let team: TeamName = "test-team".parse().expect("team");
+    if register_graft {
+        let endpoint_store = atm_runtime_test_support::open_graft_receiver_endpoint_store(
+            root.path().join("runtime").join("mail.sqlite3"),
+        )
+        .expect("graft endpoint store");
+        endpoint_store
+            .register(
+                &atm_storage::GraftReceiverRegistration {
+                    team: team.clone(),
+                    agent: "graft-recipient".parse().expect("graft recipient"),
+                    endpoint: "127.0.0.1:9".parse().expect("endpoint"),
+                    capability: atm_core::local_http::LocalCapability::generate()
+                        .expect("capability"),
+                    owner_generation: atm_storage::OwnerGeneration::new(
+                        "01J00000000000000000000000",
+                    )
+                    .expect("owner generation"),
+                },
+                IsoTimestamp::now().into_inner(),
+            )
+            .expect("register graft recipient");
+        runtime = runtime.with_graft_receiver_endpoint_store(endpoint_store);
+    }
     runtime
         .shared_roster_store_arc()
         .save_roster(&atm_storage::RosterSnapshot {
             team_name: team.clone(),
-            members: vec![
-                roster_member(&team, "sender", None),
-                roster_member(
-                    &team,
-                    "recipient",
-                    Some(PaneId::from_cli("%9").expect("pane")),
-                ),
-            ],
+            members,
             refreshed_at: None,
         })
         .expect("seed roster");
@@ -204,6 +246,25 @@ fn roster_member(
     }
 }
 
+fn herdr_roster_member(team: &TeamName, agent: &str) -> atm_core::boundary::RosterEntry {
+    let mut metadata = atm_core::delivery_channel::test_backend_type_metadata("herdr");
+    metadata.insert("herdrSession".to_owned(), serde_json::json!("ax1-herdr"));
+    atm_core::boundary::RosterEntry {
+        team_name: team.clone(),
+        agent_name: agent.parse().expect("agent"),
+        member_kind: RosterMemberKind::Permanent,
+        harness: RosterHarness::CodexCli,
+        agent_type: atm_core::schema::AgentType::default(),
+        model: ModelName::default(),
+        recipient_pane_id: None,
+        metadata_json: metadata,
+    }
+}
+
+fn graft_roster_member(team: &TeamName) -> atm_core::boundary::RosterEntry {
+    roster_member(team, "graft-recipient", None)
+}
+
 fn write_request(
     home_dir: &std::path::Path,
     team: &TeamName,
@@ -211,20 +272,48 @@ fn write_request(
     message_id: AtmMessageId,
     timestamp: IsoTimestamp,
 ) -> WriteRequest {
+    write_request_for(
+        home_dir,
+        team,
+        "recipient",
+        WriteRequestOptions {
+            nudge_mode,
+            requires_ack: false,
+            task_id: None,
+        },
+        message_id,
+        timestamp,
+    )
+}
+
+struct WriteRequestOptions {
+    nudge_mode: NudgeMode,
+    requires_ack: bool,
+    task_id: Option<TaskId>,
+}
+
+fn write_request_for(
+    home_dir: &std::path::Path,
+    team: &TeamName,
+    recipient: &str,
+    options: WriteRequestOptions,
+    message_id: AtmMessageId,
+    timestamp: IsoTimestamp,
+) -> WriteRequest {
     WriteRequest::new(
         home_dir.to_path_buf(),
         home_dir.to_path_buf(),
         "sender".parse::<AgentName>().expect("sender"),
-        "recipient@test-team",
+        &format!("{recipient}@{team}"),
         team.clone(),
         SendMessageSource::Inline("nudge mode fixture".to_owned()),
         None,
-        false,
-        None,
+        options.requires_ack,
+        options.task_id,
         false,
     )
     .expect("write request")
-    .with_nudge_mode(nudge_mode)
+    .with_nudge_mode(options.nudge_mode)
     .with_origin_metadata(message_id, timestamp)
 }
 
@@ -235,9 +324,18 @@ fn task_write_request(
     message_id: AtmMessageId,
     timestamp: IsoTimestamp,
 ) -> WriteRequest {
-    let mut request = write_request(home_dir, team, nudge_mode, message_id, timestamp);
-    request.task_id = Some("task-ax1".parse::<TaskId>().expect("task id"));
-    request
+    write_request_for(
+        home_dir,
+        team,
+        "recipient",
+        WriteRequestOptions {
+            nudge_mode,
+            requires_ack: false,
+            task_id: Some("task-ax1".parse::<TaskId>().expect("task id")),
+        },
+        message_id,
+        timestamp,
+    )
 }
 
 #[test]
@@ -553,59 +651,258 @@ fn task_tagged_async_prepare_forces_deferred_mode() {
     );
 }
 
-#[test]
-fn tmux_and_herdr_delivery_families_share_the_nudge_kind_table() {
-    let event = |requires_ack, task_id| PostSendHookEvent {
-        sender: "sender".parse().expect("sender"),
-        sender_chat_id: None,
-        sender_team: "test-team".parse().expect("sender team"),
-        sender_host: None,
-        recipient: "recipient".parse().expect("recipient"),
-        recipient_team: "test-team".parse().expect("recipient team"),
-        message_id: AtmMessageId::new(),
-        description: "fixture".to_owned(),
-        requires_ack,
-        is_ack: false,
-        task_id,
-        recipient_pane_id: None,
-    };
-    let task_id = Some("task-ax1".parse::<TaskId>().expect("task id"));
-    for backend in ["tmux", "herdr"] {
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(
-                &event(false, None),
-                NudgeKind::Steer,
-            ),
-            atm_core::boundary::BuiltInNudgeTemplateKind::Delivery,
-            "{backend} Delivery"
-        );
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event(true, None), NudgeKind::Steer,),
-            atm_core::boundary::BuiltInNudgeTemplateKind::DeliveryAck,
-            "{backend} DeliveryAck"
-        );
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(
-                &event(false, None),
-                NudgeKind::Queue,
-            ),
-            atm_core::boundary::BuiltInNudgeTemplateKind::Queue,
-            "{backend} Queue"
-        );
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event(true, None), NudgeKind::Queue,),
-            atm_core::boundary::BuiltInNudgeTemplateKind::QueueAck,
-            "{backend} QueueAck"
-        );
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(
-                &event(true, task_id.clone()),
-                NudgeKind::Queue,
-            ),
-            atm_core::boundary::BuiltInNudgeTemplateKind::Task,
-            "{backend} task"
-        );
+fn assert_local_target(dispatch: &atm_core::boundary::BuiltInPostSendDispatch, herdr: bool) {
+    if herdr {
+        assert!(matches!(
+            dispatch.target,
+            PostSendBuiltInTarget::LocalSteer(atm_core::boundary::LocalSteerTarget::Herdr(_))
+        ));
+    } else {
+        assert!(matches!(
+            dispatch.target,
+            PostSendBuiltInTarget::LocalSteer(atm_core::boundary::LocalSteerTarget::Tmux(_))
+        ));
     }
+}
+
+fn assert_local_matrix(herdr: bool) {
+    let team: TeamName = "test-team".parse().expect("team");
+    let recipient = if herdr {
+        herdr_roster_member(&team, "recipient")
+    } else {
+        roster_member(
+            &team,
+            "recipient",
+            Some(PaneId::from_cli("%9").expect("pane")),
+        )
+    };
+    let (root, runtime, recording_store, _) = setup_with_roster(
+        false,
+        vec![roster_member(&team, "sender", None), recipient],
+        false,
+    );
+    let home_dir = root.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+
+    let immediate = |requires_ack, expected_kind| {
+        let mut prepared = prepare_write_with_runtime(
+            write_request_for(
+                &home_dir,
+                &team,
+                "recipient",
+                WriteRequestOptions {
+                    nudge_mode: NudgeMode::Immediate,
+                    requires_ack,
+                    task_id: None,
+                },
+                AtmMessageId::new(),
+                IsoTimestamp::now(),
+            ),
+            &NullObservability,
+            &runtime,
+        )
+        .expect("prepare immediate write");
+        let dispatches = prepared
+            .build_received_hook_dispatches(&runtime)
+            .expect("build immediate dispatch");
+        assert_eq!(dispatches.len(), 1);
+        assert_local_target(&dispatches[0], herdr);
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(
+                &dispatches[0].event,
+                dispatches[0].kind,
+            ),
+            expected_kind,
+        );
+        prepared
+            .finish(&runtime, &NullObservability)
+            .expect("finish immediate write");
+    };
+    immediate(
+        false,
+        atm_core::boundary::BuiltInNudgeTemplateKind::Delivery,
+    );
+    immediate(
+        true,
+        atm_core::boundary::BuiltInNudgeTemplateKind::DeliveryAck,
+    );
+
+    let queued = |requires_ack, expected_kind| {
+        let message_id = AtmMessageId::new();
+        let mut prepared = prepare_write_with_runtime(
+            write_request_for(
+                &home_dir,
+                &team,
+                "recipient",
+                WriteRequestOptions {
+                    nudge_mode: NudgeMode::Deferred,
+                    requires_ack,
+                    task_id: None,
+                },
+                message_id,
+                IsoTimestamp::now(),
+            ),
+            &NullObservability,
+            &runtime,
+        )
+        .expect("prepare queued write");
+        assert!(
+            prepared
+                .build_received_hook_dispatches(&runtime)
+                .expect("deferred local dispatch")
+                .is_empty()
+        );
+        prepared
+            .finish(&runtime, &NullObservability)
+            .expect("finish queued write");
+        prepared
+            .mark_pending_if_deferred(&runtime)
+            .expect("mark queued write");
+        let member = MemberKey::new(team.clone(), "recipient".parse().expect("recipient"));
+        let dispatch =
+            rebuild_received_hook_dispatch(&runtime, &member, message_id, NudgeKind::Queue)
+                .expect("rebuild queued dispatch")
+                .expect("queued dispatch");
+        assert_local_target(&dispatch, herdr);
+        assert_eq!(dispatch.kind, NudgeKind::Queue);
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&dispatch.event, dispatch.kind),
+            expected_kind,
+        );
+    };
+    queued(false, atm_core::boundary::BuiltInNudgeTemplateKind::Queue);
+    queued(true, atm_core::boundary::BuiltInNudgeTemplateKind::QueueAck);
+
+    let task = |mode| {
+        let message_id = AtmMessageId::new();
+        let mut prepared = prepare_write_with_runtime(
+            write_request_for(
+                &home_dir,
+                &team,
+                "recipient",
+                WriteRequestOptions {
+                    nudge_mode: mode,
+                    requires_ack: false,
+                    task_id: Some("task-ax1".parse().expect("task id")),
+                },
+                message_id,
+                IsoTimestamp::now(),
+            ),
+            &NullObservability,
+            &runtime,
+        )
+        .expect("prepare task write");
+        assert_eq!(
+            prepared.outbound_request().nudge_mode,
+            NudgeMode::Deferred,
+            "task writes are deferred for every local backend"
+        );
+        assert!(
+            prepared
+                .build_received_hook_dispatches(&runtime)
+                .expect("deferred task dispatch")
+                .is_empty()
+        );
+        prepared
+            .finish(&runtime, &NullObservability)
+            .expect("finish task write");
+        prepared
+            .mark_pending_if_deferred(&runtime)
+            .expect("mark task write");
+        let member = MemberKey::new(team.clone(), "recipient".parse().expect("recipient"));
+        let dispatch =
+            rebuild_received_hook_dispatch(&runtime, &member, message_id, NudgeKind::Queue)
+                .expect("rebuild task dispatch")
+                .expect("task dispatch");
+        assert_local_target(&dispatch, herdr);
+        assert_eq!(dispatch.kind, NudgeKind::Queue);
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&dispatch.event, dispatch.kind),
+            atm_core::boundary::BuiltInNudgeTemplateKind::Task,
+        );
+    };
+    task(NudgeMode::Immediate);
+    task(NudgeMode::Deferred);
+
+    assert_eq!(
+        recording_store.mark_pending_call_count(),
+        4,
+        "every deferred local write sets one durable marker"
+    );
+}
+
+#[test]
+fn actual_dispatch_matrix_covers_tmux_and_herdr_members() {
+    assert_local_matrix(false);
+    assert_local_matrix(true);
+}
+
+fn assert_graft_task_dispatch(async_path: bool) {
+    let team: TeamName = "test-team".parse().expect("team");
+    let (root, runtime, _recording_store, _) = setup_with_roster(
+        false,
+        vec![
+            roster_member(&team, "sender", None),
+            graft_roster_member(&team),
+        ],
+        true,
+    );
+    let home_dir = root.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let message_id = AtmMessageId::new();
+    let request = write_request_for(
+        &home_dir,
+        &team,
+        "graft-recipient",
+        WriteRequestOptions {
+            nudge_mode: NudgeMode::Immediate,
+            requires_ack: false,
+            task_id: Some("task-ax1".parse().expect("task id")),
+        },
+        message_id,
+        IsoTimestamp::now(),
+    );
+    let mut prepared = if async_path {
+        block_on(atm_core::send::prepare_write_with_async_runtime(
+            request,
+            &NullObservability,
+            &runtime,
+        ))
+        .expect("prepare async graft task write")
+    } else {
+        prepare_write_with_runtime(request, &NullObservability, &runtime)
+            .expect("prepare sync graft task write")
+    };
+    assert_eq!(
+        prepared.outbound_request().nudge_mode,
+        NudgeMode::Deferred,
+        "graft task writes are deferred before queue handoff"
+    );
+    let dispatches = prepared
+        .build_received_hook_dispatches(&runtime)
+        .expect("build graft task dispatch");
+    assert_eq!(dispatches.len(), 1);
+    assert!(matches!(
+        dispatches[0].target,
+        PostSendBuiltInTarget::Graft(_)
+    ));
+    assert_eq!(dispatches[0].kind, NudgeKind::Queue);
+    assert_eq!(
+        built_in_nudge_template_kind_from_post_send_event(&dispatches[0].event, dispatches[0].kind,),
+        atm_core::boundary::BuiltInNudgeTemplateKind::Task,
+    );
+    prepared
+        .finish(&runtime, &NullObservability)
+        .expect("finish graft task write");
+    prepared
+        .mark_pending_if_deferred(&runtime)
+        .expect("mark graft task write");
+}
+
+#[test]
+fn sync_and_async_graft_task_writes_use_the_queue_dispatch_kind() {
+    assert_graft_task_dispatch(false);
+    assert_graft_task_dispatch(true);
 }
 
 #[test]

--- a/crates/atm-core/tests/nudge_mode.rs
+++ b/crates/atm-core/tests/nudge_mode.rs
@@ -7,8 +7,8 @@
 use std::sync::{Arc, Mutex};
 
 use atm_core::boundary::{
-    MemberKey, NudgeClaim, PendingNudgeStore, PostSendBuiltInTarget, RosterHarness,
-    RosterMemberKind,
+    MemberKey, NudgeClaim, NudgeKind, PendingNudgeStore, PostSendBuiltInTarget, PostSendHookEvent,
+    RosterHarness, RosterMemberKind, built_in_nudge_template_kind_from_post_send_event,
 };
 use atm_core::error::AtmError;
 use atm_core::observability::NullObservability;
@@ -16,7 +16,7 @@ use atm_core::schema::AtmMessageId;
 use atm_core::send::{
     NudgeMode, SendMessageSource, WriteRequest, prepare_write_with_runtime, write_mail_with_runtime,
 };
-use atm_core::types::{AgentName, IsoTimestamp, ModelName, PaneId, TeamName};
+use atm_core::types::{AgentName, IsoTimestamp, ModelName, PaneId, TaskId, TeamName};
 
 /// Records every `mark_pending` call; every other method is a trivial no-op
 /// since this suite never exercises the durable claim/requeue lifecycle.
@@ -174,6 +174,18 @@ fn write_request(
     .expect("write request")
     .with_nudge_mode(nudge_mode)
     .with_origin_metadata(message_id, timestamp)
+}
+
+fn task_write_request(
+    home_dir: &std::path::Path,
+    team: &TeamName,
+    nudge_mode: NudgeMode,
+    message_id: AtmMessageId,
+    timestamp: IsoTimestamp,
+) -> WriteRequest {
+    let mut request = write_request(home_dir, team, nudge_mode, message_id, timestamp);
+    request.task_id = Some("task-ax1".parse::<TaskId>().expect("task id"));
+    request
 }
 
 #[test]
@@ -438,5 +450,120 @@ fn failing_marker_store_does_not_fail_the_deferred_write() {
         failing_store.mark_pending_call_count(),
         1,
         "the failing store double must exercise the marker error path"
+    );
+}
+
+#[test]
+fn task_tagged_sync_prepare_forces_deferred_mode() {
+    let (root, runtime, _recording_store, team) = setup();
+    let home_dir = root.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let request = task_write_request(
+        &home_dir,
+        &team,
+        NudgeMode::Immediate,
+        AtmMessageId::new(),
+        IsoTimestamp::now(),
+    );
+
+    let prepared =
+        prepare_write_with_runtime(request, &NullObservability, &runtime).expect("prepare write");
+    assert_eq!(
+        prepared.outbound_request().nudge_mode,
+        NudgeMode::Deferred,
+        "task-tagged sync writes are always queued"
+    );
+}
+
+#[tokio::test]
+async fn task_tagged_async_prepare_forces_deferred_mode() {
+    let (root, runtime, _recording_store, team) = setup();
+    let home_dir = root.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    let request = task_write_request(
+        &home_dir,
+        &team,
+        NudgeMode::Immediate,
+        AtmMessageId::new(),
+        IsoTimestamp::now(),
+    );
+
+    let prepared =
+        atm_core::send::prepare_write_with_async_runtime(request, &NullObservability, &runtime)
+            .await
+            .expect("prepare async write");
+    assert_eq!(
+        prepared.outbound_request().nudge_mode,
+        NudgeMode::Deferred,
+        "task-tagged async writes are always queued"
+    );
+}
+
+#[test]
+fn tmux_and_herdr_delivery_families_share_the_nudge_kind_table() {
+    let event = |requires_ack, task_id| PostSendHookEvent {
+        sender: "sender".parse().expect("sender"),
+        sender_chat_id: None,
+        sender_team: "test-team".parse().expect("sender team"),
+        sender_host: None,
+        recipient: "recipient".parse().expect("recipient"),
+        recipient_team: "test-team".parse().expect("recipient team"),
+        message_id: AtmMessageId::new(),
+        description: "fixture".to_owned(),
+        requires_ack,
+        is_ack: false,
+        task_id,
+        recipient_pane_id: None,
+    };
+    let task_id = Some("task-ax1".parse::<TaskId>().expect("task id"));
+    for backend in ["tmux", "herdr"] {
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(
+                &event(false, None),
+                NudgeKind::Steer,
+            ),
+            atm_core::boundary::BuiltInNudgeTemplateKind::Delivery,
+            "{backend} Delivery"
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&event(true, None), NudgeKind::Steer,),
+            atm_core::boundary::BuiltInNudgeTemplateKind::DeliveryAck,
+            "{backend} DeliveryAck"
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(
+                &event(false, None),
+                NudgeKind::Queue,
+            ),
+            atm_core::boundary::BuiltInNudgeTemplateKind::Queue,
+            "{backend} Queue"
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&event(true, None), NudgeKind::Queue,),
+            atm_core::boundary::BuiltInNudgeTemplateKind::QueueAck,
+            "{backend} QueueAck"
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(
+                &event(true, task_id.clone()),
+                NudgeKind::Queue,
+            ),
+            atm_core::boundary::BuiltInNudgeTemplateKind::Task,
+            "{backend} task"
+        );
+    }
+}
+
+#[test]
+fn acknowledge_default_templates_match_recorded_pre_ax1_fixtures() {
+    assert_eq!(
+        atm_core::send::default_template(atm_core::boundary::BuiltInNudgeTemplateKind::Acknowledge),
+        "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
+    );
+    assert_eq!(
+        atm_core::send::default_template(
+            atm_core::boundary::BuiltInNudgeTemplateKind::AcknowledgeTask
+        ),
+        "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\" task-id=\"{{task_id}}\"/>"
     );
 }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -31,6 +31,7 @@ mod shared_db_reader_lanes;
 mod team_roster_schema;
 mod template_catalog_schema;
 mod template_catalog_store;
+mod template_override_migration;
 mod writer;
 
 pub use reader_pool::{ReaderLaneMetricsSnapshot, ReaderLanesMetricsSnapshot};

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -28,6 +28,7 @@ mod search_store;
 mod shared_db;
 mod shared_db_diagnostics;
 mod shared_db_reader_lanes;
+mod shared_db_support;
 mod team_roster_schema;
 mod template_catalog_schema;
 mod template_catalog_store;

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -233,6 +233,29 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_override_store_round_trips_queue_family_and_task_kinds() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let team = "test-team".parse().expect("team");
+        for (kind, body) in [
+            (BuiltInNudgeTemplateKind::Queue, "<queue/>"),
+            (BuiltInNudgeTemplateKind::QueueAck, "<queue-ack/>"),
+            (BuiltInNudgeTemplateKind::Task, "<task/>"),
+        ] {
+            backend
+                .nudge_template_override_store()
+                .save_template_override(&team, kind, body)
+                .expect("save");
+            let row = backend
+                .nudge_template_override_store()
+                .load_template_override(&team, kind)
+                .expect("lookup")
+                .expect("row");
+            assert_eq!(row.kind, kind);
+            assert_eq!(row.template_body(), Some(body));
+        }
+    }
+
+    #[test]
     fn sqlite_override_store_returns_none_for_missing_row() {
         let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
 

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -271,6 +271,43 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_override_store_returns_none_for_retired_kind_after_migration() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let db = backend.shared_db_for_test();
+        db.with_connection(|connection| {
+            connection
+                .execute_batch(
+                    "DROP TABLE team_nudge_template_overrides;
+                     CREATE TABLE team_nudge_template_overrides (
+                         team_name TEXT NOT NULL,
+                         template_kind TEXT NOT NULL CHECK(template_kind IN (
+                             'delivery', 'delivery_ack', 'delivery_task', 'delivery_task_ack',
+                             'acknowledge', 'acknowledge_task'
+                         )),
+                         template_body TEXT NOT NULL,
+                         updated_at TEXT NOT NULL,
+                         PRIMARY KEY (team_name, template_kind)
+                     );
+                     INSERT INTO team_nudge_template_overrides
+                         (team_name, template_kind, template_body, updated_at)
+                     VALUES ('test-team', 'delivery_task', '<retired/>', '2026-09-05T00:00:00Z');",
+                )
+                .map_err(|error| db.error("failed to seed retired override row", error))?;
+            crate::shared_db::ensure_schema(connection, db.target())
+        })
+        .expect("migrate retired override row");
+
+        let row = backend
+            .nudge_template_override_store()
+            .load_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::Task,
+            )
+            .expect("lookup");
+        assert!(row.is_none());
+    }
+
+    #[test]
     fn sqlite_override_store_returns_none_after_override_row_is_deleted() {
         let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
         let team = "test-team".parse().expect("team");

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -717,77 +717,55 @@ fn ensure_team_nudge_template_override_columns(
     Ok(())
 }
 
-fn migrate_template_override_kinds_to_seven(
-    connection: &mut Connection,
+type TemplateOverrideRow = (String, String, String, String, String);
+
+fn load_template_override_rows(
+    connection: &Connection,
     target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    let table_sql = connection
-        .query_row(
-            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
-            [],
-            |row| row.get::<_, Option<String>>(0),
+) -> Result<Vec<TemplateOverrideRow>, AtmError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT team_name, template_kind, mode, template_body, updated_at
+             FROM team_nudge_template_overrides;",
         )
         .map_err(|error| {
             sqlite_error(
                 target,
-                "failed to inspect nudge-template override schema",
+                "failed to read nudge-template overrides for migration",
                 error,
             )
         })?;
-    let Some(table_sql) = table_sql else {
-        return Ok(());
-    };
-    if table_sql.to_ascii_lowercase().contains("'queue'") {
-        return Ok(());
-    }
-
-    let rows = {
-        let mut statement = connection
-            .prepare(
-                "SELECT team_name, template_kind, mode, template_body, updated_at
-                 FROM team_nudge_template_overrides;",
+    statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to enumerate nudge-template overrides for migration",
+                error,
             )
-            .map_err(|error| {
-                sqlite_error(
-                    target,
-                    "failed to read nudge-template overrides for migration",
-                    error,
-                )
-            })?;
-        statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, String>(3)?,
-                    row.get::<_, String>(4)?,
-                ))
-            })
-            .map_err(|error| {
-                sqlite_error(
-                    target,
-                    "failed to enumerate nudge-template overrides for migration",
-                    error,
-                )
-            })?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| {
-                sqlite_error(
-                    target,
-                    "failed to read nudge-template override row for migration",
-                    error,
-                )
-            })?
-    };
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to read nudge-template override row for migration",
+                error,
+            )
+        })
+}
 
-    let transaction = connection.transaction().map_err(|error| {
-        sqlite_error(
-            target,
-            "failed to begin nudge-template override migration",
-            error,
-        )
-    })?;
+fn create_seven_kind_override_table(
+    transaction: &rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
     transaction
         .execute_batch(
             "CREATE TABLE team_template_overrides_rebuild (
@@ -810,8 +788,14 @@ fn migrate_template_override_kinds_to_seven(
                 "failed to create seven-kind nudge-template override table",
                 error,
             )
-        })?;
+        })
+}
 
+fn copy_seven_kind_override_rows(
+    transaction: &rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+    rows: Vec<TemplateOverrideRow>,
+) -> Result<(), AtmError> {
     for (team_name, template_kind, mode, template_body, updated_at) in rows {
         if matches!(
             template_kind.as_str(),
@@ -853,7 +837,13 @@ fn migrate_template_override_kinds_to_seven(
                 )
             })?;
     }
+    Ok(())
+}
 
+fn replace_override_table(
+    transaction: rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
     transaction
         .execute_batch(
             "DROP TABLE team_nudge_template_overrides;
@@ -875,6 +865,44 @@ fn migrate_template_override_kinds_to_seven(
             error,
         )
     })
+}
+
+fn migrate_template_override_kinds_to_seven(
+    connection: &mut Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let table_sql = connection
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to inspect nudge-template override schema",
+                error,
+            )
+        })?;
+    let Some(table_sql) = table_sql else {
+        return Ok(());
+    };
+    if table_sql.to_ascii_lowercase().contains("'queue'") {
+        return Ok(());
+    }
+
+    let rows = load_template_override_rows(connection, target)?;
+
+    let transaction = connection.transaction().map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to begin nudge-template override migration",
+            error,
+        )
+    })?;
+    create_seven_kind_override_table(&transaction, target)?;
+    copy_seven_kind_override_rows(&transaction, target, rows)?;
+    replace_override_table(transaction, target)
 }
 
 fn ensure_mail_message_states_nudge_columns(

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -80,8 +80,9 @@ CREATE TABLE IF NOT EXISTS team_nudge_template_overrides (
         CHECK(template_kind IN (
             'delivery',
             'delivery_ack',
-            'delivery_task',
-            'delivery_task_ack',
+            'queue',
+            'queue_ack',
+            'task',
             'acknowledge',
             'acknowledge_task'
         )),
@@ -579,6 +580,7 @@ pub(crate) fn ensure_schema(
     ensure_team_roster_columns(connection, target)?;
     crate::team_roster_schema::ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
+    migrate_template_override_kinds_to_seven(connection, target)?;
     ensure_mail_message_states_nudge_columns(connection, target)?;
     crate::graft_receiver_endpoint_schema::ensure_schema(connection, target)?;
     ensure_column(
@@ -713,6 +715,166 @@ fn ensure_team_nudge_template_override_columns(
             )
         })?;
     Ok(())
+}
+
+fn migrate_template_override_kinds_to_seven(
+    connection: &mut Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let table_sql = connection
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to inspect nudge-template override schema",
+                error,
+            )
+        })?;
+    let Some(table_sql) = table_sql else {
+        return Ok(());
+    };
+    if table_sql.to_ascii_lowercase().contains("'queue'") {
+        return Ok(());
+    }
+
+    let rows = {
+        let mut statement = connection
+            .prepare(
+                "SELECT team_name, template_kind, mode, template_body, updated_at
+                 FROM team_nudge_template_overrides;",
+            )
+            .map_err(|error| {
+                sqlite_error(
+                    target,
+                    "failed to read nudge-template overrides for migration",
+                    error,
+                )
+            })?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })
+            .map_err(|error| {
+                sqlite_error(
+                    target,
+                    "failed to enumerate nudge-template overrides for migration",
+                    error,
+                )
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                sqlite_error(
+                    target,
+                    "failed to read nudge-template override row for migration",
+                    error,
+                )
+            })?
+    };
+
+    let transaction = connection.transaction().map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to begin nudge-template override migration",
+            error,
+        )
+    })?;
+    transaction
+        .execute_batch(
+            "CREATE TABLE team_template_overrides_rebuild (
+                team_name TEXT NOT NULL,
+                template_kind TEXT NOT NULL
+                    CHECK(template_kind IN (
+                        'delivery', 'delivery_ack', 'queue', 'queue_ack', 'task',
+                        'acknowledge', 'acknowledge_task'
+                    )),
+                mode TEXT NOT NULL DEFAULT 'override'
+                    CHECK(mode IN ('override', 'disabled')),
+                template_body TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (team_name, template_kind)
+            );",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to create seven-kind nudge-template override table",
+                error,
+            )
+        })?;
+
+    for (team_name, template_kind, mode, template_body, updated_at) in rows {
+        if matches!(
+            template_kind.as_str(),
+            "delivery_task" | "delivery_task_ack"
+        ) {
+            tracing::warn!(
+                team = %team_name,
+                kind = %template_kind,
+                "dropping retired nudge-template override during seven-kind migration"
+            );
+            continue;
+        }
+        if !matches!(
+            template_kind.as_str(),
+            "delivery"
+                | "delivery_ack"
+                | "queue"
+                | "queue_ack"
+                | "task"
+                | "acknowledge"
+                | "acknowledge_task"
+        ) {
+            return Err(AtmError::validation(format!(
+                "cannot migrate unknown nudge-template kind `{template_kind}` for team `{team_name}`"
+            )));
+        }
+        transaction
+            .execute(
+                "INSERT INTO team_template_overrides_rebuild
+                    (team_name, template_kind, mode, template_body, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5);",
+                rusqlite::params![team_name, template_kind, mode, template_body, updated_at],
+            )
+            .map_err(|error| {
+                sqlite_error(
+                    target,
+                    "failed to copy nudge-template override during seven-kind migration",
+                    error,
+                )
+            })?;
+    }
+
+    transaction
+        .execute_batch(
+            "DROP TABLE team_nudge_template_overrides;
+             ALTER TABLE team_template_overrides_rebuild RENAME TO team_nudge_template_overrides;
+             CREATE INDEX IF NOT EXISTS idx_team_nudge_template_overrides_team_name
+                 ON team_nudge_template_overrides(team_name);",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to replace nudge-template override table",
+                error,
+            )
+        })?;
+    transaction.commit().map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to commit seven-kind nudge-template override migration",
+            error,
+        )
+    })
 }
 
 fn ensure_mail_message_states_nudge_columns(
@@ -1345,6 +1507,90 @@ mod tests {
             )
             .expect("query migrated mode");
         assert_eq!(mode, "disabled");
+    }
+
+    #[test]
+    fn ensure_schema_rebuilds_six_kind_override_table_and_is_idempotent() {
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:atm-storage-rusqlite-shared-db-test-{}?mode=memory&cache=shared",
+                NEXT_IN_MEMORY_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_connection_for_target(&target).expect("open connection");
+        connection
+            .execute_batch(
+                "CREATE TABLE team_nudge_template_overrides (
+                    team_name TEXT NOT NULL,
+                    template_kind TEXT NOT NULL CHECK(template_kind IN (
+                        'delivery', 'delivery_ack', 'delivery_task', 'delivery_task_ack',
+                        'acknowledge', 'acknowledge_task'
+                    )),
+                    template_body TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (team_name, template_kind)
+                );
+                INSERT INTO team_nudge_template_overrides
+                    (team_name, template_kind, template_body, updated_at)
+                VALUES
+                    ('test-team', 'delivery_task', '<old-task/>', '2026-09-05T00:00:00Z'),
+                    ('test-team', 'delivery_ack', '<delivery-ack/>', '2026-09-05T00:00:00Z');",
+            )
+            .expect("create six-kind table");
+
+        ensure_schema(&mut connection, &target).expect("migrate six-kind table");
+
+        let row_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM team_nudge_template_overrides WHERE team_name = 'test-team';",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count migrated rows");
+        assert_eq!(row_count, 1, "only the retired row should be dropped");
+        let retained_kind: String = connection
+            .query_row(
+                "SELECT template_kind FROM team_nudge_template_overrides WHERE team_name = 'test-team';",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read retained row");
+        assert_eq!(retained_kind, "delivery_ack");
+        connection
+            .execute(
+                "INSERT INTO team_nudge_template_overrides
+                    (team_name, template_kind, mode, template_body, updated_at)
+                 VALUES ('test-team', 'queue_ack', 'override', '<queue-ack/>', '2026-09-05T00:00:00Z');",
+                [],
+            )
+            .expect("new queue kind should satisfy migrated check");
+        let schema_sql: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read migrated schema");
+        assert!(schema_sql.contains("'queue'"));
+
+        let schema_before_second_open = schema_sql.clone();
+        ensure_schema(&mut connection, &target).expect("second schema ensure");
+        let schema_after_second_open: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read schema after second open");
+        assert_eq!(schema_after_second_open, schema_before_second_open);
+        let row_count_after_second_open: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM team_nudge_template_overrides WHERE team_name = 'test-team';",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count rows after second open");
+        assert_eq!(row_count_after_second_open, 2);
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -136,26 +136,9 @@ DROP TABLE IF EXISTS peer_sync_policies;
 // `team_roster` is the single canonical durable roster truth. Runtime pid
 // continuity is transient daemon-owned state and must not be persisted here.
 
-pub(crate) type SqliteConnection = Connection;
-
-#[derive(Debug, Clone)]
-pub(crate) enum SharedDbTarget {
-    Path(PathBuf),
-    #[cfg(test)]
-    InMemory {
-        uri: String,
-    },
-}
-
-impl SharedDbTarget {
-    pub(crate) fn display(&self) -> String {
-        match self {
-            Self::Path(path) => path.display().to_string(),
-            #[cfg(test)]
-            Self::InMemory { uri } => uri.clone(),
-        }
-    }
-}
+pub(crate) use crate::shared_db_support::{
+    SharedDbTarget, SqliteConnection, ensure_column, sqlite_error, sqlite_open_error,
+};
 
 /// Test-only instrumentation at the concrete SQLite open sites. Entries are
 /// keyed by the target so parallel tests cannot contaminate each other's
@@ -749,55 +732,6 @@ fn ensure_mail_messages_message_id_compat(
     )
 }
 
-pub(crate) fn ensure_column(
-    connection: &Connection,
-    target: &SharedDbTarget,
-    table: &str,
-    column: &str,
-    ddl: &str,
-) -> Result<(), AtmError> {
-    let mut statement = connection
-        .prepare(&format!("PRAGMA table_info({table});"))
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                format!("failed to inspect sqlite table {table}"),
-                error,
-            )
-        })?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>(1))
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                format!("failed to enumerate sqlite columns for {table}"),
-                error,
-            )
-        })?;
-    let collected = columns
-        .into_iter()
-        .map(|entry| {
-            entry.map_err(|error| {
-                sqlite_error(
-                    target,
-                    format!("failed to read sqlite column metadata for {table}"),
-                    error,
-                )
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    if collected.into_iter().any(|value| value == column) {
-        return Ok(());
-    }
-    connection.execute_batch(ddl).map_err(|error| {
-        sqlite_error(
-            target,
-            format!("failed to migrate sqlite table {table}"),
-            error,
-        )
-    })
-}
-
 fn table_exists(
     connection: &Connection,
     target: &SharedDbTarget,
@@ -817,57 +751,6 @@ fn table_exists(
                 error,
             )
         })
-}
-
-pub(crate) fn sqlite_open_error(target: &SharedDbTarget, source: RusqliteError) -> AtmError {
-    sqlite_error(
-        target,
-        format!("failed to open sqlite database {}", target.display()),
-        source,
-    )
-}
-
-pub(crate) fn sqlite_error(
-    target: &SharedDbTarget,
-    message: impl Into<String>,
-    source: RusqliteError,
-) -> AtmError {
-    let message = message.into();
-    // Every arm keeps the stable code/message contract; the raw SQLite
-    // failure rides along as the machine-preserved cause so a constraint
-    // violation or schema mismatch is diagnosable from the surfaced error.
-    let error =
-        match &source {
-            RusqliteError::SqliteFailure(error, _) => match error.code {
-                rusqlite::ffi::ErrorCode::ConstraintViolation => AtmError::validation(message),
-                rusqlite::ffi::ErrorCode::DatabaseBusy
-                | rusqlite::ffi::ErrorCode::DatabaseLocked => match target {
-                    SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
-                    #[cfg(test)]
-                    SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(format!(
-                        "timed out waiting for sqlite database lock on {}",
-                        target.display()
-                    )),
-                },
-                rusqlite::ffi::ErrorCode::OperationInterrupted => match target {
-                    SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
-                    #[cfg(test)]
-                    SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(
-                        "sqlite query exceeded its caller-provided execution budget",
-                    ),
-                },
-                rusqlite::ffi::ErrorCode::CannotOpen => AtmError::mailbox_write(message),
-                rusqlite::ffi::ErrorCode::ReadOnly => AtmError::mailbox_write(message),
-                rusqlite::ffi::ErrorCode::DatabaseCorrupt
-                | rusqlite::ffi::ErrorCode::NotADatabase => AtmError::mailbox_read(message),
-                rusqlite::ffi::ErrorCode::SystemIoFailure | rusqlite::ffi::ErrorCode::DiskFull => {
-                    AtmError::mailbox_write(message)
-                }
-                _ => AtmError::mailbox_write(message),
-            },
-            _ => AtmError::mailbox_write(message),
-        };
-    error.with_cause(source)
 }
 
 fn json_error(message: impl Into<String>, source: serde_json::Error) -> AtmError {

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -579,8 +579,12 @@ pub(crate) fn ensure_schema(
     crate::search_schema::ensure_schema(connection, target)?;
     ensure_team_roster_columns(connection, target)?;
     crate::team_roster_schema::ensure_team_roster_harness_values(connection, target)?;
-    ensure_team_nudge_template_override_columns(connection, target)?;
-    migrate_template_override_kinds_to_seven(connection, target)?;
+    crate::template_override_migration::ensure_team_nudge_template_override_columns(
+        connection, target,
+    )?;
+    crate::template_override_migration::migrate_template_override_kinds_to_seven(
+        connection, target,
+    )?;
     ensure_mail_message_states_nudge_columns(connection, target)?;
     crate::graft_receiver_endpoint_schema::ensure_schema(connection, target)?;
     ensure_column(
@@ -687,222 +691,6 @@ fn ensure_team_roster_columns(
         "metadata_json",
         "ALTER TABLE team_roster ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';",
     )
-}
-
-fn ensure_team_nudge_template_override_columns(
-    connection: &Connection,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    ensure_column(
-        connection,
-        target,
-        "team_nudge_template_overrides",
-        "mode",
-        "ALTER TABLE team_nudge_template_overrides ADD COLUMN mode TEXT NOT NULL DEFAULT 'override';",
-    )?;
-    connection
-        .execute(
-            "UPDATE team_nudge_template_overrides
-             SET mode = 'disabled'
-             WHERE mode = 'override' AND template_body = '';",
-            [],
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to normalize legacy empty nudge-template override rows",
-                error,
-            )
-        })?;
-    Ok(())
-}
-
-type TemplateOverrideRow = (String, String, String, String, String);
-
-fn load_template_override_rows(
-    connection: &Connection,
-    target: &SharedDbTarget,
-) -> Result<Vec<TemplateOverrideRow>, AtmError> {
-    let mut statement = connection
-        .prepare(
-            "SELECT team_name, template_kind, mode, template_body, updated_at
-             FROM team_nudge_template_overrides;",
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to read nudge-template overrides for migration",
-                error,
-            )
-        })?;
-    statement
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-            ))
-        })
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to enumerate nudge-template overrides for migration",
-                error,
-            )
-        })?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to read nudge-template override row for migration",
-                error,
-            )
-        })
-}
-
-fn create_seven_kind_override_table(
-    transaction: &rusqlite::Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    transaction
-        .execute_batch(
-            "CREATE TABLE team_template_overrides_rebuild (
-                team_name TEXT NOT NULL,
-                template_kind TEXT NOT NULL
-                    CHECK(template_kind IN (
-                        'delivery', 'delivery_ack', 'queue', 'queue_ack', 'task',
-                        'acknowledge', 'acknowledge_task'
-                    )),
-                mode TEXT NOT NULL DEFAULT 'override'
-                    CHECK(mode IN ('override', 'disabled')),
-                template_body TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                PRIMARY KEY (team_name, template_kind)
-            );",
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to create seven-kind nudge-template override table",
-                error,
-            )
-        })
-}
-
-fn copy_seven_kind_override_rows(
-    transaction: &rusqlite::Transaction<'_>,
-    target: &SharedDbTarget,
-    rows: Vec<TemplateOverrideRow>,
-) -> Result<(), AtmError> {
-    for (team_name, template_kind, mode, template_body, updated_at) in rows {
-        if matches!(
-            template_kind.as_str(),
-            "delivery_task" | "delivery_task_ack"
-        ) {
-            tracing::warn!(
-                team = %team_name,
-                kind = %template_kind,
-                "dropping retired nudge-template override during seven-kind migration"
-            );
-            continue;
-        }
-        if !matches!(
-            template_kind.as_str(),
-            "delivery"
-                | "delivery_ack"
-                | "queue"
-                | "queue_ack"
-                | "task"
-                | "acknowledge"
-                | "acknowledge_task"
-        ) {
-            return Err(AtmError::validation(format!(
-                "cannot migrate unknown nudge-template kind `{template_kind}` for team `{team_name}`"
-            )));
-        }
-        transaction
-            .execute(
-                "INSERT INTO team_template_overrides_rebuild
-                    (team_name, template_kind, mode, template_body, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5);",
-                rusqlite::params![team_name, template_kind, mode, template_body, updated_at],
-            )
-            .map_err(|error| {
-                sqlite_error(
-                    target,
-                    "failed to copy nudge-template override during seven-kind migration",
-                    error,
-                )
-            })?;
-    }
-    Ok(())
-}
-
-fn replace_override_table(
-    transaction: rusqlite::Transaction<'_>,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    transaction
-        .execute_batch(
-            "DROP TABLE team_nudge_template_overrides;
-             ALTER TABLE team_template_overrides_rebuild RENAME TO team_nudge_template_overrides;
-             CREATE INDEX IF NOT EXISTS idx_team_nudge_template_overrides_team_name
-                 ON team_nudge_template_overrides(team_name);",
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to replace nudge-template override table",
-                error,
-            )
-        })?;
-    transaction.commit().map_err(|error| {
-        sqlite_error(
-            target,
-            "failed to commit seven-kind nudge-template override migration",
-            error,
-        )
-    })
-}
-
-fn migrate_template_override_kinds_to_seven(
-    connection: &mut Connection,
-    target: &SharedDbTarget,
-) -> Result<(), AtmError> {
-    let table_sql = connection
-        .query_row(
-            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
-            [],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .map_err(|error| {
-            sqlite_error(
-                target,
-                "failed to inspect nudge-template override schema",
-                error,
-            )
-        })?;
-    let Some(table_sql) = table_sql else {
-        return Ok(());
-    };
-    if table_sql.to_ascii_lowercase().contains("'queue'") {
-        return Ok(());
-    }
-
-    let rows = load_template_override_rows(connection, target)?;
-
-    let transaction = connection.transaction().map_err(|error| {
-        sqlite_error(
-            target,
-            "failed to begin nudge-template override migration",
-            error,
-        )
-    })?;
-    create_seven_kind_override_table(&transaction, target)?;
-    copy_seven_kind_override_rows(&transaction, target, rows)?;
-    replace_override_table(transaction, target)
 }
 
 fn ensure_mail_message_states_nudge_columns(
@@ -1514,8 +1302,11 @@ mod tests {
             )
             .expect("insert legacy empty-body row");
 
-        ensure_team_nudge_template_override_columns(&connection, &target)
-            .expect("migrate override table");
+        crate::template_override_migration::ensure_team_nudge_template_override_columns(
+            &connection,
+            &target,
+        )
+        .expect("migrate override table");
 
         let mode_exists = connection
             .prepare("PRAGMA table_info(team_nudge_template_overrides);")

--- a/crates/atm-storage-rusqlite/src/shared_db_support.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db_support.rs
@@ -1,0 +1,122 @@
+use atm_storage::error::AtmError;
+use rusqlite::{Connection, Error as RusqliteError};
+use std::path::PathBuf;
+
+pub(crate) type SqliteConnection = Connection;
+
+#[derive(Debug, Clone)]
+pub(crate) enum SharedDbTarget {
+    Path(PathBuf),
+    #[cfg(test)]
+    InMemory {
+        uri: String,
+    },
+}
+
+impl SharedDbTarget {
+    pub(crate) fn display(&self) -> String {
+        match self {
+            Self::Path(path) => path.display().to_string(),
+            #[cfg(test)]
+            Self::InMemory { uri } => uri.clone(),
+        }
+    }
+}
+
+pub(crate) fn sqlite_open_error(target: &SharedDbTarget, source: RusqliteError) -> AtmError {
+    sqlite_error(
+        target,
+        format!("failed to open sqlite database {}", target.display()),
+        source,
+    )
+}
+
+pub(crate) fn sqlite_error(
+    target: &SharedDbTarget,
+    message: impl Into<String>,
+    source: RusqliteError,
+) -> AtmError {
+    let message = message.into();
+    let error =
+        match &source {
+            RusqliteError::SqliteFailure(error, _) => match error.code {
+                rusqlite::ffi::ErrorCode::ConstraintViolation => AtmError::validation(message),
+                rusqlite::ffi::ErrorCode::DatabaseBusy
+                | rusqlite::ffi::ErrorCode::DatabaseLocked => match target {
+                    SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
+                    #[cfg(test)]
+                    SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(format!(
+                        "timed out waiting for sqlite database lock on {}",
+                        target.display()
+                    )),
+                },
+                rusqlite::ffi::ErrorCode::OperationInterrupted => match target {
+                    SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
+                    #[cfg(test)]
+                    SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(
+                        "sqlite query exceeded its caller-provided execution budget",
+                    ),
+                },
+                rusqlite::ffi::ErrorCode::CannotOpen | rusqlite::ffi::ErrorCode::ReadOnly => {
+                    AtmError::mailbox_write(message)
+                }
+                rusqlite::ffi::ErrorCode::DatabaseCorrupt
+                | rusqlite::ffi::ErrorCode::NotADatabase => AtmError::mailbox_read(message),
+                rusqlite::ffi::ErrorCode::SystemIoFailure | rusqlite::ffi::ErrorCode::DiskFull => {
+                    AtmError::mailbox_write(message)
+                }
+                _ => AtmError::mailbox_write(message),
+            },
+            _ => AtmError::mailbox_write(message),
+        };
+    error.with_cause(source)
+}
+
+pub(crate) fn ensure_column(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+    table: &str,
+    column: &str,
+    ddl: &str,
+) -> Result<(), AtmError> {
+    let mut statement = connection
+        .prepare(&format!("PRAGMA table_info({table});"))
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to inspect sqlite table {table}"),
+                error,
+            )
+        })?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                format!("failed to enumerate sqlite columns for {table}"),
+                error,
+            )
+        })?;
+    let collected = columns
+        .into_iter()
+        .map(|entry| {
+            entry.map_err(|error| {
+                sqlite_error(
+                    target,
+                    format!("failed to read sqlite column metadata for {table}"),
+                    error,
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if collected.into_iter().any(|value| value == column) {
+        return Ok(());
+    }
+    connection.execute_batch(ddl).map_err(|error| {
+        sqlite_error(
+            target,
+            format!("failed to migrate sqlite table {table}"),
+            error,
+        )
+    })
+}

--- a/crates/atm-storage-rusqlite/src/template_override_migration.rs
+++ b/crates/atm-storage-rusqlite/src/template_override_migration.rs
@@ -1,0 +1,219 @@
+use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
+use atm_storage::error::AtmError;
+
+type TemplateOverrideRow = (String, String, String, String, String);
+
+pub(crate) fn ensure_team_nudge_template_override_columns(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    crate::shared_db::ensure_column(
+        connection,
+        target,
+        "team_nudge_template_overrides",
+        "mode",
+        "ALTER TABLE team_nudge_template_overrides ADD COLUMN mode TEXT NOT NULL DEFAULT 'override';",
+    )?;
+    connection
+        .execute(
+            "UPDATE team_nudge_template_overrides
+             SET mode = 'disabled'
+             WHERE mode = 'override' AND template_body = '';",
+            [],
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to normalize legacy empty nudge-template override rows",
+                error,
+            )
+        })?;
+    Ok(())
+}
+
+fn load_template_override_rows(
+    connection: &SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<Vec<TemplateOverrideRow>, AtmError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT team_name, template_kind, mode, template_body, updated_at
+             FROM team_nudge_template_overrides;",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to read nudge-template overrides for migration",
+                error,
+            )
+        })?;
+    statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to enumerate nudge-template overrides for migration",
+                error,
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to read nudge-template override row for migration",
+                error,
+            )
+        })
+}
+
+fn create_seven_kind_override_table(
+    transaction: &rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    transaction
+        .execute_batch(
+            "CREATE TABLE team_template_overrides_rebuild (
+                team_name TEXT NOT NULL,
+                template_kind TEXT NOT NULL
+                    CHECK(template_kind IN (
+                        'delivery', 'delivery_ack', 'queue', 'queue_ack', 'task',
+                        'acknowledge', 'acknowledge_task'
+                    )),
+                mode TEXT NOT NULL DEFAULT 'override'
+                    CHECK(mode IN ('override', 'disabled')),
+                template_body TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (team_name, template_kind)
+            );",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to create seven-kind nudge-template override table",
+                error,
+            )
+        })
+}
+
+fn copy_seven_kind_override_rows(
+    transaction: &rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+    rows: Vec<TemplateOverrideRow>,
+) -> Result<(), AtmError> {
+    for (team_name, template_kind, mode, template_body, updated_at) in rows {
+        if matches!(
+            template_kind.as_str(),
+            "delivery_task" | "delivery_task_ack"
+        ) {
+            tracing::warn!(
+                team = %team_name,
+                kind = %template_kind,
+                "dropping retired nudge-template override during seven-kind migration"
+            );
+            continue;
+        }
+        if !matches!(
+            template_kind.as_str(),
+            "delivery"
+                | "delivery_ack"
+                | "queue"
+                | "queue_ack"
+                | "task"
+                | "acknowledge"
+                | "acknowledge_task"
+        ) {
+            return Err(AtmError::validation(format!(
+                "cannot migrate unknown nudge-template kind `{template_kind}` for team `{team_name}`"
+            )));
+        }
+        transaction
+            .execute(
+                "INSERT INTO team_template_overrides_rebuild
+                    (team_name, template_kind, mode, template_body, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5);",
+                rusqlite::params![team_name, template_kind, mode, template_body, updated_at],
+            )
+            .map_err(|error| {
+                sqlite_error(
+                    target,
+                    "failed to copy nudge-template override during seven-kind migration",
+                    error,
+                )
+            })?;
+    }
+    Ok(())
+}
+
+fn replace_override_table(
+    transaction: rusqlite::Transaction<'_>,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    transaction
+        .execute_batch(
+            "DROP TABLE team_nudge_template_overrides;
+             ALTER TABLE team_template_overrides_rebuild RENAME TO team_nudge_template_overrides;
+             CREATE INDEX IF NOT EXISTS idx_team_nudge_template_overrides_team_name
+                 ON team_nudge_template_overrides(team_name);",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to replace nudge-template override table",
+                error,
+            )
+        })?;
+    transaction.commit().map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to commit seven-kind nudge-template override migration",
+            error,
+        )
+    })
+}
+
+pub(crate) fn migrate_template_override_kinds_to_seven(
+    connection: &mut SqliteConnection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let table_sql = connection
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_nudge_template_overrides';",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to inspect nudge-template override schema",
+                error,
+            )
+        })?;
+    let Some(table_sql) = table_sql else {
+        return Ok(());
+    };
+    if table_sql.to_ascii_lowercase().contains("'queue'") {
+        return Ok(());
+    }
+
+    let rows = load_template_override_rows(connection, target)?;
+    let transaction = connection
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to begin nudge-template override migration",
+                error,
+            )
+        })?;
+    create_seven_kind_override_table(&transaction, target)?;
+    copy_seven_kind_override_rows(&transaction, target, rows)?;
+    replace_override_table(transaction, target)
+}

--- a/crates/atm-storage-rusqlite/src/template_override_migration.rs
+++ b/crates/atm-storage-rusqlite/src/template_override_migration.rs
@@ -1,4 +1,4 @@
-use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
+use crate::shared_db_support::{SharedDbTarget, SqliteConnection, ensure_column, sqlite_error};
 use atm_storage::error::AtmError;
 
 type TemplateOverrideRow = (String, String, String, String, String);
@@ -7,7 +7,7 @@ pub(crate) fn ensure_team_nudge_template_override_columns(
     connection: &SqliteConnection,
     target: &SharedDbTarget,
 ) -> Result<(), AtmError> {
-    crate::shared_db::ensure_column(
+    ensure_column(
         connection,
         target,
         "team_nudge_template_overrides",

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -172,8 +172,9 @@ impl FromStr for AckTransition {
 pub enum BuiltInNudgeTemplateKind {
     Delivery,
     DeliveryAck,
-    DeliveryTask,
-    DeliveryTaskAck,
+    Queue,
+    QueueAck,
+    Task,
     Acknowledge,
     AcknowledgeTask,
 }
@@ -183,8 +184,9 @@ impl BuiltInNudgeTemplateKind {
         match self {
             Self::Delivery => "delivery",
             Self::DeliveryAck => "delivery_ack",
-            Self::DeliveryTask => "delivery_task",
-            Self::DeliveryTaskAck => "delivery_task_ack",
+            Self::Queue => "queue",
+            Self::QueueAck => "queue_ack",
+            Self::Task => "task",
             Self::Acknowledge => "acknowledge",
             Self::AcknowledgeTask => "acknowledge_task",
         }
@@ -204,10 +206,14 @@ impl FromStr for BuiltInNudgeTemplateKind {
         match value {
             "delivery" => Ok(Self::Delivery),
             "delivery_ack" => Ok(Self::DeliveryAck),
-            "delivery_task" => Ok(Self::DeliveryTask),
-            "delivery_task_ack" => Ok(Self::DeliveryTaskAck),
+            "queue" => Ok(Self::Queue),
+            "queue_ack" => Ok(Self::QueueAck),
+            "task" => Ok(Self::Task),
             "acknowledge" => Ok(Self::Acknowledge),
             "acknowledge_task" => Ok(Self::AcknowledgeTask),
+            "delivery_task" | "delivery_task_ack" => Err(AtmError::validation(format!(
+                "template kind `{value}` was retired; use \"task\""
+            ))),
             other => Err(AtmError::validation(format!(
                 "unsupported built-in nudge template kind `{other}`"
             ))),
@@ -1498,6 +1504,32 @@ mod tests {
         graft_receiver_endpoint_store
             .unregister(&registration.team, &registration.agent, &generation)
             .expect("unregister");
+    }
+
+    #[test]
+    fn built_in_nudge_template_kind_round_trips_seven_kinds() {
+        let kinds = [
+            BuiltInNudgeTemplateKind::Delivery,
+            BuiltInNudgeTemplateKind::DeliveryAck,
+            BuiltInNudgeTemplateKind::Queue,
+            BuiltInNudgeTemplateKind::QueueAck,
+            BuiltInNudgeTemplateKind::Task,
+            BuiltInNudgeTemplateKind::Acknowledge,
+            BuiltInNudgeTemplateKind::AcknowledgeTask,
+        ];
+        for kind in kinds {
+            assert_eq!(kind.as_str().parse::<BuiltInNudgeTemplateKind>(), Ok(kind));
+        }
+    }
+
+    #[test]
+    fn built_in_nudge_template_kind_rejects_retired_task_kinds() {
+        for retired in ["delivery_task", "delivery_task_ack"] {
+            let error = retired
+                .parse::<BuiltInNudgeTemplateKind>()
+                .expect_err("retired kind");
+            assert!(error.message().contains("was retired; use \"task\""));
+        }
     }
 
     #[test]

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -65,14 +65,16 @@ struct InternalNudgeInput {
 
 impl InternalNudgeInput {
     fn from_env() -> Result<Self> {
-        let raw_payload = std::env::var(INTERNAL_NUDGE_ENV).map_err(|_| {
+        let raw_payload = std::env::var(INTERNAL_NUDGE_ENV).map_err(|source| {
             AtmError::validation("missing ATM_INTERNAL_NUDGE payload for built-in post-send nudge")
+                .with_cause(source)
         })?;
         let payload: InternalNudgeEnvelope =
-            serde_json::from_str(&raw_payload).map_err(|_source| {
+            serde_json::from_str(&raw_payload).map_err(|source| {
                 AtmError::validation(
                     "failed to decode ATM_INTERNAL_NUDGE payload for built-in nudge",
                 )
+                .with_cause(source)
             })?;
         Ok(Self {
             event: payload.event,

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -302,8 +302,8 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::boundary::{
-        BuiltInNudgeSinkTarget, BuiltInNudgeTemplateKind, InternalNudgeEnvelope, PostSendHookEvent,
-        ResolvedBuiltInNudgeTemplate, TMUX_DOUBLE_ENTER_DELAY,
+        BuiltInNudgeSinkTarget, BuiltInNudgeTemplateKind, InternalNudgeEnvelope, NudgeKind,
+        PostSendHookEvent, ResolvedBuiltInNudgeTemplate, TMUX_DOUBLE_ENTER_DELAY,
         built_in_nudge_template_kind_from_post_send_event,
     };
     use atm_core::send::default_template;
@@ -350,37 +350,40 @@ mod tests {
     }
 
     #[test]
-    fn built_in_template_kind_selection_covers_six_paths() {
+    fn built_in_template_kind_selection_covers_seven_paths() {
         let mut event = base_event();
         assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Steer),
             BuiltInNudgeTemplateKind::Delivery
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Queue),
+            BuiltInNudgeTemplateKind::Queue
         );
         event.requires_ack = true;
         assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Steer),
             BuiltInNudgeTemplateKind::DeliveryAck
+        );
+        assert_eq!(
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Queue),
+            BuiltInNudgeTemplateKind::QueueAck
         );
         event.requires_ack = false;
         event.task_id = Some("AD.21".parse().expect("task"));
         assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
-            BuiltInNudgeTemplateKind::DeliveryTask
-        );
-        event.requires_ack = true;
-        assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
-            BuiltInNudgeTemplateKind::DeliveryTaskAck
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Queue),
+            BuiltInNudgeTemplateKind::Task
         );
         event.is_ack = true;
         event.requires_ack = false;
         assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Steer),
             BuiltInNudgeTemplateKind::AcknowledgeTask
         );
         event.task_id = None;
         assert_eq!(
-            built_in_nudge_template_kind_from_post_send_event(&event),
+            built_in_nudge_template_kind_from_post_send_event(&event, NudgeKind::Steer),
             BuiltInNudgeTemplateKind::Acknowledge
         );
     }
@@ -438,7 +441,7 @@ mod tests {
             },
             sink_target: BuiltInNudgeSinkTarget::Tmux,
             template: ResolvedBuiltInNudgeTemplate {
-                kind: BuiltInNudgeTemplateKind::DeliveryTaskAck,
+                kind: BuiltInNudgeTemplateKind::Task,
                 body: Some("<atm from=\"{{from}}\" message-id=\"{{message_id}}\"/>".to_string()),
             },
         })
@@ -450,10 +453,7 @@ mod tests {
 
         assert_eq!(input.sink_target, BuiltInNudgeSinkTarget::Tmux);
         assert_eq!(input.event.task_id.expect("task").as_str(), "AD.21");
-        assert_eq!(
-            input.template.kind,
-            BuiltInNudgeTemplateKind::DeliveryTaskAck
-        );
+        assert_eq!(input.template.kind, BuiltInNudgeTemplateKind::Task);
         assert_eq!(
             input.template.body.as_deref(),
             Some("<atm from=\"{{from}}\" message-id=\"{{message_id}}\"/>")

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -863,6 +863,30 @@ mod tests {
     }
 
     #[test]
+    fn set_nudge_template_rejects_retired_task_steer_kind_with_task_hint_and_cli_exit_three() {
+        let command = SetNudgeTemplateCommand {
+            team: TEST_TEAM.to_string(),
+            kind: "delivery_task".to_string(),
+            template_body: "<atm/>".to_string(),
+            json: false,
+        };
+
+        let error = command
+            .build_request(CallerContext {
+                caller_identity: TEST_SENDER.parse().expect("caller"),
+                caller_chat_id: None,
+                caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
+            })
+            .expect_err("retired kind");
+
+        let atm_error = error.downcast_ref::<AtmError>().expect("AtmError");
+        assert_eq!(atm_error.code(), AtmErrorCode::MessageValidationFailed);
+        assert!(atm_error.message().contains("use \"task\""), "{atm_error}");
+        assert_eq!(crate::exit_code_for_atm_error(atm_error), 3);
+    }
+
+    #[test]
     fn set_nudge_template_build_request_rejects_empty_template_body_before_core() {
         let command = SetNudgeTemplateCommand {
             team: TEST_TEAM.to_string(),

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -154,7 +154,10 @@ struct RemoveMemberCommand {
 struct SetNudgeTemplateCommand {
     #[arg(long)]
     team: String,
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task"
+    )]
     kind: String,
 
     #[arg(long = "template-body")]
@@ -168,7 +171,10 @@ struct SetNudgeTemplateCommand {
 struct DisableNudgeTemplateCommand {
     #[arg(long)]
     team: String,
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task"
+    )]
     kind: String,
 
     #[arg(long)]
@@ -179,7 +185,10 @@ struct DisableNudgeTemplateCommand {
 struct ClearNudgeTemplateCommand {
     #[arg(long)]
     team: String,
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task"
+    )]
     kind: String,
 
     #[arg(long)]

--- a/docs/adr/ADR-019-direct-post-send-and-claude-json-retirement.md
+++ b/docs/adr/ADR-019-direct-post-send-and-claude-json-retirement.md
@@ -171,3 +171,26 @@ The accepted architecture above stayed fixed while implementation converged:
   readiness
 - any remaining operational dependency on Claude inbox-append runtime artifacts
   must be replaced before release
+
+## Amendment — Phase AX seven-kind queue template surface (2026-09-05)
+
+Phase AX adds queue-specific built-in template kinds and retires the two
+unreachable task-steer kinds. The complete seven-kind inventory is:
+
+- `delivery`
+- `delivery_ack`
+- `queue`
+- `queue_ack`
+- `task`
+- `acknowledge`
+- `acknowledge_task`
+
+`NudgeKind` selects the delivery or queue family. Task-tagged messages always
+select `task` and are deferred on every backend. The former
+`delivery_task` and `delivery_task_ack` values are rejected on input with a
+recovery hint to use `task`.
+
+Existing SQLite override tables are rebuilt on database open when their
+constraint does not include `queue`; accepted rows are copied, retired rows
+are dropped with a warning naming the team and kind, and unknown rows fail the
+open loudly. Fresh databases use the seven-value constraint directly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2733,9 +2733,10 @@ Architectural rules:
   (ADR-054), and neither kind ever precedes persistence
 - the shipped default emitter path is the receiver-only
   `MessageReceivedHookEmitter` delivery path
-- the built-in renderer selects exactly one of six named template kinds:
-  `delivery`, `delivery_ack`, `delivery_task`, `delivery_task_ack`,
-  `acknowledge`, and `acknowledge_task`
+- the built-in renderer selects exactly one of seven named template kinds:
+  `delivery`, `delivery_ack`, `queue`, `queue_ack`, `task`, `acknowledge`,
+  and `acknowledge_task`; `NudgeKind` selects the delivery or queue family,
+  while task-tagged messages select `task`
 - any team-scoped built-in template override row must be resolved through the
   storage-neutral `NudgeTemplateOverrideStore` contract before the built-in
   emitter/render path runs; `atm` and `atm-core` must not perform direct

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -244,8 +244,11 @@ Notes:
 - the first concrete implementation remains `atm-storage-rusqlite`
 - [../adr/ADR-024-nudge-template-override-storage-ownership-relocation.md](../adr/ADR-024-nudge-template-override-storage-ownership-relocation.md)
   supersedes ADR-021's older `atm-core` ownership assumption
-- `atm` remains the owner of the six built-in product template bodies and the
-  bounded placeholder substitution/rendering policy.
+- `atm` remains the owner of the seven built-in product template bodies —
+  `delivery`, `delivery_ack`, `queue`, `queue_ack`, `task`, `acknowledge`, and
+  `acknowledge_task` — and the bounded placeholder substitution/rendering
+  policy. `NudgeKind` selects the delivery or queue family; task-tagged
+  messages select `task`.
 - Accepted row semantics are explicit:
   - no row => product default
   - override row => stored non-empty template body

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -143,8 +143,10 @@ Required rules:
     - `template_body TEXT NOT NULL`
     - `updated_at TEXT NOT NULL`
     - primary key `(team_name, template_kind)`
-    - template-kind values constrained to the six built-in template kinds
-      accepted in `AD.21`
+    - template-kind values constrained to the seven built-in template kinds
+      accepted in `AD.21`: `delivery`, `delivery_ack`, `queue`, `queue_ack`,
+      `task`, `acknowledge`, and `acknowledge_task`; `NudgeKind` selects the
+      delivery or queue family and task-tagged messages select `task`
     - `mode` values constrained to `override` or `disabled`
     - reset-to-default modeled as row deletion, not as a third persisted mode
 - weak provenance round-trip fields such as `imported_from` must not be part

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -140,10 +140,13 @@ Required rules:
   carrying exactly one built-in template kind:
   - `delivery`
   - `delivery_ack`
-  - `delivery_task`
-  - `delivery_task_ack`
+  - `queue`
+  - `queue_ack`
+  - `task`
   - `acknowledge`
   - `acknowledge_task`
+  `NudgeKind` selects the delivery or queue family, and task-tagged messages
+  select `task` in either family.
 - `atm` owns direct placeholder substitution for those templates; no Jinja or
   conditional template language is allowed on the built-in path
 - `atm internal-nudge` must read the resolved built-in envelope from
@@ -152,7 +155,7 @@ Required rules:
   - the concrete sink target
   - the resolved template kind
   - the resolved template body or explicit disabled state
-- the accepted built-in path is bounded to six default template bodies, but any
+- the accepted built-in path is bounded to seven default template bodies, but any
   team-scoped override lookup for those bodies must cross the storage-neutral
   `NudgeTemplateOverrideStore` contract upstream of `MessageReceivedHookEmitter`
   rather than performing direct SQLite access or runtime/store reopening in

--- a/docs/plans/phase-ax/sprint-AX.1-queue-template-class.md
+++ b/docs/plans/phase-ax/sprint-AX.1-queue-template-class.md
@@ -5,7 +5,7 @@ title: Queue template class and default template fixes
 branch: feature/ax1-queue-template-class
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ax1-queue-template-class
 integration_branch: integrate/phase-ax
-status: draft
+status: complete
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_track: A
@@ -35,9 +35,9 @@ This is the authoritative deliverable checklist. Every listed deliverable
 lands production-ready for the scope this sprint claims; partial or
 shape-only completion fails the sprint.
 
-- [ ] D1 — `BuiltInNudgeTemplateKind` becomes seven kinds
+- [x] D1 — `BuiltInNudgeTemplateKind` becomes seven kinds
   (`crates/atm-storage/src/contract.rs`). Code contract C1.
-- [ ] D2 — override-table migration
+- [x] D2 — override-table migration
   (`crates/atm-storage-rusqlite/src/shared_db.rs`): new function
   `migrate_template_override_kinds_to_seven(conn)` called from the
   existing schema-ensure path that runs on every database open (CLI and
@@ -54,7 +54,7 @@ shape-only completion fails the sprint.
   rows. Idempotent: a database already on the seven-value `CHECK` is
   left untouched. The `CREATE TABLE IF NOT EXISTS` at line 77 also
   carries the seven-value `CHECK` for fresh databases.
-- [ ] D3 — kind selection takes the nudge mode. Code contract C2.
+- [x] D3 — kind selection takes the nudge mode. Code contract C2.
   `built_in_nudge_template_kind_from_post_send_event` gains the
   `NudgeKind` parameter (`crates/atm-core/src/boundary/mod.rs`);
   `render_built_in_nudge_for_dispatch` in
@@ -68,16 +68,16 @@ shape-only completion fails the sprint.
   `built_in_template_kind_selection_covers_seven_paths` and asserts every
   row of the C2 table; fixtures that name `DeliveryTask` /
   `DeliveryTaskAck` are changed to `Task`.
-- [ ] D4 — default bodies (`crates/atm-core/src/send/nudge_template.rs`
+- [x] D4 — default bodies (`crates/atm-core/src/send/nudge_template.rs`
   `default_template`). Code contract C3.
-- [ ] D5 — CLI: `crates/atm/src/commands/teams.rs` `set-nudge-template`,
+- [x] D5 — CLI: `crates/atm/src/commands/teams.rs` `set-nudge-template`,
   `disable-nudge-template`, `clear-nudge-template` accept `queue`,
   `queue_ack`, `task`; a retired string is rejected with
   `ATM_MESSAGE_VALIDATION_FAILED` and the hint `use "task"`; help text
   lists all seven kinds. `crates/atm-core/src/team_admin.rs` request
   types carry the kind unchanged (verify by test that a `queue_ack`
   override round-trips through `set_nudge_template_override_with_store`).
-- [ ] D6 — normative docs lose the six-kind bound:
+- [x] D6 — normative docs lose the six-kind bound:
   `docs/requirements.md` line 1094 ("exactly six named template cases"),
   line 1105 ("those six built-in template bodies"), and line 4496 ("the
   six built-in nudge template bodies"); each must read "seven";
@@ -93,7 +93,7 @@ shape-only completion fails the sprint.
   seven-kind inventory, the retirement, the migration in D2, and the
   `NudgeKind` rule; `docs/adr/INDEX.md` entry text updated if the ADR
   status line changes.
-- [ ] D7 — user docs and examples: `docs/user-documents/nudge-templates.md`
+- [x] D7 — user docs and examples: `docs/user-documents/nudge-templates.md`
   documents the seven kinds (line 23 "exactly six" becomes "seven"), the
   C2 mapping, the migration, and the corrected read action, and records
   the retirement with the sentence "Two former task steer kinds were
@@ -104,12 +104,12 @@ shape-only completion fails the sprint.
   `delivery.xml`, `delivery_ack.xml`, `manage-templates.sh`; delete
   `delivery_task.xml` and `delivery_task_ack.xml`; add `queue.xml`,
   `queue_ack.xml`, `task.xml` matching C3.
-- [ ] D8 — live nudge-text producers outside the crates:
+- [x] D8 — live nudge-text producers outside the crates:
   `scripts/atm-nudge.py` line 266, `scripts/atm-nudge.sh` line 50,
   `scripts/test_atm_nudge.py` lines 281 and 287, and
   `.claude/skills/restore-team-communications/SKILL.md` line 76 replace
   `read atm --team <team>` / `read atm` with the targeted read action.
-- [ ] D9 — task-tagged mail is always deferred (phase plan §2 "tasks are
+- [x] D9 — task-tagged mail is always deferred (phase plan §2 "tasks are
   always queued"): new `pub(crate) fn send_mode_for_task_request(request:
   &SendRequest, task_id: &Option<TaskId>) -> NudgeMode` beside
   `request_requires_ack` in `crates/atm-core/src/send/mod.rs` returning
@@ -128,7 +128,7 @@ shape-only completion fails the sprint.
   natively until idle, the same way it distinguishes steer from queue
   today); a Herdr recipient gets the marker and the pump. (AX.5 removes
   the marker for Herdr recipients only.) Code contract C5.
-- [ ] D10 — tests listed under Required validation.
+- [x] D10 — tests listed under Required validation.
 
 ### Paths to delete
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1616,7 +1616,7 @@ Phase AX sprint status:
 
 | Sprint | Track | Execute | Status | Branch | Artifacts |
 | --- | --- | --- | --- | --- | --- |
-| `AX.1` | A | parallel with AX.3/AX.4 | `planned` | `feature/ax1-queue-template-class` | `docs/plans/phase-ax/sprint-AX.1-queue-template-class.md`, ADR-019 amendment |
+| `AX.1` | A | parallel with AX.3/AX.4 | `complete` | `feature/ax1-queue-template-class` | `docs/plans/phase-ax/sprint-AX.1-queue-template-class.md`, ADR-019 amendment |
 | `AX.2` | A | after AX.1; parallel with AX.3/AX.4 | `planned` | `feature/ax2-herdr-template-rendering` | `docs/plans/phase-ax/sprint-AX.2-herdr-template-rendering.md`, ADR-058 amendment, `boundaries/atm-herdr/herdr-process-adapter.toml`, `docs/atm-herdr/requirements.md` |
 | `AX.3` | B | parallel with AX.1/AX.2 | `planned` | `feature/ax3-task-state-machine` | `docs/plans/phase-ax/sprint-AX.3-task-state-machine.md`, `docs/adr/ADR-061-task-state-machine.md`, ADR-054 amendment, `boundaries/atm-storage/task-store.toml`, `boundaries/atm-storage-rusqlite/task-store-sqlite.toml` |
 | `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `planned` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1091,18 +1091,21 @@ Post-send-hook rules:
   `home_dir` metadata rather than the caller's live process working directory
 - if no matching external `[[atm.post_send_hooks]]` rule is configured, ATM
   must still attempt the shipped built-in in-process post-send path
-- the built-in shipped nudge path must support exactly six named template
+- the built-in shipped nudge path must support exactly seven named template
   cases:
   - `delivery`
   - `delivery_ack`
-  - `delivery_task`
-  - `delivery_task_ack`
+  - `queue`
+  - `queue_ack`
+  - `task`
   - `acknowledge`
   - `acknowledge_task`
+  `NudgeKind` selects the delivery or queue family; task-tagged messages select
+  `task` in either family.
 - the default built-in acknowledge nudge shapes are intentionally compact:
   - `<atm kind="ack" from="..." message-id="..."/>`
   - `<atm kind="ack" from="..." message-id="..." task-id="..."/>`
-- teams may override any subset of those six built-in template bodies through
+- teams may override any subset of those seven built-in template bodies through
   host-scoped, team-keyed ATM-managed override rows resolved through the
   storage-neutral `NudgeTemplateOverrideStore` contract
 - built-in precedence is:
@@ -4493,7 +4496,7 @@ mail correctness.
     persistence
   - the shipped default post-send path is the built-in in-process
     implementation
-  - teams may override any subset of the six built-in nudge template bodies
+  - teams may override any subset of the seven built-in nudge template bodies
     through host-scoped, team-keyed ATM-managed override rows resolved through
     the storage-neutral `NudgeTemplateOverrideStore` contract
   - emission failure must be logged and surfaced as a sender-visible warning

--- a/docs/user-documents/examples/nudge-templates/delivery.xml
+++ b/docs/user-documents/examples/nudge-templates/delivery.xml
@@ -1,5 +1,5 @@
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
+  <action>atm read --message-id {{message_id}}</action>
   <description>{{description}}</description>
   <action>execute the assigned task</action>
   <when idle="immediate" busy="after-current-task"/>

--- a/docs/user-documents/examples/nudge-templates/manage-templates.sh
+++ b/docs/user-documents/examples/nudge-templates/manage-templates.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 atm teams set-nudge-template \
   --team atm-dev \
   --kind delivery_ack \
-  --template-body '<atm from="{{from}}" message-id="{{message_id}}"><action>read atm --team {{team}}</action><action>ack the message</action><description>{{description}}</description><action>execute the assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>'
+  --template-body '<atm from="{{from}}" message-id="{{message_id}}"><action>atm read --message-id {{message_id}}</action><action>ack the message</action><description>{{description}}</description><action>execute the assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>'
 
 atm teams disable-nudge-template --team atm-dev --kind delivery_ack
 atm teams clear-nudge-template --team atm-dev --kind delivery_ack

--- a/docs/user-documents/examples/nudge-templates/queue.xml
+++ b/docs/user-documents/examples/nudge-templates/queue.xml
@@ -1,8 +1,6 @@
 <atm from="{{from}}" message-id="{{message_id}}">
   <action>atm read --message-id {{message_id}}</action>
-  <action>ack the message</action>
   <description>{{description}}</description>
   <action>execute the assigned task</action>
-  <when idle="immediate" busy="after-current-task"/>
   <console announce="concise" pause="false"/>
 </atm>

--- a/docs/user-documents/examples/nudge-templates/queue_ack.xml
+++ b/docs/user-documents/examples/nudge-templates/queue_ack.xml
@@ -1,7 +1,7 @@
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
-  <task id="{{task_id}}">{{description}}</task>
+  <action>atm read --message-id {{message_id}}</action>
+  <action>ack the message</action>
+  <description>{{description}}</description>
   <action>execute the assigned task</action>
-  <when idle="immediate" busy="after-current-task"/>
   <console announce="concise" pause="false"/>
 </atm>

--- a/docs/user-documents/examples/nudge-templates/task.xml
+++ b/docs/user-documents/examples/nudge-templates/task.xml
@@ -1,8 +1,7 @@
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
+  <action>atm read --message-id {{message_id}}</action>
   <action>ack the message</action>
   <task id="{{task_id}}">{{description}}</task>
   <action>execute the assigned task</action>
-  <when idle="immediate" busy="after-current-task"/>
   <console announce="concise" pause="false"/>
 </atm>

--- a/docs/user-documents/nudge-templates.md
+++ b/docs/user-documents/nudge-templates.md
@@ -18,19 +18,22 @@ attention.
 This document covers supported template usage and override behavior. It does
 not authorize direct database edits or unsupported template engines.
 
-## Six Built-In Template Kinds
+## Seven Built-In Template Kinds
 
-ATM ships exactly six built-in template kinds:
+ATM ships exactly seven built-in template kinds:
 
 - `delivery`
 - `delivery_ack`
-- `delivery_task`
-- `delivery_task_ack`
+- `queue`
+- `queue_ack`
+- `task`
 - `acknowledge`
 - `acknowledge_task`
 
-The `delivery*` forms are for delivered work notifications. The
-`acknowledge*` forms are intentionally compact acknowledgement nudges.
+`NudgeKind` selects the delivery (`delivery`, `delivery_ack`) or queue
+(`queue`, `queue_ack`) family. Task-tagged messages always use `task` and are
+always queued. The `acknowledge*` forms are intentionally compact
+acknowledgement nudges.
 
 ## Supported Placeholders
 
@@ -66,7 +69,7 @@ Empty-string template bodies are invalid. Use the explicit team-admin commands
 instead:
 
 ```bash
-atm teams set-nudge-template --team atm-dev --kind delivery_ack --template-body '<atm from="{{from}}" message-id="{{message_id}}"><action>read atm --team {{team}}</action><action>ack the message</action><description>{{description}}</description><action>execute the assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>'
+atm teams set-nudge-template --team atm-dev --kind delivery_ack --template-body '<atm from="{{from}}" message-id="{{message_id}}"><action>atm read --message-id {{message_id}}</action><action>ack the message</action><description>{{description}}</description><action>execute the assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>'
 atm teams disable-nudge-template --team atm-dev --kind delivery_ack
 atm teams clear-nudge-template --team atm-dev --kind delivery_ack
 ```
@@ -77,7 +80,7 @@ Delivery without required acknowledgement:
 
 ```xml
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
+  <action>atm read --message-id {{message_id}}</action>
   <description>{{description}}</description>
   <action>execute the assigned task</action>
   <when idle="immediate" busy="after-current-task"/>
@@ -89,7 +92,7 @@ Delivery with required acknowledgement:
 
 ```xml
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
+  <action>atm read --message-id {{message_id}}</action>
   <action>ack the message</action>
   <description>{{description}}</description>
   <action>execute the assigned task</action>
@@ -98,30 +101,48 @@ Delivery with required acknowledgement:
 </atm>
 ```
 
-Task delivery without required acknowledgement:
+Queue without required acknowledgement:
 
 ```xml
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
-  <task id="{{task_id}}">{{description}}</task>
+  <action>atm read --message-id {{message_id}}</action>
+  <description>{{description}}</description>
   <action>execute the assigned task</action>
-  <when idle="immediate" busy="after-current-task"/>
   <console announce="concise" pause="false"/>
 </atm>
 ```
 
-Task delivery with required acknowledgement:
+Queue with required acknowledgement:
 
 ```xml
 <atm from="{{from}}" message-id="{{message_id}}">
-  <action>read atm --team {{team}}</action>
+  <action>atm read --message-id {{message_id}}</action>
+  <action>ack the message</action>
+  <description>{{description}}</description>
+  <action>execute the assigned task</action>
+  <console announce="concise" pause="false"/>
+</atm>
+```
+
+Task messages are always queued and require acknowledgement:
+
+```xml
+<atm from="{{from}}" message-id="{{message_id}}">
+  <action>atm read --message-id {{message_id}}</action>
   <action>ack the message</action>
   <task id="{{task_id}}">{{description}}</task>
   <action>execute the assigned task</action>
-  <when idle="immediate" busy="after-current-task"/>
   <console announce="concise" pause="false"/>
 </atm>
 ```
+
+Two former task steer kinds were retired in phase AX and are rejected on
+input; see the ADR-019 amendment for their names and the migration.
+
+On database open, ATM upgrades the override table to the seven-kind constraint,
+preserves every supported row, and removes only retired rows. The migration is
+idempotent and accepts new `queue`, `queue_ack`, and `task` overrides after the
+upgrade.
 
 Compact acknowledgement defaults:
 

--- a/scripts/atm-nudge.py
+++ b/scripts/atm-nudge.py
@@ -263,7 +263,8 @@ def build_message(team: str, payload: dict[str, object] | None = None) -> str:
             return f'{base} kind="ack" task-id="{task_id}"/>'
         return f'{base} kind="ack"/>'
 
-    body = [f"{base}>", f"<action>read atm --team {team}</action>"]
+    read_action = f"atm read --message-id {message_id}" if message_id else "atm read"
+    body = [f"{base}>", f"<action>{read_action}</action>"]
     if requires_ack:
         body.append("<action>ack the message</action>")
     if task_id:

--- a/scripts/atm-nudge.sh
+++ b/scripts/atm-nudge.sh
@@ -47,7 +47,8 @@ if is_ack:
     else:
         message = f'{base} kind="ack"/>'
 else:
-    parts = [f"{base}>", f"<action>read atm --team {team}</action>"]
+    read_action = f"atm read --message-id {message_id}" if message_id else "atm read"
+    parts = [f"{base}>", f"<action>{read_action}</action>"]
     if requires_ack:
         parts.append("<action>ack the message</action>")
     if task_id:

--- a/scripts/test_atm_nudge.py
+++ b/scripts/test_atm_nudge.py
@@ -278,16 +278,26 @@ class TestOverrideMode(unittest.TestCase):
         self.assertEqual(rc, 0)
         _, recipient, message = mock_nudge.call_args[0]
         self.assertEqual(recipient, TEST_AGENT)
-        self.assertIn(f"read atm --team {TEST_TEAM}", message)
+        self.assertIn("atm read", message)
 
 
 class TestBuildMessage(unittest.TestCase):
     def test_default_send_message_requests_assigned_task_execution(self):
         message = _MOD.build_message(TEST_TEAM, {})
-        self.assertIn(f"read atm --team {TEST_TEAM}", message)
+        self.assertIn("atm read", message)
         self.assertIn("execute the assigned task", message)
         self.assertIn('busy="after-current-task"', message)
         self.assertIn("<description></description>", message)
+
+    def test_default_send_message_targets_message_when_id_is_present(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {"message_id": "01JSENDTEST0000000000000000"},
+        )
+        self.assertIn(
+            "atm read --message-id 01JSENDTEST0000000000000000",
+            message,
+        )
 
     def test_send_message_includes_message_id_as_attribute_when_present(self):
         message = _MOD.build_message(


### PR DESCRIPTION
Sprint AX.1 of Phase AX (#1173). Sprint doc: `docs/plans/phase-ax/sprint-AX.1-queue-template-class.md`; phase plan `docs/plans/phase-ax/phase-ax-plan.md`.

Dev: cipher, completion at 1452df008 (`just test` green; `just validate` substantive gates green, Wyvern absent locally).

Stack A bottom: this PR targets `integrate/phase-ax`; AX.2 stacks on this branch. Merge commits only; merged via `gh stack merge --merge` after quality-mgr's Final Quality Report is posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)