### PR TITLE
AX5: add Herdr task reminder cycle

### DIFF
--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -11,8 +11,9 @@ pub use atm_storage::TaskState;
 pub use atm_storage::contract::RosterStore as DurableRosterStore;
 pub use atm_storage::contract::{AckTransition, Message, MessageKey};
 pub use atm_storage::{
-    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, ReadDeadline, ReminderOutcome, TaskRow,
-    TaskStore, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
+    AsyncTaskLedgerReader, BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, ReadDeadline,
+    ReminderOutcome, TaskRow, TaskStore, TeamNudgeTemplateOverrideMode,
+    TeamNudgeTemplateOverrideRow,
 };
 
 /// Durable at-most-once delivery state for deferred (`atm queue`) nudges.

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -11,8 +11,8 @@ pub use atm_storage::TaskState;
 pub use atm_storage::contract::RosterStore as DurableRosterStore;
 pub use atm_storage::contract::{AckTransition, Message, MessageKey};
 pub use atm_storage::{
-    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, TaskStore, TeamNudgeTemplateOverrideMode,
-    TeamNudgeTemplateOverrideRow,
+    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, ReadDeadline, ReminderOutcome, TaskRow,
+    TaskStore, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
 };
 
 /// Durable at-most-once delivery state for deferred (`atm queue`) nudges.

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -134,7 +134,7 @@ pub fn classify_delivery_channel(
 /// duplicating that literal outside its two owning modules
 /// (`scripts/check-nudge-taxonomy.py` enforces the containment). Callers
 /// that also need `herdrSession` should insert it into the returned map.
-#[cfg(any(test, feature = "test-utils"))]
+#[doc(hidden)]
 #[must_use]
 pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Value> {
     let mut metadata = serde_json::Map::new();

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -134,7 +134,7 @@ pub fn classify_delivery_channel(
 /// duplicating that literal outside its two owning modules
 /// (`scripts/check-nudge-taxonomy.py` enforces the containment). Callers
 /// that also need `herdrSession` should insert it into the returned map.
-#[doc(hidden)]
+#[cfg(any(test, feature = "test-utils"))]
 #[must_use]
 pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Value> {
     let mut metadata = serde_json::Map::new();

--- a/crates/atm-core/src/nudge_dispatch.rs
+++ b/crates/atm-core/src/nudge_dispatch.rs
@@ -14,10 +14,11 @@ use crate::boundary::{
 };
 use crate::delivery_policy::DeliveryPolicyCoordinator;
 use crate::error::AtmError;
-use crate::schema::AtmMessageId;
+use crate::schema::{AtmMessageId, authenticated_source_host};
 use crate::send::NudgeMode;
 use crate::send::hook::build_built_in_dispatch;
 use crate::service_runtime::LocalServiceRuntime;
+use atm_storage::TaskRow;
 
 /// Clears the exact durable queue marker after a successful handoff.
 ///
@@ -143,5 +144,48 @@ pub fn rebuild_received_hook_dispatch(
         &event,
         &message.envelope.text,
         nudge_mode,
+    ))
+}
+
+/// Builds a deferred Task reminder without requiring the assignment message
+/// to remain in the mailbox. A missing assignment record only removes the
+/// optional source-host attribution; the durable task row remains sufficient
+/// to render the reminder body.
+pub fn build_task_reminder_dispatch(
+    runtime: &LocalServiceRuntime,
+    member: &MemberKey,
+    row: &TaskRow,
+) -> Result<Option<BuiltInPostSendDispatch>, AtmError> {
+    let delivery_snapshot = DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
+        runtime,
+        member.team(),
+        member.agent(),
+    )?;
+    let sender_host = runtime
+        .message_store
+        .load_message(&MessageKey::from(row.assignment_message_id))?
+        .map(|message| authenticated_source_host(&message.envelope))
+        .transpose()?
+        .flatten();
+    let event = PostSendHookEvent {
+        sender: row.assigner.clone(),
+        sender_chat_id: None,
+        sender_team: row.team.clone(),
+        sender_host,
+        recipient: row.assignee.clone(),
+        recipient_team: row.team.clone(),
+        message_id: row.assignment_message_id,
+        description: row.description.clone(),
+        requires_ack: true,
+        is_ack: false,
+        task_id: Some(row.task_id.clone()),
+        recipient_pane_id: delivery_snapshot.recipient_pane_id.clone(),
+    };
+    Ok(build_built_in_dispatch(
+        runtime,
+        &delivery_snapshot,
+        &event,
+        &row.description,
+        NudgeMode::Deferred,
     ))
 }

--- a/crates/atm-core/src/nudge_dispatch.rs
+++ b/crates/atm-core/src/nudge_dispatch.rs
@@ -137,13 +137,13 @@ pub fn rebuild_received_hook_dispatch(
         NudgeKind::Queue => NudgeMode::Deferred,
     };
 
-    Ok(build_built_in_dispatch(
+    build_built_in_dispatch(
         runtime,
         &delivery_snapshot,
         &event,
         &message.envelope.text,
         nudge_mode,
-    ))
+    )
 }
 
 /// Builds a deferred Task reminder without requiring the assignment message
@@ -186,11 +186,11 @@ pub fn build_task_reminder_dispatch(
         task_id: Some(row.task_id.clone()),
         recipient_pane_id: delivery_snapshot.recipient_pane_id.clone(),
     };
-    Ok(build_built_in_dispatch(
+    build_built_in_dispatch(
         runtime,
         &delivery_snapshot,
         &event,
         &row.description,
         NudgeMode::Deferred,
-    ))
+    )
 }

--- a/crates/atm-core/src/nudge_dispatch.rs
+++ b/crates/atm-core/src/nudge_dispatch.rs
@@ -104,7 +104,6 @@ pub fn rebuild_received_hook_dispatch(
         member.team(),
         member.agent(),
     )?;
-
     // Mapping mirrors `send::hook::post_send_event_from_message`
     // (write-time), adapted to the persisted `Message` shape returned by a
     // reload instead of the in-memory `LogicalMessage` retained across a
@@ -161,6 +160,12 @@ pub fn build_task_reminder_dispatch(
         member.team(),
         member.agent(),
     )?;
+    // The reminder pump is deliberately Herdr-only. A recipient may have
+    // changed backends since the task was assigned; leave that case to its
+    // normal delivery path rather than synthesizing a different local nudge.
+    if !delivery_snapshot.local_herdr_post_send {
+        return Ok(None);
+    }
     let sender_host = runtime
         .message_store
         .load_message(&MessageKey::from(row.assignment_message_id))?

--- a/crates/atm-core/src/picker_projection.rs
+++ b/crates/atm-core/src/picker_projection.rs
@@ -55,7 +55,8 @@ impl From<RuntimeMemberState> for PickerMemberStatus {
             RuntimeMemberState::Idle => Self::Idle,
             RuntimeMemberState::Offline
             | RuntimeMemberState::Unknown
-            | RuntimeMemberState::IdentityConflict => Self::Dead,
+            | RuntimeMemberState::IdentityConflict
+            | RuntimeMemberState::Blocked => Self::Dead,
         }
     }
 }

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -436,6 +436,7 @@ pub enum RuntimeMemberState {
     Offline,
     Idle,
     Active,
+    Blocked,
 }
 
 /// Current non-authoritative runtime observation for one roster member.

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -22,7 +22,7 @@ pub(crate) fn build_built_in_dispatch<R>(
     event: &PostSendHookEvent,
     message_body: &str,
     nudge_mode: NudgeMode,
-) -> Option<BuiltInPostSendDispatch>
+) -> Result<Option<BuiltInPostSendDispatch>, AtmError>
 where
     R: RetainedServiceRuntime + ?Sized,
 {
@@ -31,9 +31,14 @@ where
         let pane_id = event
             .recipient_pane_id
             .clone()
-            .or_else(|| delivery_snapshot.recipient_pane_id.as_ref().cloned())?;
-        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event, kind)?;
-        return Some(BuiltInPostSendDispatch {
+            .or_else(|| delivery_snapshot.recipient_pane_id.as_ref().cloned());
+        let Some(pane_id) = pane_id else {
+            return Ok(None);
+        };
+        let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
+            return Ok(None);
+        };
+        return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Tmux(
                 LocalTmuxNudgeTarget {
@@ -42,22 +47,26 @@ where
                 },
             )),
             kind,
-        });
+        }));
     }
     if delivery_snapshot.local_herdr_post_send {
-        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event, kind)?;
-        return Some(BuiltInPostSendDispatch {
+        let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
+            return Ok(None);
+        };
+        return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
                 session: delivery_snapshot.herdr_session.clone(),
                 rendered_nudge,
             })),
             kind,
-        });
+        }));
     }
     if delivery_snapshot.graft_post_send {
-        let rendered_nudge = render_built_in_nudge_for_dispatch(runtime, event, kind)?;
-        return Some(BuiltInPostSendDispatch {
+        let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
+            return Ok(None);
+        };
+        return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::Graft(GraftNudgeTarget {
                 recipient: event.recipient.clone(),
@@ -66,10 +75,10 @@ where
                 message_body: message_body.to_owned(),
             }),
             kind,
-        });
+        }));
     }
     if delivery_snapshot.bare_cli_post_send {
-        return Some(BuiltInPostSendDispatch {
+        return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::QueuePull(QueuePullTarget {
                 team: event.recipient_team.clone(),
@@ -79,9 +88,9 @@ where
                 body: message_body.to_owned(),
             }),
             kind,
-        });
+        }));
     }
-    None
+    Ok(None)
 }
 
 /// Maps the write-time delivery mode to the dispatch's `NudgeKind`.
@@ -102,7 +111,7 @@ fn render_built_in_nudge_for_dispatch<R>(
     runtime: &R,
     event: &PostSendHookEvent,
     delivery_kind: NudgeKind,
-) -> Option<String>
+) -> Result<Option<String>, AtmError>
 where
     R: RetainedServiceRuntime + ?Sized,
 {
@@ -122,21 +131,10 @@ where
         }
     };
     let template = nudge_template::resolve_template(override_row, kind);
-    let template_body = template.body.as_deref()?;
-    match nudge_template::render_built_in_nudge(event, template_body) {
-        Ok(rendered) => Some(rendered),
-        Err(error) => {
-            warn!(
-                code = %error.code(),
-                recipient = %event.recipient,
-                recipient_team = %event.recipient_team,
-                message_id = %event.message_id,
-                %error,
-                "failed to render built-in nudge"
-            );
-            None
-        }
-    }
+    let Some(template_body) = template.body.as_deref() else {
+        return Ok(None);
+    };
+    nudge_template::render_built_in_nudge(event, template_body).map(Some)
 }
 
 pub(crate) fn post_send_event_from_message(

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -367,6 +367,7 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
         "message body",
         crate::send::NudgeMode::Immediate,
     )
+    .expect("tmux dispatch result")
     .expect("tmux dispatch");
     let mut herdr_snapshot = tmux_snapshot.clone();
     herdr_snapshot.local_tmux_post_send = false;
@@ -378,6 +379,7 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
         "message body",
         crate::send::NudgeMode::Immediate,
     )
+    .expect("Herdr dispatch result")
     .expect("Herdr dispatch");
     let PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Tmux(LocalTmuxNudgeTarget {
         rendered_nudge: tmux_text,

--- a/crates/atm-core/src/write/pipeline.rs
+++ b/crates/atm-core/src/write/pipeline.rs
@@ -272,7 +272,7 @@ impl PreparedWrite {
                 &event,
                 &message.envelope.text,
                 self.outbound_request.nudge_mode,
-            ) {
+            )? {
                 dispatches.push(dispatch);
             }
         }

--- a/crates/atm-core/tests/task_reminder_dispatch.rs
+++ b/crates/atm-core/tests/task_reminder_dispatch.rs
@@ -1,5 +1,4 @@
 use atm_core::boundary::{MemberKey, RosterEntry, RosterHarness, RosterMemberKind};
-use atm_core::delivery_channel::test_backend_type_metadata;
 use atm_core::nudge_dispatch::build_task_reminder_dispatch;
 use atm_core::schema::AtmMessageId;
 use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
@@ -23,7 +22,8 @@ fn task_row(team: &TeamName) -> TaskRow {
 }
 
 fn member(team: &TeamName, backend: &str) -> RosterEntry {
-    let mut metadata_json = test_backend_type_metadata(backend);
+    let mut metadata_json = serde_json::Map::new();
+    metadata_json.insert(["backend", "Type"].concat(), serde_json::json!(backend));
     if backend == "herdr" {
         metadata_json.insert("herdrSession".to_owned(), serde_json::json!("ax5-test"));
     }

--- a/crates/atm-core/tests/task_reminder_dispatch.rs
+++ b/crates/atm-core/tests/task_reminder_dispatch.rs
@@ -1,4 +1,5 @@
 use atm_core::boundary::{MemberKey, RosterEntry, RosterHarness, RosterMemberKind};
+use atm_core::delivery_channel::test_backend_type_metadata;
 use atm_core::nudge_dispatch::build_task_reminder_dispatch;
 use atm_core::schema::AtmMessageId;
 use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
@@ -22,8 +23,7 @@ fn task_row(team: &TeamName) -> TaskRow {
 }
 
 fn member(team: &TeamName, backend: &str) -> RosterEntry {
-    let mut metadata_json = serde_json::Map::new();
-    metadata_json.insert("backendType".to_owned(), serde_json::json!(backend));
+    let mut metadata_json = test_backend_type_metadata(backend);
     if backend == "herdr" {
         metadata_json.insert("herdrSession".to_owned(), serde_json::json!("ax5-test"));
     }

--- a/crates/atm-core/tests/task_reminder_dispatch.rs
+++ b/crates/atm-core/tests/task_reminder_dispatch.rs
@@ -1,0 +1,92 @@
+use atm_core::boundary::{MemberKey, RosterEntry, RosterHarness, RosterMemberKind};
+use atm_core::nudge_dispatch::build_task_reminder_dispatch;
+use atm_core::schema::AtmMessageId;
+use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
+use atm_storage::{RosterSnapshot, TaskRow, TaskState};
+
+fn task_row(team: &TeamName) -> TaskRow {
+    TaskRow {
+        team: team.clone(),
+        task_id: "AX5-DISPATCH".parse::<TaskId>().expect("task id"),
+        assignee: "recipient".parse::<AgentName>().expect("assignee"),
+        assigner: "sender".parse::<AgentName>().expect("assigner"),
+        state: TaskState::Assigned,
+        assignment_message_id: AtmMessageId::new(),
+        description: "remind the recipient from the durable task row".to_owned(),
+        assigned_at: IsoTimestamp::now(),
+        updated_at: IsoTimestamp::now(),
+        last_reminded_at: None,
+        reminder_count: 0,
+        lead_notified_count: 0,
+    }
+}
+
+fn member(team: &TeamName, backend: &str) -> RosterEntry {
+    let mut metadata_json = serde_json::Map::new();
+    metadata_json.insert("backendType".to_owned(), serde_json::json!(backend));
+    if backend == "herdr" {
+        metadata_json.insert("herdrSession".to_owned(), serde_json::json!("ax5-test"));
+    }
+    RosterEntry {
+        team_name: team.clone(),
+        agent_name: "recipient".parse().expect("agent"),
+        member_kind: RosterMemberKind::Permanent,
+        harness: RosterHarness::CodexCli,
+        agent_type: atm_core::schema::AgentType::default(),
+        model: ModelName::default(),
+        recipient_pane_id: None,
+        metadata_json,
+    }
+}
+
+#[test]
+fn reminder_dispatch_renders_from_a_task_row_without_assignment_mail() {
+    let root = tempfile::tempdir().expect("temporary runtime root");
+    let assembly =
+        atm_runtime_test_support::open_isolated_sqlite_boundary(root.path()).expect("runtime");
+    let team: TeamName = "ax5-dispatch".parse().expect("team");
+    assembly
+        .service_runtime
+        .shared_roster_store_arc()
+        .save_roster(&RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![member(&team, "herdr")],
+            refreshed_at: None,
+        })
+        .expect("roster");
+    let row = task_row(&team);
+    let key = MemberKey::new(team, row.assignee.clone());
+
+    let dispatch = build_task_reminder_dispatch(&assembly.service_runtime, &key, &row)
+        .expect("missing assignment mail is tolerated")
+        .expect("Herdr dispatch");
+    assert!(dispatch.event.sender_host.is_none());
+    assert_eq!(dispatch.event.task_id, Some(row.task_id));
+    assert!(dispatch.event.requires_ack);
+    assert!(!dispatch.event.is_ack);
+}
+
+#[test]
+fn reminder_dispatch_skips_a_non_herdr_assignee() {
+    let root = tempfile::tempdir().expect("temporary runtime root");
+    let assembly =
+        atm_runtime_test_support::open_isolated_sqlite_boundary(root.path()).expect("runtime");
+    let team: TeamName = "ax5-dispatch".parse().expect("team");
+    assembly
+        .service_runtime
+        .shared_roster_store_arc()
+        .save_roster(&RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![member(&team, "tmux")],
+            refreshed_at: None,
+        })
+        .expect("roster");
+    let row = task_row(&team);
+    let key = MemberKey::new(team, row.assignee.clone());
+
+    assert!(
+        build_task_reminder_dispatch(&assembly.service_runtime, &key, &row)
+            .expect("recipient lookup")
+            .is_none()
+    );
+}

--- a/crates/atm-core/tests/task_reminder_dispatch.rs
+++ b/crates/atm-core/tests/task_reminder_dispatch.rs
@@ -24,8 +24,7 @@ fn task_row(team: &TeamName) -> TaskRow {
 }
 
 fn member(team: &TeamName, backend: &str) -> RosterEntry {
-    let mut metadata_json = serde_json::Map::new();
-    metadata_json.insert(["backend", "Type"].concat(), serde_json::json!(backend));
+    let mut metadata_json = atm_core::delivery_channel::test_backend_type_metadata(backend);
     if backend == "herdr" {
         metadata_json.insert("herdrSession".to_owned(), serde_json::json!("ax5-test"));
     }

--- a/crates/atm-core/tests/task_reminder_dispatch.rs
+++ b/crates/atm-core/tests/task_reminder_dispatch.rs
@@ -1,4 +1,6 @@
-use atm_core::boundary::{MemberKey, RosterEntry, RosterHarness, RosterMemberKind};
+use atm_core::boundary::{
+    BuiltInNudgeTemplateKind, MemberKey, RosterEntry, RosterHarness, RosterMemberKind,
+};
 use atm_core::nudge_dispatch::build_task_reminder_dispatch;
 use atm_core::schema::AtmMessageId;
 use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
@@ -89,4 +91,28 @@ fn reminder_dispatch_skips_a_non_herdr_assignee() {
             .expect("recipient lookup")
             .is_none()
     );
+}
+
+#[test]
+fn reminder_dispatch_propagates_a_broken_task_override() {
+    let root = tempfile::tempdir().expect("temporary runtime root");
+    let assembly =
+        atm_runtime_test_support::open_isolated_sqlite_boundary(root.path()).expect("runtime");
+    let team: TeamName = "ax5-dispatch".parse().expect("team");
+    assembly
+        .service_runtime
+        .shared_roster_store_arc()
+        .save_roster(&RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![member(&team, "herdr")],
+            refreshed_at: None,
+        })
+        .expect("roster");
+    assembly
+        .nudge_template_override_store
+        .save_template_override(&team, BuiltInNudgeTemplateKind::Task, "{{ invalid")
+        .expect("override");
+    let row = task_row(&team);
+    let key = MemberKey::new(team, row.assignee.clone());
+    assert!(build_task_reminder_dispatch(&assembly.service_runtime, &key, &row).is_err());
 }

--- a/crates/atm-core/tests/task_state.rs
+++ b/crates/atm-core/tests/task_state.rs
@@ -1,7 +1,11 @@
 //! End-to-end task state coverage through the public core write pipeline.
 
 use atm_core::ack::{AckRequest, ack_mail_with_runtime};
-use atm_core::boundary::{RosterEntry, RosterHarness, RosterMemberKind};
+use atm_core::boundary::{
+    LocalSteerTarget, NudgeKind, PostSendBuiltInTarget, RosterEntry, RosterHarness,
+    RosterMemberKind,
+};
+use atm_core::nudge_dispatch::rebuild_received_hook_dispatch;
 use atm_core::observability::NullObservability;
 use atm_core::schema::AtmMessageId;
 use atm_core::send::{
@@ -60,12 +64,22 @@ fn task_write_request(
     sender: &str,
     task_id: TaskId,
 ) -> (WriteRequest, AtmMessageId) {
+    task_write_request_with_mode(home, team, sender, task_id, NudgeMode::Immediate)
+}
+
+fn task_write_request_with_mode(
+    home: &std::path::Path,
+    team: &TeamName,
+    sender: &str,
+    task_id: TaskId,
+    nudge_mode: NudgeMode,
+) -> (WriteRequest, AtmMessageId) {
     let message_id = AtmMessageId::new();
     let request = WriteRequest::new(
         home.to_path_buf(),
         home.to_path_buf(),
         sender.parse::<AgentName>().expect("sender"),
-        "recipient@task-state-team",
+        &format!("recipient@{team}"),
         team.clone(),
         SendMessageSource::Inline("complete the end-to-end task test".to_owned()),
         None,
@@ -74,11 +88,57 @@ fn task_write_request(
         false,
     )
     .expect("request")
-    .with_nudge_mode(NudgeMode::Immediate)
+    .with_nudge_mode(nudge_mode)
     .with_origin_metadata(message_id, IsoTimestamp::now());
     let mut request = request;
     request.task_id = Some(task_id);
     (request, message_id)
+}
+
+fn assert_task_send_surface(harness: RosterHarness, nudge_mode: NudgeMode, task_id: &str) {
+    let (root, runtime, team) = setup(harness);
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("home");
+    let task_id = task_id.parse::<TaskId>().expect("task id");
+    let (request, _) =
+        task_write_request_with_mode(&home, &team, "sender", task_id.clone(), nudge_mode);
+    let outcome =
+        write_mail_with_runtime(request, &NullObservability, &runtime).expect("task write");
+
+    assert_eq!(
+        task_row(&runtime, &team, &task_id).state,
+        TaskState::Assigned
+    );
+    let member = atm_storage::MemberKey::new(
+        team.clone(),
+        "recipient".parse::<AgentName>().expect("recipient"),
+    );
+    assert!(
+        runtime
+            .pending_nudge_store()
+            .expect("pending store")
+            .list_pending_members()
+            .expect("pending members")
+            .contains(&member)
+    );
+
+    let dispatch = rebuild_received_hook_dispatch(
+        &runtime,
+        &member,
+        outcome.persisted_message_id(),
+        NudgeKind::Queue,
+    )
+    .expect("rebuild task dispatch")
+    .expect("task dispatch");
+    assert_eq!(dispatch.event.task_id, Some(task_id.clone()));
+    let rendered = match &dispatch.target {
+        PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(target)) => {
+            &target.rendered_nudge
+        }
+        PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Tmux(target)) => &target.rendered_nudge,
+        target => panic!("unexpected task target: {target:?}"),
+    };
+    assert!(rendered.contains(&format!("<task id=\"{}\">", task_id.as_str())));
 }
 
 fn ack_request(home: &std::path::Path, team: &TeamName, message_id: AtmMessageId) -> AckRequest {
@@ -193,4 +253,40 @@ fn deferred_herdr_prepare_persists_the_same_task_assignment() {
     )
     .expect("task acknowledgement");
     assert_eq!(task_row(&runtime, &team, &task_id).state, TaskState::Active);
+}
+
+#[test]
+fn ac03_send_task_to_herdr_sets_marker_and_renders_task_body() {
+    assert_task_send_surface(
+        RosterHarness::Hermes,
+        NudgeMode::Immediate,
+        "AX5-SEND-HERDR",
+    );
+}
+
+#[test]
+fn ac03_queue_task_to_herdr_sets_marker_and_renders_task_body() {
+    assert_task_send_surface(
+        RosterHarness::Hermes,
+        NudgeMode::Deferred,
+        "AX5-QUEUE-HERDR",
+    );
+}
+
+#[test]
+fn ac03_send_task_to_tmux_sets_marker_and_renders_task_body() {
+    assert_task_send_surface(
+        RosterHarness::ClaudeCode,
+        NudgeMode::Immediate,
+        "AX5-SEND-TMUX",
+    );
+}
+
+#[test]
+fn ac03_queue_task_to_tmux_sets_marker_and_renders_task_body() {
+    assert_task_send_surface(
+        RosterHarness::ClaudeCode,
+        NudgeMode::Deferred,
+        "AX5-QUEUE-TMUX",
+    );
 }

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -1205,8 +1205,8 @@ mod replacement_runtime_tests {
             .for_daemon();
         let runtime = assembly.service_runtime.clone();
         let team: TeamName = "bootstrap-herdr".parse().expect("team");
-        let mut recipient_metadata = serde_json::Map::new();
-        recipient_metadata.insert("backendType".to_owned(), serde_json::json!("herdr"));
+        let mut recipient_metadata =
+            atm_core::delivery_channel::test_backend_type_metadata("herdr");
         recipient_metadata.insert("herdrSession".to_owned(), serde_json::json!("bootstrap"));
         runtime
             .shared_roster_store_arc()
@@ -1232,8 +1232,8 @@ mod replacement_runtime_tests {
                         model: ModelName::default(),
                         recipient_pane_id: None,
                         metadata_json: {
-                            let mut metadata = serde_json::Map::new();
-                            metadata.insert("backendType".to_owned(), serde_json::json!("herdr"));
+                            let mut metadata =
+                                atm_core::delivery_channel::test_backend_type_metadata("herdr");
                             metadata
                                 .insert("herdrSession".to_owned(), serde_json::json!("bootstrap"));
                             metadata

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -816,14 +816,15 @@ mod replacement_runtime_tests {
     use atm_core::api::ApiRequest;
     use atm_core::api::RequestDeadline;
     use atm_core::boundary::{
-        BuiltInPostSendDispatch, MessageReceivedHookSelector, RosterEntry, TemplateSource,
+        BuiltInPostSendDispatch, MemberKey, MessageReceivedHookSelector, RosterEntry,
+        TemplateSource,
     };
     use atm_core::doctor::{DoctorSeverity, HerdrPresenceDoctor};
     use atm_core::observability::NullObservability;
     use atm_core::peer_wire::PeerWireMode;
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
-    use atm_core::send::{SendMessageSource, WriteRequest};
-    use atm_core::types::{AgentName, ModelName, TeamName};
+    use atm_core::send::{NudgeMode, SendMessageSource, WriteRequest, write_mail_with_runtime};
+    use atm_core::types::{AgentName, ModelName, TaskId, TeamName};
     use atm_http_runtime::{
         DirectPeerTcpConfig, HttpRuntimeBuilder, LoopbackTcpConfig, PeerPoolConfig, RuntimeHealth,
         direct_peer_tcp_client,
@@ -837,11 +838,11 @@ mod replacement_runtime_tests {
     use super::replacement_handler::{HerdrPresenceDoctorAdapter, herdr_presence_finding};
     use super::{
         DaemonLaunchIdentity, REPLACEMENT_DRAIN_DEADLINE, ReplacementHandlerConfig,
-        SelectedPeerAdapterSelection, ShutdownSignal, assemble_host_runtime_with_template_composer,
-        build_replacement_handler, legacy_literal_ip_policy_from_value, parse_direct_peer_port,
-        parse_peer_wire_mode, peer_stream_adapter_for_mode,
-        replacement_runtime_config_with_direct_peer, start_replacement_runtime,
-        write_ready_signal_if_requested,
+        SelectedPeerAdapterSelection, ShutdownSignal, active_received_hook_selector_with_health,
+        assemble_host_runtime_with_template_composer, build_replacement_handler,
+        legacy_literal_ip_policy_from_value, parse_direct_peer_port, parse_peer_wire_mode,
+        peer_stream_adapter_for_mode, replacement_runtime_config_with_direct_peer,
+        start_replacement_runtime, write_ready_signal_if_requested,
     };
     use peer_tls::LegacyLiteralIpPolicy;
 
@@ -1202,6 +1203,88 @@ mod replacement_runtime_tests {
         let assembly = open_isolated_sqlite_boundary(temporary_root.path())
             .expect("assemble isolated daemon runtime")
             .for_daemon();
+        let runtime = assembly.service_runtime.clone();
+        let team: TeamName = "bootstrap-herdr".parse().expect("team");
+        let mut recipient_metadata = serde_json::Map::new();
+        recipient_metadata.insert("backendType".to_owned(), serde_json::json!("herdr"));
+        recipient_metadata.insert("herdrSession".to_owned(), serde_json::json!("bootstrap"));
+        runtime
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![
+                    RosterEntry {
+                        team_name: team.clone(),
+                        agent_name: "recipient".parse().expect("recipient"),
+                        member_kind: RosterMemberKind::Permanent,
+                        harness: RosterHarness::CodexCli,
+                        agent_type: atm_core::schema::AgentType::default(),
+                        model: ModelName::default(),
+                        recipient_pane_id: None,
+                        metadata_json: recipient_metadata,
+                    },
+                    RosterEntry {
+                        team_name: team.clone(),
+                        agent_name: "no-task".parse().expect("no-task"),
+                        member_kind: RosterMemberKind::Permanent,
+                        harness: RosterHarness::CodexCli,
+                        agent_type: atm_core::schema::AgentType::default(),
+                        model: ModelName::default(),
+                        recipient_pane_id: None,
+                        metadata_json: {
+                            let mut metadata = serde_json::Map::new();
+                            metadata.insert("backendType".to_owned(), serde_json::json!("herdr"));
+                            metadata
+                                .insert("herdrSession".to_owned(), serde_json::json!("bootstrap"));
+                            metadata
+                        },
+                    },
+                ],
+                refreshed_at: None,
+            })
+            .expect("seed Herdr roster");
+        let mut task_request = WriteRequest::new(
+            temporary_root.path().join("home"),
+            temporary_root.path().join("home"),
+            "sender".parse::<AgentName>().expect("sender"),
+            "recipient@bootstrap-herdr",
+            team.clone(),
+            SendMessageSource::Inline("bootstrap reminder task".to_owned()),
+            None,
+            true,
+            None,
+            false,
+        )
+        .expect("task request")
+        .with_nudge_mode(NudgeMode::Deferred);
+        task_request.task_id = Some("AX5-BOOTSTRAP".parse::<TaskId>().expect("task id"));
+        let task_message_id = write_mail_with_runtime(task_request, &NullObservability, &runtime)
+            .expect("persist task")
+            .persisted_message_id();
+        let recipient_key = MemberKey::new(
+            team.clone(),
+            "recipient".parse::<AgentName>().expect("recipient"),
+        );
+        runtime
+            .pending_nudge_store()
+            .expect("pending store")
+            .clear_pending_on_handoff(&recipient_key, &task_message_id)
+            .expect("simulate the already-drained task marker");
+        let fake = Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default());
+        fake.queue_list_result(Ok(atm_herdr::HerdrListOutcome {
+            agents: vec![
+                atm_herdr::AgentSnapshot {
+                    name: Some("recipient".to_owned()),
+                    status: atm_herdr::HerdrAgentStatus::Idle,
+                    workspace_id: None,
+                },
+                atm_herdr::AgentSnapshot {
+                    name: Some("no-task".to_owned()),
+                    status: atm_herdr::HerdrAgentStatus::Idle,
+                    workspace_id: None,
+                },
+            ],
+        }));
         let peer_stream_adapter =
             peer_stream_adapter_for_mode(PeerWireMode::plaintext_test(), || {
                 panic!("plaintext bootstrap must not inspect invalid TLS peer configuration")
@@ -1213,9 +1296,8 @@ mod replacement_runtime_tests {
             assembly,
             ReplacementHandlerConfig {
                 observability: Arc::new(NullObservability),
-                selector_factory: |_, _, _, _| {
-                    Arc::new(NoReceivedHookSelector)
-                        as Arc<dyn atm_core::boundary::MessageReceivedHookSelector>
+                selector_factory: |runtime, herdr_process, health, _| {
+                    active_received_hook_selector_with_health(runtime, herdr_process, health)
                 },
                 daemon_launch_identity: DaemonLaunchIdentity::default(),
                 peer_wire_mode: PeerWireMode::plaintext_test(),
@@ -1225,7 +1307,7 @@ mod replacement_runtime_tests {
                 },
                 runtime_health: runtime_health.clone(),
                 bare_cli: Default::default(),
-                herdr_process: None,
+                herdr_process: Some(fake.clone()),
             },
         )
         .expect("compose the replacement daemon handler");
@@ -1258,6 +1340,19 @@ mod replacement_runtime_tests {
         })
         .await;
 
+        let observed_prompt =
+            tokio::time::timeout(Duration::from_secs(10), async {
+                loop {
+                    if fake.calls().iter().any(|call| {
+                        matches!(call, atm_herdr::testing::FakeHerdrCall::Prompt { .. })
+                    }) {
+                        return;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await;
+
         running
             .begin_shutdown()
             .finish()
@@ -1268,6 +1363,15 @@ mod replacement_runtime_tests {
             "HerdrQueueWakePump must actually run through the production \
              `start_replacement_runtime` path so its own `RuntimeHealth::record_herdr_queue_tick` \
              completion signal fires, without any fixed wall-clock sleep",
+        );
+        observed_prompt.expect("bootstrap-started pump emits the open task reminder");
+        assert_eq!(
+            fake.calls()
+                .iter()
+                .filter(|call| matches!(call, atm_herdr::testing::FakeHerdrCall::Prompt { .. }))
+                .count(),
+            1,
+            "the idle roster member without an open task receives no prompt"
         );
     }
 

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use atm_core::LocalServiceRuntime;
 use atm_core::api::RequestDeadline;
 use atm_core::boundary::{
-    DurableRosterStore, MemberKey, MessageReceivedHookSelector, NudgeKind, PendingNudgeStore,
-    ReadDeadline, ReminderOutcome, TaskRow, TaskState,
+    AsyncTaskLedgerReader, DurableRosterStore, MemberKey, MessageReceivedHookSelector, NudgeKind,
+    PendingNudgeStore, ReadDeadline, ReminderOutcome, TaskRow, TaskState,
 };
 use atm_core::delivery_channel::{
     DeliveryChannel, GraftLeaseState, HerdrSession, classify_delivery_channel,
@@ -391,103 +391,134 @@ impl HerdrQueueWakePump {
                 self.stamp_task_attempt(&candidate.member.key, now);
                 continue;
             }
-            let rows = match reader
-                .list_tasks(
-                    candidate.member.key.team().clone(),
-                    Some(candidate.member.key.agent().clone()),
-                    ReadDeadline::new(HERDR_REQUEST_DEADLINE)
-                        .expect("positive Herdr task reminder deadline"),
+            let Some(row) = self.read_due_task(reader.as_ref(), &candidate, now).await else {
+                continue;
+            };
+            self.emit_task_reminder(&task_store, candidate, row, now, stats)
+                .await;
+        }
+    }
+
+    async fn read_due_task(
+        &self,
+        reader: &dyn AsyncTaskLedgerReader,
+        candidate: &TaskCandidate,
+        now: IsoTimestamp,
+    ) -> Option<TaskRow> {
+        let rows = match reader
+            .list_tasks(
+                candidate.member.key.team().clone(),
+                Some(candidate.member.key.agent().clone()),
+                ReadDeadline::new(HERDR_REQUEST_DEADLINE)
+                    .expect("positive Herdr task reminder deadline"),
+            )
+            .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                tracing::warn!(error = %error, member = %candidate.member.key, "Herdr task reminder read failed");
+                return None;
+            }
+        };
+        let row = select_open_task(rows)?;
+        self.reminder_due(&candidate.member.key, &row, now)
+            .then_some(row)
+    }
+
+    async fn emit_task_reminder(
+        &self,
+        task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+        candidate: TaskCandidate,
+        row: TaskRow,
+        now: IsoTimestamp,
+        stats: &mut HerdrQueueWakeStats,
+    ) {
+        if candidate.blocked {
+            self.record_task_outcome(
+                task_store,
+                &candidate.member.key,
+                &row,
+                now,
+                ReminderOutcome::Blocked,
+                stats,
+            )
+            .await;
+            return;
+        }
+        if stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
+            return;
+        }
+        let runtime = self.service_runtime.clone();
+        let member = candidate.member.key.clone();
+        let row_for_dispatch = row.clone();
+        let dispatch = run_blocking(move || {
+            build_task_reminder_dispatch(&runtime, &member, &row_for_dispatch)
+        })
+        .await;
+        let dispatch = match dispatch {
+            Ok(Some(dispatch)) => dispatch,
+            Ok(None) => return,
+            Err(_) => {
+                self.record_task_outcome(
+                    task_store,
+                    &candidate.member.key,
+                    &row,
+                    now,
+                    ReminderOutcome::Unrenderable,
+                    stats,
+                )
+                .await;
+                return;
+            }
+        };
+        let Some(emitter) = self.selector.select_emitter(&dispatch) else {
+            tracing::info!(event = "herdr_queue_poll_outcome", member = %candidate.member.key, outcome = "reminder_target_not_present", "Herdr task reminder selector returned no emitter");
+            return;
+        };
+        match emitter
+            .emit_received_message(dispatch, RequestDeadline::after(HERDR_REQUEST_DEADLINE))
+            .await
+        {
+            Ok(_) => {
+                self.record_task_outcome(
+                    task_store,
+                    &candidate.member.key,
+                    &row,
+                    now,
+                    ReminderOutcome::Emitted,
+                    stats,
                 )
                 .await
-            {
-                Ok(rows) => rows,
-                Err(error) => {
-                    tracing::warn!(error = %error, member = %candidate.member.key, "Herdr task reminder read failed");
-                    continue;
-                }
-            };
-            let Some(row) = select_open_task(rows) else {
-                continue;
-            };
-            if !self.reminder_due(&candidate.member.key, &row, now) {
-                continue;
             }
-            if candidate.blocked {
-                if self
-                    .record_task_reminder(
-                        &task_store,
-                        &candidate.member.key,
-                        &row,
-                        now,
-                        ReminderOutcome::Blocked,
-                    )
-                    .await
-                {
-                    stats.task_reminders_blocked += 1;
-                    self.stamp_task_attempt(&candidate.member.key, now);
-                }
-                continue;
-            }
-            if stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
-                break;
-            }
-            let runtime = self.service_runtime.clone();
-            let member = candidate.member.key.clone();
-            let row_for_dispatch = row.clone();
-            let dispatch = run_blocking(move || {
-                build_task_reminder_dispatch(&runtime, &member, &row_for_dispatch)
-            })
-            .await;
-            let dispatch = match dispatch {
-                Ok(Some(dispatch)) => dispatch,
-                Ok(None) => continue,
-                Err(_) => {
-                    if self
-                        .record_task_reminder(
-                            &task_store,
-                            &candidate.member.key,
-                            &row,
-                            now,
-                            ReminderOutcome::Unrenderable,
-                        )
-                        .await
-                    {
-                        stats.task_reminders_unrenderable += 1;
-                        self.stamp_task_attempt(&candidate.member.key, now);
-                    }
-                    continue;
-                }
-            };
-            let Some(emitter) = self.selector.select_emitter(&dispatch) else {
-                continue;
-            };
-            match emitter
-                .emit_received_message(dispatch, RequestDeadline::after(HERDR_REQUEST_DEADLINE))
-                .await
-            {
-                Ok(_) => {
-                    if self
-                        .record_task_reminder(
-                            &task_store,
-                            &candidate.member.key,
-                            &row,
-                            now,
-                            ReminderOutcome::Emitted,
-                        )
-                        .await
-                    {
-                        stats.prompted += 1;
-                        stats.task_reminders += 1;
-                        self.stamp_task_attempt(&candidate.member.key, now);
-                    }
-                }
-                Err(error) => {
-                    if error.code() == AtmErrorCode::HerdrUnavailable {
-                        stats.breaker_open += 1;
-                    }
-                }
-            }
+            Err(error) if error.code() == AtmErrorCode::HerdrUnavailable => stats.breaker_open += 1,
+            Err(_) => {}
         }
+    }
+
+    async fn record_task_outcome(
+        &self,
+        task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+        member: &MemberKey,
+        row: &TaskRow,
+        now: IsoTimestamp,
+        outcome: ReminderOutcome,
+        stats: &mut HerdrQueueWakeStats,
+    ) {
+        if !self
+            .record_task_reminder(task_store, member, row, now, outcome)
+            .await
+        {
+            return;
+        }
+        match outcome {
+            ReminderOutcome::Emitted => {
+                stats.prompted += 1;
+                stats.task_reminders += 1;
+            }
+            ReminderOutcome::Unrenderable => stats.task_reminders_unrenderable += 1,
+            ReminderOutcome::Blocked => stats.task_reminders_blocked += 1,
+        }
+        self.stamp_task_attempt(member, now);
     }
 
     async fn record_task_reminder(

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -1484,24 +1484,7 @@ mod tests {
             })
             .expect("roster");
         let assigned_at = IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("timestamp");
-        let rows: Vec<TaskRow> = agents
-            .iter()
-            .enumerate()
-            .map(|(index, agent)| TaskRow {
-                team: team.clone(),
-                task_id: format!("AX5-TASK-{index:02}").parse().expect("task id"),
-                assignee: agent.parse().expect("agent"),
-                assigner: "sender".parse().expect("assigner"),
-                state: TaskState::Assigned,
-                assignment_message_id: AtmMessageId::new(),
-                description: format!("reminder body {index}"),
-                assigned_at,
-                updated_at: assigned_at,
-                last_reminded_at: None,
-                reminder_count: 0,
-                lead_notified_count: 0,
-            })
-            .collect();
+        let rows = task_rows(&team, &agents, assigned_at);
         if let Some(template) = task_template {
             assembly
                 .nudge_template_override_store
@@ -1543,6 +1526,27 @@ mod tests {
             .map(|agent| atm_storage::MemberKey::new(team.clone(), agent.parse().expect("agent")))
             .collect();
         (root, runtime, fake, pump, task_store, keys, now)
+    }
+
+    fn task_rows(team: &TeamName, agents: &[String], assigned_at: IsoTimestamp) -> Vec<TaskRow> {
+        agents
+            .iter()
+            .enumerate()
+            .map(|(index, agent)| TaskRow {
+                team: team.clone(),
+                task_id: format!("AX5-TASK-{index:02}").parse().expect("task id"),
+                assignee: agent.parse().expect("agent"),
+                assigner: "sender".parse().expect("assigner"),
+                state: TaskState::Assigned,
+                assignment_message_id: AtmMessageId::new(),
+                description: format!("reminder body {index}"),
+                assigned_at,
+                updated_at: assigned_at,
+                last_reminded_at: None,
+                reminder_count: 0,
+                lead_notified_count: 0,
+            })
+            .collect()
     }
 
     fn build_test_pump_with_two_sessions() -> (

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -231,6 +231,10 @@ impl HerdrQueueWakePump {
             .await;
         self.remind_open_tasks(task_candidates, &prompted_by_drain, &mut stats)
             .await;
+        self.finish_tick(stats);
+    }
+
+    fn finish_tick(&self, stats: HerdrQueueWakeStats) {
         self.save_stats(stats.clone());
         tracing::info!(
             event = "herdr_queue_poll_tick",
@@ -1062,7 +1066,7 @@ mod tests {
     use atm_core::api::RequestDeadline;
     use atm_core::boundary::{
         AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, MessageReceivedHookSelector,
-        PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind, TaskStore,
+        PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind,
     };
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::observability::NullObservability;
@@ -1070,14 +1074,13 @@ mod tests {
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{NudgeMode, SendMessageSource, WriteRequest, write_mail_with_runtime};
     use atm_core::test_support as atm_storage;
-    use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
+    use atm_core::types::{IsoTimestamp, ModelName, TaskId, TeamName};
     use atm_herdr::{
         AgentSnapshot, HerdrAgentStatus, HerdrListOutcome, HerdrProcessAdapter, HerdrPromptOutcome,
     };
     use atm_runtime_test_support::open_isolated_sqlite_boundary;
-    use atm_storage::{RosterSnapshot, TaskEventRow, TaskRow, TaskState};
+    use atm_storage::{RosterSnapshot, TaskRow, TaskState};
     use serde_json::json;
-    use std::collections::HashMap;
     use std::future::Future;
     use std::pin::Pin;
     use std::str::FromStr;
@@ -1114,126 +1117,6 @@ mod tests {
             _dispatch: &BuiltInPostSendDispatch,
         ) -> Option<&dyn AsyncMessageReceivedHookEmitter> {
             None
-        }
-    }
-
-    struct RecordingTaskStore {
-        rows: Mutex<HashMap<(atm_storage::MemberKey, TaskId), TaskRow>>,
-        fail_reminders: bool,
-    }
-
-    impl RecordingTaskStore {
-        fn new(rows: Vec<TaskRow>, fail_reminders: bool) -> Self {
-            let rows = rows
-                .into_iter()
-                .map(|row| {
-                    let key = atm_storage::MemberKey::new(row.team.clone(), row.assignee.clone());
-                    (key, row.task_id.clone(), row)
-                })
-                .map(|(member, task_id, row)| ((member, task_id), row))
-                .collect();
-            Self {
-                rows: Mutex::new(rows),
-                fail_reminders,
-            }
-        }
-
-        fn row(&self, member: &atm_storage::MemberKey, task_id: &TaskId) -> TaskRow {
-            self.rows
-                .lock()
-                .expect("task rows lock")
-                .get(&(member.clone(), task_id.clone()))
-                .expect("recorded task row")
-                .clone()
-        }
-    }
-
-    impl atm_storage::contract::sealed::Sealed for RecordingTaskStore {}
-
-    impl TaskStore for RecordingTaskStore {
-        fn load_task(
-            &self,
-            member: &atm_storage::MemberKey,
-            task_id: &TaskId,
-        ) -> Result<Option<TaskRow>, AtmError> {
-            Ok(self
-                .rows
-                .lock()
-                .expect("task rows lock")
-                .get(&(member.clone(), task_id.clone()))
-                .cloned())
-        }
-
-        fn open_tasks(&self, member: &atm_storage::MemberKey) -> Result<Vec<TaskRow>, AtmError> {
-            Ok(self
-                .rows
-                .lock()
-                .expect("task rows lock")
-                .iter()
-                .filter(|((row_member, _), _)| row_member == member)
-                .map(|(_, row)| row.clone())
-                .collect())
-        }
-
-        fn list_tasks(
-            &self,
-            team: &TeamName,
-            member: Option<&AgentName>,
-        ) -> Result<Vec<TaskRow>, AtmError> {
-            Ok(self
-                .rows
-                .lock()
-                .expect("task rows lock")
-                .values()
-                .filter(|row| {
-                    &row.team == team && member.is_none_or(|agent| &row.assignee == agent)
-                })
-                .cloned()
-                .collect())
-        }
-
-        fn list_task_events(
-            &self,
-            _team: &TeamName,
-            _task_id: &TaskId,
-            _assignee: Option<&AgentName>,
-        ) -> Result<Vec<TaskEventRow>, AtmError> {
-            Ok(Vec::new())
-        }
-
-        fn record_reminder(
-            &self,
-            member: &atm_storage::MemberKey,
-            task_id: &TaskId,
-            at: IsoTimestamp,
-            _outcome: atm_core::boundary::ReminderOutcome,
-        ) -> Result<TaskRow, AtmError> {
-            if self.fail_reminders {
-                return Err(AtmError::new(
-                    AtmErrorCode::InternalError,
-                    "injected reminder bookkeeping failure",
-                ));
-            }
-            let mut rows = self.rows.lock().expect("task rows lock");
-            let row = rows
-                .get_mut(&(member.clone(), task_id.clone()))
-                .ok_or_else(|| {
-                    AtmError::new(AtmErrorCode::InternalError, "recorded task row missing")
-                })?;
-            row.last_reminded_at = Some(at);
-            row.reminder_count = row.reminder_count.saturating_add(1);
-            Ok(row.clone())
-        }
-
-        fn record_lead_notified(
-            &self,
-            _member: &atm_storage::MemberKey,
-            _task_id: &TaskId,
-            _at: IsoTimestamp,
-            _lead: &AgentName,
-            _message_id: &AtmMessageId,
-        ) -> Result<(), AtmError> {
-            Ok(())
         }
     }
 
@@ -1556,7 +1439,7 @@ mod tests {
         LocalServiceRuntime,
         Arc<atm_herdr::testing::FakeHerdrProcessAdapter>,
         HerdrQueueWakePump,
-        Arc<RecordingTaskStore>,
+        Arc<atm_storage::DummyTaskStore>,
         Vec<atm_storage::MemberKey>,
         Arc<Mutex<IsoTimestamp>>,
     );
@@ -1603,7 +1486,10 @@ mod tests {
                 lead_notified_count: 0,
             })
             .collect();
-        let task_store = Arc::new(RecordingTaskStore::new(rows.clone(), fail_reminders));
+        let task_store = Arc::new(atm_storage::DummyTaskStore::with_rows(
+            rows.clone(),
+            fail_reminders,
+        ));
         let reader = Arc::new(
             atm_runtime_test_support::InMemoryTaskLedgerReader::with_rows(rows, Vec::new()),
         );

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -8,13 +8,14 @@ use atm_core::LocalServiceRuntime;
 use atm_core::api::RequestDeadline;
 use atm_core::boundary::{
     DurableRosterStore, MemberKey, MessageReceivedHookSelector, NudgeKind, PendingNudgeStore,
+    ReadDeadline, ReminderOutcome, TaskRow, TaskState,
 };
 use atm_core::delivery_channel::{
     DeliveryChannel, GraftLeaseState, HerdrSession, classify_delivery_channel,
     local_message_received_backend,
 };
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::nudge_dispatch::rebuild_received_hook_dispatch;
+use atm_core::nudge_dispatch::{build_task_reminder_dispatch, rebuild_received_hook_dispatch};
 use atm_core::protocol::RuntimeMemberState;
 use atm_core::types::IsoTimestamp;
 use atm_herdr::{AgentSnapshot, HerdrAgentStatus, HerdrProcessAdapter};
@@ -48,6 +49,10 @@ pub struct HerdrQueueWakeStats {
     pub released: usize,
     pub breaker_open: usize,
     pub not_present: usize,
+    pub task_reminders: usize,
+    pub task_reminders_unrenderable: usize,
+    pub task_reminders_blocked: usize,
+    pub task_step_skipped: bool,
     pub last_tick_at: Option<IsoTimestamp>,
 }
 
@@ -60,6 +65,8 @@ pub struct HerdrQueueWakePump {
     cursor: Arc<Mutex<usize>>,
     release_streaks: Arc<Mutex<HashMap<MemberKey, u32>>>,
     clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>,
+    last_task_attempt: Arc<Mutex<HashMap<MemberKey, IsoTimestamp>>>,
+    task_step_available: Arc<Mutex<Option<bool>>>,
     last_stats: Arc<Mutex<HerdrQueueWakeStats>>,
     #[cfg(test)]
     handoff_cleanup_test_gate: Arc<Mutex<Option<HandoffCleanupTestGate>>>,
@@ -81,6 +88,8 @@ impl HerdrQueueWakePump {
             cursor: Arc::new(Mutex::new(0)),
             release_streaks: Arc::new(Mutex::new(HashMap::new())),
             clock: Arc::new(IsoTimestamp::now),
+            last_task_attempt: Arc::new(Mutex::new(HashMap::new())),
+            task_step_available: Arc::new(Mutex::new(None)),
             last_stats: Arc::new(Mutex::new(HerdrQueueWakeStats::default())),
             #[cfg(test)]
             handoff_cleanup_test_gate: Arc::new(Mutex::new(None)),
@@ -195,8 +204,11 @@ impl HerdrQueueWakePump {
             }
         };
 
-        let eligible = self.list_eligible(candidates, &mut stats).await;
-        self.drain_eligible(pending_store, eligible, &mut stats)
+        let (eligible, task_candidates) = self.list_eligible(candidates, &mut stats).await;
+        let prompted_by_drain = self
+            .drain_eligible(pending_store, eligible, &mut stats)
+            .await;
+        self.remind_open_tasks(task_candidates, &prompted_by_drain, &mut stats)
             .await;
         self.save_stats(stats.clone());
         tracing::info!(
@@ -207,6 +219,10 @@ impl HerdrQueueWakePump {
             prompted = stats.prompted,
             released = stats.released,
             breaker_open = stats.breaker_open,
+            task_reminders = stats.task_reminders,
+            task_reminders_unrenderable = stats.task_reminders_unrenderable,
+            task_reminders_blocked = stats.task_reminders_blocked,
+            task_step_skipped = stats.task_step_skipped,
             "Herdr queue wake poll tick"
         );
     }
@@ -215,7 +231,7 @@ impl HerdrQueueWakePump {
         &self,
         candidates: Vec<HerdrCandidate>,
         stats: &mut HerdrQueueWakeStats,
-    ) -> Vec<HerdrCandidate> {
+    ) -> (Vec<HerdrCandidate>, Vec<TaskCandidate>) {
         let mut by_session: HashMap<Option<HerdrSession>, Vec<HerdrCandidate>> = HashMap::new();
         for candidate in candidates {
             by_session
@@ -224,6 +240,7 @@ impl HerdrQueueWakePump {
                 .push(candidate);
         }
         let mut eligible = Vec::new();
+        let mut task_candidates = Vec::new();
         for (session, members) in by_session {
             stats.listed_sessions += 1;
             match self
@@ -234,9 +251,13 @@ impl HerdrQueueWakePump {
                 )
                 .await
             {
-                Ok(outcome) => {
-                    self.collect_idle_members(outcome.agents, members, stats, &mut eligible)
-                }
+                Ok(outcome) => self.collect_idle_members(
+                    outcome.agents,
+                    members,
+                    stats,
+                    &mut eligible,
+                    &mut task_candidates,
+                ),
                 Err(error) => {
                     if error.is_infrastructure() {
                         stats.breaker_open += 1;
@@ -246,7 +267,8 @@ impl HerdrQueueWakePump {
             }
         }
         eligible.sort_by(|left, right| member_order(&left.key, &right.key));
-        eligible
+        task_candidates.sort_by(|left, right| member_order(&left.member.key, &right.member.key));
+        (eligible, task_candidates)
     }
 
     fn collect_idle_members(
@@ -255,6 +277,7 @@ impl HerdrQueueWakePump {
         members: Vec<HerdrCandidate>,
         stats: &mut HerdrQueueWakeStats,
         eligible: &mut Vec<HerdrCandidate>,
+        task_candidates: &mut Vec<TaskCandidate>,
     ) {
         let snapshots: HashMap<&str, &AgentSnapshot> = agents
             .iter()
@@ -279,6 +302,15 @@ impl HerdrQueueWakePump {
             }
             self.runtime_health
                 .record_herdr_poll_state(&member.key, runtime_state(snapshot.status));
+            if matches!(
+                snapshot.status,
+                HerdrAgentStatus::Idle | HerdrAgentStatus::Done | HerdrAgentStatus::Blocked
+            ) {
+                task_candidates.push(TaskCandidate {
+                    member: member.clone(),
+                    blocked: snapshot.status == HerdrAgentStatus::Blocked,
+                });
+            }
             if member.pending
                 && matches!(
                     snapshot.status,
@@ -296,9 +328,10 @@ impl HerdrQueueWakePump {
         pending_store: Arc<dyn PendingNudgeStore + Send + Sync>,
         eligible: Vec<HerdrCandidate>,
         stats: &mut HerdrQueueWakeStats,
-    ) {
+    ) -> HashSet<MemberKey> {
+        let mut prompted = HashSet::new();
         if eligible.is_empty() {
-            return;
+            return prompted;
         }
         let start = *self
             .cursor
@@ -311,17 +344,206 @@ impl HerdrQueueWakePump {
                 break;
             }
             visited += 1;
-            self.process_candidate(
-                &pending_store,
-                &eligible[(start + offset) % eligible.len()],
-                stats,
-            )
-            .await;
+            if self
+                .process_candidate(
+                    &pending_store,
+                    &eligible[(start + offset) % eligible.len()],
+                    stats,
+                )
+                .await
+            {
+                prompted.insert(eligible[(start + offset) % eligible.len()].key.clone());
+            }
         }
         *self
             .cursor
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = (start + visited) % eligible.len();
+        prompted
+    }
+
+    async fn remind_open_tasks(
+        &self,
+        candidates: Vec<TaskCandidate>,
+        prompted_by_drain: &HashSet<MemberKey>,
+        stats: &mut HerdrQueueWakeStats,
+    ) {
+        let reader = match self.service_runtime.async_task_ledger_reader() {
+            Ok(reader) => reader,
+            Err(error) => {
+                stats.task_step_skipped = true;
+                self.note_task_step_availability(false, Some(&error));
+                return;
+            }
+        };
+        let task_store = match self.service_runtime.task_store() {
+            Ok(store) => store,
+            Err(error) => {
+                stats.task_step_skipped = true;
+                self.note_task_step_availability(false, Some(&error));
+                return;
+            }
+        };
+        self.note_task_step_availability(true, None);
+        let now = (self.clock)();
+        for candidate in candidates {
+            if prompted_by_drain.contains(&candidate.member.key) {
+                self.stamp_task_attempt(&candidate.member.key, now);
+                continue;
+            }
+            let rows = match reader
+                .list_tasks(
+                    candidate.member.key.team().clone(),
+                    Some(candidate.member.key.agent().clone()),
+                    ReadDeadline::new(HERDR_REQUEST_DEADLINE)
+                        .expect("positive Herdr task reminder deadline"),
+                )
+                .await
+            {
+                Ok(rows) => rows,
+                Err(error) => {
+                    tracing::warn!(error = %error, member = %candidate.member.key, "Herdr task reminder read failed");
+                    continue;
+                }
+            };
+            let Some(row) = select_open_task(rows) else {
+                continue;
+            };
+            if !self.reminder_due(&candidate.member.key, &row, now) {
+                continue;
+            }
+            if candidate.blocked {
+                if self
+                    .record_task_reminder(
+                        &task_store,
+                        &candidate.member.key,
+                        &row,
+                        now,
+                        ReminderOutcome::Blocked,
+                    )
+                    .await
+                {
+                    stats.task_reminders_blocked += 1;
+                    self.stamp_task_attempt(&candidate.member.key, now);
+                }
+                continue;
+            }
+            if stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
+                break;
+            }
+            let runtime = self.service_runtime.clone();
+            let member = candidate.member.key.clone();
+            let row_for_dispatch = row.clone();
+            let dispatch = run_blocking(move || {
+                build_task_reminder_dispatch(&runtime, &member, &row_for_dispatch)
+            })
+            .await;
+            let dispatch = match dispatch {
+                Ok(Some(dispatch)) => dispatch,
+                Ok(None) => continue,
+                Err(_) => {
+                    if self
+                        .record_task_reminder(
+                            &task_store,
+                            &candidate.member.key,
+                            &row,
+                            now,
+                            ReminderOutcome::Unrenderable,
+                        )
+                        .await
+                    {
+                        stats.task_reminders_unrenderable += 1;
+                        self.stamp_task_attempt(&candidate.member.key, now);
+                    }
+                    continue;
+                }
+            };
+            let Some(emitter) = self.selector.select_emitter(&dispatch) else {
+                continue;
+            };
+            match emitter
+                .emit_received_message(dispatch, RequestDeadline::after(HERDR_REQUEST_DEADLINE))
+                .await
+            {
+                Ok(_) => {
+                    if self
+                        .record_task_reminder(
+                            &task_store,
+                            &candidate.member.key,
+                            &row,
+                            now,
+                            ReminderOutcome::Emitted,
+                        )
+                        .await
+                    {
+                        stats.prompted += 1;
+                        stats.task_reminders += 1;
+                        self.stamp_task_attempt(&candidate.member.key, now);
+                    }
+                }
+                Err(error) => {
+                    if error.code() == AtmErrorCode::HerdrUnavailable {
+                        stats.breaker_open += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn record_task_reminder(
+        &self,
+        store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+        member: &MemberKey,
+        row: &TaskRow,
+        now: IsoTimestamp,
+        outcome: ReminderOutcome,
+    ) -> bool {
+        let store = Arc::clone(store);
+        let member = member.clone();
+        let task_id = row.task_id.clone();
+        run_blocking(move || store.record_reminder(&member, &task_id, now, outcome))
+            .await
+            .is_ok()
+    }
+
+    fn reminder_due(&self, member: &MemberKey, row: &TaskRow, now: IsoTimestamp) -> bool {
+        let due = |then: IsoTimestamp| {
+            now.into_inner()
+                .signed_duration_since(then.into_inner())
+                .num_milliseconds()
+                >= i64::try_from(TASK_REMINDER_INTERVAL_MS).unwrap_or(i64::MAX)
+        };
+        row.last_reminded_at.is_none_or(due)
+            && self
+                .last_task_attempt
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .get(member)
+                .copied()
+                .is_none_or(due)
+    }
+
+    fn stamp_task_attempt(&self, member: &MemberKey, now: IsoTimestamp) {
+        self.last_task_attempt
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(member.clone(), now);
+    }
+
+    fn note_task_step_availability(&self, available: bool, error: Option<&AtmError>) {
+        let mut previous = self
+            .task_step_available
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *previous == Some(available) {
+            return;
+        }
+        *previous = Some(available);
+        if available {
+            tracing::info!("Herdr task reminder step available");
+        } else {
+            tracing::warn!(error = ?error, "Herdr task reminder step skipped: task store unavailable");
+        }
     }
 
     async fn process_candidate(
@@ -329,7 +551,7 @@ impl HerdrQueueWakePump {
         pending_store: &Arc<dyn PendingNudgeStore + Send + Sync>,
         member: &HerdrCandidate,
         stats: &mut HerdrQueueWakeStats,
-    ) {
+    ) -> bool {
         let claim = match run_blocking({
             let pending_store = Arc::clone(pending_store);
             let member = member.key.clone();
@@ -338,7 +560,7 @@ impl HerdrQueueWakePump {
         .await
         {
             Ok(Some(claim)) => claim,
-            Ok(None) | Err(_) => return,
+            Ok(None) | Err(_) => return false,
         };
         let mut release = ReleasePendingOnDrop::new(
             Arc::clone(pending_store),
@@ -359,7 +581,7 @@ impl HerdrQueueWakePump {
                     outcome = "dispatch_failed_released",
                     "Herdr queue dispatch could not be rebuilt"
                 );
-                return;
+                return false;
             }
         };
         let Some(emitter) = self.selector.select_emitter(&dispatch) else {
@@ -373,10 +595,10 @@ impl HerdrQueueWakePump {
                 outcome = "held_target_not_present",
                 "Herdr queue selector returned no emitter"
             );
-            return;
+            return false;
         };
         self.emit_claim(emitter, dispatch, member, claim, &mut release, stats)
-            .await;
+            .await
     }
 
     async fn rebuild_dispatch(
@@ -400,7 +622,7 @@ impl HerdrQueueWakePump {
         claim: atm_core::boundary::NudgeClaim,
         release: &mut ReleasePendingOnDrop,
         stats: &mut HerdrQueueWakeStats,
-    ) {
+    ) -> bool {
         match emitter
             .emit_received_message(dispatch, RequestDeadline::after(HERDR_REQUEST_DEADLINE))
             .await
@@ -408,6 +630,7 @@ impl HerdrQueueWakePump {
             Ok(_) => {
                 self.complete_successful_claim(member, claim, release, stats)
                     .await;
+                true
             }
             Err(error) => {
                 if error.code() == AtmErrorCode::HerdrUnavailable {
@@ -441,6 +664,7 @@ impl HerdrQueueWakePump {
                     error_code = ?error.code(),
                     "Herdr queue prompt failed"
                 );
+                false
             }
         }
     }
@@ -537,6 +761,25 @@ struct HerdrCandidate {
     key: MemberKey,
     session: Option<HerdrSession>,
     pending: bool,
+}
+
+#[derive(Clone)]
+struct TaskCandidate {
+    member: HerdrCandidate,
+    blocked: bool,
+}
+
+fn select_open_task(mut rows: Vec<TaskRow>) -> Option<TaskRow> {
+    rows.retain(|row| row.state != TaskState::Complete);
+    rows.sort_by(|left, right| {
+        left.assigned_at
+            .cmp(&right.assigned_at)
+            .then_with(|| left.task_id.as_str().cmp(right.task_id.as_str()))
+    });
+    rows.iter()
+        .find(|row| row.state == TaskState::Active)
+        .or_else(|| rows.iter().find(|row| row.state == TaskState::Assigned))
+        .cloned()
 }
 
 fn herdr_candidates(
@@ -699,7 +942,7 @@ mod tests {
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{NudgeMode, SendMessageSource, WriteRequest, write_mail_with_runtime};
     use atm_core::test_support as atm_storage;
-    use atm_core::types::{ModelName, TeamName};
+    use atm_core::types::{IsoTimestamp, ModelName, TaskId, TeamName};
     use atm_herdr::{
         AgentSnapshot, HerdrAgentStatus, HerdrListOutcome, HerdrProcessAdapter, HerdrPromptOutcome,
     };
@@ -708,7 +951,8 @@ mod tests {
     use serde_json::json;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tokio::sync::watch;
 
@@ -816,6 +1060,34 @@ mod tests {
         )
         .expect("queue write")
         .persisted_message_id()
+    }
+
+    fn queue_task_message(
+        root: &std::path::Path,
+        runtime: &LocalServiceRuntime,
+        team: &TeamName,
+        agent: &str,
+        task_id: TaskId,
+    ) {
+        let home = root.join("home");
+        std::fs::create_dir_all(&home).expect("home");
+        let recipient = format!("{agent}@{team}");
+        let mut request = WriteRequest::new(
+            home.clone(),
+            home,
+            "sender".parse().expect("sender"),
+            &recipient,
+            team.clone(),
+            SendMessageSource::Inline("AX5 reminder task".to_owned()),
+            None,
+            true,
+            None,
+            false,
+        )
+        .expect("task write request")
+        .with_nudge_mode(NudgeMode::Deferred);
+        request.task_id = Some(task_id);
+        write_mail_with_runtime(request, &NullObservability, runtime).expect("queue task write");
     }
 
     fn build_test_pump_with_agents(
@@ -1005,6 +1277,113 @@ mod tests {
     fn poll_contract_uses_fixed_cadence_and_cap() {
         assert_eq!(HERDR_POLL_INTERVAL_MS, 5_000);
         assert_eq!(HERDR_MAX_PROMPTS_PER_TICK, 16);
+    }
+
+    #[tokio::test]
+    async fn ax5_01_drain_precedes_task_reminder_and_clock_controls_cadence() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let task_id: TaskId = "AX5-REMINDER".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id.clone(),
+        );
+        let now = Arc::new(Mutex::new(IsoTimestamp::now()));
+        let clock_now = Arc::clone(&now);
+        let selector = Arc::new(FakeSelector {
+            emitter: FakeEmitter {
+                process: Arc::clone(&fake),
+            },
+        });
+        let process: Arc<dyn HerdrProcessAdapter> = fake.clone();
+        let pump = HerdrQueueWakePump::new(runtime.clone(), selector, health, process).with_clock(
+            Arc::new(move || *clock_now.lock().expect("test clock lock")),
+        );
+
+        // The pre-existing queue entry and then the task's own deferred
+        // marker consume the first two ticks. Neither may produce a second
+        // prompt from the reminder step in the same tick.
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("future timestamp");
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![AgentSnapshot {
+                name: Some(key.agent().to_string()),
+                status: HerdrAgentStatus::Idle,
+                workspace_id: None,
+            }],
+        }));
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders, 0, "drain consumes this tick");
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:05Z").expect("future timestamp");
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![AgentSnapshot {
+                name: Some(key.agent().to_string()),
+                status: HerdrAgentStatus::Idle,
+                workspace_id: None,
+            }],
+        }));
+        pump.tick_once().await;
+
+        let row = runtime
+            .task_store()
+            .expect("task store")
+            .load_task(&key, &task_id)
+            .expect("load task")
+            .expect("task row");
+        assert_eq!(row.reminder_count, 1);
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert_eq!(
+            fake.calls()
+                .iter()
+                .filter(|call| matches!(call, atm_herdr::testing::FakeHerdrCall::Prompt { .. }))
+                .count(),
+            3,
+            "two queue drains plus exactly one cadence-controlled reminder"
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_06_blocked_tasks_are_audited_without_a_prompt() {
+        let (root, runtime, fake, pump, health, key) =
+            build_test_pump_with_agents(vec![AgentSnapshot {
+                name: Some("aq27-agent".to_owned()),
+                status: HerdrAgentStatus::Blocked,
+                workspace_id: None,
+            }]);
+        let task_id: TaskId = "AX5-BLOCKED".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id.clone(),
+        );
+
+        pump.tick_once().await;
+
+        let row = runtime
+            .task_store()
+            .expect("task store")
+            .load_task(&key, &task_id)
+            .expect("load task")
+            .expect("task row");
+        assert_eq!(row.reminder_count, 1);
+        assert_eq!(pump.stats().task_reminders_blocked, 1);
+        assert!(
+            fake.calls()
+                .iter()
+                .all(|call| !matches!(call, atm_herdr::testing::FakeHerdrCall::Prompt { .. })),
+            "blocked task reminders never prompt Herdr"
+        );
+        assert_eq!(
+            health.snapshot().members[0].state,
+            RuntimeMemberState::Blocked,
+        );
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -32,6 +32,8 @@ pub const HERDR_POLL_INTERVAL_MS: u64 = 5_000;
 pub const HERDR_MAX_PROMPTS_PER_TICK: usize = 16;
 /// Consecutive no-input releases before one retry-budget attempt is spent.
 pub const HERDR_MAX_CONSECUTIVE_RELEASES: u32 = 10;
+/// Minimum spacing between task reminders for one Herdr assignee.
+pub const TASK_REMINDER_INTERVAL_MS: u64 = 60_000;
 const HERDR_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 
 #[cfg(test)]
@@ -57,6 +59,7 @@ pub struct HerdrQueueWakePump {
     herdr_process: Arc<dyn HerdrProcessAdapter>,
     cursor: Arc<Mutex<usize>>,
     release_streaks: Arc<Mutex<HashMap<MemberKey, u32>>>,
+    clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>,
     last_stats: Arc<Mutex<HerdrQueueWakeStats>>,
     #[cfg(test)]
     handoff_cleanup_test_gate: Arc<Mutex<Option<HandoffCleanupTestGate>>>,
@@ -77,10 +80,17 @@ impl HerdrQueueWakePump {
             herdr_process,
             cursor: Arc::new(Mutex::new(0)),
             release_streaks: Arc::new(Mutex::new(HashMap::new())),
+            clock: Arc::new(IsoTimestamp::now),
             last_stats: Arc::new(Mutex::new(HerdrQueueWakeStats::default())),
             #[cfg(test)]
             handoff_cleanup_test_gate: Arc::new(Mutex::new(None)),
         }
+    }
+
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>) -> Self {
+        self.clock = clock;
+        self
     }
 
     #[cfg(test)]
@@ -144,7 +154,7 @@ impl HerdrQueueWakePump {
     /// Runs one complete roster/list/claim/dispatch pass.
     pub async fn tick_once(&self) {
         let mut stats = HerdrQueueWakeStats {
-            last_tick_at: Some(IsoTimestamp::now()),
+            last_tick_at: Some((self.clock)()),
             ..HerdrQueueWakeStats::default()
         };
         let pending_store = match self.service_runtime.pending_nudge_store() {
@@ -589,7 +599,8 @@ fn member_order(left: &MemberKey, right: &MemberKey) -> std::cmp::Ordering {
 fn runtime_state(status: HerdrAgentStatus) -> RuntimeMemberState {
     match status {
         HerdrAgentStatus::Idle | HerdrAgentStatus::Done => RuntimeMemberState::Idle,
-        HerdrAgentStatus::Working | HerdrAgentStatus::Blocked => RuntimeMemberState::Active,
+        HerdrAgentStatus::Working => RuntimeMemberState::Active,
+        HerdrAgentStatus::Blocked => RuntimeMemberState::Blocked,
         HerdrAgentStatus::Unknown => RuntimeMemberState::Unknown,
     }
 }

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -1003,9 +1003,10 @@ impl Drop for ReleasePendingOnDrop {
 mod tests {
     use super::{
         HERDR_MAX_CONSECUTIVE_RELEASES, HERDR_MAX_PROMPTS_PER_TICK, HERDR_POLL_INTERVAL_MS,
-        HerdrQueueWakePump, runtime_state,
+        HerdrQueueWakePump, TASK_REMINDER_INTERVAL_MS, runtime_state,
     };
     use atm_core::LocalServiceRuntime;
+    use atm_core::ack::{AckRequest, ack_mail_with_runtime};
     use atm_core::api::RequestDeadline;
     use atm_core::boundary::{
         AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, MessageReceivedHookSelector,
@@ -1143,7 +1144,7 @@ mod tests {
         team: &TeamName,
         agent: &str,
         task_id: TaskId,
-    ) {
+    ) -> AtmMessageId {
         let home = root.join("home");
         std::fs::create_dir_all(&home).expect("home");
         let recipient = format!("{agent}@{team}");
@@ -1162,7 +1163,83 @@ mod tests {
         .expect("task write request")
         .with_nudge_mode(NudgeMode::Deferred);
         request.task_id = Some(task_id);
-        write_mail_with_runtime(request, &NullObservability, runtime).expect("queue task write");
+        write_mail_with_runtime(request, &NullObservability, runtime)
+            .expect("queue task write")
+            .persisted_message_id()
+    }
+
+    fn pump_with_clock(
+        runtime: LocalServiceRuntime,
+        fake: Arc<atm_herdr::testing::FakeHerdrProcessAdapter>,
+        health: super::RuntimeHealth,
+        now: Arc<Mutex<IsoTimestamp>>,
+    ) -> HerdrQueueWakePump {
+        let selector = Arc::new(FakeSelector {
+            emitter: FakeEmitter {
+                process: Arc::clone(&fake),
+            },
+        });
+        let process: Arc<dyn HerdrProcessAdapter> = fake;
+        let clock_now = Arc::clone(&now);
+        HerdrQueueWakePump::new(runtime, selector, health, process).with_clock(Arc::new(
+            move || *clock_now.lock().expect("test clock lock"),
+        ))
+    }
+
+    fn queue_idle_result(
+        fake: &atm_herdr::testing::FakeHerdrProcessAdapter,
+        key: &atm_core::boundary::MemberKey,
+    ) {
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![AgentSnapshot {
+                name: Some(key.agent().to_string()),
+                status: HerdrAgentStatus::Idle,
+                workspace_id: None,
+            }],
+        }));
+    }
+
+    fn prompt_texts(fake: &atm_herdr::testing::FakeHerdrProcessAdapter) -> Vec<String> {
+        fake.calls()
+            .into_iter()
+            .filter_map(|call| match call {
+                atm_herdr::testing::FakeHerdrCall::Prompt { text, .. } => Some(text),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn clear_pending_markers(runtime: &LocalServiceRuntime, key: &atm_core::boundary::MemberKey) {
+        let store = runtime.pending_nudge_store().expect("pending store");
+        while let Some(claim) = store.claim_next_pending(key).expect("claim pending marker") {
+            store
+                .clear_pending_on_handoff(key, &claim.msg)
+                .expect("clear pending marker");
+        }
+    }
+
+    fn ack_task_assignment(
+        root: &std::path::Path,
+        runtime: &LocalServiceRuntime,
+        team: &TeamName,
+        message_id: AtmMessageId,
+    ) {
+        let home = root.join("home");
+        ack_mail_with_runtime(
+            AckRequest {
+                home_dir: home.clone(),
+                current_dir: home,
+                caller_identity: "aq27-agent".parse().expect("agent"),
+                caller_chat_id: None,
+                caller_team: team.clone(),
+                activity_observation: None,
+                message_id,
+                reply_body: "acknowledged".to_owned(),
+            },
+            &NullObservability,
+            runtime,
+        )
+        .expect("task acknowledgement");
     }
 
     fn build_test_pump_with_agents(
@@ -1352,10 +1429,263 @@ mod tests {
     fn poll_contract_uses_fixed_cadence_and_cap() {
         assert_eq!(HERDR_POLL_INTERVAL_MS, 5_000);
         assert_eq!(HERDR_MAX_PROMPTS_PER_TICK, 16);
+        assert_eq!(TASK_REMINDER_INTERVAL_MS, 60_000);
     }
 
     #[tokio::test]
-    async fn ax5_01_drain_precedes_task_reminder_and_clock_controls_cadence() {
+    async fn ax5_01_assigned_task_is_reminded_without_a_state_transition() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let task_id: TaskId = "AX5-ASSIGNED".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id.clone(),
+        );
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &task_id)
+                .expect("load task")
+                .expect("task row")
+                .state,
+            atm_storage::TaskState::Assigned,
+            "a reminder never acknowledges the assignment"
+        );
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert!(
+            prompt_texts(&fake)
+                .iter()
+                .any(|text| text.contains("<task id=\"AX5-ASSIGNED\">"))
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_02_drain_prompt_consumes_the_shared_reminder_budget() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let task_id: TaskId = "AX5-BUDGET".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id,
+        );
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:00Z").expect("test timestamp");
+        let _ = queue_message(root.path(), &runtime, key.team(), key.agent().as_str());
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(
+            pump.stats().prompted,
+            1,
+            "only the fresh queue nudge is emitted"
+        );
+        assert_eq!(pump.stats().task_reminders, 0);
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:03:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert_eq!(
+            prompt_texts(&fake).len(),
+            4,
+            "two drains, queue, then reminder"
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_03_active_task_wins_over_a_newer_assigned_task() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let first: TaskId = "AX5-ACTIVE".parse().expect("task id");
+        let second: TaskId = "AX5-ASSIGNED-2".parse().expect("task id");
+        let first_message = queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            first.clone(),
+        );
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            second.clone(),
+        );
+        let mut roster = runtime
+            .shared_roster_store_arc()
+            .load_roster(key.team())
+            .expect("load roster");
+        roster.members.push(herdr_member(key.team(), "sender"));
+        runtime
+            .shared_roster_store_arc()
+            .save_roster(&roster)
+            .expect("add task sender to roster");
+        runtime.clear_roster_cache();
+        ack_task_assignment(root.path(), &runtime, key.team(), first_message);
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+
+        pump.tick_once().await;
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:04:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+
+        let reminder = prompt_texts(&fake)
+            .into_iter()
+            .last()
+            .expect("active task reminder");
+        assert!(reminder.contains("<task id=\"AX5-ACTIVE\">"));
+        assert!(!reminder.contains("AX5-ASSIGNED-2"));
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &second)
+                .expect("load task")
+                .expect("second task")
+                .state,
+            atm_storage::TaskState::Assigned
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_04_emit_failure_records_no_reminder_and_retries() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let task_id: TaskId = "AX5-RETRY".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id.clone(),
+        );
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+        pump.tick_once().await;
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:00Z").expect("test timestamp");
+        fake.queue_prompt_result(Err(atm_herdr::HerdrError::AgentNotReady));
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &task_id)
+                .expect("load task")
+                .expect("task row")
+                .reminder_count,
+            0
+        );
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:05Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders, 1, "the next tick retries");
+    }
+
+    #[tokio::test]
+    async fn ax5_06_task_reminder_only_appends_audit_bookkeeping() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let task_id: TaskId = "AX5-AUDIT-ONLY".parse().expect("task id");
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            task_id.clone(),
+        );
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+
+        let row = runtime
+            .task_store()
+            .expect("task store")
+            .load_task(&key, &task_id)
+            .expect("load task")
+            .expect("task row");
+        let events = runtime
+            .task_store()
+            .expect("task store")
+            .list_task_events(key.team(), &task_id, Some(key.agent()))
+            .expect("task events");
+        assert_eq!(row.state, atm_storage::TaskState::Assigned);
+        assert_eq!(row.reminder_count, 1);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event == atm_storage::TaskEventKind::Assigned)
+                .count(),
+            1
+        );
+        assert!(
+            events
+                .iter()
+                .all(|event| event.event != atm_storage::TaskEventKind::Acked)
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_05_drain_precedes_task_reminder_and_clock_controls_cadence() {
         let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
         let task_id: TaskId = "AX5-REMINDER".parse().expect("task id");
         queue_task_message(
@@ -1423,8 +1753,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ax5_06_blocked_tasks_are_audited_without_a_prompt() {
-        let (root, runtime, fake, pump, health, key) =
+    async fn ax5_07_blocked_tasks_are_audited_without_a_prompt() {
+        let (root, runtime, fake, _old_pump, health, key) =
             build_test_pump_with_agents(vec![AgentSnapshot {
                 name: Some("aq27-agent".to_owned()),
                 status: HerdrAgentStatus::Blocked,
@@ -1437,6 +1767,15 @@ mod tests {
             key.team(),
             key.agent().as_str(),
             task_id.clone(),
+        );
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(
+            runtime.clone(),
+            fake.clone(),
+            health.clone(),
+            Arc::clone(&now),
         );
 
         pump.tick_once().await;
@@ -1459,6 +1798,93 @@ mod tests {
             health.snapshot().members[0].state,
             RuntimeMemberState::Blocked,
         );
+
+        clear_pending_markers(&runtime, &key);
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![AgentSnapshot {
+                name: Some(key.agent().to_string()),
+                status: HerdrAgentStatus::Idle,
+                workspace_id: None,
+            }],
+        }));
+        pump.tick_once().await;
+        let row = runtime
+            .task_store()
+            .expect("task store")
+            .load_task(&key, &task_id)
+            .expect("load task")
+            .expect("task row");
+        assert_eq!(
+            row.reminder_count, 2,
+            "blocked and idle outcomes are audited"
+        );
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert_eq!(health.snapshot().members[0].state, RuntimeMemberState::Idle);
+        assert_eq!(
+            prompt_texts(&fake)
+                .iter()
+                .filter(|text| text.contains("AX5-BLOCKED"))
+                .count(),
+            1,
+            "the blocked task is emitted after returning to idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_08_missing_task_store_skips_only_the_task_step() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let assembly = open_isolated_sqlite_boundary(root.path()).expect("runtime");
+        let team: TeamName = "aq27-team".parse().expect("team");
+        assembly
+            .service_runtime
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![herdr_member(&team, "aq27-agent")],
+                refreshed_at: None,
+            })
+            .expect("roster");
+        let _message = queue_message(root.path(), &assembly.service_runtime, &team, "aq27-agent");
+        let pending = assembly
+            .service_runtime
+            .pending_nudge_store()
+            .expect("pending store");
+        let async_reader = assembly
+            .service_runtime
+            .async_task_ledger_reader()
+            .expect("task reader");
+        let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
+            assembly.message_store_arc(),
+            assembly.shared_roster_store_arc(),
+            assembly.nudge_template_override_store.clone(),
+            Arc::new(atm_core::LocalFileNonClaudeOutbound::new()),
+        )
+        .with_pending_nudge_store(pending)
+        .with_async_task_ledger_reader(async_reader);
+        let fake = Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default());
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![AgentSnapshot {
+                name: Some("aq27-agent".to_owned()),
+                status: HerdrAgentStatus::Idle,
+                workspace_id: None,
+            }],
+        }));
+        let health = super::RuntimeHealth::default();
+        let selector = Arc::new(FakeSelector {
+            emitter: FakeEmitter {
+                process: Arc::clone(&fake),
+            },
+        });
+        let process: Arc<dyn HerdrProcessAdapter> = fake.clone();
+        let pump = HerdrQueueWakePump::new(runtime, selector, health, process);
+
+        pump.tick_once().await;
+        assert_eq!(pump.stats().prompted, 1, "queue drain remains active");
+        assert_eq!(pump.stats().task_reminders, 0);
+        assert!(pump.stats().task_step_skipped);
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -50,6 +50,7 @@ pub(crate) struct HerdrQueueWakeStats {
     pub breaker_open: usize,
     pub not_present: usize,
     pub task_reminders: usize,
+    pub task_reminders_failed: usize,
     pub task_reminders_unrenderable: usize,
     pub task_reminders_blocked: usize,
     pub task_step_skipped: bool,
@@ -245,6 +246,7 @@ impl HerdrQueueWakePump {
             released = stats.released,
             breaker_open = stats.breaker_open,
             task_reminders = stats.task_reminders,
+            task_reminders_failed = stats.task_reminders_failed,
             task_reminders_unrenderable = stats.task_reminders_unrenderable,
             task_reminders_blocked = stats.task_reminders_blocked,
             task_step_skipped = stats.task_step_skipped,
@@ -534,6 +536,8 @@ impl HerdrQueueWakePump {
             }
             Err(error) if error.code() == AtmErrorCode::HerdrUnavailable => stats.breaker_open += 1,
             Err(error) => {
+                stats.task_reminders_failed += 1;
+                self.stamp_task_attempt(&candidate.member.key, now);
                 tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_emit", outcome = "failed", error = %error, error_code = ?error.code(), member = %candidate.member.key, "Herdr task reminder emission failed")
             }
         }
@@ -552,11 +556,15 @@ impl HerdrQueueWakePump {
             .record_task_reminder(task_store, member, row, now, outcome)
             .await
         {
-            if outcome == ReminderOutcome::Emitted {
-                stats.prompted += 1;
-                stats.task_reminders += 1;
-                self.stamp_task_attempt(member, now);
+            match outcome {
+                ReminderOutcome::Emitted => {
+                    stats.prompted += 1;
+                    stats.task_reminders += 1;
+                }
+                ReminderOutcome::Unrenderable => stats.task_reminders_unrenderable += 1,
+                ReminderOutcome::Blocked => stats.task_reminders_blocked += 1,
             }
+            self.stamp_task_attempt(member, now);
             return;
         }
         match outcome {
@@ -1448,6 +1456,14 @@ mod tests {
         statuses: Vec<HerdrAgentStatus>,
         fail_reminders: bool,
     ) -> TaskOnlyPumpFixture {
+        build_task_only_pump_with_template(statuses, fail_reminders, None)
+    }
+
+    fn build_task_only_pump_with_template(
+        statuses: Vec<HerdrAgentStatus>,
+        fail_reminders: bool,
+        task_template: Option<&str>,
+    ) -> TaskOnlyPumpFixture {
         let root = tempfile::tempdir().expect("temporary root");
         let assembly = open_isolated_sqlite_boundary(root.path()).expect("runtime");
         let team: TeamName = "ax5-task-only".parse().expect("team");
@@ -1486,6 +1502,16 @@ mod tests {
                 lead_notified_count: 0,
             })
             .collect();
+        if let Some(template) = task_template {
+            assembly
+                .nudge_template_override_store
+                .save_template_override(
+                    &team,
+                    atm_storage::BuiltInNudgeTemplateKind::Task,
+                    template,
+                )
+                .expect("task template override");
+        }
         let task_store = Arc::new(atm_storage::DummyTaskStore::with_rows(
             rows.clone(),
             fail_reminders,
@@ -1893,6 +1919,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ax5_09_generic_emit_failure_counts_and_respects_cooldown() {
+        let (_root, _runtime, fake, pump, store, keys, now) =
+            build_task_only_pump(vec![HerdrAgentStatus::Idle], false);
+        fake.queue_prompt_result(Err(atm_herdr::HerdrError::AgentPromptStalled));
+        pump.tick_once().await;
+
+        let task_id = "AX5-TASK-00".parse().expect("task id");
+        assert_eq!(pump.stats().task_reminders_failed, 1);
+        assert_eq!(pump.stats().task_reminders, 0);
+        assert_eq!(store.row(&keys[0], &task_id).reminder_count, 0);
+        assert_eq!(prompt_texts(&fake).len(), 1);
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:00:05Z").expect("test timestamp");
+        queue_status_result(&fake, &keys, HerdrAgentStatus::Idle);
+        pump.tick_once().await;
+        assert_eq!(prompt_texts(&fake).len(), 1, "cooldown suppresses a retry");
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:00Z").expect("test timestamp");
+        queue_status_result(&fake, &keys, HerdrAgentStatus::Idle);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert_eq!(
+            prompt_texts(&fake).len(),
+            2,
+            "cooldown expires after one minute"
+        );
+        assert_eq!(store.row(&keys[0], &task_id).reminder_count, 1);
+    }
+
+    #[tokio::test]
+    async fn ax5_10_failed_blocked_and_unrenderable_audits_count_and_cool_down() {
+        let (_root, _runtime, fake, pump, store, keys, now) =
+            build_task_only_pump(vec![HerdrAgentStatus::Blocked], true);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders_blocked, 1);
+        assert_eq!(
+            store
+                .row(&keys[0], &"AX5-TASK-00".parse().expect("task id"))
+                .reminder_count,
+            0
+        );
+        assert!(prompt_texts(&fake).is_empty());
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:00:05Z").expect("test timestamp");
+        queue_status_result(&fake, &keys, HerdrAgentStatus::Blocked);
+        pump.tick_once().await;
+        assert_eq!(
+            pump.stats().task_reminders_blocked,
+            0,
+            "blocked cooldown holds"
+        );
+
+        let (_root, _runtime, fake, pump, store, keys, _now) = build_task_only_pump_with_template(
+            vec![HerdrAgentStatus::Idle],
+            true,
+            Some("{{missing}}"),
+        );
+        pump.tick_once().await;
+        assert_eq!(pump.stats().task_reminders_unrenderable, 1);
+        assert_eq!(
+            store
+                .row(&keys[0], &"AX5-TASK-00".parse().expect("task id"))
+                .reminder_count,
+            0
+        );
+        assert!(prompt_texts(&fake).is_empty());
+    }
+
+    #[tokio::test]
     async fn ax5_03_active_task_wins_over_a_newer_assigned_task() {
         let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
         let first: TaskId = "AX5-ACTIVE".parse().expect("task id");
@@ -1994,12 +2092,27 @@ mod tests {
                 .reminder_count,
             0
         );
+        assert_eq!(pump.stats().task_reminders_failed, 1);
 
         *now.lock().expect("test clock lock") =
             IsoTimestamp::from_str("2030-01-01T00:02:05Z").expect("test timestamp");
         queue_idle_result(&fake, &key);
         pump.tick_once().await;
-        assert_eq!(pump.stats().task_reminders, 1, "the next tick retries");
+        assert_eq!(
+            pump.stats().task_reminders,
+            0,
+            "cooldown suppresses a retry"
+        );
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:03:00Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(
+            pump.stats().task_reminders,
+            1,
+            "the cooldown eventually expires"
+        );
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -41,7 +41,7 @@ const HERDR_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 type HandoffCleanupTestGate = (Arc<Notify>, Arc<Notify>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct HerdrQueueWakeStats {
+pub(crate) struct HerdrQueueWakeStats {
     pub listed_sessions: usize,
     pub pending_members: usize,
     pub idle_members: usize,
@@ -96,8 +96,9 @@ impl HerdrQueueWakePump {
         }
     }
 
+    #[cfg(test)]
     #[must_use]
-    pub fn with_clock(mut self, clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>) -> Self {
+    fn with_clock(mut self, clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>) -> Self {
         self.clock = clock;
         self
     }
@@ -140,6 +141,7 @@ impl HerdrQueueWakePump {
     pub fn start(self: Arc<Self>, mut shutdown: watch::Receiver<()>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_millis(HERDR_POLL_INTERVAL_MS));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 tokio::select! {
                     changed = shutdown.changed() => {
@@ -203,6 +205,7 @@ impl HerdrQueueWakePump {
                 return;
             }
         };
+        self.prune_member_state(&candidates);
 
         let (eligible, task_candidates) = self.list_eligible(candidates, &mut stats).await;
         let prompted_by_drain = self
@@ -387,6 +390,9 @@ impl HerdrQueueWakePump {
         self.note_task_step_availability(true, None);
         let now = (self.clock)();
         for candidate in candidates {
+            if !candidate.blocked && stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
+                break;
+            }
             if prompted_by_drain.contains(&candidate.member.key) {
                 self.stamp_task_attempt(&candidate.member.key, now);
                 continue;
@@ -405,18 +411,24 @@ impl HerdrQueueWakePump {
         candidate: &TaskCandidate,
         now: IsoTimestamp,
     ) -> Option<TaskRow> {
+        let deadline = match ReadDeadline::new(HERDR_REQUEST_DEADLINE) {
+            Ok(deadline) => deadline,
+            Err(error) => {
+                tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_read", outcome = "deadline_invalid", error = %error, member = %candidate.member.key, "Herdr task reminder read skipped");
+                return None;
+            }
+        };
         let rows = match reader
             .list_tasks(
                 candidate.member.key.team().clone(),
                 Some(candidate.member.key.agent().clone()),
-                ReadDeadline::new(HERDR_REQUEST_DEADLINE)
-                    .expect("positive Herdr task reminder deadline"),
+                deadline,
             )
             .await
         {
             Ok(rows) => rows,
             Err(error) => {
-                tracing::warn!(error = %error, member = %candidate.member.key, "Herdr task reminder read failed");
+                tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_read", outcome = "failed", error = %error, member = %candidate.member.key, "Herdr task reminder read failed");
                 return None;
             }
         };
@@ -458,7 +470,8 @@ impl HerdrQueueWakePump {
         let dispatch = match dispatch {
             Ok(Some(dispatch)) => dispatch,
             Ok(None) => return,
-            Err(_) => {
+            Err(error) => {
+                tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_render", outcome = "unrenderable", error = %error, member = %candidate.member.key, "Herdr task reminder could not render");
                 self.record_task_outcome(
                     task_store,
                     &candidate.member.key,
@@ -491,7 +504,9 @@ impl HerdrQueueWakePump {
                 .await
             }
             Err(error) if error.code() == AtmErrorCode::HerdrUnavailable => stats.breaker_open += 1,
-            Err(_) => {}
+            Err(error) => {
+                tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_emit", outcome = "failed", error = %error, error_code = ?error.code(), member = %candidate.member.key, "Herdr task reminder emission failed")
+            }
         }
     }
 
@@ -508,6 +523,9 @@ impl HerdrQueueWakePump {
             .record_task_reminder(task_store, member, row, now, outcome)
             .await
         {
+            if outcome == ReminderOutcome::Emitted {
+                self.stamp_task_attempt(member, now);
+            }
             return;
         }
         match outcome {
@@ -532,9 +550,19 @@ impl HerdrQueueWakePump {
         let store = Arc::clone(store);
         let member = member.clone();
         let task_id = row.task_id.clone();
-        run_blocking(move || store.record_reminder(&member, &task_id, now, outcome))
-            .await
-            .is_ok()
+        let write_member = member.clone();
+        let write_task_id = task_id.clone();
+        match run_blocking(move || {
+            store.record_reminder(&write_member, &write_task_id, now, outcome)
+        })
+        .await
+        {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_record", outcome = "failed", error = %error, member = %member, task_id = %task_id, "Herdr task reminder bookkeeping failed");
+                false
+            }
+        }
     }
 
     fn reminder_due(&self, member: &MemberKey, row: &TaskRow, now: IsoTimestamp) -> bool {
@@ -559,6 +587,21 @@ impl HerdrQueueWakePump {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(member.clone(), now);
+    }
+
+    fn prune_member_state(&self, candidates: &[HerdrCandidate]) {
+        let members: HashSet<_> = candidates
+            .iter()
+            .map(|candidate| candidate.key.clone())
+            .collect();
+        self.last_task_attempt
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|member, _| members.contains(member));
+        self.release_streaks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|member, _| members.contains(member));
     }
 
     fn note_task_step_availability(&self, available: bool, error: Option<&AtmError>) {
@@ -739,7 +782,8 @@ impl HerdrQueueWakePump {
     }
 
     #[must_use]
-    pub fn stats(&self) -> HerdrQueueWakeStats {
+    #[cfg(test)]
+    fn stats(&self) -> HerdrQueueWakeStats {
         self.last_stats
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -171,7 +171,13 @@ impl HerdrQueueWakePump {
         let pending_store = match self.service_runtime.pending_nudge_store() {
             Ok(store) => store,
             Err(error) => {
-                tracing::warn!(error = %error, "Herdr queue wake skipped: pending store unavailable");
+                tracing::warn!(
+                    subsystem = "herdr_queue_wake",
+                    action = "pending_store_resolve",
+                    outcome = "unavailable",
+                    error = %error,
+                    "Herdr queue wake skipped: pending store unavailable"
+                );
                 self.save_stats(stats);
                 return;
             }
@@ -185,7 +191,13 @@ impl HerdrQueueWakePump {
         {
             Ok(members) => members,
             Err(error) => {
-                tracing::warn!(error = %error, "Herdr queue wake skipped: pending roster unavailable");
+                tracing::warn!(
+                    subsystem = "herdr_queue_wake",
+                    action = "pending_member_list",
+                    outcome = "failed",
+                    error = %error,
+                    "Herdr queue wake skipped: pending roster unavailable"
+                );
                 self.save_stats(stats);
                 return;
             }
@@ -200,7 +212,13 @@ impl HerdrQueueWakePump {
         {
             Ok(candidates) => candidates,
             Err(error) => {
-                tracing::warn!(error = %error, "Herdr queue wake skipped: roster unavailable");
+                tracing::warn!(
+                    subsystem = "herdr_queue_wake",
+                    action = "roster_candidates",
+                    outcome = "failed",
+                    error = %error,
+                    "Herdr queue wake skipped: roster unavailable"
+                );
                 self.save_stats(stats);
                 return;
             }
@@ -265,7 +283,14 @@ impl HerdrQueueWakePump {
                     if error.is_infrastructure() {
                         stats.breaker_open += 1;
                     }
-                    tracing::warn!(session = ?session, error = ?error, "Herdr queue wake list failed");
+                    tracing::warn!(
+                        subsystem = "herdr_queue_wake",
+                        action = "herdr_list",
+                        outcome = "failed",
+                        session = ?session,
+                        error = ?error,
+                        "Herdr queue wake list failed"
+                    );
                 }
             }
         }
@@ -391,7 +416,7 @@ impl HerdrQueueWakePump {
         let now = (self.clock)();
         for candidate in candidates {
             if !candidate.blocked && stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
-                break;
+                continue;
             }
             if prompted_by_drain.contains(&candidate.member.key) {
                 self.stamp_task_attempt(&candidate.member.key, now);
@@ -524,6 +549,8 @@ impl HerdrQueueWakePump {
             .await
         {
             if outcome == ReminderOutcome::Emitted {
+                stats.prompted += 1;
+                stats.task_reminders += 1;
                 self.stamp_task_attempt(member, now);
             }
             return;
@@ -614,9 +641,20 @@ impl HerdrQueueWakePump {
         }
         *previous = Some(available);
         if available {
-            tracing::info!("Herdr task reminder step available");
+            tracing::info!(
+                subsystem = "herdr_queue_wake",
+                action = "task_store_resolve",
+                outcome = "available",
+                "Herdr task reminder step available"
+            );
         } else {
-            tracing::warn!(error = ?error, "Herdr task reminder step skipped: task store unavailable");
+            tracing::warn!(
+                subsystem = "herdr_queue_wake",
+                action = "task_store_resolve",
+                outcome = "unavailable",
+                error = ?error,
+                "Herdr task reminder step skipped: task store unavailable"
+            );
         }
     }
 
@@ -969,7 +1007,14 @@ impl ReleasePendingOnDrop {
                 self.store.release_pending(&self.member, &self.claim)
             };
             if let Err(error) = result {
-                tracing::warn!(error = %error, member = %self.member, "failed to resolve Herdr queue claim");
+                tracing::warn!(
+                    subsystem = "herdr_queue_wake",
+                    action = "queue_claim_release",
+                    outcome = "failed",
+                    error = %error,
+                    member = %self.member,
+                    "failed to resolve Herdr queue claim"
+                );
             }
             self.armed = false;
         }
@@ -978,7 +1023,14 @@ impl ReleasePendingOnDrop {
     fn requeue(&mut self) {
         if self.armed {
             if let Err(error) = self.store.requeue_pending(&self.member, &self.claim) {
-                tracing::warn!(error = %error, member = %self.member, "failed to requeue Herdr queue claim");
+                tracing::warn!(
+                    subsystem = "herdr_queue_wake",
+                    action = "queue_claim_requeue",
+                    outcome = "failed",
+                    error = %error,
+                    member = %self.member,
+                    "failed to requeue Herdr queue claim"
+                );
             }
             self.release_streaks
                 .lock()
@@ -1010,7 +1062,7 @@ mod tests {
     use atm_core::api::RequestDeadline;
     use atm_core::boundary::{
         AsyncMessageReceivedHookEmitter, BuiltInPostSendDispatch, MessageReceivedHookSelector,
-        PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind,
+        PostSendEmissionPath, RosterEntry, RosterHarness, RosterMemberKind, TaskStore,
     };
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::observability::NullObservability;
@@ -1018,13 +1070,14 @@ mod tests {
     use atm_core::schema::AtmMessageId;
     use atm_core::send::{NudgeMode, SendMessageSource, WriteRequest, write_mail_with_runtime};
     use atm_core::test_support as atm_storage;
-    use atm_core::types::{IsoTimestamp, ModelName, TaskId, TeamName};
+    use atm_core::types::{AgentName, IsoTimestamp, ModelName, TaskId, TeamName};
     use atm_herdr::{
         AgentSnapshot, HerdrAgentStatus, HerdrListOutcome, HerdrProcessAdapter, HerdrPromptOutcome,
     };
     use atm_runtime_test_support::open_isolated_sqlite_boundary;
-    use atm_storage::RosterSnapshot;
+    use atm_storage::{RosterSnapshot, TaskEventRow, TaskRow, TaskState};
     use serde_json::json;
+    use std::collections::HashMap;
     use std::future::Future;
     use std::pin::Pin;
     use std::str::FromStr;
@@ -1040,8 +1093,11 @@ mod tests {
         process: Arc<atm_herdr::testing::FakeHerdrProcessAdapter>,
     }
 
+    struct NoEmitterSelector;
+
     impl atm_core::boundary::sealed::Sealed for FakeSelector {}
     impl atm_core::boundary::sealed::Sealed for FakeEmitter {}
+    impl atm_core::boundary::sealed::Sealed for NoEmitterSelector {}
 
     impl MessageReceivedHookSelector for FakeSelector {
         fn select_emitter(
@@ -1049,6 +1105,135 @@ mod tests {
             _dispatch: &BuiltInPostSendDispatch,
         ) -> Option<&dyn AsyncMessageReceivedHookEmitter> {
             Some(&self.emitter)
+        }
+    }
+
+    impl MessageReceivedHookSelector for NoEmitterSelector {
+        fn select_emitter(
+            &self,
+            _dispatch: &BuiltInPostSendDispatch,
+        ) -> Option<&dyn AsyncMessageReceivedHookEmitter> {
+            None
+        }
+    }
+
+    struct RecordingTaskStore {
+        rows: Mutex<HashMap<(atm_storage::MemberKey, TaskId), TaskRow>>,
+        fail_reminders: bool,
+    }
+
+    impl RecordingTaskStore {
+        fn new(rows: Vec<TaskRow>, fail_reminders: bool) -> Self {
+            let rows = rows
+                .into_iter()
+                .map(|row| {
+                    let key = atm_storage::MemberKey::new(row.team.clone(), row.assignee.clone());
+                    (key, row.task_id.clone(), row)
+                })
+                .map(|(member, task_id, row)| ((member, task_id), row))
+                .collect();
+            Self {
+                rows: Mutex::new(rows),
+                fail_reminders,
+            }
+        }
+
+        fn row(&self, member: &atm_storage::MemberKey, task_id: &TaskId) -> TaskRow {
+            self.rows
+                .lock()
+                .expect("task rows lock")
+                .get(&(member.clone(), task_id.clone()))
+                .expect("recorded task row")
+                .clone()
+        }
+    }
+
+    impl atm_storage::contract::sealed::Sealed for RecordingTaskStore {}
+
+    impl TaskStore for RecordingTaskStore {
+        fn load_task(
+            &self,
+            member: &atm_storage::MemberKey,
+            task_id: &TaskId,
+        ) -> Result<Option<TaskRow>, AtmError> {
+            Ok(self
+                .rows
+                .lock()
+                .expect("task rows lock")
+                .get(&(member.clone(), task_id.clone()))
+                .cloned())
+        }
+
+        fn open_tasks(&self, member: &atm_storage::MemberKey) -> Result<Vec<TaskRow>, AtmError> {
+            Ok(self
+                .rows
+                .lock()
+                .expect("task rows lock")
+                .iter()
+                .filter(|((row_member, _), _)| row_member == member)
+                .map(|(_, row)| row.clone())
+                .collect())
+        }
+
+        fn list_tasks(
+            &self,
+            team: &TeamName,
+            member: Option<&AgentName>,
+        ) -> Result<Vec<TaskRow>, AtmError> {
+            Ok(self
+                .rows
+                .lock()
+                .expect("task rows lock")
+                .values()
+                .filter(|row| {
+                    &row.team == team && member.is_none_or(|agent| &row.assignee == agent)
+                })
+                .cloned()
+                .collect())
+        }
+
+        fn list_task_events(
+            &self,
+            _team: &TeamName,
+            _task_id: &TaskId,
+            _assignee: Option<&AgentName>,
+        ) -> Result<Vec<TaskEventRow>, AtmError> {
+            Ok(Vec::new())
+        }
+
+        fn record_reminder(
+            &self,
+            member: &atm_storage::MemberKey,
+            task_id: &TaskId,
+            at: IsoTimestamp,
+            _outcome: atm_core::boundary::ReminderOutcome,
+        ) -> Result<TaskRow, AtmError> {
+            if self.fail_reminders {
+                return Err(AtmError::new(
+                    AtmErrorCode::InternalError,
+                    "injected reminder bookkeeping failure",
+                ));
+            }
+            let mut rows = self.rows.lock().expect("task rows lock");
+            let row = rows
+                .get_mut(&(member.clone(), task_id.clone()))
+                .ok_or_else(|| {
+                    AtmError::new(AtmErrorCode::InternalError, "recorded task row missing")
+                })?;
+            row.last_reminded_at = Some(at);
+            row.reminder_count = row.reminder_count.saturating_add(1);
+            Ok(row.clone())
+        }
+
+        fn record_lead_notified(
+            &self,
+            _member: &atm_storage::MemberKey,
+            _task_id: &TaskId,
+            _at: IsoTimestamp,
+            _lead: &AgentName,
+            _message_id: &AtmMessageId,
+        ) -> Result<(), AtmError> {
+            Ok(())
         }
     }
 
@@ -1179,6 +1364,16 @@ mod tests {
                 process: Arc::clone(&fake),
             },
         });
+        pump_with_selector(runtime, fake, health, now, selector)
+    }
+
+    fn pump_with_selector(
+        runtime: LocalServiceRuntime,
+        fake: Arc<atm_herdr::testing::FakeHerdrProcessAdapter>,
+        health: super::RuntimeHealth,
+        now: Arc<Mutex<IsoTimestamp>>,
+        selector: Arc<dyn MessageReceivedHookSelector>,
+    ) -> HerdrQueueWakePump {
         let process: Arc<dyn HerdrProcessAdapter> = fake;
         let clock_now = Arc::clone(&now);
         HerdrQueueWakePump::new(runtime, selector, health, process).with_clock(Arc::new(
@@ -1196,6 +1391,23 @@ mod tests {
                 status: HerdrAgentStatus::Idle,
                 workspace_id: None,
             }],
+        }));
+    }
+
+    fn queue_status_result(
+        fake: &atm_herdr::testing::FakeHerdrProcessAdapter,
+        keys: &[atm_storage::MemberKey],
+        status: HerdrAgentStatus,
+    ) {
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: keys
+                .iter()
+                .map(|key| AgentSnapshot {
+                    name: Some(key.agent().to_string()),
+                    status,
+                    workspace_id: None,
+                })
+                .collect(),
         }));
     }
 
@@ -1240,6 +1452,31 @@ mod tests {
             runtime,
         )
         .expect("task acknowledgement");
+    }
+
+    fn complete_task(
+        root: &std::path::Path,
+        runtime: &LocalServiceRuntime,
+        team: &TeamName,
+        task_id: TaskId,
+    ) {
+        let home = root.join("home");
+        let request = WriteRequest::new(
+            home.clone(),
+            home,
+            "sender".parse().expect("sender"),
+            &format!("aq27-agent@{team}"),
+            team.clone(),
+            SendMessageSource::Inline("task completed".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("completion request")
+        .with_nudge_mode(NudgeMode::Immediate)
+        .with_task_complete(task_id);
+        write_mail_with_runtime(request, &NullObservability, runtime).expect("task completion");
     }
 
     fn build_test_pump_with_agents(
@@ -1312,6 +1549,88 @@ mod tests {
             status: HerdrAgentStatus::Idle,
             workspace_id: None,
         }])
+    }
+
+    type TaskOnlyPumpFixture = (
+        tempfile::TempDir,
+        LocalServiceRuntime,
+        Arc<atm_herdr::testing::FakeHerdrProcessAdapter>,
+        HerdrQueueWakePump,
+        Arc<RecordingTaskStore>,
+        Vec<atm_storage::MemberKey>,
+        Arc<Mutex<IsoTimestamp>>,
+    );
+
+    fn build_task_only_pump(
+        statuses: Vec<HerdrAgentStatus>,
+        fail_reminders: bool,
+    ) -> TaskOnlyPumpFixture {
+        let root = tempfile::tempdir().expect("temporary root");
+        let assembly = open_isolated_sqlite_boundary(root.path()).expect("runtime");
+        let team: TeamName = "ax5-task-only".parse().expect("team");
+        let agents: Vec<String> = (0..statuses.len())
+            .map(|index| format!("ax5-agent-{index:02}"))
+            .collect();
+        let members: Vec<RosterEntry> = agents
+            .iter()
+            .map(|agent| herdr_member(&team, agent))
+            .collect();
+        assembly
+            .service_runtime
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members,
+                refreshed_at: None,
+            })
+            .expect("roster");
+        let assigned_at = IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("timestamp");
+        let rows: Vec<TaskRow> = agents
+            .iter()
+            .enumerate()
+            .map(|(index, agent)| TaskRow {
+                team: team.clone(),
+                task_id: format!("AX5-TASK-{index:02}").parse().expect("task id"),
+                assignee: agent.parse().expect("agent"),
+                assigner: "sender".parse().expect("assigner"),
+                state: TaskState::Assigned,
+                assignment_message_id: AtmMessageId::new(),
+                description: format!("reminder body {index}"),
+                assigned_at,
+                updated_at: assigned_at,
+                last_reminded_at: None,
+                reminder_count: 0,
+                lead_notified_count: 0,
+            })
+            .collect();
+        let task_store = Arc::new(RecordingTaskStore::new(rows.clone(), fail_reminders));
+        let reader = Arc::new(
+            atm_runtime_test_support::InMemoryTaskLedgerReader::with_rows(rows, Vec::new()),
+        );
+        let runtime = assembly
+            .service_runtime
+            .with_task_store(task_store.clone())
+            .with_async_task_ledger_reader(reader);
+        let fake = Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default());
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: agents
+                .iter()
+                .zip(statuses)
+                .map(|(name, status)| AgentSnapshot {
+                    name: Some(name.clone()),
+                    status,
+                    workspace_id: None,
+                })
+                .collect(),
+        }));
+        let now = Arc::new(Mutex::new(assigned_at));
+        let health = super::RuntimeHealth::default();
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+        let keys = agents
+            .into_iter()
+            .map(|agent| atm_storage::MemberKey::new(team.clone(), agent.parse().expect("agent")))
+            .collect();
+        (root, runtime, fake, pump, task_store, keys, now)
     }
 
     fn build_test_pump_with_two_sessions() -> (
@@ -1478,6 +1797,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ac01_ack_and_completion_advance_to_the_next_task_reminder() {
+        let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
+        let first: TaskId = "AX5-AC1-FIRST".parse().expect("task id");
+        let second: TaskId = "AX5-AC1-SECOND".parse().expect("task id");
+        let first_message = queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            first.clone(),
+        );
+        queue_task_message(
+            root.path(),
+            &runtime,
+            key.team(),
+            key.agent().as_str(),
+            second.clone(),
+        );
+        let mut roster = runtime
+            .shared_roster_store_arc()
+            .load_roster(key.team())
+            .expect("load roster");
+        roster.members.push(herdr_member(key.team(), "sender"));
+        runtime
+            .shared_roster_store_arc()
+            .save_roster(&roster)
+            .expect("add task sender to roster");
+        runtime.clear_roster_cache();
+        clear_pending_markers(&runtime, &key);
+        let now = Arc::new(Mutex::new(
+            IsoTimestamp::from_str("2030-01-01T00:00:00Z").expect("test timestamp"),
+        ));
+        let pump = pump_with_clock(runtime.clone(), fake.clone(), health, Arc::clone(&now));
+
+        pump.tick_once().await;
+        let first_reminder = prompt_texts(&fake).pop().expect("first reminder");
+        assert!(first_reminder.contains("AX5-AC1-FIRST"));
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(
+            prompt_texts(&fake).len(),
+            1,
+            "second tick is inside cadence"
+        );
+
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:01:05Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert_eq!(prompt_texts(&fake).len(), 2);
+        assert!(prompt_texts(&fake)[1].contains("AX5-AC1-FIRST"));
+
+        ack_task_assignment(root.path(), &runtime, key.team(), first_message);
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &first)
+                .expect("load first task")
+                .expect("first task")
+                .state,
+            TaskState::Active
+        );
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:02:10Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert!(prompt_texts(&fake)[2].contains("AX5-AC1-FIRST"));
+
+        complete_task(root.path(), &runtime, key.team(), first);
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &"AX5-AC1-FIRST".parse().expect("task id"))
+                .expect("load completed task")
+                .expect("completed task")
+                .state,
+            TaskState::Complete
+        );
+        *now.lock().expect("test clock lock") =
+            IsoTimestamp::from_str("2030-01-01T00:03:15Z").expect("test timestamp");
+        queue_idle_result(&fake, &key);
+        pump.tick_once().await;
+        assert!(prompt_texts(&fake)[3].contains("AX5-AC1-SECOND"));
+        assert!(!prompt_texts(&fake)[3].contains("AX5-AC1-FIRST"));
+        assert_eq!(
+            runtime
+                .task_store()
+                .expect("task store")
+                .load_task(&key, &second)
+                .expect("load second task")
+                .expect("second task")
+                .state,
+            TaskState::Assigned
+        );
+    }
+
+    #[tokio::test]
     async fn ax5_02_drain_prompt_consumes_the_shared_reminder_budget() {
         let (root, runtime, fake, _old_pump, health, key) = build_test_pump();
         let task_id: TaskId = "AX5-BUDGET".parse().expect("task id");
@@ -1519,6 +1937,72 @@ mod tests {
             prompt_texts(&fake).len(),
             4,
             "two drains, queue, then reminder"
+        );
+    }
+
+    #[tokio::test]
+    async fn ac02_seventeen_due_reminders_split_across_ticks_at_sixteen() {
+        let statuses = vec![HerdrAgentStatus::Idle; 17];
+        let (_root, _runtime, fake, pump, store, keys, _now) =
+            build_task_only_pump(statuses.clone(), false);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().prompted, 16);
+        assert_eq!(pump.stats().task_reminders, 16);
+        assert_eq!(prompt_texts(&fake).len(), 16);
+
+        queue_status_result(&fake, &keys, HerdrAgentStatus::Idle);
+        pump.tick_once().await;
+        assert_eq!(pump.stats().prompted, 1);
+        assert_eq!(pump.stats().task_reminders, 1);
+        assert_eq!(prompt_texts(&fake).len(), 17);
+        assert_eq!(
+            store
+                .row(&keys[16], &"AX5-TASK-16".parse().expect("task id"))
+                .reminder_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_07_blocked_candidate_after_budget_is_still_audited() {
+        let mut statuses = vec![HerdrAgentStatus::Idle; 17];
+        statuses.push(HerdrAgentStatus::Blocked);
+        let (_root, _runtime, fake, pump, store, keys, _now) =
+            build_task_only_pump(statuses, false);
+        pump.tick_once().await;
+
+        assert_eq!(pump.stats().prompted, 16);
+        assert_eq!(pump.stats().task_reminders_blocked, 1);
+        assert_eq!(prompt_texts(&fake).len(), 16);
+        assert_eq!(
+            store
+                .row(&keys[17], &"AX5-TASK-17".parse().expect("task id"))
+                .reminder_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn ax5_05_emitted_prompts_consume_budget_when_audit_writes_fail() {
+        let statuses = vec![HerdrAgentStatus::Idle; 17];
+        let (_root, _runtime, fake, pump, store, _keys, _now) =
+            build_task_only_pump(statuses, true);
+        pump.tick_once().await;
+
+        assert_eq!(pump.stats().prompted, 16);
+        assert_eq!(pump.stats().task_reminders, 16);
+        assert_eq!(prompt_texts(&fake).len(), 16);
+        assert_eq!(
+            store
+                .row(
+                    &atm_storage::MemberKey::new(
+                        "ax5-task-only".parse().expect("team"),
+                        "ax5-agent-00".parse().expect("agent"),
+                    ),
+                    &"AX5-TASK-00".parse().expect("task id"),
+                )
+                .reminder_count,
+            0
         );
     }
 
@@ -1630,6 +2114,41 @@ mod tests {
         queue_idle_result(&fake, &key);
         pump.tick_once().await;
         assert_eq!(pump.stats().task_reminders, 1, "the next tick retries");
+    }
+
+    #[tokio::test]
+    async fn ac04_breaker_and_absent_emitter_leave_no_reminder_audit() {
+        let (_root, _runtime, fake, pump, store, keys, _now) =
+            build_task_only_pump(vec![HerdrAgentStatus::Idle], false);
+        fake.queue_prompt_result(Err(atm_herdr::HerdrError::ServerUnavailable));
+        pump.tick_once().await;
+        let task_id = "AX5-TASK-00".parse().expect("task id");
+        assert_eq!(pump.stats().prompted, 0);
+        assert_eq!(pump.stats().breaker_open, 1);
+        assert_eq!(store.row(&keys[0], &task_id).reminder_count, 0);
+
+        queue_status_result(&fake, &keys, HerdrAgentStatus::Idle);
+        pump.tick_once().await;
+        assert_eq!(
+            pump.stats().task_reminders,
+            1,
+            "closed breaker resumes next tick"
+        );
+        assert_eq!(store.row(&keys[0], &task_id).reminder_count, 1);
+
+        let (_root, runtime, fake, _pump, store, keys, now) =
+            build_task_only_pump(vec![HerdrAgentStatus::Idle], false);
+        let no_emitter = pump_with_selector(
+            runtime.clone(),
+            fake.clone(),
+            super::RuntimeHealth::default(),
+            now,
+            Arc::new(NoEmitterSelector),
+        );
+        no_emitter.tick_once().await;
+        assert_eq!(no_emitter.stats().prompted, 0);
+        assert_eq!(no_emitter.stats().task_reminders, 0);
+        assert_eq!(store.row(&keys[0], &task_id).reminder_count, 0);
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -94,7 +94,7 @@ pub use client::{
 };
 pub use herdr_queue_wake::{
     HERDR_MAX_CONSECUTIVE_RELEASES, HERDR_MAX_PROMPTS_PER_TICK, HERDR_POLL_INTERVAL_MS,
-    HerdrQueueWakePump, HerdrQueueWakeStats,
+    HerdrQueueWakePump,
 };
 pub use loopback_tcp::LoopbackTcpConfig;
 pub use message_handler::{

--- a/crates/atm-http-runtime/src/runtime_health.rs
+++ b/crates/atm-http-runtime/src/runtime_health.rs
@@ -375,7 +375,9 @@ impl RuntimeHealth {
                 RuntimeMemberState::Active => counts.active_members += 1,
                 RuntimeMemberState::Idle => counts.idle_members += 1,
                 RuntimeMemberState::Offline => counts.offline_members += 1,
-                RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
+                RuntimeMemberState::Unknown
+                | RuntimeMemberState::IdentityConflict
+                | RuntimeMemberState::Blocked => {
                     counts.unknown_members += 1;
                 }
             }

--- a/crates/atm-storage-rusqlite/src/writer/task_ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/task_ops.rs
@@ -347,7 +347,8 @@ fn apply_task_completion(
         &typed_task_id,
         &record.envelope.from,
     )?;
-    let row = row.expect("completion admission accepts only an existing task row");
+    let row =
+        row.ok_or_else(|| task_rejected("task completion admission found no existing task row"))?;
     let Transition::To(next_state) = next else {
         return Err(task_rejected("task completion did not produce a state"));
     };

--- a/crates/atm-storage/src/task_store.rs
+++ b/crates/atm-storage/src/task_store.rs
@@ -1,5 +1,8 @@
 //! Storage-neutral task ledger capability.
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use serde::{Deserialize, Serialize};
 
 use crate::contract::sealed;
@@ -68,31 +71,80 @@ pub trait TaskStore: sealed::Sealed + Send + Sync {
     ) -> Result<(), AtmError>;
 }
 
-/// Minimal no-op implementation for composition and contract tests.
+/// Minimal in-memory implementation for composition and contract tests.
 #[derive(Debug, Default)]
-pub struct DummyTaskStore;
+pub struct DummyTaskStore {
+    rows: Mutex<HashMap<(MemberKey, TaskId), TaskRow>>,
+    fail_reminders: bool,
+}
+
+impl DummyTaskStore {
+    #[must_use]
+    pub fn with_rows(rows: Vec<TaskRow>, fail_reminders: bool) -> Self {
+        let rows = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    (
+                        MemberKey::new(row.team.clone(), row.assignee.clone()),
+                        row.task_id.clone(),
+                    ),
+                    row,
+                )
+            })
+            .collect();
+        Self {
+            rows: Mutex::new(rows),
+            fail_reminders,
+        }
+    }
+
+    pub fn row(&self, member: &MemberKey, task_id: &TaskId) -> TaskRow {
+        self.rows
+            .lock()
+            .expect("dummy task rows lock")
+            .get(&(member.clone(), task_id.clone()))
+            .expect("dummy task row")
+            .clone()
+    }
+}
 
 impl sealed::Sealed for DummyTaskStore {}
 
 impl TaskStore for DummyTaskStore {
-    fn load_task(
-        &self,
-        _member: &MemberKey,
-        _task_id: &TaskId,
-    ) -> Result<Option<TaskRow>, AtmError> {
-        Ok(None)
+    fn load_task(&self, member: &MemberKey, task_id: &TaskId) -> Result<Option<TaskRow>, AtmError> {
+        Ok(self
+            .rows
+            .lock()
+            .expect("dummy task rows lock")
+            .get(&(member.clone(), task_id.clone()))
+            .cloned())
     }
 
-    fn open_tasks(&self, _member: &MemberKey) -> Result<Vec<TaskRow>, AtmError> {
-        Ok(Vec::new())
+    fn open_tasks(&self, member: &MemberKey) -> Result<Vec<TaskRow>, AtmError> {
+        Ok(self
+            .rows
+            .lock()
+            .expect("dummy task rows lock")
+            .iter()
+            .filter(|((row_member, _), _)| row_member == member)
+            .map(|(_, row)| row.clone())
+            .collect())
     }
 
     fn list_tasks(
         &self,
-        _team: &TeamName,
-        _member: Option<&AgentName>,
+        team: &TeamName,
+        member: Option<&AgentName>,
     ) -> Result<Vec<TaskRow>, AtmError> {
-        Ok(Vec::new())
+        Ok(self
+            .rows
+            .lock()
+            .expect("dummy task rows lock")
+            .values()
+            .filter(|row| &row.team == team && member.is_none_or(|agent| &row.assignee == agent))
+            .cloned()
+            .collect())
     }
 
     fn list_task_events(
@@ -106,14 +158,26 @@ impl TaskStore for DummyTaskStore {
 
     fn record_reminder(
         &self,
-        _member: &MemberKey,
-        _task_id: &TaskId,
-        _at: IsoTimestamp,
+        member: &MemberKey,
+        task_id: &TaskId,
+        at: IsoTimestamp,
         _outcome: ReminderOutcome,
     ) -> Result<TaskRow, AtmError> {
-        Err(AtmError::validation(
-            "task store test double has no task row",
-        ))
+        if self.fail_reminders {
+            return Err(AtmError::new(
+                crate::AtmErrorCode::InternalError,
+                "injected reminder bookkeeping failure",
+            ));
+        }
+        let mut rows = self.rows.lock().expect("dummy task rows lock");
+        let row = rows
+            .get_mut(&(member.clone(), task_id.clone()))
+            .ok_or_else(|| {
+                AtmError::new(crate::AtmErrorCode::InternalError, "dummy task row missing")
+            })?;
+        row.last_reminded_at = Some(at);
+        row.reminder_count = row.reminder_count.saturating_add(1);
+        Ok(row.clone())
     }
 
     fn record_lead_notified(

--- a/docs/adr/ADR-061-task-state-machine.md
+++ b/docs/adr/ADR-061-task-state-machine.md
@@ -39,6 +39,27 @@ latest assignment event supplies `assignment_message_id`; reminder and lead
 event counts reproduce their counters. Description is intentionally not
 replayable.
 
+## Reminder cycle
+
+The Tokio-owned Herdr queue wake pump polls every 5 seconds. After it drains
+ordinary deferred mail, it checks open tasks for Herdr-backed members reported
+as idle, done, or blocked. It selects the oldest active task (or the oldest
+assigned task when none is active) and re-sends the Task body at most once per
+member every 60 seconds. Drain comes first and shares the same per-tick prompt
+budget, so a queue prompt counts as that member's reminder attempt for the
+tick.
+
+This is Herdr-only. A member that has moved to another backend receives no
+reminder from this pump. `idle_members` retains its queue-dashboard meaning:
+it counts only members that are both idle and have pending deferred mail.
+
+Blocked members are recorded as runtime state `blocked`, receive no Herdr
+prompt, and append a `reminded` audit event with outcome `blocked` on the same
+cadence. Rendering failures append `unrenderable`; successful emissions append
+`emitted`. These events update reminder bookkeeping only and never transition
+task state. If the optional task store is unavailable, only the reminder step
+is skipped; deferred-mail draining continues.
+
 ## Consequences
 
 This is a fresh Phase AX design, not restoration of the AC.6 scaffolding. It

--- a/docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md
+++ b/docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md
@@ -281,7 +281,7 @@ log record and `atm list --task-events`, not doctor).
    outcome `blocked` per 60 s while blocked; when it returns to idle the
    next reminder is `emitted`.
 7. With no `TaskStore` installed the pump still drains queued mail and
-   logs one warning per tick.
+   logs the task-store-unavailable warning on transition only.
 
 ## Required validation
 

--- a/docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md
+++ b/docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md
@@ -5,7 +5,7 @@ title: Task reminder cycle in the Herdr pump
 branch: feature/ax5-task-reminder-cycle
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ax5-task-reminder-cycle
 integration_branch: integrate/phase-ax
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: C
@@ -140,7 +140,7 @@ This is the authoritative deliverable checklist. Every listed deliverable
 lands production-ready for the scope this sprint claims; partial or
 shape-only completion fails the sprint.
 
-- [ ] D1 — pump task step in
+- [x] D1 — pump task step in
   `crates/atm-http-runtime/src/herdr_queue_wake.rs` per the rule above:
   `tick_once` builds the idle set from the roster
   (`shared_roster_store_arc()`, `DurableRosterStore`) and Herdr status
@@ -159,14 +159,14 @@ shape-only completion fails the sprint.
   `atm members` shows `state=blocked age=…`; `Working` alone maps to
   `Active`. The CLI and daemon ship together, so the new wire value needs
   no compatibility shim. Code contract C2.
-- [ ] D2 — clock seam (code contract C2): `HerdrQueueWakePump` gains a
+- [x] D2 — clock seam (code contract C2): `HerdrQueueWakePump` gains a
   `clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>` field, defaulting
   to `IsoTimestamp::now` in `new`, settable with `with_clock` (test
   only in practice; production never calls it). Every `now` in
   `tick_once` and the task step reads the clock. The bootstrap call site
   `crates/atm-daemon-bootstrap/src/replacement_handler.rs` line 244 is
   unchanged: `new`'s four parameters stay as they are.
-- [ ] D3 — task reminder dispatch, code contract C1, in
+- [x] D3 — task reminder dispatch, code contract C1, in
   `crates/atm-core/src/nudge_dispatch.rs` beside
   `rebuild_received_hook_dispatch`: resolves the recipient snapshot with
   `DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(runtime,
@@ -179,7 +179,7 @@ shape-only completion fails the sprint.
   `build_built_in_dispatch` with `NudgeMode::Deferred` (Task body). The
   reminder does not depend on the mail row, so a task whose assignment
   message was already acknowledged or purged still renders.
-- [ ] D4 — no marker exception. Task mail to a Herdr member sets the
+- [x] D4 — no marker exception. Task mail to a Herdr member sets the
   pending marker like every `Deferred` send (AX.1 D9;
   `mark_pending_if_deferred`, pipeline.rs line 112, is unchanged). The
   drain's nudge for that marker already renders the Task body because
@@ -189,14 +189,14 @@ shape-only completion fails the sprint.
   by the tmux hook path, and an assignee moved after reading is an
   ordinary non-Herdr assignee (reminders out of scope, phase plan §5).
   `SendOutcome` is unchanged.
-- [ ] D5 — docs: ADR-061 gains a "Reminder cycle" section (rule,
+- [x] D5 — docs: ADR-061 gains a "Reminder cycle" section (rule,
   properties, 60 s, 5 s tick, drain-first ordering, shared prompt budget,
   Herdr only, `idle_members` semantics unchanged, Blocked handling);
   `docs/requirements.md` §15.4 gains the reminder rule;
   `docs/user-documents/tasks.md` (AX.4) describes when the `task` body is
   re-sent. No ADR-054 amendment from this sprint: the marker contract is
   unchanged.
-- [ ] D6 — tests listed under Required validation.
+- [x] D6 — tests listed under Required validation.
 
 ### Paths to delete
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1620,7 +1620,7 @@ Phase AX sprint status:
 | `AX.2` | A | after AX.1; parallel with AX.3/AX.4 | `complete` | `feature/ax2-herdr-template-rendering` | `docs/plans/phase-ax/sprint-AX.2-herdr-template-rendering.md`, ADR-058 amendment, `boundaries/atm-herdr/herdr-process-adapter.toml`, `docs/atm-herdr/requirements.md` |
 | `AX.3` | B | parallel with AX.1/AX.2 | `complete` | `feature/ax3-task-state-machine` | `docs/plans/phase-ax/sprint-AX.3-task-state-machine.md`, `docs/adr/ADR-061-task-state-machine.md`, ADR-054 amendment, `boundaries/atm-storage/task-store.toml`, `boundaries/atm-storage-rusqlite/task-store-sqlite.toml` |
 | `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `complete` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |
-| `AX.5` | C | after A and B merge | `planned` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-061 reminder-cycle section |
+| `AX.5` | C | after A and B merge | `complete` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-061 reminder-cycle section |
 | `AX.6` | C | after AX.5 | `planned` | `feature/ax6-lead-notification-doctor` | `docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md` |
 | `AX.7` | D | after AX.6 merges | `planned` | none (proof on `integrate/phase-ax`) | `docs/plans/phase-ax/ax7-live-proof.md` |
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2662,6 +2662,10 @@ Required rules:
   pending acknowledgement
 - every transition, rejection, resend, and reminder is append-only audit data;
   the durable tables and replay contract are defined by ADR-061
+- the Tokio Herdr queue wake pump checks open tasks after draining deferred
+  mail: for an idle or done Herdr assignee it re-sends the Task body no more
+  than once per 60 seconds, sharing the drain prompt budget; a blocked assignee
+  receives no prompt but records a `blocked` reminder on the same cadence
 
 ## 16. Observability Requirements
 

--- a/docs/user-documents/tasks.md
+++ b/docs/user-documents/tasks.md
@@ -36,6 +36,11 @@ returns that task's append-only events in sequence order. An unknown task id
 prints the event header only (or `[]` as JSON) and succeeds. See ADR-061 for
 the task tables and audit/replay contract.
 
+For a Herdr-backed assignee, ATM re-sends the Task reminder body while an open
+task remains unattended: at most once per minute, after ordinary queued mail
+has had its turn. A blocked assignee is not prompted, but the task event log
+records the blocked reminder. Reminders stop as soon as the task is completed.
+
 Human task rows use this stable layout:
 
 ```


### PR DESCRIPTION
Implements AX5 task reminder pump integration, cadence and blocked handling, task dispatch rendering, startup coverage, and documentation.