### PR TITLE
fix(phase-aw): redesign flaky/race test findings B1-B8 with deterministic sync

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -136,7 +136,7 @@ allowed_dependencies = ["async-trait", "atm-error", "atm-runtime-test-support", 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-observability/Cargo.toml"
 boundary_record_path = "boundaries/atm-observability/tracing-bridge.toml"
-allowed_dependencies = ["atm-core", "sc-observability", "sc-observability-types", "serde_json", "tempfile", "tracing", "tracing-subscriber"]
+allowed_dependencies = ["atm-core", "sc-observability", "sc-observability-types", "serde_json", "serial_test", "tempfile", "tracing", "tracing-subscriber"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-error/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "sc-observability",
  "sc-observability-types",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/boundaries/atm-observability/tracing-bridge.toml
+++ b/boundaries/atm-observability/tracing-bridge.toml
@@ -21,7 +21,7 @@ io_forbidden = ["daemon_lifecycle", "database_io"]
 
 [dependencies]
 allowed_dependents = ["atm-daemon-bootstrap", "atm", "atm-graft-python"]
-allowed_dependencies = ["atm-core", "sc-observability", "sc-observability-types", "serde_json", "tempfile", "tracing", "tracing-subscriber"]
+allowed_dependencies = ["atm-core", "sc-observability", "sc-observability-types", "serde_json", "serial_test", "tempfile", "tracing", "tracing-subscriber"]
 forbidden_edges = [
   "atm-daemon -> atm-observability",
   "atm-observability -> atm-daemon-bootstrap",

--- a/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
+++ b/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
@@ -539,9 +539,20 @@ mod tests {
             let mut sinks = monitor.sinks.lock().expect("monitor state");
             let state = sinks.get_mut("timeline").expect("degraded state");
             assert!(state.degraded_since.is_some());
+            // `Instant::now() - Duration` panics on arithmetic underflow if
+            // the process monotonic clock has less uptime than the offset
+            // (possible on a just-booted VM). Use `checked_sub` and fail with
+            // a clear diagnostic instead of an opaque subtraction panic.
             state.degraded_since = Some(
                 std::time::Instant::now()
-                    - std::time::Duration::from_secs(DEGRADATION_RECOVERY_WINDOW_SECS + 1),
+                    .checked_sub(std::time::Duration::from_secs(
+                        DEGRADATION_RECOVERY_WINDOW_SECS + 1,
+                    ))
+                    .expect(
+                        "process monotonic clock must have at least \
+                         DEGRADATION_RECOVERY_WINDOW_SECS + 1s of uptime to exercise \
+                         the recovery-window transition",
+                    ),
             );
             state.last_transition = None;
         }

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -977,6 +977,24 @@ mod tests {
         }
     }
 
+    /// Returns a directory unique to this call for the fallback logger used
+    /// by tests that don't assert on fallback-log content (see
+    /// [`test_session_with_fallback_path`] for the path that does). A shared
+    /// `std::env::temp_dir()` subdirectory would collide across parallel
+    /// tests in this binary and across concurrent `cargo test` invocations on
+    /// the same host; a fresh [`TempDir`] per call has no such collision.
+    /// The directory is intentionally leaked (never removed) rather than
+    /// tied to the caller's stack: the fallback logger's writer keeps
+    /// appending to it for the life of the `PyGraftSession`, which in these
+    /// tests is the whole test function, so there is no drop point earlier
+    /// than process exit that would be safe to remove it at.
+    fn leaked_fallback_dir() -> std::path::PathBuf {
+        let tempdir = TempDir::new().expect("per-call fallback logger directory");
+        let path = tempdir.path().to_path_buf();
+        std::mem::forget(tempdir);
+        path
+    }
+
     fn test_session(
         initial: Arc<FakeClientTransport>,
         replacement: Arc<FakeClientTransport>,
@@ -987,9 +1005,7 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(initial))),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(Some(GraftClient::from_fake_transport_for_test(
                 replacement,
             ))),
@@ -1314,9 +1330,7 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(None),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
             reconnect_fallback_attempts: AtomicUsize::new(0),
@@ -1517,9 +1531,7 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(None),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
             reconnect_fallback_attempts: AtomicUsize::new(0),
@@ -1878,9 +1890,7 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(None),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
             reconnect_fallback_attempts: AtomicUsize::new(0),
@@ -1980,9 +1990,7 @@ mod tests {
             caller: caller.to_typed().expect("typed caller"),
             client: Mutex::new(Some(GraftClient::from_fake_transport_for_test(transport))),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
             reconnect_fallback_attempts: AtomicUsize::new(0),
@@ -2043,9 +2051,7 @@ mod tests {
                 })),
             )))),
             receiver: Mutex::new(None),
-            fallback_logger: observability::new_logger(
-                &std::env::temp_dir().join("atm-graft-python-tests"),
-            ),
+            fallback_logger: observability::new_logger(&leaked_fallback_dir()),
             reconnect_replacement: Mutex::new(None),
             reconnect_attempts: AtomicUsize::new(0),
             reconnect_fallback_attempts: AtomicUsize::new(0),

--- a/crates/atm-graft-python/src/tool_types.rs
+++ b/crates/atm-graft-python/src/tool_types.rs
@@ -7,7 +7,6 @@ use atm_core::send::{SendOutcome, WriteOutcome};
 use atm_core::types::{CommandAction, ReadSelection};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use std::sync::OnceLock;
 
 use super::PyMessage;
 use crate::observability::ObservabilityStatus;
@@ -291,7 +290,16 @@ impl From<atm_core::list::ListRow> for AtmListRow {
     }
 }
 
-static FROM_AGENT_WARNING: OnceLock<()> = OnceLock::new();
+static FROM_AGENT_WARNING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Resets the warn-once latch so a test doesn't depend on whichever test in
+/// this binary happens to touch `from_agent` first. Test-only: production
+/// code has exactly one process-lifetime latch by design.
+#[cfg(test)]
+pub(crate) fn reset_from_agent_warning_for_test() {
+    FROM_AGENT_WARNING.store(false, std::sync::atomic::Ordering::SeqCst);
+}
 
 #[pymethods]
 impl AtmListRow {
@@ -302,7 +310,7 @@ impl AtmListRow {
 
     #[getter(from_agent)]
     fn agent_name_deprecated(&self, py: Python<'_>) -> PyResult<String> {
-        if FROM_AGENT_WARNING.set(()).is_ok() {
+        if !FROM_AGENT_WARNING.swap(true, std::sync::atomic::Ordering::SeqCst) {
             let warnings = py.import("warnings")?;
             let warning_type = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
             warnings.call_method1(
@@ -564,6 +572,11 @@ mod tests {
     #[test]
     fn deprecated_from_agent_warns_once_and_matches_from() {
         Python::initialize();
+        // The warn-once latch is process-global by design (one Python
+        // DeprecationWarning per process, not per call). Reset it here so
+        // this assertion doesn't depend on test execution order within the
+        // binary.
+        super::reset_from_agent_warning_for_test();
         Python::attach(|py| {
             let row = AtmListRow {
                 message_id: None,

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -4,17 +4,45 @@ Local runs stay opt-in: set ``ATM_CLI_PARITY_FIXTURE`` to a JSON fixture
 pointing at an operator-owned disposable daemon. CI sets
 ``ATM_CLI_PARITY_CI=1``; in that mode this module creates an isolated roster,
 starts the checked-out CLI's paired daemon, and tears it down after the test.
+
+KNOWN ISOLATION GAP (readiness-review B5, tracked as a follow-up, not fixed
+here): ``_GeneratedParityFixture._environment`` below sets ``HOME``,
+``ATM_HOME``, ``ATM_LOG_DIR``, and ``TMPDIR`` to a disposable per-run
+directory, but ``atm-core::home::current_host_runtime_scope`` (the daemon's
+own runtime-scope resolver) intentionally ignores all of those and always
+resolves ``owner.lock``, the endpoint, and the durable state root from the
+real OS user record (``getpwuid``/equivalent) -- that is deliberate host-scope
+behavior for the real daemon, not a bug, and this test file must not change
+it. The practical effect is that the "disposable" daemon this fixture starts
+actually owns the operator's real ``~/.atm/daemon`` and writes the real
+``~/.atm/db``: this class is therefore host-exclusive today. It reliably
+passes only on a host with no other ``atm-daemon`` already running (e.g. a
+fresh CI VM); running it on a workstation with a live personal daemon will
+fail on the ``owner.lock`` acquisition, not because of a defect in this test.
+Until a real runtime-scope override lands for tests, treat this suite as
+serialized/host-exclusive and do not run it concurrently with any other
+``atm-daemon`` instance on the same machine.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import queue
+import threading
 from pathlib import Path
 import subprocess
 import tempfile
 import time
 import unittest
+
+# Bounded wait for the daemon readiness handshake and for every CLI
+# subprocess invocation. Every blocking call in this module must be bounded
+# by one of these deadlines rather than able to hang indefinitely: a stalled
+# daemon or CLI process fails the test with a clear message instead of
+# wedging the whole suite.
+_DAEMON_READY_TIMEOUT_SECONDS = 30
+_CLI_SUBPROCESS_TIMEOUT_SECONDS = 30
 
 
 def _without_observability(value: object) -> object:
@@ -64,6 +92,9 @@ class _GeneratedParityFixture:
         self._temporary = tempfile.TemporaryDirectory(prefix="atm-cli-parity-")
         self.root = Path(self._temporary.name)
         self.process: subprocess.Popen[str] | None = None
+        self._stderr_lines: list[str] = []
+        self._stderr_thread: threading.Thread | None = None
+        self._stdout_thread: threading.Thread | None = None
 
     def _environment(self) -> dict[str, str]:
         home = self.root / "home"
@@ -108,7 +139,7 @@ class _GeneratedParityFixture:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=30,
+            timeout=_CLI_SUBPROCESS_TIMEOUT_SECONDS,
             check=False,
         )
         if completed.returncode != 0:
@@ -157,19 +188,61 @@ class _GeneratedParityFixture:
             encoding="utf-8",
             errors="replace",
         )
-        deadline = time.monotonic() + 30
+
+        # Drain stderr continuously on its own thread from the moment the
+        # process starts. Without this, a chatty daemon can fill the stderr
+        # pipe buffer (commonly 64 KiB) and block on write() forever while
+        # this fixture is only reading stdout -- a classic two-process
+        # deadlock, not a timing race, and no readiness deadline below can
+        # rescue it once that happens.
+        assert self.process.stderr is not None
+        stderr_pipe = self.process.stderr
+
+        def _drain_stderr() -> None:
+            for line in iter(stderr_pipe.readline, ""):
+                self._stderr_lines.append(line)
+
+        self._stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+        self._stderr_thread.start()
+
+        # Pump stdout lines onto a queue on its own thread so the readiness
+        # wait below can use `Queue.get(timeout=...)`, a single call with a
+        # real bounded deadline, instead of a plain `readline()` that can
+        # block past the deadline if the daemon never writes another line.
+        assert self.process.stdout is not None
+        stdout_pipe = self.process.stdout
+        stdout_lines: queue.Queue[str | None] = queue.Queue()
+
+        def _pump_stdout() -> None:
+            for line in iter(stdout_pipe.readline, ""):
+                stdout_lines.put(line)
+            stdout_lines.put(None)
+
+        self._stdout_thread = threading.Thread(target=_pump_stdout, daemon=True)
+        self._stdout_thread.start()
+
+        deadline = time.monotonic() + _DAEMON_READY_TIMEOUT_SECONDS
         ready = False
-        while time.monotonic() < deadline:
-            if self.process.poll() is not None:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or self.process.poll() is not None:
                 break
-            line = self.process.stdout.readline() if self.process.stdout else ""
+            try:
+                line = stdout_lines.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if line is None:
+                break
             if line.strip() == "ATM_DAEMON_READY":
                 ready = True
                 break
         if not ready:
-            stderr = self.process.stderr.read().strip() if self.process.stderr else ""
             self.stop()
-            raise RuntimeError(f"parity daemon did not become ready: {stderr}")
+            stderr_text = "".join(self._stderr_lines).strip()
+            raise RuntimeError(
+                "parity daemon did not become ready within "
+                f"{_DAEMON_READY_TIMEOUT_SECONDS}s: {stderr_text}"
+            )
 
         return {
             "atm": str(atm),
@@ -182,14 +255,20 @@ class _GeneratedParityFixture:
         }
 
     def stop(self) -> None:
-        if self.process is None or self.process.poll() is not None:
-            return
-        self.process.terminate()
-        try:
-            self.process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            self.process.kill()
-            self.process.wait(timeout=5)
+        if self.process is not None and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+        # Bounded joins: once the process has exited, both reader threads
+        # observe EOF on their pipe and return on their own; a timeout here
+        # only guards against this method itself ever hanging.
+        if self._stdout_thread is not None:
+            self._stdout_thread.join(timeout=5)
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=5)
 
     def close(self) -> None:
         self.stop()
@@ -260,6 +339,7 @@ class CliParityTests(unittest.TestCase):
             capture_output=True,
             text=True,
             env=environment,
+            timeout=_CLI_SUBPROCESS_TIMEOUT_SECONDS,
         )
         return json.loads(completed.stdout)
 

--- a/crates/atm-observability/Cargo.toml
+++ b/crates/atm-observability/Cargo.toml
@@ -19,4 +19,5 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 atm-core = { workspace = true, features = ["test-utils"] }
+serial_test = "3"
 tempfile = "3"

--- a/crates/atm-observability/src/lib.rs
+++ b/crates/atm-observability/src/lib.rs
@@ -41,6 +41,18 @@ impl RetainedLogger {
         self.0.health()
     }
 
+    /// Synchronously flushes all registered sinks through the writer-owned
+    /// runtime. Test-only: production callers rely on the writer's own
+    /// maintenance cadence and must not force a flush on the hot path.
+    ///
+    /// # Errors
+    /// Returns the underlying [`sc_observability_types::FlushError`] when a
+    /// sink fails to flush.
+    #[cfg(test)]
+    pub(crate) fn flush(&self) -> Result<(), sc_observability_types::FlushError> {
+        self.0.flush()
+    }
+
     pub fn try_log(&self, event: sc_observability_types::LogEvent) -> RetainedLogOffer {
         #[cfg(test)]
         if queue_full_for_test() {

--- a/crates/atm-observability/src/tracing_bridge.rs
+++ b/crates/atm-observability/src/tracing_bridge.rs
@@ -414,7 +414,7 @@ impl Visit for RetainedVisitor {
 mod tests {
     use std::fs;
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use tempfile::TempDir;
     use tracing_subscriber::prelude::*;
@@ -448,16 +448,20 @@ mod tests {
         );
     }
 
-    fn lines(tempdir: &TempDir, expected: usize) -> String {
+    /// Reads the retained log file after a synchronous flush. The writer
+    /// runtime's own `flush()` (sc-observability runtime.rs) blocks until the
+    /// async writer has drained its queue, so there is no clock or poll loop
+    /// here: once `flush()` returns, every event offered before it is on
+    /// disk.
+    fn lines(tempdir: &TempDir, bridge: &TracingBridgeLayer, expected: usize) -> String {
+        bridge.logger.flush().expect("flush retained logger");
         let path = tempdir.path().join("logs/atm.log.jsonl");
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let content = fs::read_to_string(&path).unwrap_or_default();
-            if content.lines().count() >= expected || Instant::now() >= deadline {
-                return content;
-            }
-            std::thread::yield_now();
-        }
+        let content = fs::read_to_string(&path).unwrap_or_default();
+        assert!(
+            content.lines().count() >= expected,
+            "expected >= {expected} lines after synchronous flush, got: {content}"
+        );
+        content
     }
 
     #[test]
@@ -468,7 +472,7 @@ mod tests {
             tracing::error!(target: "atm_runtime::dispatch", code = "ATM_RUNTIME_ERROR", correlation_id = "c-runtime", "runtime error");
             tracing::warn!(target: "atm_storage_rusqlite::maintenance", code = "ATM_STORAGE_WARN", correlation_id = "c-storage", "storage warning");
         });
-        let content = lines(&tempdir, 3);
+        let content = lines(&tempdir, &bridge, 3);
         for expected in [
             "atm_http_runtime::delivery",
             "atm_runtime::dispatch",
@@ -492,7 +496,7 @@ mod tests {
             tracing::info!(target: "atm_http_runtime::listener", "listener");
             tracing::info!(target: "atm_storage_rusqlite::maintenance", "maintenance");
         });
-        let content = lines(&tempdir, 3);
+        let content = lines(&tempdir, &bridge, 3);
         assert!(!content.contains("excluded"), "{content}");
         for target in [
             "atm_daemon_bootstrap::lifecycle",
@@ -525,15 +529,19 @@ mod tests {
 
     #[test]
     fn ac4_queue_full_offer_is_non_blocking() {
+        // `force_queue_full_for_test` makes `try_log` return `QueueFull`
+        // synchronously, before any real queue is touched, so the offer path
+        // cannot block on writer backpressure by construction: there is no
+        // wall-clock window to race, so we assert the outcome directly
+        // (dropped-queue-full counter incremented, no panic/recursion)
+        // instead of timing the call.
         let (_tempdir, bridge) = bridge();
-        let start = Instant::now();
         RetainedLogger::force_queue_full_for_test(|| {
             tracing::subscriber::with_default(
                 tracing_subscriber::Registry::default().with((*bridge).clone()),
                 || tracing::warn!(target: "atm_http_runtime::listener", "queue pressure"),
             );
         });
-        assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(
             bridge
                 .stats()
@@ -550,7 +558,7 @@ mod tests {
             &bridge,
             || tracing::warn!(target: "atm_http_runtime::delivery", body = "body-secret", recipient = "recipient-secret", token = "token-secret", env = "env-secret", code = "ATM_REDACTION", "redact"),
         );
-        let content = lines(&tempdir, 1);
+        let content = lines(&tempdir, &bridge, 1);
         for secret in [
             "body-secret",
             "recipient-secret",
@@ -562,6 +570,12 @@ mod tests {
     }
 
     #[test]
+    // `tracing::subscriber::set_global_default` is genuinely process-global
+    // (once-per-process, no reset hook), so this is the one test in this
+    // binary allowed to touch it. `#[serial]` makes that exclusivity an
+    // enforced contract rather than an implicit fact that silently breaks if
+    // another test starts installing a global subscriber.
+    #[serial_test::serial(global_tracing_subscriber_install)]
     fn ac7_second_global_install_is_rejected() {
         let (_tempdir, first) = bridge();
         assert!(

--- a/crates/atm-storage-rusqlite/src/diagnostic_timeline.rs
+++ b/crates/atm-storage-rusqlite/src/diagnostic_timeline.rs
@@ -140,8 +140,6 @@ pub(crate) fn truncate_detail(detail: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
     use super::{
         DIAGNOSTIC_DETAIL_MAX_BYTES, DIAGNOSTIC_MAX_ROWS, SqliteDiagnosticTimeline, truncate_detail,
     };
@@ -174,20 +172,22 @@ mod tests {
                 detail: None,
             }])
             .expect("non-blocking diagnostic offer");
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let rows = timeline
-                .query(&DiagnosticQuery::default())
-                .expect("timeline query");
-            if rows
-                .iter()
-                .any(|row| row.code.as_deref() == Some("ATM_TEST"))
-            {
-                break;
-            }
-            assert!(Instant::now() < deadline, "diagnostic writer did not drain");
-            std::thread::yield_now();
-        }
+        // The diagnostic writer lane is a single FIFO channel: `prune()`
+        // sends a `Prune{reply}` message on that same channel and blocks on
+        // its reply, so once it returns, every message queued ahead of it
+        // (including our `record_batch` offer above) has already been
+        // applied. That gives a deterministic synchronization point with no
+        // clock or poll loop; `now_unix_ms = 0` prunes nothing (the cutoff is
+        // seven days before the epoch), so the seeded row survives.
+        timeline.prune(0).expect("prune reply drains the FIFO lane");
+        let rows = timeline
+            .query(&DiagnosticQuery::default())
+            .expect("timeline query");
+        assert!(
+            rows.iter()
+                .any(|row| row.code.as_deref() == Some("ATM_TEST")),
+            "diagnostic writer did not persist the batch before the prune reply: {rows:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes all 8 flaky/wall-clock/race test-hardening findings from the phase-aw
production-readiness review (`review-phase-aw-r1-fenix-b-flaky.txt`). Per
the Fix Standard: no retries, no timeout widening, no busy-poll — every
fix replaces a wall-clock or ordering assumption with an explicit,
deterministic synchronization point, and every remaining wait has a hard
bounded deadline with a clear failure message.

## Findings

### B1 (AW-READY-N1) — `atm-observability/src/tracing_bridge.rs`
Busy-poll `lines()` test helper waited on retained JSONL log content.
**Redesigned**: added a test-only synchronous `RetainedLogger::flush()`
(`atm-observability/src/lib.rs`) that blocks on the writer's own async
drain (`sc-observability` runtime.rs). Once `flush()` returns, every event
offered before it is guaranteed on disk — no clock, no poll loop.
**Cannot block forever**: `flush()` either returns or propagates a
`FlushError`; there is no unbounded wait introduced.

### B2 (AW-READY-N2) — `atm-observability/src/tracing_bridge.rs`
`ac4_queue_full_offer_is_non_blocking` asserted `elapsed < 1s` as proof of
non-blocking behavior. **Redesigned**: removed the wall-clock assertion.
`force_queue_full_for_test` makes `try_log` return `QueueFull`
synchronously before any real queue is touched, so there is no timing
window to race in the first place — the outcome (dropped-queue-full
counter) is asserted directly. **Cannot block forever**: no timing
dependency remains; the call is synchronous by construction.

### B3 (AW-READY-N3) — `atm-storage-rusqlite/src/diagnostic_timeline.rs`
`fresh_database_migrates_and_writer_lane_persists_a_diagnostic` polled the
query result up to a 2s deadline waiting on the async writer lane.
**Redesigned**: the diagnostic writer lane is a single FIFO channel;
`prune()` sends a `Prune{reply}` message on that same channel and blocks
on the reply, so once `prune(0)` returns (cutoff is 7 days before the
epoch, so nothing is deleted), every message queued ahead of it — including
the earlier `record_batch` offer — has already been applied. No clock or
poll loop. **Cannot block forever**: `prune()` blocks on a bounded reply
channel already exercised (and proven not to hang) elsewhere in this
module.

### B4 (AW-READY-N4) — `atm-graft-python/src/lib.rs`
6 fallback-logger test call sites shared a single
`std::env::temp_dir().join("atm-graft-python-tests")` directory, which
collides across parallel tests in this binary and across concurrent
`cargo test` invocations on the same host. **Redesigned**: added
`leaked_fallback_dir()`, which creates a fresh `TempDir` per call and
leaks it (`std::mem::forget`) so the fallback logger's writer can keep
appending for the life of the `PyGraftSession` without a premature drop.
Each test now gets a collision-free directory deterministically.
**Cannot block forever**: no wait introduced; this is a pure collision fix.

### B5 (AW-READY-N5) — `atm-graft-python/tests/test_cli_parity.py`
The CLI-parity daemon fixture used a blocking `readline()` for readiness
detection (unbounded hang risk) and never drained stderr (deadlock risk
once the ~64KiB pipe buffer fills); the `CliParityTests` classmethod's
`_cli()` `subprocess.run` had no timeout at all.
**Redesigned**: stderr is drained continuously on a background thread;
stdout lines are pumped onto a `queue.Queue` from a background thread and
readiness is awaited via `queue.get(timeout=remaining)` against a hard
monotonic deadline (`_DAEMON_READY_TIMEOUT_SECONDS = 30s`) — on timeout or
early process exit, `stop()` is called and a `RuntimeError` is raised with
the drained stderr text. `stop()` joins both reader threads with a bounded
timeout as a safety net (both threads observe EOF and return on their own
once the process exits). Added `timeout=_CLI_SUBPROCESS_TIMEOUT_SECONDS`
(30s) to the previously-untimed classmethod `_cli()` call.
**Note**: `current_host_runtime_scope()` intentionally ignores
HOME/ATM_HOME (`home.rs`) by design and was **not** changed — that is a
separate, documented isolation-gap follow-up, noted in the module
docstring. This fix only removes the hang hazards.
**Cannot block forever**: every wait now has an explicit deadline
(subprocess timeout or queue-get timeout) with a diagnostic failure
message.

### B6 (AW-READY-N6 bundle) — `atm-graft-python/src/tool_types.rs`
`FROM_AGENT_WARNING` was a `OnceLock` with no reset hook, making
`deprecated_from_agent_warns_once_and_matches_from` depend on whichever
test in the binary happened to touch the warn-once latch first.
**Redesigned**: switched to an `AtomicBool` plus a `#[cfg(test)]`
`reset_from_agent_warning_for_test()` hook, called at the start of the
test, so the assertion no longer depends on execution order within the
binary. **Cannot block forever**: no wait involved; this is an ordering
fix.

### B7 (AW-READY-N6 bundle) — `atm-daemon-bootstrap/src/diagnostic_timeline.rs`
The recovery-window transition test computed `degraded_since` via
`Instant::now() - Duration::from_secs(...)`, which panics on arithmetic
underflow if the process monotonic clock has less uptime than the offset
(possible on a just-booted VM/CI runner). **Redesigned**: use
`Instant::checked_sub` with `.expect()` and a clear diagnostic message
instead of raw subtraction. **Cannot block forever**: no wait involved;
this converts a possible panic into a clear, actionable failure message.

### B8 (AW-READY-N6 bundle) — `atm-observability/src/tracing_bridge.rs`
`ac7_second_global_install_is_rejected` touches
`tracing::subscriber::set_global_default`, which is genuinely
process-global (once-per-process, no reset hook), and could silently
interact with other tests installing subscribers. **Redesigned**: guarded
with `#[serial_test::serial(global_tracing_subscriber_install)]`, making
the required test exclusivity an enforced contract instead of an implicit
fact. **Cannot block forever**: `serial_test` only serializes test
execution order within the same binary; it introduces no wait or timeout
of its own.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 warnings, 24 workspace members), before and after merging `origin/integrate/phase-aw`
- `cargo test -p atm-observability -p atm-storage-rusqlite -p atm-daemon-bootstrap -p atm-graft-python --lib` — 134 passed, 0 failed (post-merge)
- `cargo test -p atm-observability --lib` run 5x in a loop pre-merge — all passed, no flakiness observed
- `cargo test -p atm-storage-rusqlite --lib diagnostic_timeline` run 3x in a loop pre-merge — all passed
- `python3 -m py_compile crates/atm-graft-python/tests/test_cli_parity.py` — OK
- `ruff check crates/atm-graft-python/tests/test_cli_parity.py` — All checks passed

Legacy synchronous daemon code was not touched (frozen, Phase-AM deletion
target). No benchmark floors/baselines were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK