### PR TITLE
fix(cross-host): AV-HOTFIX-001..004 consolidated round (no local echo, trust validation, versioned envelope, rejection diagnostics)

### DIFF
--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -24,7 +24,7 @@ use base64::Engine as _;
 
 pub const MAX_HTTP_REQUEST_BODY_BYTES: usize = 1_048_576;
 /// Version of the daemon's HTTP request contract.
-pub const HTTP_API_VERSION: &str = crate::protocol::HTTP_API_VERSION;
+pub use crate::protocol::HTTP_API_VERSION;
 /// HTTP response header carrying the canonical clear outcome for the `204`
 /// clear route. Framework adapters use this shared contract instead of
 /// inventing a JSON body for a no-content response.

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -245,7 +245,7 @@ pub fn peer_config_doctor_report(
     store: &(dyn PeerConfigStore + Send + Sync),
 ) -> (PeerConfigDoctorReport, Vec<DoctorFinding>) {
     match peer_config_doctor_report_inner(store) {
-        Ok(report) => (report, Vec::new()),
+        Ok((report, findings)) => (report, findings),
         Err(error) => {
             let finding = DoctorFinding {
                 severity: DoctorSeverity::Error,
@@ -269,30 +269,77 @@ pub fn peer_config_doctor_report(
 
 fn peer_config_doctor_report_inner(
     store: &(dyn PeerConfigStore + Send + Sync),
-) -> Result<PeerConfigDoctorReport, crate::error::AtmError> {
+) -> Result<(PeerConfigDoctorReport, Vec<DoctorFinding>), crate::error::AtmError> {
     let interfaces = store.list_interfaces()?;
     let peers = store.list_trusted_peers()?;
     let certificate = store.local_certificate()?;
-    Ok(PeerConfigDoctorReport {
-        configured_interface_count: interfaces.len(),
-        enabled_interface_count: interfaces
-            .iter()
-            .filter(|interface| interface.enabled)
-            .count(),
-        certificate_fingerprint: certificate.map(|certificate| certificate.fingerprint.to_string()),
-        trusted_peer_count: peers.len(),
-        enabled_trusted_peer_count: peers.iter().filter(|peer| peer.enabled).count(),
-        trusted_peers: peers
-            .iter()
-            .map(|peer| PeerAuthorityDoctorReport {
-                host: peer.host.to_string(),
-                https_port: peer.https_port.get(),
-                enabled: peer.enabled,
-            })
-            .collect(),
-        legacy_literal_ip_peers: legacy_literal_ip_peer_reports(&peers),
-        validation_failure: None,
-    })
+    let findings = peer_config_doctor_warnings(&interfaces, &peers);
+    Ok((
+        PeerConfigDoctorReport {
+            configured_interface_count: interfaces.len(),
+            enabled_interface_count: interfaces
+                .iter()
+                .filter(|interface| interface.enabled)
+                .count(),
+            certificate_fingerprint: certificate
+                .map(|certificate| certificate.fingerprint.to_string()),
+            trusted_peer_count: peers.len(),
+            enabled_trusted_peer_count: peers.iter().filter(|peer| peer.enabled).count(),
+            trusted_peers: peers
+                .iter()
+                .map(|peer| PeerAuthorityDoctorReport {
+                    host: peer.host.to_string(),
+                    https_port: peer.https_port.get(),
+                    enabled: peer.enabled,
+                })
+                .collect(),
+            legacy_literal_ip_peers: legacy_literal_ip_peer_reports(&peers),
+            validation_failure: None,
+        },
+        findings,
+    ))
+}
+
+fn peer_config_doctor_warnings(
+    interfaces: &[atm_storage::HttpsInterface],
+    peers: &[atm_storage::TrustedPeer],
+) -> Vec<DoctorFinding> {
+    let malformed_fingerprint_findings = peers
+        .iter()
+        .filter(|peer| {
+            let fingerprint = peer.fingerprint.as_str();
+            fingerprint.len() != 64 || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+        .map(|peer| DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::PeerConfigValidationFailed,
+            message: format!(
+                "trusted peer '{}' has a malformed certificate fingerprint",
+                peer.host
+            ),
+            remediation: Some(
+                "Replace the trusted peer fingerprint with exactly 64 hexadecimal characters."
+                    .to_string(),
+            ),
+        });
+    let literal_advertise_host_findings = interfaces
+        .iter()
+        .filter(|interface| !interface.advertise_host.is_durable_hostname())
+        .map(|interface| DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::PeerConfigValidationFailed,
+            message: format!(
+                "peer interface {} advertises literal IP '{}' instead of a stable hostname",
+                interface.bind_addr, interface.advertise_host
+            ),
+            remediation: Some(
+                "Set --advertise-host to a stable hostname; literal IP addresses remain supported for compatibility."
+                    .to_string(),
+            ),
+        });
+    malformed_fingerprint_findings
+        .chain(literal_advertise_host_findings)
+        .collect()
 }
 
 /// Projects legacy literal-IP trusted-peer rows (enabled or disabled) with
@@ -890,18 +937,43 @@ mod tests {
 
     struct StubPeerConfigStore {
         failure: Option<AtmError>,
+        interfaces: Vec<HttpsInterface>,
+        peers: Vec<TrustedPeer>,
     }
 
     impl atm_storage::contract::sealed::Sealed for StubPeerConfigStore {}
 
     impl StubPeerConfigStore {
         fn healthy() -> Self {
-            Self { failure: None }
+            Self {
+                failure: None,
+                interfaces: vec![HttpsInterface {
+                    bind_addr: "127.0.0.1:43101".parse().expect("socket address"),
+                    advertise_host: "localhost".parse().expect("host name"),
+                    enabled: true,
+                }],
+                peers: vec![TrustedPeer {
+                    host: "peer.example".parse::<HostName>().expect("host name"),
+                    fingerprint: "a".repeat(64).parse().expect("fingerprint"),
+                    enabled: true,
+                    https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
+                }],
+            }
         }
 
         fn failing(error: AtmError) -> Self {
             Self {
                 failure: Some(error),
+                interfaces: Vec::new(),
+                peers: Vec::new(),
+            }
+        }
+
+        fn with_peer_config(interfaces: Vec<HttpsInterface>, peers: Vec<TrustedPeer>) -> Self {
+            Self {
+                failure: None,
+                interfaces,
+                peers,
             }
         }
 
@@ -912,11 +984,7 @@ mod tests {
 
     impl PeerConfigStore for StubPeerConfigStore {
         fn list_interfaces(&self) -> Result<Vec<HttpsInterface>, AtmError> {
-            self.result(vec![HttpsInterface {
-                bind_addr: "127.0.0.1:43101".parse().expect("socket address"),
-                advertise_host: "localhost".parse().expect("host name"),
-                enabled: true,
-            }])
+            self.result(self.interfaces.clone())
         }
 
         fn save_interface(&self, _interface: &HttpsInterface) -> Result<(), AtmError> {
@@ -943,14 +1011,7 @@ mod tests {
         }
 
         fn list_trusted_peers(&self) -> Result<Vec<TrustedPeer>, AtmError> {
-            self.result(vec![TrustedPeer {
-                host: "peer.example".parse::<HostName>().expect("host name"),
-                fingerprint: "sha256:peer"
-                    .parse::<CertificateFingerprint>()
-                    .expect("fingerprint"),
-                enabled: true,
-                https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
-            }])
+            self.result(self.peers.clone())
         }
 
         fn trusted_peer(&self, _host: &HostName) -> Result<Option<TrustedPeer>, AtmError> {
@@ -1931,6 +1992,41 @@ mod tests {
         let serialized = serde_json::to_string(&report).expect("serialize doctor projection");
         assert!(!serialized.contains("keychain:secret"));
         assert!(!serialized.contains("private_key_ref"));
+    }
+
+    #[test]
+    fn peer_config_doctor_warns_on_malformed_pins_and_literal_advertise_hosts() {
+        let store = StubPeerConfigStore::with_peer_config(
+            vec![HttpsInterface {
+                bind_addr: "0.0.0.0:43101".parse().expect("socket address"),
+                advertise_host: "192.168.128.82".parse().expect("literal IP host"),
+                enabled: true,
+            }],
+            vec![TrustedPeer {
+                host: "peer.example".parse().expect("host name"),
+                fingerprint: "sha256:test-peer".parse().expect("legacy fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
+            }],
+        );
+
+        let (_report, findings) = peer_config_doctor_report(&store);
+
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().all(|finding| {
+            finding.severity == DoctorSeverity::Warning
+                && finding.code == AtmErrorCode::PeerConfigValidationFailed
+        }));
+        assert!(findings.iter().any(|finding| {
+            finding
+                .message
+                .contains("malformed certificate fingerprint")
+        }));
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("literal IP"))
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -93,7 +93,7 @@ pub enum ResponseEnvelope {
 }
 
 pub const CLI_SCHEMA_VERSION: u16 = 1;
-pub const HTTP_API_VERSION: &str = "1.0.0";
+pub const HTTP_API_VERSION: &str = "1.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -134,6 +134,11 @@ pub struct WriteRequest {
     /// persists an inbound record. It is not trusted from wire JSON.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authenticated_source_host: Option<HostName>,
+    /// Schema version attached by a locally admitted cross-host sender. Peer
+    /// ingress validates only the major version; absent values remain
+    /// compatible with the deployed 1.x baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_http_api_version: Option<crate::protocol::HttpApiVersion>,
     /// The immutable identity assigned by the origin canonical writer.
     /// Authenticated peer ingress preserves it so both hosts store one ULID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -193,6 +198,7 @@ impl WriteRequest {
             caller_team,
             activity_observation: None,
             authenticated_source_host: None,
+            peer_http_api_version: None,
             origin_message_id: None,
             origin_timestamp: None,
             to: Some(to.parse()?),
@@ -249,6 +255,12 @@ impl WriteRequest {
     #[must_use]
     pub fn with_origin_message_id(mut self, message_id: AtmMessageId) -> Self {
         self.origin_message_id = Some(message_id);
+        self
+    }
+
+    #[must_use]
+    pub fn with_peer_http_api_version(mut self) -> Self {
+        self.peer_http_api_version = Some(crate::protocol::HttpApiVersion::current());
         self
     }
 

--- a/crates/atm-core/src/write/acknowledgement.rs
+++ b/crates/atm-core/src/write/acknowledgement.rs
@@ -409,6 +409,7 @@ pub(crate) fn canonical_ack_write_request(
         caller_team: team.clone(),
         activity_observation: request.activity_observation.clone(),
         authenticated_source_host: None,
+        peer_http_api_version: None,
         origin_message_id: None,
         origin_timestamp: None,
         to: Some(crate::address::AgentAddress::new(

--- a/crates/atm-core/src/write/mod.rs
+++ b/crates/atm-core/src/write/mod.rs
@@ -60,6 +60,7 @@ impl AckRequest {
             caller_team: self.caller_team,
             activity_observation: self.activity_observation,
             authenticated_source_host: None,
+            peer_http_api_version: None,
             origin_message_id: None,
             origin_timestamp: None,
             to: None,

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -371,12 +371,23 @@ async fn post_messages_with_request_id(
         Ok(ingress) => ingress,
         Err(error) => return error_response(error),
     };
+    let peer_ingress = matches!(
+        ingress,
+        AuthenticatedIngress::Peer | AuthenticatedIngress::UntrustedSmoke(_)
+    );
     let deadline = RequestDeadline::after(state.request_timeout);
 
     let response = state
         .handler
         .write_with_request_id(request, ingress, deadline, request_id)
         .await;
+    if peer_ingress && let Err(error) = &response {
+        warn!(
+            %request_id,
+            error_code = %error.code(),
+            "rejected inbound peer write"
+        );
+    }
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -18,8 +18,8 @@ use atm_core::doctor::DoctorQuery;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::protocol::{
     CompatibilityPreflight, GraftReceiverLookupRequest, GraftReceiverRefreshRequest,
-    GraftReceiverRegistration, GraftReceiverUnregistration, QueueGetNextRequest, RequestId,
-    ResponseEnvelope, SendResponseEnvelope, TeamMemberHeartbeatRequest, next_request_id,
+    GraftReceiverRegistration, GraftReceiverUnregistration, HttpApiVersion, QueueGetNextRequest,
+    RequestId, ResponseEnvelope, SendResponseEnvelope, TeamMemberHeartbeatRequest, next_request_id,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::search::SearchRequest;
@@ -172,6 +172,7 @@ impl AuthenticatedConnector {
                 Ok(AuthenticatedIngress::Local)
             }
             Self::Peer { source_host } => {
+                validate_peer_write_version(request.peer_http_api_version.take())?;
                 request.authenticated_source_host = Some(source_host.clone());
                 if let Some(destination) = request.to.take() {
                     request.to = Some(destination.without_host());
@@ -197,6 +198,7 @@ impl AuthenticatedConnector {
                 // explicit plaintext test reply to the actual socket peer
                 // without accepting a JSON-forged value.
                 request.authenticated_source_host = Some(source_host.clone());
+                validate_peer_write_version(request.peer_http_api_version.take())?;
                 if let Some(destination) = request.to.take() {
                     request.to = Some(destination.without_host());
                 }
@@ -221,6 +223,20 @@ impl AuthenticatedConnector {
             },
         }
     }
+}
+
+fn validate_peer_write_version(peer_version: Option<HttpApiVersion>) -> Result<(), AtmError> {
+    let peer_version = peer_version.unwrap_or_else(HttpApiVersion::current);
+    let local_version = HttpApiVersion::current();
+    if peer_version.major() == local_version.major() {
+        return Ok(());
+    }
+    Err(AtmError::new(
+        AtmErrorCode::ClientDaemonVersionIncompatible,
+        format!(
+            "peer HTTP API major-version mismatch: sender {peer_version}, receiver {local_version}"
+        ),
+    ))
 }
 
 #[derive(Clone)]
@@ -792,7 +808,7 @@ mod tests {
 
     use atm_core::api::HttpRequest;
     use atm_core::error::{AtmError, AtmErrorCode};
-    use atm_core::protocol::ResponseEnvelope;
+    use atm_core::protocol::{HttpApiVersion, ResponseEnvelope};
     use atm_core::search::{SearchRequest, SearchResponse};
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
@@ -1699,6 +1715,22 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(serialization.code(), AtmErrorCode::SerializationFailed);
+    }
+
+    #[test]
+    fn peer_write_version_tolerates_minor_skew_and_rejects_major_skew() {
+        super::validate_peer_write_version(Some(
+            HttpApiVersion::parse("1.0.0").expect("minor-skew fixture"),
+        ))
+        .expect("same-major peer version is compatible");
+
+        let error = super::validate_peer_write_version(Some(
+            HttpApiVersion::parse("2.0.0").expect("major-skew fixture"),
+        ))
+        .expect_err("different-major peer version is incompatible");
+        assert_eq!(error.code(), AtmErrorCode::ClientDaemonVersionIncompatible);
+        assert!(error.message().contains("sender 2.0.0"));
+        assert!(error.message().contains("receiver 1.1.0"));
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -973,6 +973,29 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;
+            // ACK replies may acquire their host-qualified recipient while the
+            // write is prepared.  These must be forwarded after their local
+            // durable record is created; raw host-qualified sends returned
+            // above and therefore never reach this post-commit path.
+            if ingress == AuthenticatedIngress::Local
+                && committed.newly_persisted
+                && committed
+                    .canonical_request
+                    .to
+                    .as_ref()
+                    .and_then(|recipient| recipient.host())
+                    .is_some()
+            {
+                let _ = self
+                    .dispatch_resolved_peer_write(
+                        &committed.canonical_request,
+                        committed.message_id,
+                        committed.persisted_timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
+            }
             if committed.newly_persisted {
                 let hook = self.clone();
                 let hook_task = async move {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -500,6 +500,33 @@ impl StorageAndNudgeRouter {
         }
     }
 
+    /// Routes a raw local host-qualified write before local admission.
+    ///
+    /// Prepared ACK replies are different: they acquire their recipient only
+    /// after commit and are handled by the post-commit branch in
+    /// `write_with_request_id`.
+    async fn dispatch_raw_host_qualified_local_write(
+        &self,
+        request: &atm_core::send::WriteRequest,
+        ingress: &AuthenticatedIngress,
+        deadline: RequestDeadline,
+        request_id: RequestId,
+    ) -> Result<Option<WriteOutcome>, AtmError> {
+        if *ingress != AuthenticatedIngress::Local
+            || request
+                .to
+                .as_ref()
+                .and_then(|recipient| recipient.host())
+                .is_none()
+        {
+            return Ok(None);
+        }
+        let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
+        self.dispatch_resolved_peer_write(request, message_id, timestamp, deadline, request_id)
+            .await
+            .map(Some)
+    }
+
     async fn emit_received_hook(
         &self,
         dispatches: Result<Vec<atm_core::boundary::BuiltInPostSendDispatch>, AtmError>,
@@ -953,23 +980,10 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             // shared writer uses them for its state and file-policy paths.
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
-            if ingress == AuthenticatedIngress::Local
-                && request
-                    .to
-                    .as_ref()
-                    .and_then(|recipient| recipient.host())
-                    .is_some()
+            if let Some(outcome) = self
+                .dispatch_raw_host_qualified_local_write(&request, &ingress, deadline, request_id)
+                .await?
             {
-                let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
-                let outcome = self
-                    .dispatch_resolved_peer_write(
-                        &request.with_origin_metadata(message_id, timestamp),
-                        message_id,
-                        timestamp,
-                        deadline,
-                        request_id,
-                    )
-                    .await?;
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -432,11 +432,11 @@ impl StorageAndNudgeRouter {
         })
     }
 
-    /// Delivers one locally admitted host-qualified write using the daemon's
-    /// selected peer-wire mode. The record is already durable at this point;
-    /// this method creates neither a second application route nor delivery
-    /// recovery state. Per ADR-057, connection reuse can redial only before
-    /// exchange; it never retries a request after handing it to the sender.
+    /// Delivers a host-qualified write through the selected peer-wire mode.
+    ///
+    /// Cross-host writes are intentionally not admitted into the local mailbox:
+    /// without the durable outbox design, a failed peer exchange must leave no
+    /// misleading local echo or local nudge behind.
     async fn dispatch_resolved_peer_write(
         &self,
         request: &atm_core::send::WriteRequest,
@@ -444,9 +444,11 @@ impl StorageAndNudgeRouter {
         timestamp: atm_core::types::IsoTimestamp,
         deadline: RequestDeadline,
         _request_id: RequestId,
-    ) -> Result<(), AtmError> {
+    ) -> Result<WriteOutcome, AtmError> {
         let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
-            return Ok(());
+            return Err(AtmError::validation(
+                "cross-host delivery requires a host-qualified recipient",
+            ));
         };
         let remaining = deadline.remaining().ok_or_else(|| {
             AtmError::daemon_unavailable(
@@ -480,7 +482,13 @@ impl StorageAndNudgeRouter {
             .await?
             .into_inner()
         {
-            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => Ok(()),
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
+                Ok(WriteOutcome::Sent(outcome))
+            }
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
+                Ok(WriteOutcome::Acknowledged(outcome))
+            }
+            ResponseEnvelope::Error(error) => Err(error),
             response => Err(AtmError::new(
                 atm_core::error_codes::AtmErrorCode::InternalError,
                 "cross-host daemon-owned delivery returned a non-write response",
@@ -942,6 +950,25 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             // shared writer uses them for its state and file-policy paths.
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
+            if ingress == AuthenticatedIngress::Local
+                && request
+                    .to
+                    .as_ref()
+                    .and_then(|recipient| recipient.host())
+                    .is_some()
+            {
+                let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
+                let outcome = self
+                    .dispatch_resolved_peer_write(
+                        &request.with_origin_metadata(message_id, timestamp),
+                        message_id,
+                        timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
+                return Ok(ApiResponse::new(write_response(outcome)));
+            }
             let mut committed = self.commit_write(request, deadline).await?;
             if ingress == AuthenticatedIngress::Local
                 && committed.newly_persisted
@@ -952,14 +979,15 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                     .and_then(|recipient| recipient.host())
                     .is_some()
             {
-                self.dispatch_resolved_peer_write(
-                    &committed.canonical_request,
-                    committed.message_id,
-                    committed.persisted_timestamp,
-                    deadline,
-                    request_id,
-                )
-                .await?;
+                let _ = self
+                    .dispatch_resolved_peer_write(
+                        &committed.canonical_request,
+                        committed.message_id,
+                        committed.persisted_timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
             }
             if committed.newly_persisted {
                 let hook = self.clone();
@@ -4331,6 +4359,20 @@ mod tests {
             response.into_inner(),
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
         ));
+        assert!(
+            local
+                .message_store
+                .list_messages(&MessageQuery {
+                    team: "test-team".parse().expect("team"),
+                    agent: "recipient".parse().expect("agent"),
+                    sender: None,
+                    task_id: None,
+                    limit: None,
+                })
+                .expect("read local recipient mailbox")
+                .is_empty(),
+            "a host-qualified send must not leave a local mailbox echo"
+        );
         assert_eq!(
             remote
                 .message_store
@@ -4344,7 +4386,7 @@ mod tests {
                 .expect("read remote recipient mailbox")
                 .len(),
             1,
-            "the peer listener receives exactly the locally admitted canonical write"
+            "the peer listener receives exactly one canonical write"
         );
         remote_runtime
             .begin_shutdown()

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -973,25 +973,6 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;
-            if ingress == AuthenticatedIngress::Local
-                && committed.newly_persisted
-                && committed
-                    .canonical_request
-                    .to
-                    .as_ref()
-                    .and_then(|recipient| recipient.host())
-                    .is_some()
-            {
-                let _ = self
-                    .dispatch_resolved_peer_write(
-                        &committed.canonical_request,
-                        committed.message_id,
-                        committed.persisted_timestamp,
-                        deadline,
-                        request_id,
-                    )
-                    .await?;
-            }
             if committed.newly_persisted {
                 let hook = self.clone();
                 let hook_task = async move {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -4663,6 +4663,107 @@ mod tests {
             .expect("remote direct peer runtime drains");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn local_ack_returns_peer_delivery_failure_after_the_local_commit() {
+        let remote = fixture(true, None, None);
+        let remote_runtime = HttpRuntimeBuilder::new(
+            direct_peer_runtime_config(&remote, crate::DirectPeerTcpConfig::ephemeral_for_test()),
+            Arc::new(remote.router.clone()),
+        )
+        .build()
+        .expect("valid remote direct peer configuration")
+        .start()
+        .await
+        .expect("remote direct peer runtime starts");
+        let remote_port = remote_runtime
+            .direct_peer_address()
+            .expect("ephemeral remote direct peer listener is bound")
+            .port();
+
+        let mut local = fixture(true, None, None);
+        local.router = local
+            .router
+            .clone()
+            .with_direct_peer_port(std::num::NonZeroU16::new(remote_port).expect("non-zero port"));
+        let local_runtime = HttpRuntimeBuilder::new(
+            direct_peer_runtime_config(&local, crate::DirectPeerTcpConfig::ephemeral_for_test()),
+            Arc::new(local.router.clone()),
+        )
+        .build()
+        .expect("valid local direct peer configuration")
+        .start()
+        .await
+        .expect("local direct peer runtime starts");
+        let local_port = local_runtime
+            .direct_peer_address()
+            .expect("ephemeral local direct peer listener is bound")
+            .port();
+
+        let received_id = AtmMessageId::new();
+        let mut incoming = write_request(remote.home_dir.clone(), remote.current_dir.clone())
+            .with_origin_metadata(received_id, atm_core::types::IsoTimestamp::now());
+        incoming.requires_ack = true;
+        let local_peer_client = direct_peer_tcp_client(
+            "127.0.0.1".parse().expect("loopback source host"),
+            std::num::NonZeroU16::new(local_port).expect("non-zero port"),
+            Duration::from_secs(5),
+        )
+        .expect("local direct peer client");
+        local_peer_client
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(incoming))))
+            .await
+            .expect("incoming required message reaches local daemon");
+
+        remote_runtime
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("remote direct peer runtime drains before acknowledgement");
+
+        let acknowledgement = atm_core::ack::AckRequest {
+            home_dir: local.home_dir.clone(),
+            current_dir: local.current_dir.clone(),
+            caller_identity: "recipient".parse().expect("recipient"),
+            caller_chat_id: None,
+            caller_team: "test-team".parse().expect("team"),
+            activity_observation: None,
+            message_id: received_id,
+            reply_body: "received".to_owned(),
+        }
+        .into_write_request();
+        let error = local
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(acknowledgement))),
+                atm_core::AuthenticatedIngress::Local,
+                RequestDeadline::after(TWO_RUNTIME_TEST_REQUEST_BUDGET),
+            )
+            .await
+            .expect_err("post-commit peer acknowledgement forwarding failure reaches the caller");
+        assert_eq!(
+            error.code(),
+            atm_core::error_codes::AtmErrorCode::RemoteDeliveryUnconfirmed,
+            "a committed acknowledgement still reports that peer acceptance was unconfirmed"
+        );
+        assert!(
+            local
+                .message_store
+                .load_message(&MessageKey::from(received_id))
+                .expect("read acknowledged local source")
+                .expect("received source remains durable")
+                .envelope
+                .acknowledged_at
+                .is_some(),
+            "the acknowledgement's local state transition commits before the failed peer forward"
+        );
+
+        local_runtime
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("local direct peer runtime drains");
+    }
+
     #[tokio::test]
     async fn direct_peer_hook_failure_keeps_the_write_successful_with_a_warning() {
         let fixture = fixture(

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -476,7 +476,10 @@ impl StorageAndNudgeRouter {
                 )?,
             },
         };
-        let request = request.clone().with_origin_metadata(message_id, timestamp);
+        let request = request
+            .clone()
+            .with_origin_metadata(message_id, timestamp)
+            .with_peer_http_api_version();
         match client
             .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
             .await?

--- a/crates/atm/openapi.yaml
+++ b/crates/atm/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ATM daemon API
-  version: v1
+  version: 1.1.0
   description: HTTP contract shared by local UDS and future peer HTTPS adapters.
 servers:
   - url: /v1/atm
@@ -155,6 +155,9 @@ components:
         body: { type: string }
         requires_ack: { type: boolean }
         acknowledges_message_id: { type: string }
+        peer_http_api_version:
+          type: string
+          description: Optional cross-host wire API version. The current baseline is 1.1.0; receivers reject only a major-version mismatch.
     PeekQuery:
       type: object
       description: Canonical inspect query; fields are validated by the daemon.

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -450,6 +450,11 @@ fn peer(
     fingerprint: String,
     https_port: u16,
 ) -> std::result::Result<TrustedPeer, AtmError> {
+    if fingerprint.len() != 64 || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(AtmError::peer_config_validation(
+            "invalid --fingerprint: trusted-peer fingerprints must be exactly 64 hexadecimal characters",
+        ));
+    }
     Ok(TrustedPeer {
         host: trusted_peer_host(&host)?,
         fingerprint: fingerprint
@@ -679,7 +684,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "--yes",
             ],
             vec![
@@ -689,7 +694,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:replacement",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 "--yes",
             ],
             vec!["atm", "trust", "revoke", "--host", "peer.example", "--yes"],
@@ -777,7 +782,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer-one",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "--yes",
             ],
         )
@@ -792,7 +797,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer-two",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 "--yes",
             ],
         )
@@ -802,7 +807,7 @@ mod tests {
                 .trusted_peer(&"peer.example".parse().expect("host"))
                 .expect("read replaced peer")
                 .map(|peer| peer.fingerprint.to_string()),
-            Some("sha256:peer-two".to_string())
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string())
         );
         run_peer(
             &store,
@@ -830,12 +835,36 @@ mod tests {
                     "--host",
                     host,
                     "--fingerprint",
-                    "sha256:peer",
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "--yes",
                 ],
             )
             .expect_err("literal IP host must be rejected");
             assert!(error.message().contains("not stable peer identities"));
+        }
+        assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    #[test]
+    fn trust_add_and_replace_require_exactly_64_hex_fingerprint_characters() {
+        let store = InMemoryPeerConfigStore::default();
+        for command in ["add", "replace"] {
+            let error = run_peer(
+                &store,
+                &[
+                    "atm",
+                    "trust",
+                    command,
+                    "--host",
+                    "peer.example",
+                    "--fingerprint",
+                    "sha256:test-peer",
+                    "--yes",
+                ],
+            )
+            .expect_err("malformed trusted-peer fingerprint must be rejected");
+            assert_eq!(error.code(), AtmErrorCode::PeerConfigValidationFailed);
+            assert!(error.message().contains("exactly 64 hexadecimal"));
         }
         assert!(store.list_trusted_peers().expect("list peers").is_empty());
     }
@@ -999,7 +1028,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ],
             vec![
                 "atm",
@@ -1008,7 +1037,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ],
             vec!["atm", "trust", "revoke", "--host", "peer.example"],
         ];

--- a/crates/atm/tests/openapi_surface_baseline.json
+++ b/crates/atm/tests/openapi_surface_baseline.json
@@ -487,6 +487,7 @@
         "body",
         "from",
         "message_id",
+        "peer_http_api_version",
         "requires_ack",
         "to"
       ],

--- a/docs/atm-daemon/http-api.md
+++ b/docs/atm-daemon/http-api.md
@@ -9,7 +9,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Proposed — Phase AI target |
-| HTTP API SemVer | `1.0.0`; major is `/v1/atm` |
+| HTTP API SemVer | `1.1.0`; major is `/v1/atm` |
 | Authoritative ADR | ADR-033 |
 | Machine-readable publication | checked-in OpenAPI 3.1 and `atm api spec` |
 
@@ -122,7 +122,10 @@ OpenAPI document against route schemas and tests every documented route. The
 embedded document is published by `atm api spec --format json|yaml`; no daemon
 network endpoint is needed merely to retrieve documentation.
 
-The v1 resource paths are durable. Same-major additive fields, error details,
+The v1 resource paths are durable. The current `1.1.0` baseline adds the
+optional `peer_http_api_version` to cross-host write envelopes; receivers
+reject only a peer major-version mismatch and tolerate minor skew. Same-major
+additive fields, error details,
 and endpoints require a minor version: servers default omitted additive request
 fields and ignore unknown additive fields; clients tolerate additive response
 fields. Patch versions are corrective only. A new operation may require an

--- a/docs/atm-http-runtime/openapi.yaml
+++ b/docs/atm-http-runtime/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ATM daemon API
-  version: v1
+  version: 1.1.0
   description: HTTP contract shared by local UDS and future peer HTTPS adapters.
 servers:
   - url: /v1/atm
@@ -155,6 +155,9 @@ components:
         body: { type: string }
         requires_ack: { type: boolean }
         acknowledges_message_id: { type: string }
+        peer_http_api_version:
+          type: string
+          description: Optional cross-host wire API version. The current baseline is 1.1.0; receivers reject only a major-version mismatch.
     PeekQuery:
       type: object
       description: Canonical inspect query; fields are validated by the daemon.


### PR DESCRIPTION
Consolidated cross-host hotfix round from the phase-av dogfooding findings, per Rand's rulings recorded on the triage records (integrate/phase-av, `.triage/phase-av/findings/AV-HOTFIX-00{1,2,3,4}.ttl`).

Scope:
- **AV-HOTFIX-001** interim rule: a host-qualified send routes only to the peer; it is never persisted into the local same-named mailbox, and a failed peer delivery is an error with nothing left behind locally. Durable outbox (#1216) is out of scope.
- **AV-HOTFIX-002**: trust add/replace validate 64-hex fingerprints; doctor flags malformed entries and warns on bare LAN-IP advertise_host; tests never touch the live `~/.atm`.
- **AV-HOTFIX-003**: `HTTP_API_VERSION` 1.1.0; peer write envelope carries the API version; major mismatch rejected naming both versions, minor skew tolerated. Additive change only (minor bump per ADR-061).
- **AV-HOTFIX-004**: real rejection cause preserved across the HTTP boundary; receiving daemon logs rejected inbound peer writes.

All changes in the `atm-http-runtime` path; the legacy synchronous daemon is untouched. Dispatched to arch-ctm as task AV-HOTFIX-R1-1788645000; commits land incrementally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
