### PR TITLE
fix(aw2): AW2-QA-I2 real diagnostic saturation lane test (AC7)

### DIFF
--- a/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
+++ b/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
@@ -382,7 +382,7 @@ impl DegradationMonitor {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::{
         BufferedEvents, DEGRADATION_RECOVERY_WINDOW_SECS, DegradationMonitor, DiagnosticPolicy,
@@ -407,35 +407,6 @@ mod tests {
                 .expect("fixture batches")
                 .push(events.to_vec());
             Ok(())
-        }
-
-        fn query(&self, _query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
-            Ok(Vec::new())
-        }
-
-        fn prune(&self, _now_unix_ms: i64) -> Result<u64, AtmError> {
-            Ok(0)
-        }
-    }
-
-    /// Models the real lower-priority lane while its worker is paused in the
-    /// first batch: one batch is in flight and the bounded queue holds the
-    /// remaining `DIAGNOSTIC_QUEUE_BATCHES` batches.
-    #[derive(Default)]
-    struct PausedTimeline {
-        accepted_batches: AtomicUsize,
-    }
-
-    impl DiagnosticTimelineStore for PausedTimeline {
-        fn record_batch(&self, _events: &[DiagnosticEvent]) -> Result<(), AtmError> {
-            let accepted = self.accepted_batches.fetch_add(1, Ordering::Relaxed);
-            if accepted < atm_runtime_test_support::diagnostic_queue_batches_for_test() + 1 {
-                Ok(())
-            } else {
-                Err(AtmError::daemon_unavailable(
-                    "diagnostic timeline queue is full; batch dropped",
-                ))
-            }
         }
 
         fn query(&self, _query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
@@ -550,70 +521,6 @@ mod tests {
                 .expect("recovered state")
                 .degraded_since
                 .is_none()
-        );
-    }
-
-    #[test]
-    fn ac7_offer_overflow_counts_the_paused_writer_excess() {
-        let store = std::sync::Arc::new(PausedTimeline::default());
-        let writer = DiagnosticTimelineWriter {
-            store,
-            policy: DiagnosticPolicy::default(),
-            stats: std::sync::Arc::new(DiagnosticTimelineStats::default()),
-            persistence_stats: None,
-            buffered: std::sync::Mutex::new(BufferedEvents {
-                events: Vec::new(),
-                last_flush: std::time::Instant::now(),
-            }),
-        };
-        let event = info_event(atm_observability::RETAINED_INFO_TARGETS[0]);
-        let accepted_events = (atm_runtime_test_support::diagnostic_queue_batches_for_test() + 1)
-            * super::DIAGNOSTIC_BATCH_MAX;
-        for _ in 0..accepted_events {
-            assert_eq!(writer.offer(&event), SinkOffer::Accepted);
-        }
-
-        for _ in 1..super::DIAGNOSTIC_BATCH_MAX {
-            assert_eq!(writer.offer(&event), SinkOffer::Accepted);
-        }
-        assert_eq!(
-            writer.offer(&event),
-            SinkOffer::Dropped(DropReason::QueueFull)
-        );
-        assert_eq!(
-            writer
-                .stats()
-                .timeline_dropped_queue_full_total
-                .load(Ordering::Relaxed),
-            super::DIAGNOSTIC_BATCH_MAX as u64,
-            "the only excess beyond the one in-flight and bounded queued batches is dropped"
-        );
-
-        let monitor = DegradationMonitor::default();
-        let dropped_total = writer
-            .stats()
-            .timeline_dropped_queue_full_total
-            .load(Ordering::Relaxed);
-        monitor.observe("timeline", dropped_total);
-        monitor.observe("timeline", dropped_total);
-        {
-            let mut sinks = monitor.sinks.lock().expect("monitor state");
-            let state = sinks.get_mut("timeline").expect("degraded state");
-            assert_eq!(state.emitted_codes, ["ATM_LOG_SINK_DEGRADED"]);
-            state.degraded_since = Some(
-                std::time::Instant::now()
-                    - std::time::Duration::from_secs(DEGRADATION_RECOVERY_WINDOW_SECS + 1),
-            );
-            state.last_transition = None;
-        }
-        monitor.observe("timeline", dropped_total);
-        let sinks = monitor.sinks.lock().expect("monitor state");
-        assert_eq!(
-            sinks
-                .get("timeline")
-                .expect("recovered state")
-                .emitted_codes,
-            ["ATM_LOG_SINK_DEGRADED", "ATM_LOG_SINK_RECOVERED"]
         );
     }
 }

--- a/crates/atm-storage-rusqlite/src/writer/mod.rs
+++ b/crates/atm-storage-rusqlite/src/writer/mod.rs
@@ -1094,6 +1094,82 @@ mod tests {
         assert_eq!(persisted, 1);
     }
 
+    #[test]
+    fn ac7_real_diagnostic_channel_saturation_persists_a_bridged_row_after_drain() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:writer-ac7-saturation-{}?mode=memory&cache=shared",
+                NEXT_TEST_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_writer_connection_for_target(&target).expect("writer connection");
+        ensure_schema(&mut connection, &target).expect("schema");
+        let mut cache = stmt_cache::WriterStatementCache;
+        let diagnostic_stats = DiagnosticTimelinePersistenceStats::default();
+        let mut rows_since_prune = 0;
+
+        let (_primary_sender, mut primary_receiver) = tokio::sync::mpsc::channel(1);
+        let (diagnostic_sender, mut diagnostic_receiver) =
+            tokio::sync::mpsc::channel(DIAGNOSTIC_QUEUE_BATCHES);
+        let bridged = DiagnosticEvent {
+            ts_unix_ms: 42,
+            level: "warn".to_owned(),
+            component: "tracing.bridge.fixture".to_owned(),
+            code: Some("ATM_BRIDGED_FIXTURE".to_owned()),
+            correlation_id: None,
+            origin: "tracing".to_owned(),
+            message: "bridged diagnostic".to_owned(),
+            detail: None,
+        };
+        diagnostic_sender
+            .try_send(DiagnosticWriterMessage::Records(vec![bridged.clone()]))
+            .expect("enqueue bridged diagnostic on the real lower-priority channel");
+        for _ in 1..DIAGNOSTIC_QUEUE_BATCHES {
+            diagnostic_sender
+                .try_send(DiagnosticWriterMessage::Records(vec![bridged.clone()]))
+                .expect("fill the real bounded diagnostic channel");
+        }
+        assert!(matches!(
+            diagnostic_sender.try_send(DiagnosticWriterMessage::Records(vec![bridged])),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_))
+        ));
+
+        let Some(WriterWork::Diagnostics(DiagnosticWriterMessage::Records(batch))) = runtime
+            .block_on(receive_next_work(
+                &mut primary_receiver,
+                &mut diagnostic_receiver,
+                false,
+            ))
+        else {
+            panic!("the real saturated diagnostic channel must yield its first batch when idle");
+        };
+        process_diagnostic_batch(
+            &target,
+            &mut connection,
+            &mut cache,
+            batch,
+            &mut rows_since_prune,
+            &diagnostic_stats,
+        );
+
+        assert_eq!(
+            diagnostic_receiver.len(),
+            DIAGNOSTIC_QUEUE_BATCHES - 1,
+            "draining one real bounded-channel batch leaves the remaining backlog intact"
+        );
+        let persisted: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM diagnostic_events WHERE code = ?1 AND origin = ?2",
+                params!["ATM_BRIDGED_FIXTURE", "tracing"],
+                |row| row.get(0),
+            )
+            .expect("count persisted bridged row");
+        assert_eq!(persisted, 1);
+    }
+
     static NEXT_TEST_DB_ID: AtomicU64 = AtomicU64::new(1);
 
     fn message(key: &str) -> Message {


### PR DESCRIPTION
Follow-up to PR #1179 (already merged). Closes non-blocking finding AW2-QA-I2 (AC7): replaces the PausedTimeline test double with a deterministic real bounded diagnostic writer-channel test plus SQLite persistence assertion.

## Test plan
- cargo test
- required pytest
- just lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)