### PR TITLE
fix(send-to): seam the wrapper notification so tests never reach osascript

### DIFF
--- a/.just/tests/test_send_to_surface.py
+++ b/.just/tests/test_send_to_surface.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -16,6 +18,19 @@ PICKER = ROOT / "scripts/send-to/picker.py"
 COMMAND_WRAPPER = ROOT / "scripts/send-to/atm-send-to.command"
 NAUTILUS_WRAPPER = ROOT / "scripts/send-to/nautilus-atm-send-to.sh"
 FIXTURES = ROOT / "docs/plans/phase-aq/fixtures"
+VALIDATE_RELEASE = ROOT / "scripts/validate_release.py"
+
+# Test-only seam in atm-send-to.command / nautilus-atm-send-to.sh that
+# replaces the wrapper's desktop notification (`osascript display
+# notification` / `notify-send`) on the failure path. Before this seam
+# existed, every `just test` / `just lint` / `just validate` run popped a
+# real macOS notification from
+# test_command_wrapper_propagates_exit_code_and_forwards_stderr_on_failure.
+NOTIFIER_SEAM = "ATM_SEND_TO_NOTIFIER"
+# The desktop-notification binaries the wrappers reach for by default. Every
+# wrapper run in this suite shadows them on PATH with a stub that records a
+# marker; tearDown asserts the marker was never written.
+DESKTOP_NOTIFIER_BINARIES = ("osascript", "notify-send")
 
 # Load the committed PickerInput/PickerOutput fixtures verbatim (rather than
 # inline-shaped equivalents) so this suite exercises the exact bytes the
@@ -42,6 +57,33 @@ def invoke_script(script: Path, *args: Path) -> list[str]:
 
 
 class SendToSurfaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Shadow the real desktop-notification binaries for every wrapper
+        # run so a regression in the notifier seam fails this suite loudly
+        # instead of silently popping a notification on the developer's
+        # desktop. The stub only records its argv; it never shows UI.
+        self._ui_stub_dir = tempfile.TemporaryDirectory()
+        self.ui_marker = Path(self._ui_stub_dir.name) / "desktop-notification.marker"
+        if os.name != "nt":
+            for name in DESKTOP_NOTIFIER_BINARIES:
+                stub = Path(self._ui_stub_dir.name) / name
+                stub.write_text(
+                    "#!/bin/sh\n"
+                    f"printf '%s\\n' \"$0\" \"$@\" >> '{self.ui_marker}'\n",
+                    encoding="utf-8",
+                )
+                executable(stub)
+
+    def tearDown(self) -> None:
+        leaked = self.ui_marker.read_text(encoding="utf-8") if self.ui_marker.exists() else ""
+        self._ui_stub_dir.cleanup()
+        self.assertEqual(
+            leaked,
+            "",
+            "a Send-To wrapper reached a real desktop-notification binary; the "
+            f"{NOTIFIER_SEAM} seam must keep every test in this suite UI-free:\n{leaked}",
+        )
+
     def make_atm(self, directory: Path, log: Path) -> Path:
         path = fixture_path(directory, "atm")
         if os.name == "nt":
@@ -103,6 +145,12 @@ class SendToSurfaceTests(unittest.TestCase):
             env["ATM_SEND_TO_PICKER"] = str(picker)
         else:
             env.pop("ATM_SEND_TO_PICKER", None)
+        # No test here may raise a real desktop notification: suppress the
+        # wrappers' failure-path notification by default (a test that wants
+        # to observe it overrides the seam via `extra`), and put the
+        # marker-recording stubs ahead of the real binaries on PATH.
+        env[NOTIFIER_SEAM] = "none"
+        env["PATH"] = self._ui_stub_dir.name + os.pathsep + env.get("PATH", "")
         if extra:
             env.update(extra)
         return subprocess.run(invoke_script(script, *files), cwd=ROOT, env=env, text=True, capture_output=True)
@@ -300,6 +348,48 @@ class SendToSurfaceTests(unittest.TestCase):
             self.assertFalse(log.exists(), result.stderr)
             self.assertIn("send-to picker", result.stderr)
 
+    def make_recording_notifier(self, directory: Path, record: Path) -> Path:
+        """A notifier command that records its argv (one per line) to `record`."""
+        path = fixture_path(directory, "notifier-record")
+        path.write_text(
+            "#!/bin/sh\n"
+            f"printf '%s\\n' \"$@\" > '{record}'\n",
+            encoding="utf-8",
+        )
+        executable(path)
+        return path
+
+    @unittest.skipIf(os.name == "nt", "the notifying wrappers are Unix-only")
+    def test_wrapper_notification_seam_replaces_the_desktop_notification_on_failure(self) -> None:
+        expected_message = "send-to picker: at least one recipient must be selected"
+        for wrapper in (COMMAND_WRAPPER, NAUTILUS_WRAPPER):
+            for mode in ("command", "stderr"):
+                with self.subTest(wrapper=wrapper.name, mode=mode), tempfile.TemporaryDirectory() as raw:
+                    directory = Path(raw)
+                    (directory / "input.json").write_text(json.dumps(PICKER_INPUT))
+                    log = directory / "send.log"
+                    self.make_atm(directory, log)
+                    picker = self.make_noisy_failing_picker(directory, code=7)
+                    record = directory / "notifier.args"
+                    notifier = self.make_recording_notifier(directory, record)
+                    extra = {NOTIFIER_SEAM: str(notifier) if mode == "command" else "stderr"}
+                    result = self.run_surface(picker, [directory / "one.txt"], directory, log, extra, script=wrapper)
+                    # The seam must not change the wrapper's contract: real
+                    # exit code, no send, full stderr detail still forwarded.
+                    self.assertEqual(result.returncode, 7, result.stderr)
+                    self.assertFalse(log.exists(), result.stderr)
+                    self.assertIn(expected_message, result.stderr)
+                    if mode == "command":
+                        # The notification travels through the seam as
+                        # `<command> "ATM Send-To" "<last stderr line>"` ...
+                        self.assertEqual(record.read_text(encoding="utf-8").splitlines(), ["ATM Send-To", expected_message])
+                    else:
+                        self.assertFalse(record.exists())
+                        self.assertIn(f"ATM Send-To: {expected_message}", result.stderr)
+                    # ... and never through osascript / notify-send (the PATH
+                    # stubs installed by setUp would have recorded a marker).
+                    self.assertFalse(self.ui_marker.exists(), "the wrapper reached a real desktop-notification binary")
+
     @unittest.skipIf(os.name == "nt", "the command wrapper is Unix-only")
     def test_command_wrapper_exits_zero_on_success(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
@@ -328,31 +418,57 @@ class SendToSurfaceTests(unittest.TestCase):
 
 
 # RBQA-F103: ATM_SEND_TO_PICKER / ATM_SEND_TO_NATIVE_PICKER are test-only
-# override seams shipped inside atm-send-to.sh/.ps1 with no mechanical
-# enforcement that they stay documented as test-only or stay confined to the
-# two scripts (plus their own test coverage). This is that enforcement.
-SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER")
+# override seams shipped inside atm-send-to.sh/.ps1, and ATM_SEND_TO_NOTIFIER
+# is the test-only notification seam shipped inside atm-send-to.command /
+# nautilus-atm-send-to.sh, with no mechanical enforcement that they stay
+# documented as test-only or stay confined to their host scripts (plus their
+# own test coverage). This is that enforcement.
+SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER", NOTIFIER_SEAM)
 SEND_TO_SCRIPTS = (
     ROOT / "scripts/send-to/atm-send-to.sh",
     ROOT / "scripts/send-to/atm-send-to.ps1",
 )
-# Files other than the two send-to scripts and `test_*` files that
-# legitimately reference the seam today. Kept as an explicit allowlist
-# (rather than a broader glob) so any new reference is a deliberate,
-# reviewed addition rather than an accidental leak into a shipped path.
+SEND_TO_NOTIFYING_WRAPPERS = (COMMAND_WRAPPER, NAUTILUS_WRAPPER)
+# Which shipped script(s) host each seam: every seam must be read by exactly
+# these files and documented as test-only right where it is read.
+SEND_TO_SEAM_HOSTS = {
+    "ATM_SEND_TO_PICKER": SEND_TO_SCRIPTS,
+    "ATM_SEND_TO_NATIVE_PICKER": SEND_TO_SCRIPTS,
+    NOTIFIER_SEAM: SEND_TO_NOTIFYING_WRAPPERS,
+}
+# Files other than the seam hosts and `test_*` files that legitimately
+# reference a seam today. Kept as an explicit allowlist (rather than a
+# broader glob) so any new reference is a deliberate, reviewed addition
+# rather than an accidental leak into a shipped path.
 SEND_TO_SEAM_REFERENCE_ALLOWLIST = (
     ROOT / "scripts/phase-aq/run_aq5_wyvern_degradation_evidence.py",
     # RBQA-F103's own release-environment guard (see
     # validate_send_to_test_seams in scripts/validate_release.py).
-    ROOT / "scripts/validate_release.py",
+    VALIDATE_RELEASE,
+    # Operator-facing note that the notifier seam is test-only.
+    ROOT / "scripts/send-to/README.md",
 )
 
 
 class SendToTestOnlySeamLintTests(unittest.TestCase):
-    def test_both_scripts_document_the_seam_as_test_only(self) -> None:
-        for script in SEND_TO_SCRIPTS:
-            text = script.read_text(encoding="utf-8")
-            for var in SEND_TO_TEST_ONLY_ENV_VARS:
+    def test_every_seam_has_a_host_script_and_the_release_guard_lists_it(self) -> None:
+        self.assertEqual(set(SEND_TO_SEAM_HOSTS), set(SEND_TO_TEST_ONLY_ENV_VARS))
+        spec = importlib.util.spec_from_file_location("validate_release_for_seam_lint", VALIDATE_RELEASE)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        # dataclasses resolves the defining module through sys.modules at
+        # class-creation time, so the module must be registered before exec.
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        # The release-environment guard must block the exact same set of
+        # seams this lint confines, so a seam can never be added to one list
+        # without the other.
+        self.assertEqual(set(module.SEND_TO_TEST_ONLY_ENV_VARS), set(SEND_TO_TEST_ONLY_ENV_VARS))
+
+    def test_host_scripts_document_the_seam_as_test_only(self) -> None:
+        for var, hosts in SEND_TO_SEAM_HOSTS.items():
+            for script in hosts:
+                text = script.read_text(encoding="utf-8")
                 self.assertIn(var, text, f"{script}: expected a reference to {var}")
                 index = text.index(var)
                 # The documenting comment must sit close to the variable, not
@@ -369,8 +485,11 @@ class SendToTestOnlySeamLintTests(unittest.TestCase):
             ROOT / ".github" / "workflows",
             ROOT / "scripts",
             ROOT / ".just",
+            # The seams live in the shell wrappers only; production Rust must
+            # never read them.
+            ROOT / "crates",
         )
-        allowed = {*SEND_TO_SCRIPTS, *SEND_TO_SEAM_REFERENCE_ALLOWLIST}
+        allowed = {*SEND_TO_SCRIPTS, *SEND_TO_NOTIFYING_WRAPPERS, *SEND_TO_SEAM_REFERENCE_ALLOWLIST}
         stray: list[str] = []
         for root in candidate_roots:
             if not root.exists():
@@ -390,9 +509,9 @@ class SendToTestOnlySeamLintTests(unittest.TestCase):
         self.assertEqual(
             stray,
             [],
-            "the Send-To test-only picker seam must stay confined to "
-            "scripts/send-to/atm-send-to.{sh,ps1}, their tests, and the "
-            "explicit SEND_TO_SEAM_REFERENCE_ALLOWLIST entries:\n" + "\n".join(stray),
+            "the Send-To test-only seams must stay confined to their host "
+            "scripts under scripts/send-to/, their tests, and the explicit "
+            "SEND_TO_SEAM_REFERENCE_ALLOWLIST entries:\n" + "\n".join(stray),
         )
 
 

--- a/.just/tests/test_transfer_scripts.py
+++ b/.just/tests/test_transfer_scripts.py
@@ -163,12 +163,20 @@ FAKE_TRANSFER_LIB = textwrap.dedent(
     def resolve_within_profile(raw_path: str):
         \"\"\"Resolve `raw_path`, refusing (returns None) any path that would
         land outside `FAKE_PROFILE_ROOT` when that containment env var is
-        set. When it is unset, every path is accepted (the default,
-        permissive shape most contract tests use).\"\"\"
+        set. When it is unset (the default, permissive shape most contract
+        tests use), every path is accepted but re-rooted under
+        `FAKE_REMOTE_ROOT`, the fixture's per-test scratch directory: the
+        scripts under test hardcode the *remote* landing root
+        (`/tmp/atm-$(id -u)/send-to/<transfer-id>`), and this fake stands
+        in for the remote host, so it must never create that literal path
+        on the developer's real filesystem.\"\"\"
         resolved = pathlib.Path(raw_path).resolve()
         profile_root = os.environ.get("FAKE_PROFILE_ROOT")
         if profile_root is None:
-            return resolved
+            remote_root = os.environ.get("FAKE_REMOTE_ROOT")
+            if not remote_root:
+                raise SystemExit("fake ssh/scp: the test fixture must set FAKE_REMOTE_ROOT")
+            return pathlib.Path(remote_root) / resolved.relative_to(resolved.anchor)
         root_resolved = pathlib.Path(profile_root).resolve()
         try:
             resolved.relative_to(root_resolved)
@@ -273,6 +281,9 @@ class _TransferScriptContractTestsMixin:
         env = {
             "PATH": (str(bin_dir) + os.pathsep + os.environ.get("PATH", "")) if with_fake_bin else "",
             "FAKE_LOG": str(log_path),
+            # Where the fake ssh/scp materialise the "remote" landing
+            # directory (see fake_transfer_lib.resolve_within_profile).
+            "FAKE_REMOTE_ROOT": str(tmp / "remote"),
             # Ambient ATM child-environment allow-list variables (ADR-055
             # decision (c)): present in a real invocation, harmless here
             # since these scripts never read them directly.
@@ -488,6 +499,7 @@ class SftpPs1Tests(unittest.TestCase):
         env = dict(os.environ)
         env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
         env["FAKE_LOG"] = str(log_path)
+        env["FAKE_REMOTE_ROOT"] = str(tmp / "remote")
         env["ATM_TEMP"] = str(tmp / "atm-temp")
         env["ATM_IDENTITY"] = "test-agent"
         env["ATM_TEAM"] = "test-team"

--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -121,6 +121,7 @@ class ValidateReleaseContractTests(unittest.TestCase):
         clear=False,
     )
     def test_send_to_test_seams_report_every_leaked_variable(self) -> None:
+        os.environ.pop("ATM_SEND_TO_NOTIFIER", None)
         findings: list[VALIDATE_RELEASE.Finding] = []
 
         VALIDATE_RELEASE.validate_send_to_test_seams(self.root, findings)
@@ -128,6 +129,21 @@ class ValidateReleaseContractTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertIn("ATM_SEND_TO_PICKER", findings[0].detail)
         self.assertIn("ATM_SEND_TO_NATIVE_PICKER", findings[0].detail)
+
+    @mock.patch.dict(os.environ, {"ATM_SEND_TO_NOTIFIER": "none"}, clear=False)
+    def test_send_to_test_seams_block_when_the_notifier_override_leaks(self) -> None:
+        # The wrapper-level notification seam (atm-send-to.command /
+        # nautilus-atm-send-to.sh) is a test-only seam exactly like the
+        # picker overrides: a release environment must never carry it.
+        os.environ.pop("ATM_SEND_TO_PICKER", None)
+        os.environ.pop("ATM_SEND_TO_NATIVE_PICKER", None)
+        findings: list[VALIDATE_RELEASE.Finding] = []
+
+        VALIDATE_RELEASE.validate_send_to_test_seams(self.root, findings)
+
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].blocks)
+        self.assertEqual(findings[0].detail, "ATM_SEND_TO_NOTIFIER")
 
     @mock.patch.object(VALIDATE_RELEASE, "run_capture")
     def test_validate_cli_surface_uses_the_feature_gated_contract(self, run_capture: mock.Mock) -> None:

--- a/scripts/send-to/README.md
+++ b/scripts/send-to/README.md
@@ -15,7 +15,10 @@ Shortcut that receives Finder files. The native picker is AppleScript's
 `osascript Choose from list`; cancel exits nonzero and does not invoke `atm
 send`. `atm-send-to.command` also raises a native `osascript display
 notification` if the pipeline fails, since a Quick Action has no visible
-terminal to show stderr in.
+terminal to show stderr in. (`ATM_SEND_TO_NOTIFIER` is a test-only seam that
+replaces that notification -- and `nautilus-atm-send-to.sh`'s `notify-send`
+one -- with a non-UI action so the test suite never raises a real desktop
+notification; production launches never set it.)
 
 ## Windows Explorer SendTo
 

--- a/scripts/send-to/atm-send-to.command
+++ b/scripts/send-to/atm-send-to.command
@@ -22,7 +22,21 @@ fi
 
 message=$(tail -n 1 "$stderr_file" 2>/dev/null || true)
 [ -n "$message" ] || message="ATM Send-To failed (exit $status)"
-if command -v osascript >/dev/null 2>&1; then
+# Test-only seam: when set, replaces the native `osascript display
+# notification` below with a non-UI action so the wrapper's failure path can
+# be exercised by .just/tests/test_send_to_surface.py without popping a real
+# notification on the developer's desktop. `none` suppresses the
+# notification, `stderr` prints the notification text to stderr, and any
+# other value is run as `<command> "ATM Send-To" "$message"`. Production
+# launches never set this; the osascript branch below stays the default.
+notifier=${ATM_SEND_TO_NOTIFIER:-}
+if [ -n "$notifier" ]; then
+    case "$notifier" in
+        none) ;;
+        stderr) printf 'ATM Send-To: %s\n' "$message" >&2 ;;
+        *) "$notifier" "ATM Send-To" "$message" >/dev/null 2>&1 || true ;;
+    esac
+elif command -v osascript >/dev/null 2>&1; then
     escaped=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g')
     osascript -e "display notification \"$escaped\" with title \"ATM Send-To\"" >/dev/null 2>&1 || true
 fi

--- a/scripts/send-to/nautilus-atm-send-to.sh
+++ b/scripts/send-to/nautilus-atm-send-to.sh
@@ -22,7 +22,20 @@ fi
 
 message=$(tail -n 1 "$stderr_file" 2>/dev/null || true)
 [ -n "$message" ] || message="ATM Send-To failed (exit $status)"
-if command -v notify-send >/dev/null 2>&1; then
+# Test-only seam (same contract as atm-send-to.command): when set, replaces
+# the `notify-send` desktop notification below with a non-UI action so
+# .just/tests/test_send_to_surface.py never raises a real notification.
+# `none` suppresses it, `stderr` prints the notification text to stderr, and
+# any other value is run as `<command> "ATM Send-To" "$message"`. Production
+# launches never set this; the notify-send branch below stays the default.
+notifier=${ATM_SEND_TO_NOTIFIER:-}
+if [ -n "$notifier" ]; then
+    case "$notifier" in
+        none) ;;
+        stderr) printf 'ATM Send-To: %s\n' "$message" >&2 ;;
+        *) "$notifier" "ATM Send-To" "$message" >/dev/null 2>&1 || true ;;
+    esac
+elif command -v notify-send >/dev/null 2>&1; then
     notify-send "ATM Send-To" "$message" >/dev/null 2>&1 || true
 fi
 exit "$status"

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -24,8 +24,11 @@ REQUIRED_RELEASE_FILES = (
 )
 REQUIRED_RELEASE_BINARIES = ("atm", "atm-daemon")
 # RBQA-F103: test-only override seams from scripts/send-to/atm-send-to.sh /
-# .ps1 that must never be set in a real release environment.
-SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER")
+# .ps1 (picker overrides) and atm-send-to.command / nautilus-atm-send-to.sh
+# (desktop-notification override) that must never be set in a real release
+# environment. Keep in sync with SEND_TO_TEST_ONLY_ENV_VARS in
+# .just/tests/test_send_to_surface.py (a test there asserts the two agree).
+SEND_TO_TEST_ONLY_ENV_VARS = ("ATM_SEND_TO_PICKER", "ATM_SEND_TO_NATIVE_PICKER", "ATM_SEND_TO_NOTIFIER")
 KIT_RELEASE_ARTIFACTS = ".github/scripts/release_artifacts.py"
 CHECK_DEP_CURRENCY_ENV = "ATMD_CHECK_DEP_CURRENCY"
 GITHUB_ISSUE_ENV = "ATMD_GH_AUTOFIX_ISSUES"
@@ -277,13 +280,16 @@ def validate_support_files(root: Path, findings: list[Finding]) -> None:
 
 
 def validate_send_to_test_seams(root: Path, findings: list[Finding]) -> None:
-    """Fail release validation if a Send-To test-only picker override leaked
-    into the release environment.
+    """Fail release validation if a Send-To test-only override leaked into
+    the release environment.
 
     ATM_SEND_TO_PICKER / ATM_SEND_TO_NATIVE_PICKER exist only so the
     degradation harness can exercise scripts/send-to/atm-send-to.sh / .ps1
-    without a real UI (see .just/tests/test_send_to_surface.py). Neither
-    variable has a legitimate reason to be set while validating a release.
+    without a real UI, and ATM_SEND_TO_NOTIFIER only so the same harness can
+    exercise atm-send-to.command / nautilus-atm-send-to.sh's failure path
+    without raising a real desktop notification (see
+    .just/tests/test_send_to_surface.py). None of them has a legitimate
+    reason to be set while validating a release.
     """
     _ = root  # signature kept uniform with the other validate_* targets
     leaked = sorted(name for name in SEND_TO_TEST_ONLY_ENV_VARS if os.environ.get(name))
@@ -292,7 +298,7 @@ def validate_send_to_test_seams(root: Path, findings: list[Finding]) -> None:
             Finding(
                 check="send-to-test-seams",
                 severity="error",
-                summary="Send-To test-only picker override is set in the release environment",
+                summary="Send-To test-only override is set in the release environment",
                 detail=", ".join(leaked),
             )
         )


### PR DESCRIPTION
## Root cause

dcff4bac3 (AQ5 GUI notifications) made `scripts/send-to/atm-send-to.command` raise a real `osascript -e 'display notification ... with title "ATM Send-To"'` on its failure path. `.just/tests/test_send_to_surface.py::test_command_wrapper_propagates_exit_code_and_forwards_stderr_on_failure` drives exactly that path with a picker fixture that exits 7, guarded only by `skipIf(os.name == "nt")`. None of the existing `ATM_SEND_TO_*` picker seams help because the wrapper itself emits the notification after the picker seam has run. The file is run by `.just/run_pytests.py`, `.just/run_lint.py`, and `scripts/validate_release.py`, so every `just test` / `just lint` / `just validate` popped a macOS notification on the developer's desktop. Reproduced before the fix by shadowing `osascript` on PATH with a marker-writing stub.

## The seam: `ATM_SEND_TO_NOTIFIER`

Wrapper-level, test-only, POSIX sh, in `atm-send-to.command` and `nautilus-atm-send-to.sh` (the `notify-send` twin of the same leak):

| value | behaviour |
|---|---|
| unset / empty | unchanged: `osascript` / `notify-send` notification exactly as before |
| `none` | no notification |
| `stderr` | prints `ATM Send-To: <message>` to stderr |
| anything else | runs `<command> "ATM Send-To" "<message>"` (failures ignored, like the real notifier) |

The seam is never read by Rust; it lives in the shell wrappers only.

## Test harness

- `run_surface` sets `ATM_SEND_TO_NOTIFIER=none` for every wrapper run and prepends marker-recording `osascript` / `notify-send` stubs to PATH; `tearDown` asserts the marker was never written, so any future regression fails the suite instead of popping UI.
- New `test_wrapper_notification_seam_replaces_the_desktop_notification_on_failure` drives both wrappers through the `command` and `stderr` modes and asserts the notification text arrives via the seam (recorded argv `["ATM Send-To", "<last stderr line>"]`), exit code/stderr contract unchanged, and osascript/notify-send untouched.
- `.just/tests/test_picker_exclusion.py` was already hermetic (`ATM_SEND_TO_SELECTION` is consulted before any backend); unchanged.

## Registration

- `scripts/validate_release.py::SEND_TO_TEST_ONLY_ENV_VARS` (release-environment guard, `send-to-test-seams` target) now includes `ATM_SEND_TO_NOTIFIER`; new leak test in `.just/tests/test_validate_release.py`.
- `.just/tests/test_send_to_surface.py` seam-confinement lint: `SEND_TO_SEAM_HOSTS` maps each seam to the script(s) allowed to read it (documented as test-only next to the read), the stray-reference scan now also covers `crates/`, and a new test asserts the lint's list equals `validate_release.py`'s.
- `scripts/send-to/README.md` notes the seam is test-only.

## Side fix (separate commit)

The `/tmp/atm-<uid>/send-to/01J000...{42,46,47,f01}/` staging dirs came from `.just/tests/test_transfer_scripts.py`, not cargo tests: its fake `ssh`/`scp` created the *literal* remote path that `sftp.sh` / `tailscale.sh` hardcode. The fakes now re-root writes under a per-test `FAKE_REMOTE_ROOT`; assertions and production code unchanged.

## Verification

- `pytest .just/tests/test_send_to_surface.py .just/tests/test_picker_exclusion.py .just/tests/test_validate_release.py` with an external `osascript` stub on PATH: 38 passed, 1 skipped (pwsh), marker absent.
- `pytest .just/tests/test_transfer_scripts.py scripts/phase-aq/test_run_aq4_transfer_evidence.py .just/tests/test_run_lint.py`: pass; `/tmp/atm-501/send-to` mtimes unchanged across runs.
- `python3 .just/lint_codespell.py`: rc 0. `python3 scripts/validate_release.py send-to-test-seams`: pass.
- Default path (seam unset) still reaches `osascript` with the identical `display notification` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
