### PR TITLE
fix: harden diagnostics integration guards

### DIFF
--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -4177,14 +4177,12 @@ fn aw_diagnostics_composition_stays_behind_the_timeline_store_contract() {
     let doctor_observability =
         read_source(&root.join("crates/atm-http-runtime/src/doctor_observability.rs"));
     let sqlite_backend = read_source(&root.join("crates/atm-storage-rusqlite/src/lib.rs"));
-    let sqlite_backend_implementation = sqlite_backend
-        .split("impl SqliteStorageBackend {")
-        .nth(1)
-        .expect("SQLite storage backend implementation");
-    let sqlite_production = sqlite_backend_implementation
-        .split("\n    #[cfg(test)]")
-        .next()
-        .expect("storage backend production region");
+    let sqlite_production =
+        production_impl_function_source(&sqlite_backend, "SqliteStorageBackend");
+    let sqlite_production_compact = sqlite_production
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
 
     assert!(
         bootstrap.contains("let store: Arc<dyn DiagnosticTimelineStore> = store;")
@@ -4210,16 +4208,81 @@ fn aw_diagnostics_composition_stays_behind_the_timeline_store_contract() {
         );
     }
     assert_eq!(
-        sqlite_production
+        sqlite_production_compact
             .matches("SqliteDiagnosticTimeline::from_shared_db")
             .count(),
         1,
         "the storage backend must retain exactly one production construction path for its shared diagnostic timeline"
     );
     assert!(
-        !sqlite_production.contains("SqliteDiagnosticTimeline {"),
+        !sqlite_production_compact.contains("SqliteDiagnosticTimeline{"),
         "the storage backend must construct the diagnostic timeline only through from_shared_db"
     );
+}
+
+#[test]
+fn aw_diagnostics_gate_scans_production_functions_after_test_helpers() {
+    let source = r#"
+        impl SqliteStorageBackend {
+            fn production_constructor() {
+                SqliteDiagnosticTimeline::from_shared_db(db);
+            }
+
+            #[cfg(test)]
+            fn fixture_constructor() {
+                SqliteDiagnosticTimeline::from_shared_db(test_db);
+            }
+
+            fn later_production_constructor() {
+                SqliteDiagnosticTimeline::from_shared_db(later_db);
+            }
+        }
+    "#;
+    let production = production_impl_function_source(source, "SqliteStorageBackend");
+    let compact_production = production
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
+
+    assert!(production.contains("production_constructor"));
+    assert!(production.contains("later_production_constructor"));
+    assert!(!production.contains("fixture_constructor"));
+    assert_eq!(
+        compact_production
+            .matches("SqliteDiagnosticTimeline::from_shared_db")
+            .count(),
+        2,
+        "the diagnostics gate must retain production functions appearing after cfg(test) helpers"
+    );
+}
+
+fn production_impl_function_source(source: &str, self_type: &str) -> String {
+    let syntax = syn::parse_file(source).expect("production implementation source must parse");
+    syntax
+        .items
+        .into_iter()
+        .filter_map(|item| match item {
+            syn::Item::Impl(implementation)
+                if !implementation
+                    .attrs
+                    .iter()
+                    .any(is_test_configuration_attribute)
+                    && implementation.self_ty.to_token_stream().to_string() == self_type =>
+            {
+                Some(implementation)
+            }
+            _ => None,
+        })
+        .flat_map(|implementation| implementation.items)
+        .filter_map(|item| match item {
+            syn::ImplItem::Fn(function)
+                if !function.attrs.iter().any(is_test_configuration_attribute) =>
+            {
+                Some(function.to_token_stream().to_string())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 fn av3_trait_signature_types(source: &str, trait_name: &str) -> BTreeSet<String> {

--- a/crates/atm-error/src/error_codes.rs
+++ b/crates/atm-error/src/error_codes.rs
@@ -119,10 +119,12 @@ pub enum AtmErrorCode {
     ObservabilityHealthFailed,
     ObservabilityBootstrapFailed,
     ObservabilityHealthOk,
+    RetainedDiagnosticsHealthOk,
     WarningInvalidTeamMemberSkipped,
     WarningMailboxRecordSkipped,
     WarningMalformedAtmFieldIgnored,
     WarningObservabilityHealthDegraded,
+    WarningRetainedDiagnosticsDegraded,
     WarningSqliteHealthDegraded,
     WarningOriginInboxEntrySkipped,
     WarningMissingTeamConfigFallback,
@@ -289,10 +291,12 @@ impl AtmErrorCode {
             Self::ObservabilityHealthFailed => "ATM_OBSERVABILITY_HEALTH_FAILED",
             Self::ObservabilityBootstrapFailed => "ATM_OBSERVABILITY_BOOTSTRAP_FAILED",
             Self::ObservabilityHealthOk => "ATM_OBSERVABILITY_HEALTH_OK",
+            Self::RetainedDiagnosticsHealthOk => "ATM_RETAINED_DIAGNOSTICS_HEALTH_OK",
             Self::WarningInvalidTeamMemberSkipped => "ATM_WARNING_INVALID_TEAM_MEMBER_SKIPPED",
             Self::WarningMailboxRecordSkipped => "ATM_WARNING_MAILBOX_RECORD_SKIPPED",
             Self::WarningMalformedAtmFieldIgnored => "ATM_WARNING_MALFORMED_ATM_FIELD_IGNORED",
             Self::WarningObservabilityHealthDegraded => "ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED",
+            Self::WarningRetainedDiagnosticsDegraded => "ATM_WARNING_RETAINED_DIAGNOSTICS_DEGRADED",
             Self::WarningSqliteHealthDegraded => "ATM_WARNING_SQLITE_HEALTH_DEGRADED",
             Self::WarningOriginInboxEntrySkipped => "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED",
             Self::WarningMissingTeamConfigFallback => "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK",
@@ -464,11 +468,15 @@ fn parse_observability_or_warning_code(value: &str) -> Option<AtmErrorCode> {
         "ATM_OBSERVABILITY_HEALTH_FAILED" => AtmErrorCode::ObservabilityHealthFailed,
         "ATM_OBSERVABILITY_BOOTSTRAP_FAILED" => AtmErrorCode::ObservabilityBootstrapFailed,
         "ATM_OBSERVABILITY_HEALTH_OK" => AtmErrorCode::ObservabilityHealthOk,
+        "ATM_RETAINED_DIAGNOSTICS_HEALTH_OK" => AtmErrorCode::RetainedDiagnosticsHealthOk,
         "ATM_WARNING_INVALID_TEAM_MEMBER_SKIPPED" => AtmErrorCode::WarningInvalidTeamMemberSkipped,
         "ATM_WARNING_MAILBOX_RECORD_SKIPPED" => AtmErrorCode::WarningMailboxRecordSkipped,
         "ATM_WARNING_MALFORMED_ATM_FIELD_IGNORED" => AtmErrorCode::WarningMalformedAtmFieldIgnored,
         "ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED" => {
             AtmErrorCode::WarningObservabilityHealthDegraded
+        }
+        "ATM_WARNING_RETAINED_DIAGNOSTICS_DEGRADED" => {
+            AtmErrorCode::WarningRetainedDiagnosticsDegraded
         }
         "ATM_WARNING_SQLITE_HEALTH_DEGRADED" => AtmErrorCode::WarningSqliteHealthDegraded,
         "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED" => AtmErrorCode::WarningOriginInboxEntrySkipped,

--- a/crates/atm-error/src/lib.rs
+++ b/crates/atm-error/src/lib.rs
@@ -68,6 +68,23 @@ mod tests {
     }
 
     #[test]
+    fn retained_diagnostics_codes_keep_distinct_stable_wire_spellings() {
+        for (code, wire) in [
+            (
+                AtmErrorCode::RetainedDiagnosticsHealthOk,
+                "ATM_RETAINED_DIAGNOSTICS_HEALTH_OK",
+            ),
+            (
+                AtmErrorCode::WarningRetainedDiagnosticsDegraded,
+                "ATM_WARNING_RETAINED_DIAGNOSTICS_DEGRADED",
+            ),
+        ] {
+            assert_eq!(code.as_str(), wire);
+            assert_eq!(wire.parse::<AtmErrorCode>(), Ok(code));
+        }
+    }
+
+    #[test]
     fn template_send_error_codes_keep_their_stable_wire_spelling() {
         for (code, wire) in [
             (AtmErrorCode::TemplateLoadFailed, "TEMPLATE_LOAD_FAILED"),

--- a/crates/atm-http-runtime/src/doctor_observability.rs
+++ b/crates/atm-http-runtime/src/doctor_observability.rs
@@ -25,9 +25,9 @@ pub(crate) fn append_counter_finding(
         DoctorSeverity::Info
     };
     let code = if degraded {
-        AtmErrorCode::WarningObservabilityHealthDegraded
+        AtmErrorCode::WarningRetainedDiagnosticsDegraded
     } else {
-        AtmErrorCode::ObservabilityHealthOk
+        AtmErrorCode::RetainedDiagnosticsHealthOk
     };
     findings.push(DoctorFinding {
         severity,
@@ -46,4 +46,33 @@ pub(crate) fn append_counter_finding(
                 .to_owned()
         }),
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::append_counter_finding;
+    use atm_core::doctor::DoctorSeverity;
+    use atm_core::error::AtmErrorCode;
+    use atm_core::observability_counters::DiagnosticCounters;
+
+    #[test]
+    fn retained_diagnostics_finding_uses_its_own_error_codes() {
+        let mut findings = Vec::new();
+        append_counter_finding(&mut findings, DiagnosticCounters::default());
+        assert_eq!(findings[0].severity, DoctorSeverity::Info);
+        assert_eq!(findings[0].code, AtmErrorCode::RetainedDiagnosticsHealthOk);
+
+        append_counter_finding(
+            &mut findings,
+            DiagnosticCounters {
+                timeline_dropped_queue_full_total: 1,
+                ..DiagnosticCounters::default()
+            },
+        );
+        assert_eq!(findings[1].severity, DoctorSeverity::Warning);
+        assert_eq!(
+            findings[1].code,
+            AtmErrorCode::WarningRetainedDiagnosticsDegraded
+        );
+    }
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -2273,6 +2273,10 @@ mod tests {
                     expected_health.timeline.dropped_persist_error_total
                 );
                 assert_eq!(report.observability.degraded, expected_health.degraded);
+                assert!(report.findings.iter().any(|finding| {
+                    finding.code
+                        == atm_core::error::AtmErrorCode::WarningRetainedDiagnosticsDegraded
+                }));
             }
             other => panic!("expected doctor report, got {other:?}"),
         }


### PR DESCRIPTION
Summary:
- Scan every non-test SqliteStorageBackend function in the diagnostics construction gate.
- Give retained-diagnostics doctor findings distinct stable error codes.

Validation:
- just fmt
- just lint
- cargo test -p atm-architecture aw_diagnostics
- cargo test -p atm-error retained_diagnostics_codes_keep_distinct_stable_wire_spellings
- cargo test -p atm-http-runtime doctor_observability