### PR TITLE
fix: align doctor diagnostics health projection

### DIFF
--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -4167,6 +4167,61 @@ fn av3_read_handler_allowed_types() -> BTreeSet<String> {
         .collect()
 }
 
+#[test]
+fn aw_diagnostics_composition_stays_behind_the_timeline_store_contract() {
+    let root = workspace_root();
+    let bootstrap =
+        read_source(&root.join("crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs"));
+    let diagnostics_route =
+        read_source(&root.join("crates/atm-http-runtime/src/diagnostics_route.rs"));
+    let doctor_observability =
+        read_source(&root.join("crates/atm-http-runtime/src/doctor_observability.rs"));
+    let sqlite_backend = read_source(&root.join("crates/atm-storage-rusqlite/src/lib.rs"));
+    let sqlite_backend_implementation = sqlite_backend
+        .split("impl SqliteStorageBackend {")
+        .nth(1)
+        .expect("SQLite storage backend implementation");
+    let sqlite_production = sqlite_backend_implementation
+        .split("\n    #[cfg(test)]")
+        .next()
+        .expect("storage backend production region");
+
+    assert!(
+        bootstrap.contains("let store: Arc<dyn DiagnosticTimelineStore> = store;")
+            && bootstrap.contains("DiagnosticTimelineWriter::new_with_persistence("),
+        "bootstrap must erase the SQLite implementation at the diagnostic timeline composition seam"
+    );
+    assert!(
+        diagnostics_route.contains("Option<Arc<dyn DiagnosticTimelineStore>>"),
+        "the diagnostics HTTP route must accept only the timeline-store capability"
+    );
+    for forbidden in [
+        "SqliteDiagnosticTimeline",
+        "atm_storage_rusqlite",
+        "SharedDb",
+    ] {
+        assert!(
+            !diagnostics_route.contains(forbidden),
+            "the diagnostics HTTP route must not name the SQLite implementation `{forbidden}`"
+        );
+        assert!(
+            !doctor_observability.contains(forbidden),
+            "the doctor diagnostics projection must not name the SQLite implementation `{forbidden}`"
+        );
+    }
+    assert_eq!(
+        sqlite_production
+            .matches("SqliteDiagnosticTimeline::from_shared_db")
+            .count(),
+        1,
+        "the storage backend must retain exactly one production construction path for its shared diagnostic timeline"
+    );
+    assert!(
+        !sqlite_production.contains("SqliteDiagnosticTimeline {"),
+        "the storage backend must construct the diagnostic timeline only through from_shared_db"
+    );
+}
+
 fn av3_trait_signature_types(source: &str, trait_name: &str) -> BTreeSet<String> {
     let syntax = syn::parse_file(source).expect("AV.3 trait source must parse as Rust");
     let trait_item = syntax

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -578,6 +578,27 @@ pub struct AtmTimelineObservabilityCounters {
     pub dropped_persist_error_total: u64,
 }
 
+impl AtmObservabilityHealth {
+    /// Projects the shared retained-diagnostics health contract onto the
+    /// doctor report without duplicating its degradation classifier.
+    pub fn apply_retained_diagnostics(
+        &mut self,
+        retained: crate::observability_counters::RetainedObservabilityHealth,
+    ) {
+        self.jsonl = AtmJsonlObservabilityCounters {
+            forwarded_total: retained.jsonl.forwarded_total,
+            dropped_queue_full_total: retained.jsonl.dropped_queue_full_total,
+            dropped_reentrant_total: retained.jsonl.dropped_reentrant_total,
+        };
+        self.timeline = AtmTimelineObservabilityCounters {
+            written_total: retained.timeline.written_total,
+            dropped_queue_full_total: retained.timeline.dropped_queue_full_total,
+            dropped_persist_error_total: retained.timeline.dropped_persist_error_total,
+        };
+        self.degraded = retained.degraded;
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AtmMaintenanceWorkerState {

--- a/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
+++ b/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
@@ -382,7 +382,7 @@ impl DegradationMonitor {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::{
         BufferedEvents, DEGRADATION_RECOVERY_WINDOW_SECS, DegradationMonitor, DiagnosticPolicy,
@@ -407,35 +407,6 @@ mod tests {
                 .expect("fixture batches")
                 .push(events.to_vec());
             Ok(())
-        }
-
-        fn query(&self, _query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
-            Ok(Vec::new())
-        }
-
-        fn prune(&self, _now_unix_ms: i64) -> Result<u64, AtmError> {
-            Ok(0)
-        }
-    }
-
-    /// Models the real lower-priority lane while its worker is paused in the
-    /// first batch: one batch is in flight and the bounded queue holds the
-    /// remaining `DIAGNOSTIC_QUEUE_BATCHES` batches.
-    #[derive(Default)]
-    struct PausedTimeline {
-        accepted_batches: AtomicUsize,
-    }
-
-    impl DiagnosticTimelineStore for PausedTimeline {
-        fn record_batch(&self, _events: &[DiagnosticEvent]) -> Result<(), AtmError> {
-            let accepted = self.accepted_batches.fetch_add(1, Ordering::Relaxed);
-            if accepted < atm_runtime_test_support::diagnostic_queue_batches_for_test() + 1 {
-                Ok(())
-            } else {
-                Err(AtmError::daemon_unavailable(
-                    "diagnostic timeline queue is full; batch dropped",
-                ))
-            }
         }
 
         fn query(&self, _query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
@@ -550,70 +521,6 @@ mod tests {
                 .expect("recovered state")
                 .degraded_since
                 .is_none()
-        );
-    }
-
-    #[test]
-    fn ac7_offer_overflow_counts_the_paused_writer_excess() {
-        let store = std::sync::Arc::new(PausedTimeline::default());
-        let writer = DiagnosticTimelineWriter {
-            store,
-            policy: DiagnosticPolicy::default(),
-            stats: std::sync::Arc::new(DiagnosticTimelineStats::default()),
-            persistence_stats: None,
-            buffered: std::sync::Mutex::new(BufferedEvents {
-                events: Vec::new(),
-                last_flush: std::time::Instant::now(),
-            }),
-        };
-        let event = info_event(atm_observability::RETAINED_INFO_TARGETS[0]);
-        let accepted_events = (atm_runtime_test_support::diagnostic_queue_batches_for_test() + 1)
-            * super::DIAGNOSTIC_BATCH_MAX;
-        for _ in 0..accepted_events {
-            assert_eq!(writer.offer(&event), SinkOffer::Accepted);
-        }
-
-        for _ in 1..super::DIAGNOSTIC_BATCH_MAX {
-            assert_eq!(writer.offer(&event), SinkOffer::Accepted);
-        }
-        assert_eq!(
-            writer.offer(&event),
-            SinkOffer::Dropped(DropReason::QueueFull)
-        );
-        assert_eq!(
-            writer
-                .stats()
-                .timeline_dropped_queue_full_total
-                .load(Ordering::Relaxed),
-            super::DIAGNOSTIC_BATCH_MAX as u64,
-            "the only excess beyond the one in-flight and bounded queued batches is dropped"
-        );
-
-        let monitor = DegradationMonitor::default();
-        let dropped_total = writer
-            .stats()
-            .timeline_dropped_queue_full_total
-            .load(Ordering::Relaxed);
-        monitor.observe("timeline", dropped_total);
-        monitor.observe("timeline", dropped_total);
-        {
-            let mut sinks = monitor.sinks.lock().expect("monitor state");
-            let state = sinks.get_mut("timeline").expect("degraded state");
-            assert_eq!(state.emitted_codes, ["ATM_LOG_SINK_DEGRADED"]);
-            state.degraded_since = Some(
-                std::time::Instant::now()
-                    - std::time::Duration::from_secs(DEGRADATION_RECOVERY_WINDOW_SECS + 1),
-            );
-            state.last_transition = None;
-        }
-        monitor.observe("timeline", dropped_total);
-        let sinks = monitor.sinks.lock().expect("monitor state");
-        assert_eq!(
-            sinks
-                .get("timeline")
-                .expect("recovered state")
-                .emitted_codes,
-            ["ATM_LOG_SINK_DEGRADED", "ATM_LOG_SINK_RECOVERED"]
         );
     }
 }

--- a/crates/atm-http-runtime/src/doctor_observability.rs
+++ b/crates/atm-http-runtime/src/doctor_observability.rs
@@ -2,16 +2,23 @@
 
 use atm_core::doctor::{DoctorFinding, DoctorSeverity};
 use atm_core::error::AtmErrorCode;
+use atm_core::observability::AtmObservabilityHealth;
 use atm_core::observability_counters::{DiagnosticCounters, RetainedObservabilityHealth};
+
+pub(crate) fn project_counter_health(
+    observability: &mut AtmObservabilityHealth,
+    counters: DiagnosticCounters,
+) {
+    observability.apply_retained_diagnostics(RetainedObservabilityHealth::from(counters));
+}
 
 pub(crate) fn append_counter_finding(
     findings: &mut Vec<DoctorFinding>,
     counters: DiagnosticCounters,
 ) {
-    let degraded = counters.jsonl_dropped_queue_full_total > 0
-        || counters.jsonl_dropped_reentrant_total > 0
-        || counters.timeline_dropped_queue_full_total > 0
-        || counters.timeline_dropped_persist_error_total > 0;
+    let degraded = !RetainedObservabilityHealth::from(counters)
+        .degraded
+        .is_empty();
     let severity = if degraded {
         DoctorSeverity::Warning
     } else {
@@ -39,8 +46,4 @@ pub(crate) fn append_counter_finding(
                 .to_owned()
         }),
     });
-}
-
-pub(crate) fn degraded_sources(counters: DiagnosticCounters) -> Vec<String> {
-    RetainedObservabilityHealth::from(counters).degraded
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -34,7 +34,7 @@ use crate::CanonicalWriteHandler;
 use crate::PeerConnectionPool;
 use crate::RuntimeHealth;
 use crate::bare_cli_fifo::{BareCliFifo, BareCliQueueFullDrops, drain_bare_cli_messages};
-use crate::doctor_observability::{append_counter_finding, degraded_sources};
+use crate::doctor_observability::{append_counter_finding, project_counter_health};
 use crate::router_support::{ControlPathSyncBridge, DetachedReceivedHooks, retry_deferred_marker};
 
 /// The replacement implementation of the canonical write operation.
@@ -563,17 +563,7 @@ impl StorageAndNudgeRouter {
             .expect("projection retains runtime status");
         report.herdr_queue_pump.last_tick_at = runtime_status.herdr_queue_last_tick_at;
         report.herdr_queue_pump.breaker = report.herdr_breaker.clone();
-        report.observability.jsonl.forwarded_total = diagnostic_counters.jsonl_forwarded_total;
-        report.observability.jsonl.dropped_queue_full_total =
-            diagnostic_counters.jsonl_dropped_queue_full_total;
-        report.observability.jsonl.dropped_reentrant_total =
-            diagnostic_counters.jsonl_dropped_reentrant_total;
-        report.observability.timeline.written_total = diagnostic_counters.timeline_written_total;
-        report.observability.timeline.dropped_queue_full_total =
-            diagnostic_counters.timeline_dropped_queue_full_total;
-        report.observability.timeline.dropped_persist_error_total =
-            diagnostic_counters.timeline_dropped_persist_error_total;
-        report.observability.degraded = degraded_sources(diagnostic_counters);
+        project_counter_health(&mut report.observability, diagnostic_counters);
         append_counter_finding(&mut report.findings, diagnostic_counters);
         Ok(ApiResponse::new(ResponseEnvelope::Doctor(Box::new(report))))
     }
@@ -996,7 +986,9 @@ mod tests {
         PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind,
     };
     use atm_core::observability::NullObservability;
-    use atm_core::observability_counters::{DiagnosticCounters, DiagnosticCountersSource};
+    use atm_core::observability_counters::{
+        DiagnosticCounters, DiagnosticCountersSource, RetainedObservabilityHealth,
+    };
     use atm_core::protocol::{
         GraftReceiverRegistration, GraftReceiverUnregistration, HeartbeatActivity, OwnerGeneration,
         QueueGetNextRequest, QueuedNudgeMessage, RequestEnvelope, ResponseEnvelope,
@@ -2208,7 +2200,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn doctor_reports_bootstrap_injected_server_version() {
+    async fn doctor_observability_fields_match_health_projection() {
         let fixture = fixture(true, None, None);
         let assembly =
             open_sqlite_boundary(&fixture.database_path).expect("reopen doctor boundary");
@@ -2227,18 +2219,21 @@ mod tests {
             http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),
             peer_wire_security: None,
         };
+        let counters = DiagnosticCounters {
+            jsonl_forwarded_total: 13,
+            jsonl_dropped_queue_full_total: 2,
+            jsonl_dropped_reentrant_total: 1,
+            timeline_written_total: 11,
+            timeline_dropped_queue_full_total: 3,
+            timeline_dropped_persist_error_total: 1,
+        };
+        let expected_health = RetainedObservabilityHealth::from(counters);
         let response = fixture
             .router
             .clone()
             .with_doctor_projection(Arc::new(doctor_projection))
             .with_daemon_context(daemon_context.clone())
-            .with_diagnostic_counters(Arc::new(CounterFixture(DiagnosticCounters {
-                jsonl_forwarded_total: 13,
-                jsonl_dropped_reentrant_total: 1,
-                timeline_written_total: 11,
-                timeline_dropped_persist_error_total: 1,
-                ..DiagnosticCounters::default()
-            })))
+            .with_diagnostic_counters(Arc::new(CounterFixture(counters)))
             .dispatch(
                 ApiRequest::new(atm_core::protocol::RequestEnvelope::Doctor(
                     atm_core::doctor::DoctorQuery::default(),
@@ -2253,11 +2248,31 @@ mod tests {
                 assert_eq!(report.daemon_context, Some(daemon_context));
                 assert_eq!(report.herdr_queue_pump.last_tick_at, None);
                 assert_eq!(report.herdr_queue_pump.breaker, report.herdr_breaker);
-                assert_eq!(report.observability.jsonl.forwarded_total, 13);
-                assert_eq!(report.observability.jsonl.dropped_reentrant_total, 1);
-                assert_eq!(report.observability.timeline.written_total, 11);
-                assert_eq!(report.observability.timeline.dropped_persist_error_total, 1);
-                assert_eq!(report.observability.degraded, ["jsonl", "timeline"]);
+                assert_eq!(
+                    report.observability.jsonl.forwarded_total,
+                    expected_health.jsonl.forwarded_total
+                );
+                assert_eq!(
+                    report.observability.jsonl.dropped_queue_full_total,
+                    expected_health.jsonl.dropped_queue_full_total
+                );
+                assert_eq!(
+                    report.observability.jsonl.dropped_reentrant_total,
+                    expected_health.jsonl.dropped_reentrant_total
+                );
+                assert_eq!(
+                    report.observability.timeline.written_total,
+                    expected_health.timeline.written_total
+                );
+                assert_eq!(
+                    report.observability.timeline.dropped_queue_full_total,
+                    expected_health.timeline.dropped_queue_full_total
+                );
+                assert_eq!(
+                    report.observability.timeline.dropped_persist_error_total,
+                    expected_health.timeline.dropped_persist_error_total
+                );
+                assert_eq!(report.observability.degraded, expected_health.degraded);
             }
             other => panic!("expected doctor report, got {other:?}"),
         }

--- a/crates/atm-storage-rusqlite/src/writer/mod.rs
+++ b/crates/atm-storage-rusqlite/src/writer/mod.rs
@@ -1094,6 +1094,82 @@ mod tests {
         assert_eq!(persisted, 1);
     }
 
+    #[test]
+    fn ac7_real_diagnostic_channel_saturation_persists_a_bridged_row_after_drain() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:writer-ac7-saturation-{}?mode=memory&cache=shared",
+                NEXT_TEST_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_writer_connection_for_target(&target).expect("writer connection");
+        ensure_schema(&mut connection, &target).expect("schema");
+        let mut cache = stmt_cache::WriterStatementCache;
+        let diagnostic_stats = DiagnosticTimelinePersistenceStats::default();
+        let mut rows_since_prune = 0;
+
+        let (_primary_sender, mut primary_receiver) = tokio::sync::mpsc::channel(1);
+        let (diagnostic_sender, mut diagnostic_receiver) =
+            tokio::sync::mpsc::channel(DIAGNOSTIC_QUEUE_BATCHES);
+        let bridged = DiagnosticEvent {
+            ts_unix_ms: 42,
+            level: "warn".to_owned(),
+            component: "tracing.bridge.fixture".to_owned(),
+            code: Some("ATM_BRIDGED_FIXTURE".to_owned()),
+            correlation_id: None,
+            origin: "tracing".to_owned(),
+            message: "bridged diagnostic".to_owned(),
+            detail: None,
+        };
+        diagnostic_sender
+            .try_send(DiagnosticWriterMessage::Records(vec![bridged.clone()]))
+            .expect("enqueue bridged diagnostic on the real lower-priority channel");
+        for _ in 1..DIAGNOSTIC_QUEUE_BATCHES {
+            diagnostic_sender
+                .try_send(DiagnosticWriterMessage::Records(vec![bridged.clone()]))
+                .expect("fill the real bounded diagnostic channel");
+        }
+        assert!(matches!(
+            diagnostic_sender.try_send(DiagnosticWriterMessage::Records(vec![bridged])),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_))
+        ));
+
+        let Some(WriterWork::Diagnostics(DiagnosticWriterMessage::Records(batch))) = runtime
+            .block_on(receive_next_work(
+                &mut primary_receiver,
+                &mut diagnostic_receiver,
+                false,
+            ))
+        else {
+            panic!("the real saturated diagnostic channel must yield its first batch when idle");
+        };
+        process_diagnostic_batch(
+            &target,
+            &mut connection,
+            &mut cache,
+            batch,
+            &mut rows_since_prune,
+            &diagnostic_stats,
+        );
+
+        assert_eq!(
+            diagnostic_receiver.len(),
+            DIAGNOSTIC_QUEUE_BATCHES - 1,
+            "draining one real bounded-channel batch leaves the remaining backlog intact"
+        );
+        let persisted: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM diagnostic_events WHERE code = ?1 AND origin = ?2",
+                params!["ATM_BRIDGED_FIXTURE", "tracing"],
+                |row| row.get(0),
+            )
+            .expect("count persisted bridged row");
+        assert_eq!(persisted, 1);
+    }
+
     static NEXT_TEST_DB_ID: AtomicU64 = AtomicU64::new(1);
 
     fn message(key: &str) -> Message {

--- a/docs/plans/phase-aw/sprint-AW.5-native-tool-parity.md
+++ b/docs/plans/phase-aw/sprint-AW.5-native-tool-parity.md
@@ -58,8 +58,9 @@ selected (`PyMessage::from_read` → `_message_result`). The real gaps are:
    field). The ack case sends a `requires_ack` message from a second
    fixture identity, acks it natively, and compares against the CLI ack of
    a twin message. The test
-   lives in `crates/atm-graft-python/tests/test_cli_parity.py` and is in the
-   3.11–3.14 matrix.
+   lives in `crates/atm-graft-python/tests/test_cli_parity.py` and runs in
+   CI's platform test job on Python 3.14.7. The abi3 compatibility matrix
+   independently validates wheel imports on Python 3.11–3.14.
 4. **Boundary (definite)**: the binding adds its explicitly allowlisted
    `serde_json` dependency so each `to_json()` method uses the canonical
    serializer directly. The baseline this sprint diffs against is the


### PR DESCRIPTION
Summary:
- Project doctor diagnostics through the shared retained-health contract and assert field parity with /v1/health.
- Add the diagnostics composition boundary gate.
- Correct the AW.5 parity-test CI coverage statement.

Validation:
- just fmt
- just lint
- cargo test -p atm-http-runtime
- cargo test -p agent-team-mail-core doctor
- cargo test -p atm-architecture --test boundary_enforcement