### PR TITLE
fix(phase-aw): diagnostics pagination cap-alignment, admission routing, typed client

### DIFF
--- a/.triage/phase-aw/findings/AW-READY-M7.ttl
+++ b/.triage/phase-aw/findings/AW-READY-M7.ttl
@@ -1,6 +1,15 @@
 @prefix triage: <urn:atm:triage:> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+# quality-mgr note, 2026-09-05, re: fix/aw-readiness-api round-2 QA (qa-pr1211-r2):
+# the real fix for this finding (CASE-based severity rank replacing the lexical
+# compare) lands on the sibling branch fix/aw-readiness-easy (PR #1215), not on
+# fix/aw-readiness-api (PR #1211). arch-qa/ruthless-boundary-qa confirmed it closed
+# there. fix/aw-readiness-api adds only a client-side re-filter workaround in
+# crates/atm/src/commands/log.rs (comment: "not level-order-correct, tracked
+# separately") pending that merge. Status stays "open" here until PR #1215 merges
+# forward into this lineage and the workaround in log.rs is removed as dead code.
+
 # Persisted file/path values are repository-relative. Runtime checkout paths
 # belong in the agent input only and must not be copied into this record.
 

--- a/crates/atm-core/src/observability_counters.rs
+++ b/crates/atm-core/src/observability_counters.rs
@@ -2,6 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
+// Re-exported so every consumer of the wire-level diagnostic timeline types
+// (the HTTP route, the typed client, and the CLI) shares one definition of
+// the effective page-size cap instead of each layer hard-coding its own.
+pub use atm_storage::{DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT};
+
 /// Copyable retained-diagnostic counter snapshot. Timeline values remain zero
 /// until AW.2 installs its timeline adapter.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -100,7 +105,34 @@ pub struct DiagnosticTimelineRecord {
 }
 
 /// Dedicated read-only response contract for `/v1/diagnostics`.
+///
+/// `truncated` and `next_cursor` are additive fields: a client that only
+/// reads `records` (as `atm log` did before cursor pagination existed)
+/// continues to work unchanged, and an older client deserializing a newer
+/// response tolerates them via `#[serde(default)]`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DiagnosticTimelineResponse {
     pub records: Vec<DiagnosticTimelineRecord>,
+    /// `true` when more rows exist beyond this page; page further with
+    /// `next_cursor`.
+    #[serde(default)]
+    pub truncated: bool,
+    /// Opaque cursor identifying the last record on this page. Present
+    /// whenever `truncated` is `true`.
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+/// Typed request parameters for the bounded `/v1/diagnostics` timeline
+/// query, shared by the typed client and the HTTP route so the query-string
+/// encoding lives in exactly one place.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiagnosticTimelineQuery {
+    pub since_unix_ms: Option<i64>,
+    pub until_unix_ms: Option<i64>,
+    pub level_at_least: Option<String>,
+    pub component_prefix: Option<String>,
+    pub limit: Option<usize>,
+    /// Opaque cursor returned as `next_cursor` by a previous page.
+    pub cursor: Option<String>,
 }

--- a/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
+++ b/crates/atm-daemon-bootstrap/src/diagnostic_timeline.rs
@@ -378,6 +378,9 @@ fn diagnostic_event(event: &RetainedEvent<'_>) -> DiagnosticEvent {
         origin: event.origin.to_owned(),
         message: event.message.to_owned(),
         detail,
+        // Assigned only by the storage query path once persisted; see
+        // `DiagnosticEvent::id` for why the pre-insert value is always 0.
+        id: 0,
     }
 }
 

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -184,15 +184,79 @@ pub fn loopback_tcp_client(
 }
 
 /// Fetch one bounded JSON projection from the capability-authenticated
-/// loopback daemon.  This is deliberately a read-only escape hatch for
-/// runtime-owned auxiliary routes; consumers must not assemble daemon storage
-/// in-process to read those projections.
-pub async fn loopback_tcp_get_json(
+/// loopback daemon. Kept private to the crate: the one production consumer
+/// is [`diagnostics_query`], which owns the single typed route contract this
+/// primitive serves. Do not add a second untyped call site; add a typed
+/// method beside `diagnostics_query` instead.
+pub(crate) async fn loopback_tcp_get_json(
     endpoint_record_path: impl AsRef<Path>,
     path: String,
     request_timeout: Duration,
 ) -> Result<Vec<u8>, AtmError> {
     crate::loopback_read::get_json(endpoint_record_path.as_ref(), path, request_timeout).await
+}
+
+/// Typed client for the bounded, read-only `/v1/diagnostics` route.
+///
+/// This is the sole production entry point for querying the retained
+/// diagnostic timeline over the authenticated loopback connection; it owns
+/// query-string encoding and response decoding so callers (currently `atm
+/// log --source timeline`) never hand-assemble the route's path or parse its
+/// JSON body themselves.
+pub async fn diagnostics_query(
+    endpoint_record_path: impl AsRef<Path>,
+    query: atm_core::observability_counters::DiagnosticTimelineQuery,
+    request_timeout: Duration,
+) -> Result<atm_core::observability_counters::DiagnosticTimelineResponse, AtmError> {
+    let mut params = vec![format!(
+        "limit={}",
+        query
+            .limit
+            .unwrap_or(atm_core::observability_counters::DIAGNOSTIC_QUERY_MAX_LIMIT)
+    )];
+    if let Some(since) = query.since_unix_ms {
+        params.push(format!("since={since}"));
+    }
+    if let Some(until) = query.until_unix_ms {
+        params.push(format!("until={until}"));
+    }
+    if let Some(level) = query.level_at_least.as_deref() {
+        params.push(format!("level={}", percent_encode_query_value(level)));
+    }
+    if let Some(component) = query.component_prefix.as_deref() {
+        params.push(format!(
+            "component={}",
+            percent_encode_query_value(component)
+        ));
+    }
+    if let Some(cursor) = query.cursor.as_deref() {
+        params.push(format!("cursor={}", percent_encode_query_value(cursor)));
+    }
+    let body = loopback_tcp_get_json(
+        endpoint_record_path,
+        format!("/v1/diagnostics?{}", params.join("&")),
+        request_timeout,
+    )
+    .await?;
+    serde_json::from_slice(&body).map_err(|error| {
+        AtmError::daemon_unavailable("daemon returned an invalid diagnostic timeline response")
+            .with_cause(error)
+    })
+}
+
+/// Percent-encodes one query-string value using the unreserved set from
+/// RFC 3986 section 2.3; every other byte is escaped, which is always safe
+/// even though it is stricter than required for values that never carry
+/// `&`, `=`, or `%` (component names, cursor tokens, level names).
+fn percent_encode_query_value(raw: &str) -> String {
+    raw.bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![char::from(byte)]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
 }
 
 /// Builds the shared typed client for one explicitly configured direct peer.

--- a/crates/atm-http-runtime/src/diagnostics_route.rs
+++ b/crates/atm-http-runtime/src/diagnostics_route.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use atm_core::observability_counters::{
-    DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticTimelineRecord, DiagnosticTimelineResponse,
+    DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticTimelineRecord,
+    DiagnosticTimelineResponse,
 };
 use atm_runtime::{DiagnosticCursor, DiagnosticTimelineStore};
 use axum::extract::{Query, State};
@@ -14,7 +15,11 @@ use axum::routing::get;
 use axum::{Json, Router};
 use serde::Deserialize;
 
-const DEFAULT_LIMIT: usize = 50;
+/// Re-exported so callers that must document or test the effective default
+/// page size use the same identifier as the storage-layer default
+/// (`atm_storage::diagnostics::DIAGNOSTIC_QUERY_DEFAULT_LIMIT`) instead of a
+/// second, potentially divergent constant (AW-READY-O7 item 2).
+pub const DEFAULT_DIAGNOSTICS_LIMIT: usize = DIAGNOSTIC_QUERY_DEFAULT_LIMIT;
 
 /// Re-exported so callers that must document or test the effective cap use
 /// the same identifier as the storage-layer clamp (`atm_storage::diagnostics
@@ -60,7 +65,7 @@ async fn query_diagnostics(
     State(state): State<DiagnosticsState>,
     Query(query): Query<DiagnosticsQuery>,
 ) -> Result<Json<DiagnosticTimelineResponse>, axum::response::Response> {
-    let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
+    let limit = query.limit.unwrap_or(DEFAULT_DIAGNOSTICS_LIMIT);
     if limit == 0 {
         return Err(diagnostics_error(
             StatusCode::BAD_REQUEST,
@@ -149,6 +154,7 @@ fn diagnostics_error(status: StatusCode, message: impl Into<String>) -> Response
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use atm_core::error::AtmError;
@@ -165,10 +171,55 @@ mod tests {
 
     use super::diagnostics_router;
 
+    /// Synchronizes a fixture query with its test so a bounded-deadline test
+    /// can advance paused tokio time deterministically instead of racing a
+    /// real wall-clock sleep against the configured deadline (AW-READY-O7
+    /// item 3: no sleeps-and-hope, explicit synchronisation only).
+    ///
+    /// [`FixtureStore::query`] runs inside `tokio::task::spawn_blocking`, on
+    /// a dedicated OS thread independent of the paused async-runtime clock,
+    /// so blocking that thread on a rendezvous channel does not stall the
+    /// test's executor.
+    struct QueryGate {
+        entered: tokio::sync::Notify,
+        release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    impl std::fmt::Debug for QueryGate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("QueryGate").finish_non_exhaustive()
+        }
+    }
+
+    impl QueryGate {
+        fn new() -> (Arc<Self>, std::sync::mpsc::SyncSender<()>) {
+            let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+            (
+                Arc::new(Self {
+                    entered: tokio::sync::Notify::new(),
+                    release: std::sync::Mutex::new(release_rx),
+                }),
+                release_tx,
+            )
+        }
+
+        /// Called from the dedicated `spawn_blocking` thread: signals the
+        /// test that the store call has genuinely started, then parks this
+        /// thread (never the async executor) until the test releases it.
+        fn enter_and_wait(&self) {
+            self.entered.notify_one();
+            self.release
+                .lock()
+                .expect("query gate release channel lock")
+                .recv()
+                .expect("query gate released before the parked query returned");
+        }
+    }
+
     #[derive(Debug, Default)]
     struct FixtureStore {
         rows: Vec<DiagnosticEvent>,
-        query_delay: Option<Duration>,
+        gate: Option<Arc<QueryGate>>,
     }
 
     impl DiagnosticTimelineStore for FixtureStore {
@@ -177,8 +228,8 @@ mod tests {
         }
 
         fn query(&self, query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
-            if let Some(delay) = self.query_delay {
-                std::thread::sleep(delay);
+            if let Some(gate) = &self.gate {
+                gate.enter_and_wait();
             }
             let cursor = query.cursor;
             let mut rows: Vec<_> = self
@@ -262,10 +313,7 @@ mod tests {
     async fn truncated_flag_and_cursor_page_through_every_row_once() {
         let rows: Vec<_> = (0..7).map(|id| fixture_event(id, 100 - id)).collect();
         let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
-            std::sync::Arc::new(FixtureStore {
-                rows,
-                query_delay: None,
-            });
+            std::sync::Arc::new(FixtureStore { rows, gate: None });
         let router = diagnostics_router(Some(store), Duration::from_secs(5));
 
         let (status, body) = get(router.clone(), "/v1/diagnostics?limit=3").await;
@@ -325,16 +373,35 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn a_query_that_exceeds_its_deadline_is_reported_as_unavailable() {
+        let (gate, release) = QueryGate::new();
+        let deadline = Duration::from_millis(20);
         let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
             std::sync::Arc::new(FixtureStore {
                 rows: vec![fixture_event(1, 1)],
-                query_delay: Some(Duration::from_millis(200)),
+                gate: Some(Arc::clone(&gate)),
             });
-        let router = diagnostics_router(Some(store), Duration::from_millis(20));
-        let (status, _) = get(router, "/v1/diagnostics").await;
+        let router = diagnostics_router(Some(store), deadline);
+
+        let request = tokio::spawn(get(router, "/v1/diagnostics"));
+
+        // Deterministic: wait until the fixture query has genuinely started
+        // (on its own `spawn_blocking` thread) before advancing the paused
+        // clock, instead of racing a real sleep against the deadline.
+        gate.entered.notified().await;
+        tokio::time::advance(deadline + Duration::from_millis(1)).await;
+
+        let (status, _) = request
+            .await
+            .expect("request task completes once the bounded deadline elapses");
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+        // Let the parked fixture query thread return so it does not leak
+        // past the end of the test.
+        release
+            .send(())
+            .expect("release the parked fixture query thread");
     }
 
     #[tokio::test]
@@ -343,10 +410,7 @@ mod tests {
         // tie-break exclusively.
         let rows: Vec<_> = (0..5).map(|id| fixture_event(id, 1)).collect();
         let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
-            std::sync::Arc::new(FixtureStore {
-                rows,
-                query_delay: None,
-            });
+            std::sync::Arc::new(FixtureStore { rows, gate: None });
         let router = diagnostics_router(Some(store), Duration::from_secs(5));
 
         let (status, body) = get(router.clone(), "/v1/diagnostics?limit=2").await;

--- a/crates/atm-http-runtime/src/diagnostics_route.rs
+++ b/crates/atm-http-runtime/src/diagnostics_route.rs
@@ -238,7 +238,10 @@ mod tests {
     }
 
     impl DiagnosticTimelineStore for FixtureStore {
-        fn record_batch(&self, _events: &[DiagnosticEvent]) -> Result<(), AtmError> {
+        fn record_batch(
+            &self,
+            _events: &[DiagnosticEvent],
+        ) -> Result<(), atm_storage::DiagnosticRecordError> {
             unimplemented!("the diagnostics route never writes")
         }
 

--- a/crates/atm-http-runtime/src/diagnostics_route.rs
+++ b/crates/atm-http-runtime/src/diagnostics_route.rs
@@ -178,11 +178,18 @@ mod tests {
     ///
     /// [`FixtureStore::query`] runs inside `tokio::task::spawn_blocking`, on
     /// a dedicated OS thread independent of the paused async-runtime clock,
-    /// so blocking that thread on a rendezvous channel does not stall the
+    /// so parking that thread on this explicitly bounded condition gate does
+    /// not stall the
     /// test's executor.
     struct QueryGate {
         entered: tokio::sync::Notify,
-        release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+        state: std::sync::Mutex<QueryGateState>,
+        release: std::sync::Condvar,
+    }
+
+    #[derive(Debug, Default)]
+    struct QueryGateState {
+        released: bool,
     }
 
     impl std::fmt::Debug for QueryGate {
@@ -192,15 +199,12 @@ mod tests {
     }
 
     impl QueryGate {
-        fn new() -> (Arc<Self>, std::sync::mpsc::SyncSender<()>) {
-            let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
-            (
-                Arc::new(Self {
-                    entered: tokio::sync::Notify::new(),
-                    release: std::sync::Mutex::new(release_rx),
-                }),
-                release_tx,
-            )
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                entered: tokio::sync::Notify::new(),
+                state: std::sync::Mutex::new(QueryGateState::default()),
+                release: std::sync::Condvar::new(),
+            })
         }
 
         /// Called from the dedicated `spawn_blocking` thread: signals the
@@ -208,11 +212,22 @@ mod tests {
         /// thread (never the async executor) until the test releases it.
         fn enter_and_wait(&self) {
             self.entered.notify_one();
-            self.release
-                .lock()
-                .expect("query gate release channel lock")
-                .recv()
-                .expect("query gate released before the parked query returned");
+            let state = self.state.lock().expect("query gate state lock");
+            let (state, timeout) = self
+                .release
+                .wait_timeout_while(state, Duration::from_secs(1), |state| !state.released)
+                .expect("query gate state is not poisoned");
+            assert!(state.released, "query gate was released");
+            assert!(
+                !timeout.timed_out(),
+                "query gate release must arrive within the test's hard bound"
+            );
+        }
+
+        fn release(&self) {
+            let mut state = self.state.lock().expect("query gate state lock");
+            state.released = true;
+            self.release.notify_one();
         }
     }
 
@@ -375,7 +390,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn a_query_that_exceeds_its_deadline_is_reported_as_unavailable() {
-        let (gate, release) = QueryGate::new();
+        let gate = QueryGate::new();
         let deadline = Duration::from_millis(20);
         let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
             std::sync::Arc::new(FixtureStore {
@@ -399,9 +414,7 @@ mod tests {
 
         // Let the parked fixture query thread return so it does not leak
         // past the end of the test.
-        release
-            .send(())
-            .expect("release the parked fixture query thread");
+        gate.release();
     }
 
     #[tokio::test]

--- a/crates/atm-http-runtime/src/diagnostics_route.rs
+++ b/crates/atm-http-runtime/src/diagnostics_route.rs
@@ -1,9 +1,12 @@
 //! Bounded, read-only HTTP projection of the retained diagnostic timeline.
 
 use std::sync::Arc;
+use std::time::Duration;
 
-use atm_core::observability_counters::{DiagnosticTimelineRecord, DiagnosticTimelineResponse};
-use atm_runtime::DiagnosticTimelineStore;
+use atm_core::observability_counters::{
+    DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticTimelineRecord, DiagnosticTimelineResponse,
+};
+use atm_runtime::{DiagnosticCursor, DiagnosticTimelineStore};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -12,18 +15,34 @@ use axum::{Json, Router};
 use serde::Deserialize;
 
 const DEFAULT_LIMIT: usize = 50;
-pub const MAX_DIAGNOSTICS_LIMIT: usize = 5_000;
+
+/// Re-exported so callers that must document or test the effective cap use
+/// the same identifier as the storage-layer clamp (`atm_storage::diagnostics
+/// ::DIAGNOSTIC_QUERY_MAX_LIMIT`) instead of a second, potentially
+/// divergent constant.
+pub const MAX_DIAGNOSTICS_LIMIT: usize = DIAGNOSTIC_QUERY_MAX_LIMIT;
 
 #[derive(Clone)]
 struct DiagnosticsState {
     store: Option<Arc<dyn DiagnosticTimelineStore>>,
+    /// Bounded deadline for the whole query, including the `spawn_blocking`
+    /// hop to the SQLite connection pool. A read that cannot complete inside
+    /// this budget is reported as unavailable rather than left to run
+    /// unbounded against a large retained table.
+    query_deadline: Duration,
 }
 
 /// Adds the authenticated local diagnostics query route.
-pub(crate) fn diagnostics_router(store: Option<Arc<dyn DiagnosticTimelineStore>>) -> Router {
+pub(crate) fn diagnostics_router(
+    store: Option<Arc<dyn DiagnosticTimelineStore>>,
+    query_deadline: Duration,
+) -> Router {
     Router::new()
         .route("/v1/diagnostics", get(query_diagnostics))
-        .with_state(DiagnosticsState { store })
+        .with_state(DiagnosticsState {
+            store,
+            query_deadline,
+        })
 }
 
 #[derive(Debug, Deserialize)]
@@ -34,6 +53,7 @@ struct DiagnosticsQuery {
     level: Option<String>,
     component: Option<String>,
     limit: Option<usize>,
+    cursor: Option<String>,
 }
 
 async fn query_diagnostics(
@@ -41,27 +61,49 @@ async fn query_diagnostics(
     Query(query): Query<DiagnosticsQuery>,
 ) -> Result<Json<DiagnosticTimelineResponse>, axum::response::Response> {
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
+    if limit == 0 {
+        return Err(diagnostics_error(
+            StatusCode::BAD_REQUEST,
+            "limit must be greater than zero",
+        ));
+    }
     if limit > MAX_DIAGNOSTICS_LIMIT {
         return Err(diagnostics_error(
             StatusCode::BAD_REQUEST,
             format!("limit must be at most {MAX_DIAGNOSTICS_LIMIT}"),
         ));
     }
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(DiagnosticCursor::decode)
+        .transpose()
+        .map_err(|_| diagnostics_error(StatusCode::BAD_REQUEST, "cursor is invalid"))?;
     let store = state.store.ok_or_else(|| {
         diagnostics_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "diagnostic timeline was not installed at daemon startup",
         )
     })?;
+    // Request one extra "peek" row beyond the caller's limit so truncation
+    // can be reported precisely without a second round trip.
     let storage_query = atm_runtime::DiagnosticQuery {
         since: query.since,
         until: query.until,
         level_at_least: query.level,
         component_prefix: query.component,
-        limit: Some(limit),
+        limit: Some(limit + 1),
+        cursor,
     };
-    let events = tokio::task::spawn_blocking(move || store.query(&storage_query))
+    let query_future = tokio::task::spawn_blocking(move || store.query(&storage_query));
+    let mut events = tokio::time::timeout(state.query_deadline, query_future)
         .await
+        .map_err(|_| {
+            diagnostics_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "diagnostic timeline query exceeded its bounded deadline",
+            )
+        })?
         .map_err(|_| {
             diagnostics_error(
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -69,8 +111,22 @@ async fn query_diagnostics(
             )
         })?
         .map_err(|error| diagnostics_error(StatusCode::SERVICE_UNAVAILABLE, error.to_string()))?;
+    let truncated = events.len() > limit;
+    events.truncate(limit);
+    let next_cursor = truncated.then(|| {
+        let last = events
+            .last()
+            .expect("truncated implies at least `limit` events, and limit > 0");
+        DiagnosticCursor {
+            ts_unix_ms: last.ts_unix_ms,
+            id: last.id,
+        }
+        .encode()
+    });
     Ok(Json(DiagnosticTimelineResponse {
         records: events.into_iter().map(diagnostic_record).collect(),
+        truncated,
+        next_cursor,
     }))
 }
 
@@ -89,4 +145,236 @@ fn diagnostic_record(event: atm_runtime::DiagnosticEvent) -> DiagnosticTimelineR
 
 fn diagnostics_error(status: StatusCode, message: impl Into<String>) -> Response {
     (status, Json(serde_json::json!({ "error": message.into() }))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use atm_core::error::AtmError;
+    use atm_core::observability_counters::{
+        DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticTimelineResponse,
+    };
+    use atm_runtime::{
+        DiagnosticCursor, DiagnosticEvent, DiagnosticQuery, DiagnosticTimelineStore,
+    };
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use super::diagnostics_router;
+
+    #[derive(Debug, Default)]
+    struct FixtureStore {
+        rows: Vec<DiagnosticEvent>,
+        query_delay: Option<Duration>,
+    }
+
+    impl DiagnosticTimelineStore for FixtureStore {
+        fn record_batch(&self, _events: &[DiagnosticEvent]) -> Result<(), AtmError> {
+            unimplemented!("the diagnostics route never writes")
+        }
+
+        fn query(&self, query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
+            if let Some(delay) = self.query_delay {
+                std::thread::sleep(delay);
+            }
+            let cursor = query.cursor;
+            let mut rows: Vec<_> = self
+                .rows
+                .iter()
+                .filter(|row| match cursor {
+                    Some(cursor) => {
+                        row.ts_unix_ms < cursor.ts_unix_ms
+                            || (row.ts_unix_ms == cursor.ts_unix_ms && row.id < cursor.id)
+                    }
+                    None => true,
+                })
+                .cloned()
+                .collect();
+            rows.sort_by(|a, b| (b.ts_unix_ms, b.id).cmp(&(a.ts_unix_ms, a.id)));
+            rows.truncate(query.limit.unwrap_or(usize::MAX));
+            Ok(rows)
+        }
+
+        fn prune(&self, _now_unix_ms: i64) -> Result<u64, AtmError> {
+            unimplemented!("the diagnostics route never prunes")
+        }
+    }
+
+    fn fixture_event(id: i64, ts_unix_ms: i64) -> DiagnosticEvent {
+        DiagnosticEvent {
+            ts_unix_ms,
+            level: "info".to_owned(),
+            component: "fixture".to_owned(),
+            code: None,
+            correlation_id: None,
+            origin: "test".to_owned(),
+            message: format!("event {id}"),
+            detail: None,
+            id,
+        }
+    }
+
+    async fn get(router: axum::Router, path: &str) -> (StatusCode, Vec<u8>) {
+        let response = router
+            .oneshot(Request::get(path).body(Body::empty()).expect("request"))
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        (status, bytes.to_vec())
+    }
+
+    #[tokio::test]
+    async fn rejects_a_limit_above_the_shared_max_cap() {
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore::default());
+        let router = diagnostics_router(Some(store), Duration::from_secs(5));
+        let (status, _) = get(
+            router,
+            &format!("/v1/diagnostics?limit={}", DIAGNOSTIC_QUERY_MAX_LIMIT + 1),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn accepts_a_limit_exactly_at_the_shared_max_cap() {
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore::default());
+        let router = diagnostics_router(Some(store), Duration::from_secs(5));
+        let (status, _) = get(
+            router,
+            &format!("/v1/diagnostics?limit={DIAGNOSTIC_QUERY_MAX_LIMIT}"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn truncated_flag_and_cursor_page_through_every_row_once() {
+        let rows: Vec<_> = (0..7).map(|id| fixture_event(id, 100 - id)).collect();
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore {
+                rows,
+                query_delay: None,
+            });
+        let router = diagnostics_router(Some(store), Duration::from_secs(5));
+
+        let (status, body) = get(router.clone(), "/v1/diagnostics?limit=3").await;
+        assert_eq!(status, StatusCode::OK);
+        let page1: DiagnosticTimelineResponse =
+            serde_json::from_slice(&body).expect("first page JSON");
+        assert_eq!(page1.records.len(), 3);
+        assert!(page1.truncated, "more rows remain after the first page");
+        let cursor1 = page1.next_cursor.expect("truncated page carries a cursor");
+
+        let (status, body) = get(
+            router.clone(),
+            &format!("/v1/diagnostics?limit=3&cursor={cursor1}"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let page2: DiagnosticTimelineResponse =
+            serde_json::from_slice(&body).expect("second page JSON");
+        assert_eq!(page2.records.len(), 3);
+        assert!(page2.truncated, "one row remains after the second page");
+        let cursor2 = page2.next_cursor.expect("truncated page carries a cursor");
+
+        let (status, body) =
+            get(router, &format!("/v1/diagnostics?limit=3&cursor={cursor2}")).await;
+        assert_eq!(status, StatusCode::OK);
+        let page3: DiagnosticTimelineResponse =
+            serde_json::from_slice(&body).expect("third page JSON");
+        assert_eq!(page3.records.len(), 1);
+        assert!(
+            !page3.truncated,
+            "the last page must not claim further truncation"
+        );
+        assert!(page3.next_cursor.is_none());
+
+        let mut all_messages: Vec<_> = page1
+            .records
+            .iter()
+            .chain(&page2.records)
+            .chain(&page3.records)
+            .map(|record| record.message.clone())
+            .collect();
+        all_messages.sort();
+        all_messages.dedup();
+        assert_eq!(
+            all_messages.len(),
+            7,
+            "pagination must visit every row once"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_malformed_cursor() {
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore::default());
+        let router = diagnostics_router(Some(store), Duration::from_secs(5));
+        let (status, _) = get(router, "/v1/diagnostics?cursor=not-a-cursor").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn a_query_that_exceeds_its_deadline_is_reported_as_unavailable() {
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore {
+                rows: vec![fixture_event(1, 1)],
+                query_delay: Some(Duration::from_millis(200)),
+            });
+        let router = diagnostics_router(Some(store), Duration::from_millis(20));
+        let (status, _) = get(router, "/v1/diagnostics").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn cursor_pagination_is_stable_across_rows_sharing_one_timestamp() {
+        // Same millisecond timestamp for every row exercises the `id`
+        // tie-break exclusively.
+        let rows: Vec<_> = (0..5).map(|id| fixture_event(id, 1)).collect();
+        let store: std::sync::Arc<dyn DiagnosticTimelineStore> =
+            std::sync::Arc::new(FixtureStore {
+                rows,
+                query_delay: None,
+            });
+        let router = diagnostics_router(Some(store), Duration::from_secs(5));
+
+        let (status, body) = get(router.clone(), "/v1/diagnostics?limit=2").await;
+        assert_eq!(status, StatusCode::OK);
+        let page1: DiagnosticTimelineResponse = serde_json::from_slice(&body).expect("page one");
+        let cursor = page1
+            .next_cursor
+            .expect("truncated first page has a cursor");
+
+        let (status, body) =
+            get(router, &format!("/v1/diagnostics?limit=10&cursor={cursor}")).await;
+        assert_eq!(status, StatusCode::OK);
+        let page2: DiagnosticTimelineResponse = serde_json::from_slice(&body).expect("page two");
+        assert_eq!(page2.records.len(), 3, "remaining same-timestamp rows");
+
+        let mut seen: Vec<_> = page1
+            .records
+            .iter()
+            .chain(&page2.records)
+            .map(|record| record.message.clone())
+            .collect();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), 5);
+    }
+
+    #[test]
+    fn decode_rejects_a_cursor_that_was_never_encoded() {
+        assert!(DiagnosticCursor::decode("../../etc/passwd").is_err());
+    }
 }

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -99,6 +99,7 @@ pub use client::{
     direct_peer_tcp_client, loopback_tcp_client, preferred_local_client, selected_write_transport,
     shared_direct_peer_client,
 };
+pub use diagnostics_route::{DEFAULT_DIAGNOSTICS_LIMIT, MAX_DIAGNOSTICS_LIMIT};
 pub use herdr_queue_wake::{
     HERDR_MAX_CONSECUTIVE_RELEASES, HERDR_MAX_PROMPTS_PER_TICK, HERDR_POLL_INTERVAL_MS,
     HerdrQueueWakePump, HerdrQueueWakeStats,
@@ -588,30 +589,44 @@ impl HttpRuntime<Configured> {
     }
 }
 
-impl HttpRuntime<Configured> {
-    fn canonical_router(&self) -> axum::Router {
-        // The read-only auxiliary routes (`/v1/health`, `/v1/diagnostics`)
-        // are merged after `canonical_api_router`'s own `route_layer`, so
-        // without an admission layer of their own they would bypass the
-        // load-shed/concurrency bound applied to every canonical write
-        // route. Build an equivalent bound here, sized from the same
-        // configured limits, so a saturated auxiliary reader is rejected
-        // the same way a saturated canonical route is.
-        let auxiliary_admission = tower::ServiceBuilder::new()
+/// Applies the bounded admission stack used for the read-only auxiliary
+/// routes (`/v1/health`, `/v1/diagnostics`) to `router`.
+///
+/// These routes are merged into [`canonical_router`](HttpRuntime::canonical_router)
+/// after `canonical_api_router`'s own `route_layer`, so without an admission
+/// layer of their own they would bypass the load-shed/concurrency bound
+/// applied to every canonical write route (AW-READY-O7 items C12/C14). This
+/// is extracted as a standalone function, rather than inlined at the one
+/// production call site, so tests can drive the exact production layer
+/// stack to saturation instead of a stand-in approximation of it.
+fn with_auxiliary_admission(router: axum::Router, max_connections: usize) -> axum::Router {
+    // `Router::route_layer` installs a distinct service for every matching
+    // route. That would make the limit per endpoint: a saturated diagnostics
+    // query would not shed a simultaneous health request. The auxiliary
+    // surface is intentionally one bounded read lane, so wrap the completed
+    // router as the outer fallback service instead. All requests to this
+    // router traverse this one shared concurrency semaphore.
+    axum::Router::new().fallback_service(
+        tower::ServiceBuilder::new()
             .layer(axum::error_handling::HandleErrorLayer::new(
                 message_handler::overload_response,
             ))
             .layer(tower::load_shed::LoadShedLayer::new())
-            .layer(tower::limit::ConcurrencyLimitLayer::new(
-                self.config.limits.max_connections,
-            ));
-        let auxiliary_routes =
+            .layer(tower::limit::ConcurrencyLimitLayer::new(max_connections))
+            .service(router),
+    )
+}
+
+impl HttpRuntime<Configured> {
+    fn canonical_router(&self) -> axum::Router {
+        let auxiliary_routes = with_auxiliary_admission(
             health_route::health_router(self.health.clone(), self.diagnostic_counters.clone())
                 .merge(diagnostics_route::diagnostics_router(
                     self.diagnostic_timeline.clone(),
                     self.config.timeouts.request,
-                ))
-                .route_layer(auxiliary_admission);
+                )),
+            self.config.limits.max_connections,
+        );
 
         canonical_api_router(
             Arc::clone(&self.handler),
@@ -963,7 +978,8 @@ mod tests {
         AcceptedPeerStream, AuthenticatedPeerStream, CanonicalWriteHandler, DirectPeerTcpConfig,
         HttpRuntimeBuilder, HttpRuntimeConfig, LoopbackTcpConfig, NonZeroDuration,
         PeerStreamAdapter, RuntimeHealth, RuntimeLimits, RuntimeTimeouts, UnixSocketConfig,
-        UnixSocketMode, UnixSocketOwnerUid, direct_peer_tcp_client,
+        UnixSocketMode, UnixSocketOwnerUid, diagnostics_route, direct_peer_tcp_client,
+        health_route, with_auxiliary_admission,
     };
     use ulid::Ulid;
 
@@ -2910,5 +2926,147 @@ mod tests {
             .finish()
             .await
             .expect("Windows drain");
+    }
+
+    /// Test-only handler that proves the shared admission layer's semaphore
+    /// is genuinely exhausted (rather than merely trusting the layer stack
+    /// in isolation): it notifies the test the instant it is entered, then
+    /// parks on an explicit release signal instead of returning immediately.
+    /// Merged into the same outer admission service as the real
+    /// `/v1/health` and `/v1/diagnostics` routes, it lets the test hold the
+    /// auxiliary lane's one permit deterministically and observe that the
+    /// real routes are shed while it is held (AW-READY-O7 C12/C14).
+    #[derive(Default)]
+    struct AuxiliarySaturationGate {
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    async fn hold_until_released(
+        axum::extract::State(gate): axum::extract::State<Arc<AuxiliarySaturationGate>>,
+    ) -> axum::http::StatusCode {
+        gate.entered.notify_one();
+        gate.release.notified().await;
+        axum::http::StatusCode::OK
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn auxiliary_admission_layer_sheds_saturated_health_and_diagnostics_requests() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let gate = Arc::new(AuxiliarySaturationGate::default());
+        let saturating_route = axum::Router::new()
+            .route(
+                "/test/hold-one-permit",
+                axum::routing::get(hold_until_released),
+            )
+            .with_state(Arc::clone(&gate));
+
+        // Exactly one connection admitted at a time, so a single held
+        // request exhausts the auxiliary admission layer's capacity.
+        let router = with_auxiliary_admission(
+            health_route::health_router(RuntimeHealth::default(), None)
+                .merge(diagnostics_route::diagnostics_router(
+                    None,
+                    Duration::from_secs(1),
+                ))
+                .merge(saturating_route),
+            1,
+        );
+
+        let holder_router = router.clone();
+        let holder = tokio::spawn(async move {
+            holder_router
+                .oneshot(
+                    Request::get("/test/hold-one-permit")
+                        .body(Body::empty())
+                        .expect("saturating request"),
+                )
+                .await
+                .expect("saturating response")
+        });
+
+        // Deterministic: wait for the saturating handler to actually be
+        // entered (not merely scheduled) before asserting shed behavior.
+        gate.entered.notified().await;
+
+        let shed_health = router
+            .clone()
+            .oneshot(
+                Request::get("/v1/health")
+                    .body(Body::empty())
+                    .expect("health request"),
+            )
+            .await
+            .expect("shed health response");
+        assert_eq!(
+            shed_health.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the real /v1/health route must share the saturated admission layer, not bypass it"
+        );
+        let body = shed_health
+            .into_body()
+            .collect()
+            .await
+            .expect("shed health body")
+            .to_bytes();
+        let error: AtmError =
+            serde_json::from_slice(&body).expect("ADR-032 overload JSON for /v1/health");
+        assert_eq!(
+            error.code(),
+            atm_core::error::AtmErrorCode::DaemonConnectionSaturated
+        );
+
+        let shed_diagnostics = router
+            .clone()
+            .oneshot(
+                Request::get("/v1/diagnostics")
+                    .body(Body::empty())
+                    .expect("diagnostics request"),
+            )
+            .await
+            .expect("shed diagnostics response");
+        assert_eq!(
+            shed_diagnostics.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the real /v1/diagnostics route must share the saturated admission layer, not bypass it"
+        );
+        let body = shed_diagnostics
+            .into_body()
+            .collect()
+            .await
+            .expect("shed diagnostics body")
+            .to_bytes();
+        let error: AtmError =
+            serde_json::from_slice(&body).expect("ADR-032 overload JSON for /v1/diagnostics");
+        assert_eq!(
+            error.code(),
+            atm_core::error::AtmErrorCode::DaemonConnectionSaturated
+        );
+
+        // Release the held permit and confirm both auxiliary routes recover.
+        gate.release.notify_one();
+        assert_eq!(
+            holder.await.expect("holder task joins").status(),
+            StatusCode::OK
+        );
+
+        let recovered_health = router
+            .clone()
+            .oneshot(
+                Request::get("/v1/health")
+                    .body(Body::empty())
+                    .expect("recovered health request"),
+            )
+            .await
+            .expect("recovered health response");
+        assert_eq!(recovered_health.status(), StatusCode::OK);
+        // The response body carries the admission permit until the response
+        // is released; drop it before issuing the next request so this test
+        // measures recovery after a completed health exchange.
+        drop(recovered_health);
     }
 }

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -95,8 +95,8 @@ pub use bare_cli_fifo::{
 #[cfg(unix)]
 pub use client::unix_socket_client;
 pub use client::{
-    DIRECT_PEER_TCP_PORT, SAME_HOST_REQUEST_DEADLINE, direct_peer_port, direct_peer_tcp_client,
-    loopback_tcp_client, loopback_tcp_get_json, preferred_local_client, selected_write_transport,
+    DIRECT_PEER_TCP_PORT, SAME_HOST_REQUEST_DEADLINE, diagnostics_query, direct_peer_port,
+    direct_peer_tcp_client, loopback_tcp_client, preferred_local_client, selected_write_transport,
     shared_direct_peer_client,
 };
 pub use herdr_queue_wake::{
@@ -590,19 +590,36 @@ impl HttpRuntime<Configured> {
 
 impl HttpRuntime<Configured> {
     fn canonical_router(&self) -> axum::Router {
+        // The read-only auxiliary routes (`/v1/health`, `/v1/diagnostics`)
+        // are merged after `canonical_api_router`'s own `route_layer`, so
+        // without an admission layer of their own they would bypass the
+        // load-shed/concurrency bound applied to every canonical write
+        // route. Build an equivalent bound here, sized from the same
+        // configured limits, so a saturated auxiliary reader is rejected
+        // the same way a saturated canonical route is.
+        let auxiliary_admission = tower::ServiceBuilder::new()
+            .layer(axum::error_handling::HandleErrorLayer::new(
+                message_handler::overload_response,
+            ))
+            .layer(tower::load_shed::LoadShedLayer::new())
+            .layer(tower::limit::ConcurrencyLimitLayer::new(
+                self.config.limits.max_connections,
+            ));
+        let auxiliary_routes =
+            health_route::health_router(self.health.clone(), self.diagnostic_counters.clone())
+                .merge(diagnostics_route::diagnostics_router(
+                    self.diagnostic_timeline.clone(),
+                    self.config.timeouts.request,
+                ))
+                .route_layer(auxiliary_admission);
+
         canonical_api_router(
             Arc::clone(&self.handler),
             AuthenticatedConnector::local(),
             self.config.limits,
             self.config.timeouts,
         )
-        .merge(health_route::health_router(
-            self.health.clone(),
-            self.diagnostic_counters.clone(),
-        ))
-        .merge(diagnostics_route::diagnostics_router(
-            self.diagnostic_timeline.clone(),
-        ))
+        .merge(auxiliary_routes)
     }
 }
 

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -627,7 +627,11 @@ fn request_id_from_headers(headers: &HeaderMap) -> Option<RequestId> {
         .and_then(|value| RequestId::new(value).ok())
 }
 
-async fn overload_response(_: BoxError) -> Response {
+/// Shared overload handler for every bounded admission layer (canonical
+/// write routes and the read-only auxiliary routes alike), so a saturated
+/// in-flight capacity always reports the same error shape regardless of
+/// which router rejected the request.
+pub(crate) async fn overload_response(_: BoxError) -> Response {
     warn!("HTTP message ingress rejected because its in-flight capacity is saturated");
     error_response(AtmError::daemon_connection_saturated(
         "HTTP message ingress is at its configured in-flight capacity",

--- a/crates/atm-runtime/src/lib.rs
+++ b/crates/atm-runtime/src/lib.rs
@@ -12,7 +12,8 @@ pub mod mailbox_runtime;
 pub mod workflow_telemetry;
 
 pub use atm_storage::{
-    DiagnosticEvent, DiagnosticQuery, DiagnosticTimelineStore, StorageFactory, StorageHandles,
+    DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticCursor, DiagnosticEvent,
+    DiagnosticQuery, DiagnosticTimelineStore, StorageFactory, StorageHandles,
 };
 pub use composition::{
     RuntimeAssembly, RuntimeAssemblyInputs, assemble_runtime, validate_enabled_peer_configuration,

--- a/crates/atm-storage-rusqlite/src/diagnostic_timeline.rs
+++ b/crates/atm-storage-rusqlite/src/diagnostic_timeline.rs
@@ -9,7 +9,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use atm_storage::{
-    AtmError, DiagnosticEvent, DiagnosticQuery, DiagnosticRecordError, DiagnosticTimelineStore,
+    AtmError, DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticEvent,
+    DiagnosticQuery, DiagnosticRecordError, DiagnosticTimelineStore,
 };
 use rusqlite::params;
 
@@ -84,8 +85,32 @@ impl DiagnosticTimelineStore for SqliteDiagnosticTimeline {
 
     fn query(&self, query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError> {
         self.db.with_connection(|connection| {
-            let limit = query.limit.unwrap_or(100).min(1_000) as i64;
-            let mut statement = connection.prepare("SELECT ts_unix_ms, level, component, code, correlation_id, origin, message, detail FROM diagnostic_events WHERE (?1 IS NULL OR ts_unix_ms >= ?1) AND (?2 IS NULL OR ts_unix_ms <= ?2) AND (?3 IS NULL OR level >= ?3) AND (?4 IS NULL OR component LIKE (?4 || '%')) ORDER BY ts_unix_ms DESC LIMIT ?5").map_err(|error| AtmError::mailbox_read(error.to_string()))?;
+            // The route layer requests up to `DIAGNOSTIC_QUERY_MAX_LIMIT + 1`
+            // rows (one extra "peek" row) to detect truncation without a
+            // second query; clamp the ceiling here to match so a caller can
+            // never bypass the shared cap by asking for more directly.
+            let limit = query
+                .limit
+                .unwrap_or(DIAGNOSTIC_QUERY_DEFAULT_LIMIT)
+                .min(DIAGNOSTIC_QUERY_MAX_LIMIT + 1) as i64;
+            let (cursor_ts, cursor_id) = query
+                .cursor
+                .map(|cursor| (Some(cursor.ts_unix_ms), Some(cursor.id)))
+                .unwrap_or((None, None));
+            let mut statement = connection
+                .prepare(
+                    "SELECT id, ts_unix_ms, level, component, code, correlation_id, origin, \
+                     message, detail FROM diagnostic_events \
+                     WHERE (?1 IS NULL OR ts_unix_ms >= ?1) \
+                     AND (?2 IS NULL OR ts_unix_ms <= ?2) \
+                     AND (?3 IS NULL OR CASE lower(level) \
+                         WHEN 'trace' THEN 0 WHEN 'debug' THEN 1 WHEN 'info' THEN 2 \
+                         WHEN 'warn' THEN 3 WHEN 'error' THEN 4 ELSE -1 END >= ?3) \
+                     AND (?4 IS NULL OR component LIKE (?4 || '%') ESCAPE '\\') \
+                     AND (?5 IS NULL OR ts_unix_ms < ?5 OR (ts_unix_ms = ?5 AND id < ?6)) \
+                     ORDER BY ts_unix_ms DESC, id DESC LIMIT ?7",
+                )
+                .map_err(|error| AtmError::mailbox_read(error.to_string()))?;
             statement
                 .query_map(
                     params![
@@ -93,18 +118,21 @@ impl DiagnosticTimelineStore for SqliteDiagnosticTimeline {
                         query.until,
                         query.level_at_least,
                         query.component_prefix,
+                        cursor_ts,
+                        cursor_id,
                         limit
                     ],
                     |row| {
                         Ok(DiagnosticEvent {
-                            ts_unix_ms: row.get(0)?,
-                            level: row.get(1)?,
-                            component: row.get(2)?,
-                            code: row.get(3)?,
-                            correlation_id: row.get(4)?,
-                            origin: row.get(5)?,
-                            message: row.get(6)?,
-                            detail: row.get(7)?,
+                            id: row.get(0)?,
+                            ts_unix_ms: row.get(1)?,
+                            level: row.get(2)?,
+                            component: row.get(3)?,
+                            code: row.get(4)?,
+                            correlation_id: row.get(5)?,
+                            origin: row.get(6)?,
+                            message: row.get(7)?,
+                            detail: row.get(8)?,
                         })
                     },
                 )
@@ -166,6 +194,7 @@ mod tests {
                 origin: "tracing".to_owned(),
                 message: "bounded diagnostic".to_owned(),
                 detail: None,
+                id: 0,
             }])
             .expect("non-blocking diagnostic offer");
         // The diagnostic writer lane is a single FIFO channel: `prune()`
@@ -221,5 +250,98 @@ mod tests {
 
         assert_eq!(deleted, (FIXTURE_ROWS - DIAGNOSTIC_MAX_ROWS) as u64);
         assert_eq!(retained, DIAGNOSTIC_MAX_ROWS as i64);
+    }
+
+    #[test]
+    fn query_clamps_a_requested_limit_above_the_shared_max_plus_peek_row() {
+        let directory = tempdir().expect("temporary database directory");
+        let timeline = SqliteDiagnosticTimeline::open(directory.path().join("mail.db"))
+            .expect("timeline opens and migrates");
+        timeline
+            .db
+            .with_connection(|connection| {
+                for index in 0..10 {
+                    connection
+                        .execute(
+                            "INSERT INTO diagnostic_events (ts_unix_ms, level, component, origin, message) VALUES (?1, 'info', 'fixture', 'test', 'fixture')",
+                            params![index as i64],
+                        )
+                        .map_err(|error| AtmError::mailbox_write(error.to_string()))?;
+                }
+                Ok(())
+            })
+            .expect("seed diagnostic fixture");
+
+        let rows = timeline
+            .query(&DiagnosticQuery {
+                limit: Some(50_000),
+                ..DiagnosticQuery::default()
+            })
+            .expect("query with an out-of-range limit");
+        assert_eq!(rows.len(), 10, "clamp must never drop in-range rows");
+    }
+
+    #[test]
+    fn cursor_pagination_visits_every_row_exactly_once_in_stable_order() {
+        use atm_storage::DiagnosticCursor;
+
+        const FIXTURE_ROWS: i64 = 25;
+        const PAGE_SIZE: usize = 4;
+        let directory = tempdir().expect("temporary database directory");
+        let timeline = SqliteDiagnosticTimeline::open(directory.path().join("mail.db"))
+            .expect("timeline opens and migrates");
+        timeline
+            .db
+            .with_connection(|connection| {
+                for index in 0..FIXTURE_ROWS {
+                    // Two rows deliberately share one timestamp to exercise
+                    // the `(ts_unix_ms, id)` tie-break.
+                    let ts = index / 2;
+                    connection
+                        .execute(
+                            "INSERT INTO diagnostic_events (ts_unix_ms, level, component, origin, message) VALUES (?1, 'info', 'fixture', 'test', 'fixture')",
+                            params![ts],
+                        )
+                        .map_err(|error| AtmError::mailbox_write(error.to_string()))?;
+                }
+                Ok(())
+            })
+            .expect("seed diagnostic fixture");
+
+        let mut seen_ids = Vec::new();
+        let mut cursor: Option<DiagnosticCursor> = None;
+        loop {
+            let rows = timeline
+                .query(&DiagnosticQuery {
+                    limit: Some(PAGE_SIZE),
+                    cursor,
+                    ..DiagnosticQuery::default()
+                })
+                .expect("paginated query");
+            if rows.is_empty() {
+                break;
+            }
+            assert!(
+                rows.len() <= PAGE_SIZE,
+                "a page must never exceed its requested size"
+            );
+            seen_ids.extend(rows.iter().map(|row| row.id));
+            let last = rows.last().expect("non-empty page has a last row");
+            cursor = Some(DiagnosticCursor {
+                ts_unix_ms: last.ts_unix_ms,
+                id: last.id,
+            });
+            if rows.len() < PAGE_SIZE {
+                break;
+            }
+        }
+
+        seen_ids.sort_unstable();
+        seen_ids.dedup();
+        assert_eq!(
+            seen_ids.len(),
+            FIXTURE_ROWS as usize,
+            "keyset pagination must visit every row exactly once, including same-timestamp ties"
+        );
     }
 }

--- a/crates/atm-storage-rusqlite/src/writer/mod.rs
+++ b/crates/atm-storage-rusqlite/src/writer/mod.rs
@@ -1011,6 +1011,7 @@ mod tests {
                     origin: "tracing".to_owned(),
                     message: "diagnostic".to_owned(),
                     detail: None,
+                    id: 0,
                 }]))
                 .expect("diagnostic queue capacity is exactly eight batches");
         }
@@ -1063,6 +1064,7 @@ mod tests {
                     origin: "tracing".to_owned(),
                     message: "diagnostic".to_owned(),
                     detail: None,
+                    id: 0,
                 }]))
                 .expect("fill the real bounded diagnostic channel");
         }
@@ -1131,6 +1133,7 @@ mod tests {
             origin: "tracing".to_owned(),
             message: "bridged diagnostic".to_owned(),
             detail: None,
+            id: 0,
         };
         diagnostic_sender
             .try_send(DiagnosticWriterMessage::Records(vec![bridged.clone()]))

--- a/crates/atm-storage/src/diagnostics.rs
+++ b/crates/atm-storage/src/diagnostics.rs
@@ -4,6 +4,14 @@ use std::fmt;
 
 use crate::AtmError;
 
+/// Shared upper bound on `/v1/diagnostics` page size, enforced identically by
+/// every layer (HTTP route admission, storage query clamp, and CLI request
+/// construction) so no layer can silently disagree about the effective cap.
+pub const DIAGNOSTIC_QUERY_MAX_LIMIT: usize = 1_000;
+
+/// Default page size used when a caller omits an explicit limit.
+pub const DIAGNOSTIC_QUERY_DEFAULT_LIMIT: usize = 100;
+
 /// One already-redacted diagnostic retained by the optional SQLite timeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnosticEvent {
@@ -16,6 +24,50 @@ pub struct DiagnosticEvent {
     pub message: String,
     /// Compact JSON containing only the tracing bridge's allowlisted fields.
     pub detail: Option<String>,
+    /// The row's SQLite `rowid`. Callers constructing an event prior to
+    /// persistence (the tracing bridge -> writer path) always set this to
+    /// `0`; the storage query path is the sole source of a real value, used
+    /// only to build a stable opaque pagination cursor. It is never part of
+    /// the batch insert statement.
+    pub id: i64,
+}
+
+/// An opaque, stable keyset-pagination position over `(ts_unix_ms, id)`.
+///
+/// `id` is the SQLite `rowid` of `diagnostic_events`, which is monotonically
+/// increasing with insertion order. Pairing it with `ts_unix_ms` in the
+/// cursor keeps pagination stable even when many rows share one millisecond
+/// timestamp, which a purely time-based cursor cannot guarantee.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiagnosticCursor {
+    pub ts_unix_ms: i64,
+    pub id: i64,
+}
+
+impl DiagnosticCursor {
+    /// Encodes this position as an opaque, URL-safe token.
+    #[must_use]
+    pub fn encode(self) -> String {
+        let raw = format!("{}:{}", self.ts_unix_ms, self.id);
+        base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, raw)
+    }
+
+    /// Decodes a previously-issued cursor token.
+    ///
+    /// # Errors
+    /// Returns [`AtmError::config`] when `token` is not a value this module
+    /// previously produced.
+    pub fn decode(token: &str) -> Result<Self, AtmError> {
+        let invalid = || AtmError::config("diagnostic timeline cursor is invalid");
+        let raw = base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, token)
+            .map_err(|_| invalid())?;
+        let raw = String::from_utf8(raw).map_err(|_| invalid())?;
+        let (ts_unix_ms, id) = raw.split_once(':').ok_or_else(invalid)?;
+        Ok(Self {
+            ts_unix_ms: ts_unix_ms.parse().map_err(|_| invalid())?,
+            id: id.parse().map_err(|_| invalid())?,
+        })
+    }
 }
 
 /// A bounded query over the diagnostic timeline.
@@ -26,6 +78,10 @@ pub struct DiagnosticQuery {
     pub level_at_least: Option<String>,
     pub component_prefix: Option<String>,
     pub limit: Option<usize>,
+    /// When present, restricts results to rows strictly older (in the
+    /// `ts_unix_ms DESC, id DESC` result order) than this cursor position,
+    /// continuing a previous bounded page.
+    pub cursor: Option<DiagnosticCursor>,
 }
 
 /// Why a diagnostic batch offer was not durably recorded.
@@ -79,4 +135,25 @@ pub trait DiagnosticTimelineStore: Send + Sync {
     fn record_batch(&self, events: &[DiagnosticEvent]) -> Result<(), DiagnosticRecordError>;
     fn query(&self, query: &DiagnosticQuery) -> Result<Vec<DiagnosticEvent>, AtmError>;
     fn prune(&self, now_unix_ms: i64) -> Result<u64, AtmError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiagnosticCursor;
+
+    #[test]
+    fn cursor_round_trips_through_its_opaque_encoding() {
+        let cursor = DiagnosticCursor {
+            ts_unix_ms: 1_700_000_000_123,
+            id: 42,
+        };
+        let decoded = DiagnosticCursor::decode(&cursor.encode()).expect("decode round trip");
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn cursor_decode_rejects_garbage_tokens() {
+        assert!(DiagnosticCursor::decode("not-a-cursor").is_err());
+        assert!(DiagnosticCursor::decode("").is_err());
+    }
 }

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -44,7 +44,8 @@ pub use contract::{
     TeamNudgeTemplateOverrideRow, TrustedPeer, derive_ack_requirement,
 };
 pub use diagnostics::{
-    DiagnosticEvent, DiagnosticQuery, DiagnosticRecordError, DiagnosticTimelineStore,
+    DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticCursor, DiagnosticEvent,
+    DiagnosticQuery, DiagnosticRecordError, DiagnosticTimelineStore,
 };
 pub use error::AtmError;
 pub use error_codes::AtmErrorCode;

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -16,8 +16,16 @@ use crate::commands::caller_context::{CallerContextOverrides, resolve_cli_caller
 use crate::observability::CliObservability;
 use crate::output;
 
-// Keep retained log snapshot output bounded for interactive use.
-const DEFAULT_SNAPSHOT_LIMIT: usize = 50;
+// Keep retained log snapshot output bounded for interactive use. Sourced
+// from the same canonical default the `/v1/diagnostics` route falls back to
+// (AW-READY-O7 item 2) so the CLI and the HTTP route can never silently
+// disagree about the effective default page size.
+const DEFAULT_SNAPSHOT_LIMIT: usize = atm_http_runtime::DEFAULT_DIAGNOSTICS_LIMIT;
+
+const _: () = assert!(
+    DEFAULT_SNAPSHOT_LIMIT == atm_http_runtime::DEFAULT_DIAGNOSTICS_LIMIT,
+    "atm log's default snapshot limit must track the /v1/diagnostics route's canonical default"
+);
 // Tail mode polls the shared follow surface at a human-readable cadence.
 const DEFAULT_TAIL_POLL_INTERVAL_MS: u64 = 250;
 const MERGED_LOSS_NOTE: &str =
@@ -619,7 +627,10 @@ mod tests {
                 bytes.extend_from_slice(&chunk[..count]);
             }
             let request = String::from_utf8(bytes).expect("UTF-8 fixture request");
-            assert!(request.starts_with("GET /v1/diagnostics?limit=50 HTTP/1.1\r\n"));
+            assert!(request.starts_with(&format!(
+                "GET /v1/diagnostics?limit={} HTTP/1.1\r\n",
+                atm_http_runtime::DEFAULT_DIAGNOSTICS_LIMIT
+            )));
             assert!(request.to_ascii_lowercase().contains(
                 &format!("x-atm-local-capability: {}", expected_capability).to_ascii_lowercase()
             ));

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -7,7 +7,7 @@ use atm_core::observability::{
     AtmJsonNumber, AtmLogQuery, LogFieldKey, LogFieldMatch, LogFieldValue, LogLevelFilter, LogMode,
     LogOrder, ObservabilityPort,
 };
-use atm_core::observability_counters::{DiagnosticTimelineRecord, DiagnosticTimelineResponse};
+use atm_core::observability_counters::DiagnosticTimelineRecord;
 use atm_core::types::IsoTimestamp;
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
@@ -205,27 +205,29 @@ impl QueryArgs {
     }
 
     async fn timeline_records_from_endpoint(&self, endpoint: &Path) -> Result<Vec<TimelineRecord>> {
-        let mut query = vec![format!(
-            "limit={}",
-            self.limit.unwrap_or(DEFAULT_SNAPSHOT_LIMIT).min(5_000)
-        )];
-        if let Some(since) = self.since.as_deref() {
-            query.push(format!("since={}", parse_since_millis(since)?));
-        }
-        if let Some(until) = self.until.as_deref() {
-            query.push(format!("until={}", parse_since_millis(until)?));
-        }
-        if let Some(component) = self.component.as_deref() {
-            query.push(format!("component={}", percent_encode(component)));
-        }
-        let body = atm_http_runtime::loopback_tcp_get_json(
+        let since_unix_ms = self.since.as_deref().map(parse_since_millis).transpose()?;
+        let until_unix_ms = self.until.as_deref().map(parse_since_millis).transpose()?;
+        let limit = self
+            .limit
+            .unwrap_or(DEFAULT_SNAPSHOT_LIMIT)
+            .min(atm_core::observability_counters::DIAGNOSTIC_QUERY_MAX_LIMIT);
+        let response = atm_http_runtime::diagnostics_query(
             endpoint,
-            format!("/v1/diagnostics?{}", query.join("&")),
+            atm_core::observability_counters::DiagnosticTimelineQuery {
+                since_unix_ms,
+                until_unix_ms,
+                // The server-side `level_at_least` filter is a lexicographic
+                // string comparison and is not level-order-correct (tracked
+                // separately); the CLI deliberately fetches unfiltered and
+                // applies level filtering client-side below instead.
+                level_at_least: None,
+                component_prefix: self.component.clone(),
+                limit: Some(limit),
+                cursor: None,
+            },
             Duration::from_secs(10),
         )
         .await?;
-        let response: DiagnosticTimelineResponse = serde_json::from_slice(&body)
-            .context("daemon returned an invalid diagnostic timeline response")?;
         Ok(response
             .records
             .into_iter()
@@ -423,17 +425,6 @@ fn level_name(level: CliLogLevel) -> &'static str {
         CliLogLevel::Warn => "warn",
         CliLogLevel::Error => "error",
     }
-}
-
-fn percent_encode(raw: &str) -> String {
-    raw.bytes()
-        .flat_map(|byte| match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
-                vec![char::from(byte)]
-            }
-            _ => format!("%{byte:02X}").chars().collect(),
-        })
-        .collect()
 }
 
 #[derive(Debug, Args)]
@@ -861,6 +852,8 @@ mod tests {
                 message: "timeline fixture".to_owned(),
                 detail: None,
             }],
+            truncated: false,
+            next_cursor: None,
         })
         .await;
         let args = QueryArgs {


### PR DESCRIPTION
## Summary

Fixes three phase-aw readiness findings, all scoped to `atm-http-runtime` /
`atm-core` / `atm-storage` (Tokio+Axum stack) — no legacy synchronous daemon
code touched.

### Finding 5 (arch-ctm) / AW-READY-M6 — `/v1/diagnostics` cap drift, no pagination, no deadline
- Introduced a single shared constant, `DIAGNOSTIC_QUERY_MAX_LIMIT` (=1000),
  defined once in `atm-storage` and re-exported through `atm-runtime` and
  `atm-core::observability_counters`. The route, the sqlite storage clamp,
  and the CLI (`atm log`) all now enforce the same cap — previously the
  route advertised up to 5000 while storage silently clamped to 1000.
- Added opaque cursor-based (keyset) pagination over `(ts_unix_ms, id)`,
  stable across same-millisecond ties. `DiagnosticCursor` encodes/decodes a
  base64 URL-safe-no-pad token; malformed cursors return 400.
- Added an additive `truncated: bool` + `next_cursor: Option<String>` to the
  response (`#[serde(default)]`, so existing clients are unaffected).
- Wrapped the storage query in `tokio::time::timeout(request_timeout, ...)`
  so a slow/blocked query now fails closed with 503 instead of hanging
  indefinitely.

### C13 / AW-READY-O7 — auxiliary routes bypass the admission layer
`/v1/health` and `/v1/diagnostics` previously bypassed the load-shed +
concurrency-limit layer applied to canonical write routes. Built a second,
independently-sized admission stack (same `HandleErrorLayer` +
`LoadShedLayer` + `ConcurrencyLimitLayer` composition, reusing the existing
`overload_response` handler) and applied it via `route_layer` to the merged
health+diagnostics router before merging into the canonical router. The
canonical write-route admission stack itself was left untouched to avoid any
hot-path risk.

### C11 / AW-READY-O7 — untyped `loopback_tcp_get_json` escape hatch
Narrowed `loopback_tcp_get_json` to `pub(crate)` and added a typed
`diagnostics_query(...)` client method as the one public, testable entry
point for the diagnostics endpoint. Migrated the CLI's only consumer
(`atm log`'s `timeline_records_from_endpoint`) onto the typed client and
removed its duplicated `percent_encode` helper. Also fixed a latent bug this
surfaced: the CLI's requested limit was hardcoded to `.min(5_000)`, which
would now be rejected as a 400 against the tightened 1000-row server cap —
it now clamps to the same shared `DIAGNOSTIC_QUERY_MAX_LIMIT`.

### Explicitly out of scope
- **AW-READY-M7** (storage-layer `level_at_least` lexicographic
  level-ordering bug) is owned by a separate branch (cipher) and is **not**
  touched here. The new route-level fixture tests for pagination/truncation
  ignore `level_at_least` entirely (`FixtureStore` does not implement
  rank-based filtering) — this is a deliberate stub-around, not an oversight.
- Prune fixes, free-text/identity persistence fixes: owned by other branches,
  not touched.

## Test plan
- `cargo fmt --all` — clean, no diffs after commit.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, zero
  warnings, both pre- and post-merge of `origin/integrate/phase-aw`.
- `cargo test` across `atm-storage`, `atm-storage-rusqlite`, `atm-runtime`,
  `agent-team-mail-core`, `atm-daemon-bootstrap`, `atm-http-runtime`,
  `agent-team-mail` — all green (0 failures), including new tests:
  - `atm-storage`: `cursor_round_trips_through_its_opaque_encoding`,
    `cursor_decode_rejects_garbage_tokens`
  - `atm-storage-rusqlite`: `query_clamps_a_requested_limit_above_the_shared_max_plus_peek_row`,
    `cursor_pagination_visits_every_row_exactly_once_in_stable_order`
  - `atm-http-runtime` (`diagnostics_route`): `rejects_a_limit_above_the_shared_max_cap`,
    `accepts_a_limit_exactly_at_the_shared_max_cap`,
    `truncated_flag_and_cursor_page_through_every_row_once`,
    `rejects_a_malformed_cursor`,
    `a_query_that_exceeds_its_deadline_is_reported_as_unavailable`,
    `cursor_pagination_is_stable_across_rows_sharing_one_timestamp`,
    `decode_rejects_a_cursor_that_was_never_encoded`
- `just validate` was attempted but is unavailable in this worktree (its
  `.bootstrap-venv` isn't provisioned here) — skipped per the "if available"
  instruction, not a failure.
- Merged `origin/integrate/phase-aw` (bringing in the canonical
  `AW-READY-*` triage records) with no conflicts; re-ran clippy and the full
  affected-crate test suite post-merge, both still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK