### PR TITLE
docs(adr-020): fix stale atm-daemon path after crate rename

### DIFF
--- a/docs/adr/ADR-020-rule001-observability-adapter-exception.md
+++ b/docs/adr/ADR-020-rule001-observability-adapter-exception.md
@@ -11,20 +11,34 @@
 
 ---
 
+> **Amendment (2026-09-05, docs-only, team-lead):** the `atm-daemon` crate
+> was split and the daemon runtime moved to `atm-daemon-bootstrap`; the
+> sanctioned adapter module was carried forward as
+> `crates/atm-daemon-bootstrap/src/daemon_observability.rs`. Path references
+> below are updated to the current location. No policy content changed —
+> `.just/allowlists/scb_observability_allowlist.toml` (rule
+> `SCB-OBSERVABILITY-001`) already enforces the exception at this current
+> path, and a repo-wide grep confirms it remains the only non-`main.rs`
+> daemon source importing `sc_observability_types` directly.
+
+---
+
 ## Context
 
 `RULE-001` forbids direct `sc_observability_types` imports from arbitrary
 daemon library modules. During the `AD.25` through `AD.30` follow-up planning
 review, arch-qa re-verified the actual `atm-daemon` module graph and found:
 
-- `crates/atm-daemon/src/daemon_runtime_observability.rs` is declared via
-  `mod daemon_runtime_observability;` in `crates/atm-daemon/src/lib.rs`
+- `crates/atm-daemon-bootstrap/src/daemon_observability.rs` is declared via
+  `mod daemon_observability;` in `crates/atm-daemon-bootstrap/src/lib.rs`
 - `lib.rs` publicly re-exports daemon observability surface items from that
   module
 - therefore the file is a real library module, not a binary-internal file
-- `runtime_sqlite_observer.rs` and `test_observability.rs` still need access to
-  the same `ActionName` / `OutcomeLabel` types to call
-  `DaemonRuntimeObservability`
+- at the time of this decision, `runtime_sqlite_observer.rs` and
+  `test_observability.rs` needed access to the same `ActionName` /
+  `OutcomeLabel` types to call `DaemonRuntimeObservability` (those specific
+  consumer files have since been reorganized; the adapter module itself is
+  the load-bearing exception surface, not the specific consumer file names)
 
 The earlier "binary-internal seam" framing was factually wrong against the
 source tree and could not support a truthful exception.
@@ -40,7 +54,7 @@ conditions.
 Accept one sanctioned library-internal adapter exception to `RULE-001` for the
 `atm-daemon` crate:
 
-- `crates/atm-daemon/src/daemon_runtime_observability.rs` is the only
+- `crates/atm-daemon-bootstrap/src/daemon_observability.rs` is the only
   sanctioned non-`main.rs` daemon source file allowed to import
   `sc_observability_types::{ActionName, OutcomeLabel}` directly
 - that adapter module must expose a concrete achievable crate-visible
@@ -48,10 +62,9 @@ Accept one sanctioned library-internal adapter exception to `RULE-001` for the
   - `pub(crate)` aliases
   - `pub(crate)` constructor helpers
   - another equally narrow crate-visible adapter surface
-- `runtime_sqlite_observer.rs` and `test_observability.rs` must consume that
-  crate-visible adapter surface instead of importing `sc_observability_types`
-  directly
-- no other file under `crates/atm-daemon/src/` may add a new direct import of
+- every other daemon-internal consumer must consume that crate-visible
+  adapter surface instead of importing `sc_observability_types` directly
+- no other file under `crates/atm-daemon-bootstrap/src/` may add a new direct import of
   `ActionName` or `OutcomeLabel`
 
 ## Enforcement
@@ -60,7 +73,7 @@ This exception is valid only with mechanical enforcement:
 
 - `AD.26` must wire `.just/lint_boundaries.py` to reject direct
   `sc_observability_types::{ActionName, OutcomeLabel}` imports anywhere under
-  `crates/atm-daemon/src/` except the sanctioned adapter module and `main.rs`
+  `crates/atm-daemon-bootstrap/src/` except the sanctioned adapter module and `main.rs`
 - the lint rule must use the repository's existing TOML allowlist pattern
   rather than a one-off hard-coded path check
 - because the sanctioned import lives at module root, the allowlist mechanism
@@ -103,7 +116,7 @@ depends on crate-local aliases/helpers.
 The exception remains acceptable only while all of the following stay true:
 
 - the direct imports remain confined to
-  `crates/atm-daemon/src/daemon_runtime_observability.rs`
+  `crates/atm-daemon-bootstrap/src/daemon_observability.rs`
 - downstream daemon modules consume only the sanctioned crate-visible adapter
   surface
 - `.just/lint_boundaries.py` and its fixture/allowlist keep enforcing the


### PR DESCRIPTION
## Summary
- ADR-020's Decision/Enforcement/Review Conditions sections cited `crates/atm-daemon/src/daemon_runtime_observability.rs`, a path deleted in the `atm-daemon` → `atm-daemon-bootstrap` rename.
- The sanctioned RULE-001 adapter exception is correctly enforced today at `crates/atm-daemon-bootstrap/src/daemon_observability.rs` via `.just/allowlists/scb_observability_allowlist.toml` (rule `SCB-OBSERVABILITY-001`) — verified this is still the only non-`main.rs` daemon source importing `sc_observability_types` directly.
- Docs-only accuracy fix; no policy or enforcement change. Raised by arch-qa via fenix during Phase AX triage, resolved here as a team-lead housekeeping item outside the Phase AX pipeline.

## Test plan
- [x] Doc-only change; no code/build impact
- [x] Verified current allowlist path and repo-wide grep match the corrected text