### PR TITLE
fix: close Phase AW final gate findings

### DIFF
--- a/.triage/phase-aw/findings/AW-PHASEGATE-001.ttl
+++ b/.triage/phase-aw/findings/AW-PHASEGATE-001.ttl
@@ -15,23 +15,51 @@
   triage:severity "minor" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-05T10:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AW-PHASE-GATE-REVIEW ;
   triage:foundAt "2026-09-05T10:00:00Z"^^xsd:dateTime ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-001/PR1199-1> .
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-001/PR1199-1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-001/PR1200-1> ;
+  triage:closedAt "2026-09-05T11:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
+
+# CLOSURE (qa-pr1200-r1, quality-mgr): PR #1200 (fix/phase-aw-phasegate @
+# db19fd9572385ec7c488976294a54c3f2e93fa4e) adds the missing `status:` and
+# `worktree:` frontmatter fields to
+# docs/plans/phase-aw/sprint-AW.2-sqlite-diagnostic-timeline.md, now reading
+# `branch: feature/aw2-sqlite-diagnostic-timeline`,
+# `worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/aw2-sqlite-diagnostic-timeline`,
+# `status: complete` -- matching the sibling AW.1/AW.3/AW.4/AW.5 sprint docs.
+# quality-mgr independently confirmed via direct read of the fixed file in
+# /tmp/verify-pr1200. req-qa, arch-qa, rust-qa-agent, and ruthless-boundary-qa
+# all independently returned PASS on this fix in the qa-pr1200-r1 round with
+# zero remaining findings. Doc-hygiene only, no functional/test impact. This
+# closes the frontmatter gap this finding was filed for.
 
 <urn:atm:triage:occurrence/AW-PHASEGATE-001/PR1199-1>
   a triage:Occurrence ;
   triage:file "docs/plans/phase-aw/sprint-AW.2-sqlite-diagnostic-timeline.md" ;
   triage:line 1 ;
   triage:snippet "missing status:/worktree: frontmatter fields present on AW.1/AW.3/AW.4/AW.5 sprint docs" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21> .
+
+<urn:atm:triage:occurrence/AW-PHASEGATE-001/PR1200-1>
+  a triage:Occurrence ;
+  triage:file "docs/plans/phase-aw/sprint-AW.2-sqlite-diagnostic-timeline.md" ;
+  triage:line 1 ;
+  triage:snippet "adds status: complete / worktree: <path> frontmatter matching sibling sprint docs" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-001> .
 
 <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21>
   a triage:WorktreeSnapshot ;
@@ -39,3 +67,10 @@
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-001>
+  a triage:WorktreeSnapshot ;
+  triage:path "verify-pr1200" ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-aw/findings/AW-PHASEGATE-002.ttl
+++ b/.triage/phase-aw/findings/AW-PHASEGATE-002.ttl
@@ -15,23 +15,50 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-05T10:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AW-PHASE-GATE-REVIEW ;
   triage:foundAt "2026-09-05T10:00:00Z"^^xsd:dateTime ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-002/PR1199-1> .
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-002/PR1199-1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-002/PR1200-1> ;
+  triage:closedAt "2026-09-05T11:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
+
+# CLOSURE (qa-pr1200-r1, quality-mgr): PR #1200 (fix/phase-aw-phasegate @
+# db19fd9572385ec7c488976294a54c3f2e93fa4e) changes docs/project-plan.md:1563
+# from "## 55. Phase AW -- Unified Retained Runtime Logging [IN PROGRESS]" to
+# "## 55. Phase AW -- Unified Retained Runtime Logging [COMPLETE --
+# INTEGRATION PR #1199]", matching section 54's header convention at
+# project-plan.md:1579. quality-mgr independently confirmed via direct read
+# of the fixed file in /tmp/verify-pr1200. req-qa, arch-qa, rust-qa-agent, and
+# ruthless-boundary-qa all independently returned PASS on this fix in the
+# qa-pr1200-r1 round with zero remaining findings. Docs-only, no functional
+# impact. This closes the stale-header/sprint-table mismatch this finding was
+# filed for.
 
 <urn:atm:triage:occurrence/AW-PHASEGATE-002/PR1199-1>
   a triage:Occurrence ;
   triage:file "docs/project-plan.md" ;
   triage:line 1563 ;
   triage:snippet "## 55. Phase AW -- Unified Retained Runtime Logging [IN PROGRESS] -- stale against all-complete sprint table and this PR being the phase closeout" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21-002> .
+
+<urn:atm:triage:occurrence/AW-PHASEGATE-002/PR1200-1>
+  a triage:Occurrence ;
+  triage:file "docs/project-plan.md" ;
+  triage:line 1563 ;
+  triage:snippet "## 55. Phase AW -- Unified Retained Runtime Logging [COMPLETE -- INTEGRATION PR #1199]" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-002> .
 
 <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21-002>
   a triage:WorktreeSnapshot ;
@@ -39,3 +66,10 @@
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-002>
+  a triage:WorktreeSnapshot ;
+  triage:path "verify-pr1200" ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-aw/findings/AW-PHASEGATE-003.ttl
+++ b/.triage/phase-aw/findings/AW-PHASEGATE-003.ttl
@@ -15,23 +15,64 @@
   triage:severity "important" ;
   triage:repeatable true ;
   triage:sweepScope "boundary_enforcement.rs - recurring defect class, see .triage/phase-an/findings/QA-001-AN2.ttl" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-05T10:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AW-PHASE-GATE-REVIEW ;
   triage:foundAt "2026-09-05T10:00:00Z"^^xsd:dateTime ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-003/PR1199-1> .
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-003/PR1199-1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AW-PHASEGATE-003/PR1200-1> ;
+  triage:closedAt "2026-09-05T11:30:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:triageRecordVersion "2" .
+
+# CLOSURE (qa-pr1200-r1, quality-mgr): PR #1200 (fix/phase-aw-phasegate @
+# db19fd9572385ec7c488976294a54c3f2e93fa4e) implements the systemic fix this
+# finding recommended rather than the minimal patch: guarded_boundary_files()
+# (boundary_enforcement.rs:3884) is now a one-line delegate to a new
+# all_boundary_files() (boundary_enforcement.rs:3888-3910), which walks
+# boundaries/*/*.toml via fs::read_dir across every boundary subdirectory
+# instead of an explicit allowlist. A new self-check test
+# guarded_boundaries_include_every_boundary_record
+# (boundary_enforcement.rs:3911-3920) asserts guarded_boundary_files() ==
+# all_boundary_files(), proving the discovery is exhaustive. The four
+# tracing-bridge.toml forbidden_edges pairs are now present in
+# EXPECTED_FORBIDDEN_EDGES (boundary_enforcement.rs lines 31, 38-40):
+# ("atm-daemon","atm-observability"), ("atm-observability","atm-daemon-bootstrap"),
+# ("atm-observability","atm-http-runtime"), ("atm-observability","atm-storage-rusqlite").
+# quality-mgr independently confirmed all of this by direct source read in
+# /tmp/verify-pr1200 and ran `cargo test -p atm-architecture --test
+# boundary_enforcement` directly: 93 passed, 0 failed. All four reviewers
+# (req-qa, arch-qa, rust-qa-agent, ruthless-boundary-qa) independently
+# confirmed no previously-guarded boundary edge was dropped or relaxed by the
+# guarded_boundary_files() -> all_boundary_files() refactor, and all endorsed
+# the auto-discovery approach as correctly foreclosing this defect class
+# after its second recurrence (see .triage/phase-an/findings/QA-001-AN2.ttl
+# for the first). No crates/atm-daemon/ (legacy synchronous daemon) files
+# touched. This closes the mirror-guard coverage gap this finding was filed
+# for.
 
 <urn:atm:triage:occurrence/AW-PHASEGATE-003/PR1199-1>
   a triage:Occurrence ;
   triage:file "crates/atm-architecture/tests/boundary_enforcement.rs" ;
   triage:line 19 ;
   triage:snippet "EXPECTED_FORBIDDEN_EDGES and guarded_boundary_files() omit boundaries/atm-observability/tracing-bridge.toml entirely -- mirror-guard coverage gap" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21-003> .
+
+<urn:atm:triage:occurrence/AW-PHASEGATE-003/PR1200-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-architecture/tests/boundary_enforcement.rs" ;
+  triage:line 3884 ;
+  triage:snippet "guarded_boundary_files() delegates to all_boundary_files(), an fs::read_dir walk of boundaries/*/*.toml; EXPECTED_FORBIDDEN_EDGES now includes all four tracing-bridge.toml edges; guarded_boundaries_include_every_boundary_record proves exhaustiveness" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:occursIn <urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-003> .
 
 <urn:atm:triage:worktree/AW-PHASEGATE/3b0b05f21-003>
   a triage:WorktreeSnapshot ;
@@ -39,3 +80,10 @@
   triage:branch "integrate/phase-aw" ;
   triage:headSha "3b0b05f21" ;
   triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/AW-PHASEGATE/db19fd957-003>
+  a triage:WorktreeSnapshot ;
+  triage:path "verify-pr1200" ;
+  triage:branch "fix/phase-aw-phasegate" ;
+  triage:headSha "db19fd9572385ec7c488976294a54c3f2e93fa4e" ;
+  triage:orderIndex 2 .

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -18,25 +18,58 @@ use syn::visit::Visit;
 
 const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm", "atm-daemon"),
+    ("atm", "atm-peer-tls-interop"),
     ("atm", "atm-storage-rusqlite"),
+    ("atm", "peer-tls"),
+    ("atm", "telemetry-implementation"),
+    ("atm-core", "atm-daemon"),
+    ("atm-core", "atm-storage-rusqlite"),
+    ("atm-core", "sc-observability"),
     ("atm-daemon", "atm-runtime"),
+    ("atm-daemon", "atm-peer-tls-interop"),
     ("atm-daemon", "atm-storage-rusqlite"),
+    ("atm-daemon", "atm-observability"),
+    ("atm-daemon", "peer-tls"),
+    ("atm-daemon-bootstrap", "atm-peer-tls-interop"),
+    ("atm-daemon-client", "atm-daemon"),
+    ("atm-daemon-client", "atm-storage-rusqlite"),
+    ("atm-error", "atm-core"),
+    ("atm-error", "atm-storage-rusqlite"),
+    ("atm-observability", "atm-daemon-bootstrap"),
+    ("atm-observability", "atm-http-runtime"),
+    ("atm-observability", "atm-storage-rusqlite"),
     ("atm-runtime", "atm-storage-rusqlite"),
     ("atm-storage", "atm-core"),
     ("atm-storage", "atm-daemon"),
     ("atm-storage", "atm-storage-rusqlite"),
+    ("atm-storage", "telemetry-implementation"),
     ("atm-storage-rusqlite", "atm-core"),
     ("atm-storage-rusqlite", "atm-runtime"),
+    ("atm-storage-rusqlite", "telemetry-implementation"),
     ("atm-graft", "atm-daemon"),
     ("atm-graft", "atm-daemon-bootstrap"),
+    ("atm-graft", "atm-peer-tls-interop"),
     ("atm-graft", "atm-storage-rusqlite"),
     ("atm-graft", "interprocess"),
+    ("atm-graft", "peer-tls"),
+    ("atm-graft-python", "atm-daemon"),
+    ("atm-graft-python", "atm-storage-rusqlite"),
+    ("atm-graft-python", "axum"),
+    ("atm-graft-python", "hyper"),
+    ("atm-graft-python", "reqwest"),
     ("atm-daemon-bootstrap", "atm-graft"),
     ("atm-http-runtime", "atm"),
     ("atm-http-runtime", "atm-daemon-bootstrap"),
     ("atm-http-runtime", "atm-graft"),
     ("atm-http-runtime", "atm-storage-rusqlite"),
+    ("atm-http-runtime", "peer-tls"),
+    ("atm-http-runtime", "telemetry-implementation"),
+    ("atm-query-python", "atm-core"),
+    ("atm-query-python", "atm-graft"),
+    ("atm-query-python", "atm-http-runtime"),
+    ("atm-query-python", "rusqlite"),
     ("atm-runtime", "atm-daemon"),
+    ("atm-runtime", "atm-peer-tls-interop"),
     ("atm-core", "atm-template-sc-compose"),
     ("atm-storage", "atm-template-sc-compose"),
     ("atm-storage-rusqlite", "atm-template-sc-compose"),
@@ -51,6 +84,8 @@ const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm-herdr", "atm-daemon-bootstrap"),
     ("atm-herdr", "atm-http-runtime"),
     ("atm-herdr", "atm-storage-rusqlite"),
+    ("hermes-atm", "atm-daemon"),
+    ("hermes-atm", "atm-storage-rusqlite"),
 ];
 
 const RETIRED_DAEMON_CONSTRUCT_FRAGMENTS: &[(&str, &str)] = &[
@@ -3847,42 +3882,35 @@ fn missing_forbidden_edges(
 }
 
 fn guarded_boundary_files() -> Vec<PathBuf> {
-    let root = workspace_root();
-    let mut files = vec![
-        root.join("boundaries/atm/local-socket-client-transport.toml"),
-        root.join("boundaries/atm-graft/shared-client-consumer.toml"),
-        root.join("boundaries/atm-http-runtime/http-runtime.toml"),
-        root.join("boundaries/atm-http-runtime/member-state-transition-sink.toml"),
-        root.join("boundaries/atm-daemon-bootstrap/replacement-bootstrap.toml"),
-        root.join("boundaries/atm-runtime/runtime-composition.toml"),
-        root.join("boundaries/atm-template-sc-compose/sc-composer.toml"),
-        root.join("boundaries/atm-herdr/herdr-process-adapter.toml"),
-    ];
-    files.extend(boundary_files_in("atm-storage"));
-    let mut sqlite_files = fs::read_dir(root.join("boundaries/atm-storage-rusqlite"))
-        .expect("boundaries/atm-storage-rusqlite directory must be readable")
+    all_boundary_files()
+}
+
+fn all_boundary_files() -> Vec<PathBuf> {
+    let root = workspace_root().join("boundaries");
+    let mut files = fs::read_dir(&root)
+        .unwrap_or_else(|error| panic!("boundaries directory must be readable: {error}"))
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .filter(|path| path.is_dir())
+        .flat_map(|directory| {
+            fs::read_dir(&directory)
+                .unwrap_or_else(|error| {
+                    panic!("boundary directory {} must be readable: {error}", directory.display())
+                })
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+                .collect::<Vec<_>>()
+        })
         .collect::<Vec<_>>();
-    sqlite_files.sort();
-    files.extend(sqlite_files);
+    files.sort();
     files
 }
 
 #[test]
-fn guarded_boundaries_include_every_atm_storage_record() {
-    let root = workspace_root();
-    let guarded_storage_files = guarded_boundary_files()
-        .into_iter()
-        .filter(|path| path.parent() == Some(root.join("boundaries/atm-storage").as_path()))
-        .collect::<BTreeSet<_>>();
-    let storage_boundary_files = boundary_files_in("atm-storage")
-        .into_iter()
-        .collect::<BTreeSet<_>>();
-
+fn guarded_boundaries_include_every_boundary_record() {
     assert_eq!(
-        guarded_storage_files, storage_boundary_files,
-        "the architecture guard must sweep every boundaries/atm-storage TOML record"
+        guarded_boundary_files().into_iter().collect::<BTreeSet<_>>(),
+        all_boundary_files().into_iter().collect::<BTreeSet<_>>(),
+        "the architecture guard must sweep every boundaries/*/*.toml record"
     );
 }
 

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -3894,7 +3894,10 @@ fn all_boundary_files() -> Vec<PathBuf> {
         .flat_map(|directory| {
             fs::read_dir(&directory)
                 .unwrap_or_else(|error| {
-                    panic!("boundary directory {} must be readable: {error}", directory.display())
+                    panic!(
+                        "boundary directory {} must be readable: {error}",
+                        directory.display()
+                    )
                 })
                 .filter_map(|entry| entry.ok().map(|entry| entry.path()))
                 .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
@@ -3908,7 +3911,9 @@ fn all_boundary_files() -> Vec<PathBuf> {
 #[test]
 fn guarded_boundaries_include_every_boundary_record() {
     assert_eq!(
-        guarded_boundary_files().into_iter().collect::<BTreeSet<_>>(),
+        guarded_boundary_files()
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
         all_boundary_files().into_iter().collect::<BTreeSet<_>>(),
         "the architecture guard must sweep every boundaries/*/*.toml record"
     );

--- a/docs/plans/phase-aw/sprint-AW.2-sqlite-diagnostic-timeline.md
+++ b/docs/plans/phase-aw/sprint-AW.2-sqlite-diagnostic-timeline.md
@@ -2,6 +2,8 @@
 sprint: AW.2
 title: "SQLite diagnostic timeline and production SqliteObservability adapter"
 branch: feature/aw2-sqlite-diagnostic-timeline
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/aw2-sqlite-diagnostic-timeline
+status: complete
 base: integrate/phase-aw
 issues: "#905 ids 905-3, 905-4, 905-5, 905-6 (diagnostic), 905-8 (non-interference/retention/saturation)"
 must_follow: [AW.1]

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1560,7 +1560,7 @@ The authoritative plan is
 critical review round 1 folded in); phase-au sprint docs are being cut from
 it under `docs/plans/phase-au/` on branch `plan/boundary-regression`.
 
-## 55. Phase AW — Unified Retained Runtime Logging [IN PROGRESS]
+## 55. Phase AW — Unified Retained Runtime Logging [COMPLETE — INTEGRATION PR #1199]
 
 Phase AW makes replacement-runtime tracing retained and safely observable:
 AW.1 installs the allowlisted non-blocking tracing bridge, AW.2 persists the


### PR DESCRIPTION
Closes AW-PHASEGATE-001, AW-PHASEGATE-002, and AW-PHASEGATE-003.

- Completes AW.2 sprint frontmatter and Phase AW closeout marker.
- Auto-discovers every `boundaries/*/*.toml` record in the Rust mirror guard and enforces all documented forbidden edges.

Validation:
- `just lint` (36 checks)
- `cargo test -p atm-architecture --test boundary_enforcement` (93 passed)