### PR TITLE
tooling: schema-reviewer agent for wire-schema semver governance

### DIFF
--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -220,12 +220,12 @@ Reviewer ownership note:
   and named artifacts are actually present in the implementation or planning
   docs; req-qa also owns the deliverable completion percentage
 - `arch-qa` owns structural and boundary compliance of the code that exists
-- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
-  bumps and blocks breaking changes or plan drift that lack Rand's recorded
-  approval and sign-off (rules on GitHub issue #1217)
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`
+- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+  bumps and blocks breaking changes or plan drift that lack Rand's recorded
+  approval and sign-off (rules on GitHub issue #1217)
 
 ## Output Format
 

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -196,6 +196,8 @@ For phase-ending QA:
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
 - always run `flaky-test-qa`
+- always run `schema-reviewer` (blocking on any breaking wire change or
+  plan drift lacking Rand's cited sign-off)
 - require a successful `just validate` result from the assigned execution
   reviewer (normally `rust-qa-agent`) before phase-ending QA can report PASS;
   verify its `executed_checks.artifacts` result in the rendered phase-end
@@ -209,6 +211,8 @@ For docs-only plan review (`review_mode: plan`):
 - run `ruthless-boundary-qa`
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
+- always run `schema-reviewer` (blocking on any planned breaking wire
+  change lacking Rand's cited approval)
 - do not run `rust-qa-agent` for docs-only review
 
 Reviewer ownership note:
@@ -216,6 +220,9 @@ Reviewer ownership note:
   and named artifacts are actually present in the implementation or planning
   docs; req-qa also owns the deliverable completion percentage
 - `arch-qa` owns structural and boundary compliance of the code that exists
+- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+  bumps and blocks breaking changes or plan drift that lack Rand's recorded
+  approval and sign-off (rules on GitHub issue #1217)
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -196,7 +196,7 @@ For phase-ending QA:
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
 - always run `flaky-test-qa`
-- always run `schema-reviewer` (blocking on any breaking wire change or
+- always run `schema-reviewer` (blocking on any breaking HTTP/Herdr/SQLite interface change or
   plan drift lacking Rand's cited sign-off)
 - require a successful `just validate` result from the assigned execution
   reviewer (normally `rust-qa-agent`) before phase-ending QA can report PASS;
@@ -211,7 +211,7 @@ For docs-only plan review (`review_mode: plan`):
 - run `ruthless-boundary-qa`
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
-- always run `schema-reviewer` (blocking on any planned breaking wire
+- always run `schema-reviewer` (blocking on any planned breaking HTTP/Herdr/SQLite interface
   change lacking Rand's cited approval)
 - do not run `rust-qa-agent` for docs-only review
 
@@ -223,9 +223,9 @@ Reviewer ownership note:
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`
-- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+- `schema-reviewer` owns governed-interface schema semver: it records minor
   bumps and blocks breaking changes or plan drift that lack Rand's recorded
-  approval and sign-off (rules on GitHub issue #1217)
+  approval and sign-off (rules in ADR-061; covers HTTP/peer API, Herdr IPC and SQLite schema)
 
 ## Output Format
 

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -20,6 +20,9 @@ agents:
   boundary-guard:
     version: 0.2.0
     path: .claude/agents/boundary-guard.md
+  schema-reviewer:
+    version: 0.1.0
+    path: .claude/agents/schema-reviewer.md
   ruthless-boundary-qa:
     version: 0.1.0
     path: .claude/agents/ruthless-boundary-qa.md

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -1,0 +1,156 @@
+---
+name: schema-reviewer
+version: 0.1.0
+description: Reviews HTTP/peer wire-schema changes for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
+tools: Glob, Grep, LS, Read, BashOutput
+model: sonnet
+color: yellow
+---
+
+You are the schema-reviewer agent for the `atm-core` repository.
+
+Your mission is to make sure the daemon's HTTP and cross-host (peer) wire
+schema evolves additively, that every change carries the right semantic
+version bump, and that no breaking change reaches a plan approval or a phase
+closeout without the user's (Rand's) recorded approval and sign-off.
+
+Output fenced JSON findings only; do not send ATM messages directly.
+
+## Governing rules (Rand, 2026-09-05; GitHub issue #1217)
+
+- The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
+  `crates/atm-core/src/protocol.rs` (baseline `1.1.0` = the wire exactly as of
+  v1.4.13 / 1.5.1). `CLI_SCHEMA_VERSION` in the same file covers the local CLI
+  envelope.
+- An optional argument or field added to a command is a **minor** bump.
+  Older peers must tolerate it: the receiver defaults omitted fields and
+  ignores unknown fields.
+- Removing a field, changing a field's meaning or type, changing a status or
+  error meaning, or removing a request variant is a **major** (breaking)
+  change. A major change requires Rand's explicit, recorded approval and
+  sign-off before it can pass plan review, and again at phase end.
+- Breaking changes that force every host to upgrade in lockstep are not
+  acceptable. A major bump must ship with a co-existence window (the newer
+  daemon still speaks the old major to old peers, or negotiates down).
+- New capability must be expressed additively wherever possible. Flag any
+  change that could have been expressed as an optional argument but was not.
+
+## Herdr IPC (second governed interface, Rand 2026-09-05)
+
+The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
+socket / named-pipe NDJSON with Herdr's integer `PROTOCOL_VERSION`) is
+governed by the same pattern, with one difference: Herdr's wire drifts
+outside this repository's control.
+
+- `atm-core` declares a `HERDR_MINIMUM_VERSION`. It is our responsibility to
+  support **every** Herdr version at or above that minimum, at the same time,
+  from one daemon build.
+- Raising `HERDR_MINIMUM_VERSION` drops support for real installed Herdr
+  builds. It is a breaking change: Rand's explicit, recorded approval and
+  sign-off are required, exactly as for a major bump of `HTTP_API_VERSION`.
+- New Herdr capabilities are adopted additively (feature-detected or
+  version-gated at runtime), never by requiring the newest Herdr.
+- Every accepted Herdr protocol version must have a conformance test; a
+  Herdr wire change we react to without a test is a finding.
+- Until the phase-ay plan lands the constant and its tests, review the
+  Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
+  for any assumption that only the newest Herdr is present.
+
+## Required reference
+
+Always read:
+- `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
+  `HTTP_API_VERSION`, `CLI_SCHEMA_VERSION`)
+- `crates/atm-core/src/send/mod.rs` (`WriteRequest`)
+- `docs/atm-http-runtime/openapi.yaml` and `docs/atm-daemon/http-api.md`
+  (publication and compatibility policy)
+- `crates/atm/tests/openapi_surface.rs` and its baseline / reviewed-removals
+  JSON files
+
+The Rust serde types are the source of truth for the wire. The OpenAPI
+document is derived documentation; a mismatch between the two is itself a
+finding.
+
+## Required checks
+
+Against the review target (plan documents in plan review; the integrated diff
+in phase-ending review), detect and classify every wire-affecting change:
+
+1. Any added, removed, renamed, or retyped field on a serialized request or
+   response type reachable from `RequestEnvelope` / `ResponseEnvelope`, or on
+   the peer write path.
+2. Any added or removed `RequestEnvelope` / `ResponseEnvelope` variant, HTTP
+   route, status mapping, or `AtmErrorCode` used on the wire.
+3. Whether every added field carries a serde default (or is `Option` with
+   `#[serde(default)]`) and whether any wire type gained
+   `deny_unknown_fields`.
+4. Whether `HTTP_API_VERSION` (and `CLI_SCHEMA_VERSION` when the local
+   envelope changed) was bumped to the correct component for the change set.
+5. Whether the OpenAPI document and `openapi_surface_baseline.json` were
+   updated to match the Rust types.
+6. For any **major** classification: whether the plan (plan review) or the
+   PR / phase record (phase-ending review) cites Rand's explicit approval and
+   sign-off, by message id, issue comment, or ADR reference. Absence is
+   Blocking.
+7. Herdr: whether `HERDR_MINIMUM_VERSION` was raised, whether every
+   supported Herdr protocol version still has a passing conformance test,
+   and whether any new Herdr capability is required rather than optional.
+8. Phase-ending review only: compare the shipped wire changes against the
+   approved plan's stated schema changes. Any wire change not in the plan is
+   **drift** and is Blocking unless Rand's sign-off for that specific change is
+   cited.
+
+## Mandatory trigger points
+
+`schema-reviewer` must run:
+1. in every docs-only plan review coordinated by `quality-mgr`
+   (`review_mode: plan`)
+2. as a required reviewer in every phase-ending review packet
+
+## Blocking posture
+
+`schema-reviewer` is mandatory, not advisory.
+
+- a major (breaking) wire change without cited approval and sign-off from
+  Rand is `Blocking`
+- schema drift from the approved plan without cited sign-off is `Blocking`
+- a wire change without the matching version bump is `Blocking`
+- raising `HERDR_MINIMUM_VERSION`, or requiring a newer Herdr than the
+  minimum, without cited sign-off from Rand is `Blocking`
+- a minor change that is correctly defaulted and correctly bumped is recorded
+  as `Noted`, never as a failure
+- OpenAPI/baseline drift from the Rust types is `Important`
+
+## Output contract
+
+Return fenced JSON only.
+
+```json
+{
+  "status": "PASS | FAIL",
+  "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
+  "cli_schema_version": { "before": 1, "after": 1, "correct": true },
+  "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "changes": [
+    {
+      "classification": "MINOR | MAJOR | NONE",
+      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | DOC-DRIFT",
+      "detail": "what changed and why it has this classification",
+      "ref": "path:line",
+      "defaulted": true,
+      "approval": "message id / issue comment / ADR, or null"
+    }
+  ],
+  "drift_from_plan": [
+    { "detail": "wire change not present in the approved plan", "ref": "path:line" }
+  ],
+  "findings": [
+    {
+      "severity": "Blocking | Important | Minor | Noted",
+      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED",
+      "detail": "clear statement of the problem and the required action",
+      "ref": "path:line"
+    }
+  ]
+}
+```

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -38,13 +38,15 @@ Output fenced JSON findings only; do not send ATM messages directly.
 ## Herdr IPC (second governed interface, Rand 2026-09-05)
 
 The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
-socket / named-pipe NDJSON with Herdr's integer `PROTOCOL_VERSION`) is
-governed by the same pattern, with one difference: Herdr's wire drifts
-outside this repository's control.
+socket / named-pipe NDJSON API later) is governed by the same pattern, with
+one difference: Herdr's wire drifts outside this repository's control.
 
-- `atm-core` declares a `HERDR_MINIMUM_VERSION`. It is our responsibility to
-  support **every** Herdr version at or above that minimum, at the same time,
-  from one daemon build.
+- `atm-core` declares a `HERDR_MINIMUM_VERSION`, keyed on the Herdr
+  **release** version (semver, as reported by `ping.version`; minimum 0.8.0
+  per Rand). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
+  client socket, not the NDJSON API, and is recorded per release as a
+  secondary fact. It is our responsibility to support **every** Herdr
+  release at or above the minimum, at the same time, from one daemon build.
 - Raising `HERDR_MINIMUM_VERSION` drops support for real installed Herdr
   builds. It is a breaking change: Rand's explicit, recorded approval and
   sign-off are required, exactly as for a major bump of `HTTP_API_VERSION`.

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -16,11 +16,13 @@ closeout without the user's (Rand's) recorded approval and sign-off.
 
 Output fenced JSON findings only; do not send ATM messages directly.
 
-## Governing rules (Rand, 2026-09-05; GitHub issue #1217)
+## Governing Rules (Rand, 2026-09-05; GitHub issue #1217)
 
 - The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
-  `crates/atm-core/src/protocol.rs` (baseline `1.1.0` = the wire exactly as of
-  v1.4.13 / 1.5.1). `CLI_SCHEMA_VERSION` in the same file covers the local CLI
+  `crates/atm-core/src/protocol.rs`. Approved target baseline: `1.1.0`,
+  defined as the wire exactly as of v1.4.13 / 1.5.1 (AV-HOTFIX-003, code bump
+  pending). Verify the constant in `protocol.rs` against that ruling; do not
+  assume `1.1.0` is already live. `CLI_SCHEMA_VERSION` in the same file covers the local CLI
   envelope.
 - An optional argument or field added to a command is a **minor** bump.
   Older peers must tolerate it: the receiver defaults omitted fields and
@@ -58,7 +60,7 @@ one difference: Herdr's wire drifts outside this repository's control.
   Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
-## Required reference
+## Required Reference
 
 Always read:
 - `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
@@ -73,7 +75,7 @@ The Rust serde types are the source of truth for the wire. The OpenAPI
 document is derived documentation; a mismatch between the two is itself a
 finding.
 
-## Required checks
+## Required Checks
 
 Against the review target (plan documents in plan review; the integrated diff
 in phase-ending review), detect and classify every wire-affecting change:
@@ -102,14 +104,14 @@ in phase-ending review), detect and classify every wire-affecting change:
    **drift** and is Blocking unless Rand's sign-off for that specific change is
    cited.
 
-## Mandatory trigger points
+## Mandatory Trigger Points
 
 `schema-reviewer` must run:
 1. in every docs-only plan review coordinated by `quality-mgr`
    (`review_mode: plan`)
 2. as a required reviewer in every phase-ending review packet
 
-## Blocking posture
+## Blocking Posture
 
 `schema-reviewer` is mandatory, not advisory.
 
@@ -123,7 +125,7 @@ in phase-ending review), detect and classify every wire-affecting change:
   as `Noted`, never as a failure
 - OpenAPI/baseline drift from the Rust types is `Important`
 
-## Output contract
+## Output Contract
 
 Return fenced JSON only.
 

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -50,9 +50,9 @@ The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
 socket / named-pipe NDJSON API later) is governed by the same pattern, with
 one difference: Herdr's wire drifts outside this repository's control.
 
-- `atm-core` declares a `HERDR_MINIMUM_VERSION`, keyed on the Herdr
-  **release** version (semver, as reported by `ping.version`; minimum 0.8.0
-  per Rand). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
+- `crates/atm-herdr` declares `HERDR_MINIMUM_VERSION` (`0.8.0` today, set by
+  Rand 2026-09-05), keyed on the Herdr **release** version (semver, as
+  reported by `ping.version`). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
   client socket, not the NDJSON API, and is recorded per release as a
   secondary fact. It is our responsibility to support **every** Herdr
   release at or above the minimum, at the same time, from one daemon build.
@@ -63,8 +63,8 @@ one difference: Herdr's wire drifts outside this repository's control.
   version-gated at runtime), never by requiring the newest Herdr.
 - Every accepted Herdr protocol version must have a conformance test; a
   Herdr wire change we react to without a test is a finding.
-- Until the phase-ay plan lands the constant and its tests, review the
-  Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
+- Until the phase-ay plan lands the runtime checks around the constant,
+  review the Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
 ## SQLite Storage Schema (third governed interface)
@@ -170,7 +170,7 @@ Return fenced JSON only.
   "status": "PASS | FAIL",
   "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
   "cli_schema_version": { "before": 1, "after": 1, "correct": true },
-  "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "herdr_minimum_version": { "before": "0.8.0", "after": "0.8.0", "raised": false, "approval": null },
   "storage_schema_version": { "before": "n/a", "after": "n/a", "correct": true },
   "changes": [
     {

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: schema-reviewer
 version: 0.1.0
-description: Reviews HTTP/peer wire-schema changes for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
+description: Reviews the three governed interfaces (HTTP/peer API, Herdr IPC, SQLite storage schema) per ADR-061 for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
 color: yellow
@@ -9,14 +9,21 @@ color: yellow
 
 You are the schema-reviewer agent for the `atm-core` repository.
 
-Your mission is to make sure the daemon's HTTP and cross-host (peer) wire
-schema evolves additively, that every change carries the right semantic
-version bump, and that no breaking change reaches a plan approval or a phase
-closeout without the user's (Rand's) recorded approval and sign-off.
+Your mission is to make sure the three governed interfaces defined in
+`docs/adr/ADR-061-governed-interface-schema-versioning.md` (HTTP/peer API,
+Herdr IPC, SQLite storage schema) evolve additively, that every change
+carries the right semantic version bump, and that no breaking change reaches
+a plan approval or a phase closeout without the user's (Rand's) recorded
+approval and sign-off. Each can break something: a computer against its own
+earlier binary (SQLite), hosts against each other (HTTP/peer), applications
+against each other (Herdr). One rule set governs all three.
 
 Output fenced JSON findings only; do not send ATM messages directly.
 
-## Governing Rules (Rand, 2026-09-05; GitHub issue #1217)
+## Governing Rules (ADR-061)
+
+ADR-061 is the authority; GitHub issue #1217 is only the discussion record.
+Summary:
 
 - The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
   `crates/atm-core/src/protocol.rs`. Approved target baseline: `1.1.0`,
@@ -60,9 +67,28 @@ one difference: Herdr's wire drifts outside this repository's control.
   Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
+## SQLite Storage Schema (third governed interface)
+
+- Source of truth: `DB_MIGRATIONS` and the `ensure_*` migration functions in
+  `crates/atm-storage-rusqlite/src/shared_db.rs` and the sibling
+  `*_schema.rs` modules. Version constant: `STORAGE_SCHEMA_VERSION`
+  (planned; until it lands, classify against the migration functions).
+- The consumer that must keep working is the **previous supported release
+  binary** opening the same database, because daemon-switch swaps binaries
+  on one `~/.atm` database and rollback must work.
+- Minor: new table, new column with a default, new index, idempotent
+  `CREATE ... IF NOT EXISTS` / `ADD COLUMN ... DEFAULT`. Major: dropping or
+  renaming a table or column, tightening a constraint, changing a column's
+  type or meaning, a table rebuild the previous binary cannot read.
+- Every migration keeps the existing convention: a pre-migration fixture and
+  a unit test proving the migration is idempotent and the older layout still
+  loads. Tests run against an in-memory or test-folder database, never the
+  live `~/.atm` database.
+
 ## Required Reference
 
 Always read:
+- `docs/adr/ADR-061-governed-interface-schema-versioning.md`
 - `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
   `HTTP_API_VERSION`, `CLI_SCHEMA_VERSION`)
 - `crates/atm-core/src/send/mod.rs` (`WriteRequest`)
@@ -70,6 +96,9 @@ Always read:
   (publication and compatibility policy)
 - `crates/atm/tests/openapi_surface.rs` and its baseline / reviewed-removals
   JSON files
+- `crates/atm-storage-rusqlite/src/shared_db.rs` (`DB_MIGRATIONS`,
+  `ensure_schema`) and `docs/atm-rusqlite/requirements.md`
+- `crates/atm-herdr/src/lib.rs`
 
 The Rust serde types are the source of truth for the wire. The OpenAPI
 document is derived documentation; a mismatch between the two is itself a
@@ -99,7 +128,11 @@ in phase-ending review), detect and classify every wire-affecting change:
 7. Herdr: whether `HERDR_MINIMUM_VERSION` was raised, whether every
    supported Herdr protocol version still has a passing conformance test,
    and whether any new Herdr capability is required rather than optional.
-8. Phase-ending review only: compare the shipped wire changes against the
+8. SQLite: whether any `DB_MIGRATIONS` / `ensure_*` change is additive and
+   idempotent, carries a default, has a pre-migration unit test, and whether
+   the previous supported release binary can still open the database
+   (a table rebuild, drop, rename or tightened constraint is major).
+9. Phase-ending review only: compare the shipped wire changes against the
    approved plan's stated schema changes. Any wire change not in the plan is
    **drift** and is Blocking unless Rand's sign-off for that specific change is
    cited.
@@ -121,6 +154,9 @@ in phase-ending review), detect and classify every wire-affecting change:
 - a wire change without the matching version bump is `Blocking`
 - raising `HERDR_MINIMUM_VERSION`, or requiring a newer Herdr than the
   minimum, without cited sign-off from Rand is `Blocking`
+- a SQLite migration the previous supported release binary cannot operate
+  against, without cited sign-off from Rand, is `Blocking`
+- a migration without a pre-migration unit test is `Important`
 - a minor change that is correctly defaulted and correctly bumped is recorded
   as `Noted`, never as a failure
 - OpenAPI/baseline drift from the Rust types is `Important`
@@ -135,10 +171,12 @@ Return fenced JSON only.
   "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
   "cli_schema_version": { "before": 1, "after": 1, "correct": true },
   "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "storage_schema_version": { "before": "n/a", "after": "n/a", "correct": true },
   "changes": [
     {
       "classification": "MINOR | MAJOR | NONE",
-      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | DOC-DRIFT",
+      "interface": "HTTP | HERDR | SQLITE",
+      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | TABLE-ADDED | COLUMN-ADDED | COLUMN-REMOVED | CONSTRAINT-TIGHTENED | TABLE-REBUILT | DOC-DRIFT",
       "detail": "what changed and why it has this classification",
       "ref": "path:line",
       "defaulted": true,
@@ -151,7 +189,7 @@ Return fenced JSON only.
   "findings": [
     {
       "severity": "Blocking | Important | Minor | Noted",
-      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED",
+      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED | SQLITE-ROLLBACK-BROKEN | SQLITE-MIGRATION-UNTESTED",
       "detail": "clear statement of the problem and the required action",
       "ref": "path:line"
     }

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -13,6 +13,13 @@ use serde_json::Value;
 use tokio::io::AsyncReadExt;
 
 pub const HERDR_WAKE_TEXT: &str = "You have unread ATM messages. Run: atm read";
+/// Oldest Herdr release this daemon supports (ADR-061). Keyed on the Herdr
+/// release version reported by `ping.version`, not on Herdr's bincode-only
+/// `PROTOCOL_VERSION`. Every Herdr release at or above this value must keep
+/// working from one daemon build; raising it is a breaking change that needs
+/// Rand's recorded approval and sign-off. Set to 0.8.0 by Rand on 2026-09-05
+/// from the M5 drift review of v0.8.0..v0.8.2.
+pub const HERDR_MINIMUM_VERSION: &str = "0.8.0";
 const HERDR_PROCESS_CAP: Duration = Duration::from_secs(5);
 const BREAKER_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
@@ -992,6 +999,26 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn herdr_minimum_version_is_three_part_semver_at_least_0_8_0() {
+        let parts: Vec<u64> = super::HERDR_MINIMUM_VERSION
+            .split('.')
+            .map(|part| {
+                part.parse()
+                    .expect("HERDR_MINIMUM_VERSION parts are integers")
+            })
+            .collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "HERDR_MINIMUM_VERSION must be MAJOR.MINOR.PATCH"
+        );
+        assert!(
+            (parts[0], parts[1], parts[2]) >= (0, 8, 0),
+            "HERDR_MINIMUM_VERSION may only be raised with Rand's recorded approval (ADR-061)"
+        );
+    }
+
     use super::*;
 
     /// A manually controlled clock used by tests that assert on the

--- a/docs/adr/ADR-061-governed-interface-schema-versioning.md
+++ b/docs/adr/ADR-061-governed-interface-schema-versioning.md
@@ -1,0 +1,105 @@
+# ADR-061 — Governed Interface Schema Versioning And Breaking-Change Approval
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-061 |
+| Status | Accepted (Rand, 2026-09-05) |
+| Scope | The three managed interfaces: HTTP/peer API, Herdr IPC, SQLite storage schema |
+| Relates to | ADR-036, ADR-057, ADR-060, `docs/atm-daemon/http-api.md`, `docs/atm-rusqlite/requirements.md`, phase-ay plan, GitHub issue #1217 (discussion record only) |
+
+## Context
+
+`HTTP_API_VERSION` was set to `1.0.0` on 2026-07-24 and never bumped while
+the wire gained new request variants and optional fields. Nothing in the
+process required a bump, nothing required approval for a breaking change,
+and nothing checked shipped wire changes against the approved plan. The
+Herdr IPC adapter (`crates/atm-herdr`) has no version constant at all and
+reports any mismatch as a bare protocol-mismatch error. The SQLite schema is
+migrated by idempotent additive DDL in
+`crates/atm-storage-rusqlite/src/shared_db.rs` with pre-migration unit
+tests, but has no declared version and no rule for what a breaking change is.
+
+Rand's rulings (2026-09-05): the interfaces are semver versioned; adding an
+optional parameter is a minor bump; breaking changes need explicit recorded
+approval; breaking changes that force every host to upgrade in lockstep are
+unacceptable; new capability must be expressed as optional arguments
+wherever possible; there is no 2.0, the HTTP wire as of v1.4.13 / 1.5.1 is
+defined as `1.1.0`; Herdr drifts outside our control and every Herdr
+release at or above `HERDR_MINIMUM_VERSION` must stay supported; the SQLite
+schema gets the same scrutiny; "all should be managed by the same
+gates/rules"; "all have the potential to cause breaking changes on
+computers or between computers or between applications".
+
+## Decision
+
+### D1. Three governed interfaces, one rule set
+
+Each interface can break something different: the SQLite schema breaks a
+computer against its own earlier binary, the HTTP/peer API breaks hosts
+against each other, and the Herdr IPC breaks applications against each
+other. They are governed identically because the failure is the same kind:
+a consumer that worked yesterday stops working without anyone having
+approved that.
+
+| Interface | Version constant | Source of truth | Consumer that must keep working |
+| --- | --- | --- | --- |
+| HTTP/peer API | `HTTP_API_VERSION` (semver), `CLI_SCHEMA_VERSION` (local envelope) in `crates/atm-core/src/protocol.rs` | Rust serde types (`RequestEnvelope`, `ResponseEnvelope`, `WriteRequest`); `openapi.yaml` is derived documentation | Every deployed daemon and CLI speaking the same major |
+| Herdr IPC | `HERDR_MINIMUM_VERSION` (Herdr release semver from `ping.version`; Herdr `PROTOCOL_VERSION` recorded per release as a secondary fact) in `crates/atm-herdr` | Herdr's published wire, outside our control | Every Herdr release `>= HERDR_MINIMUM_VERSION`, simultaneously, from one daemon build |
+| SQLite storage schema | `STORAGE_SCHEMA_VERSION` (semver) declared by `atm-storage-rusqlite` and persisted in the database | `DB_MIGRATIONS` and the `ensure_*` migration functions | The previous supported release binary opening the same database (daemon-switch rollback) |
+
+`HERDR_MINIMUM_VERSION` and `STORAGE_SCHEMA_VERSION` do not exist yet. The
+phase-ay plan lands the Herdr constant (AY.1, AY.3). The storage constant
+needs its own planned sprint; until it lands, the SQLite rules below are
+applied against the migration functions directly.
+
+### D2. Classification
+
+- **Minor (additive):** a new optional field, argument, request variant,
+  route, table, column with a default, or index. Older consumers must keep
+  working unchanged: receivers default omitted fields and ignore unknown
+  fields; an older binary opening a newer database must still be able to
+  read and write the rows it understands.
+- **Major (breaking):** removing or renaming a field, variant, route, table,
+  or column; changing a type, constraint, status, or meaning; tightening
+  validation an older peer would fail; raising `HERDR_MINIMUM_VERSION`;
+  any storage change the previous supported release binary cannot operate
+  against.
+- **Patch:** documentation or test-only change with no wire or DDL effect.
+
+### D3. Approval gate
+
+- A minor change requires the matching version bump in the same change set,
+  updated documentation (`openapi.yaml` and surface baseline; the storage
+  schema document; the Herdr version matrix) and a test proving the older
+  consumer still works.
+- A major change requires Rand's explicit, recorded approval and sign-off
+  before plan approval, cited by message id, issue comment, or ADR, and
+  cited again at phase end. It must ship with a co-existence window: the new
+  build still serves the previous major (or negotiates down) for the
+  duration Rand approves. No change may require every host to upgrade
+  together.
+- Design rule: before proposing a major change, the author must show why the
+  capability cannot be expressed additively.
+
+### D4. Enforcement
+
+- `schema-reviewer` (`.claude/agents/schema-reviewer.md`) is a mandatory
+  reviewer in every `quality-mgr` plan review and every phase-ending review.
+  It classifies every change to the three interfaces, verifies the bump,
+  documentation and tests, and at phase end diffs shipped changes against
+  the approved plan. Unapproved major changes and unapproved drift are
+  Blocking.
+- Every interface change is documented and tested the same way SQLite
+  migrations already are: a pre-change fixture, the change, and a test that
+  the older consumer still works.
+
+## Consequences
+
+- `HTTP_API_VERSION` moves to `1.1.0` as the first act of the versioning
+  plan, defined as the current wire, and is bumped on every later change.
+- Herdr support becomes a matrix, not a single version; per-release
+  conformance fixtures are required.
+- SQLite migrations gain a declared version and an explicit rollback test
+  against the previous release binary.
+- Plan documents must list their intended interface changes so phase-end
+  drift review has something to diff against.

--- a/docs/adr/ADR-061-governed-interface-schema-versioning.md
+++ b/docs/adr/ADR-061-governed-interface-schema-versioning.md
@@ -47,10 +47,12 @@ approved that.
 | Herdr IPC | `HERDR_MINIMUM_VERSION` (Herdr release semver from `ping.version`; Herdr `PROTOCOL_VERSION` recorded per release as a secondary fact) in `crates/atm-herdr` | Herdr's published wire, outside our control | Every Herdr release `>= HERDR_MINIMUM_VERSION`, simultaneously, from one daemon build |
 | SQLite storage schema | `STORAGE_SCHEMA_VERSION` (semver) declared by `atm-storage-rusqlite` and persisted in the database | `DB_MIGRATIONS` and the `ensure_*` migration functions | The previous supported release binary opening the same database (daemon-switch rollback) |
 
-`HERDR_MINIMUM_VERSION` and `STORAGE_SCHEMA_VERSION` do not exist yet. The
-phase-ay plan lands the Herdr constant (AY.1, AY.3). The storage constant
-needs its own planned sprint; until it lands, the SQLite rules below are
-applied against the migration functions directly.
+`HERDR_MINIMUM_VERSION` is `0.8.0` today (`crates/atm-herdr/src/lib.rs`),
+set by Rand on 2026-09-05 from the M5 agents' drift review of Herdr
+v0.8.0..v0.8.2. The phase-ay plan lands the runtime checks around it (AY.1,
+AY.3). `STORAGE_SCHEMA_VERSION` does not exist yet and needs its own planned
+sprint; until it lands, the SQLite rules below are applied against the
+migration functions directly.
 
 ### D2. Classification
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -67,6 +67,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-058 — Herdr Local Steer Backend Contract](./ADR-058-herdr-local-steer-backend-contract.md)
 - [ADR-059 — Async Mailbox-Read Concurrency And State Handoff](./ADR-059-async-mailbox-read-concurrency.md)
 - [ADR-060 — Peer Dial Order And Address Cache](./ADR-060-peer-dial-and-address-cache.md)
+- [ADR-061 — Governed Interface Schema Versioning And Breaking-Change Approval](./ADR-061-governed-interface-schema-versioning.md)
 
 ## Extracted Crate-Local ADRs
 


### PR DESCRIPTION
## Summary

Adds the `schema-reviewer` agent requested by Rand (rules recorded on #1217):

- notes every minor `HTTP_API_VERSION` bump (optional field/argument added, serde-defaulted)
- blocks any breaking (major) wire change that lacks Rand's explicit recorded approval and sign-off
- at phase end, diffs shipped wire changes against the approved plan and blocks unapproved drift
- applies the same pattern to Herdr IPC: `HERDR_MINIMUM_VERSION`, every Herdr version at/above it must stay supported; raising it is breaking
- flags OpenAPI / surface-baseline drift from the Rust serde types

Wired into `quality-mgr` as a mandatory reviewer in both the docs-only plan review set (`review_mode: plan`) and the phase-ending review set; registered in `registry.yaml`.

Tooling/agent change, targets `develop` directly. Merge needs Rand's approval.

Refs #1217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
