### PR TITLE
fix(runtime): keep remote receiver hooks peer-owned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,8 @@ jobs:
         shell: bash
         env:
           ATM_CLI_PARITY_CI: "1"
-        run: "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
+        run: |
+          "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
 
       - name: Run ATM queue lifecycle hook tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,12 +350,32 @@ jobs:
           python -m pip install --disable-pip-version-check --requirement tools/bootstrap-requirements.txt
           python -m pip install --no-deps "$ATM_GRAFT_WHEEL" crates/hermes-atm
 
+      - name: Install isolated debug CLI/native parity packages
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv_root="$GITHUB_WORKSPACE/.bootstrap-venv"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            venv_python="$venv_root/Scripts/python.exe"
+            venv_bin="$venv_root/Scripts"
+          else
+            venv_python="$venv_root/bin/python"
+            venv_bin="$venv_root/bin"
+          fi
+          export VIRTUAL_ENV="$venv_root"
+          export PATH="$venv_bin:$PATH"
+          "$venv_python" -m pip install --no-deps crates/hermes-atm
+          maturin develop --manifest-path crates/atm-graft-python/Cargo.toml
+          "$venv_python" -c 'import atm_graft._atm_graft as extension; assert hasattr(extension, "_debug_runtime_scope")'
+          echo "ATM_PARITY_PYTHON=$venv_python" >> "$GITHUB_ENV"
+
       - name: Run CLI/native parity test with a generated fixture
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         shell: bash
         env:
           ATM_CLI_PARITY_CI: "1"
-        run: python -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
+        run: "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
 
       - name: Run ATM queue lifecycle hook tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -3351,7 +3351,7 @@ fn al3_received_hook_is_single_receiver_side_path_without_detached_work() {
     );
     assert!(
         router.contains("let newly_persisted = prepared.is_newly_persisted();")
-            && router.contains("if committed.newly_persisted {"),
+            && router.contains("if committed.newly_persisted"),
         "the one hook-routing decision must state the new-versus-idempotent persistence disposition explicitly"
     );
     assert_eq!(

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -418,6 +418,19 @@ fn observability_paths() -> PyResult<PyObservabilityPaths> {
     })
 }
 
+/// Return the debug runtime root selected for process-pair integration tests.
+///
+/// This private diagnostic is deliberately compiled only into debug extension
+/// artifacts. The CLI/native parity fixture uses it to fail before opening a
+/// native session when a release wheel would ignore its isolated test scope.
+#[cfg(debug_assertions)]
+#[pyfunction]
+fn _debug_runtime_scope() -> PyResult<String> {
+    atm_core::home::current_host_runtime_scope()
+        .map(|scope| scope.runtime_root.as_ref().display().to_string())
+        .map_err(atm_error)
+}
+
 impl PyGraftSession {
     fn client(&self) -> PyResult<GraftClient> {
         self.client
@@ -866,6 +879,8 @@ impl PyGraftSession {
 fn _atm_graft(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("AtmGraftError", m.py().get_type::<AtmGraftError>())?;
     m.add_function(wrap_pyfunction!(observability_paths, m)?)?;
+    #[cfg(debug_assertions)]
+    m.add_function(wrap_pyfunction!(_debug_runtime_scope, m)?)?;
     m.add_class::<PyObservability>()?;
     m.add_class::<PyObservabilityPaths>()?;
     m.add_class::<PyAgentAddress>()?;

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -18,7 +18,6 @@ import subprocess
 import tempfile
 import time
 import unittest
-from unittest import mock
 
 # Bounded wait for the daemon readiness handshake and for every CLI
 # subprocess invocation. Every blocking call in this module must be bounded
@@ -94,11 +93,15 @@ class _GeneratedParityFixture:
         temp_dir = self.root / "tmp"
         for directory in (home, atm_home, log_dir, temp_dir):
             directory.mkdir(parents=True, exist_ok=True)
-        environment = {
+        return {
             **os.environ,
             "HOME": str(home),
             "ATM_HOME": str(atm_home),
             "ATM_CONFIG_HOME": str(atm_home),
+            # current_host_runtime_scope intentionally ignores HOME and
+            # ATM_HOME for real processes. This debug/test-only override is
+            # the explicit isolation boundary for the paired CLI/daemon.
+            "ATM_TEST_RUNTIME_HOME": str(home),
             "ATM_TEAM": self.team,
             "ATM_CHAT_ID": self.chat_id,
             "ATM_LOG_DIR": str(log_dir),
@@ -106,13 +109,6 @@ class _GeneratedParityFixture:
             "TMP": str(temp_dir),
             "TEMP": str(temp_dir),
         }
-        # The mandatory parity lane loads a release atm-graft wheel. Release
-        # artifacts intentionally ignore ATM_TEST_RUNTIME_HOME, while the
-        # checked-out debug daemon would honor it; retaining the override
-        # would split the paired native client and daemon across two sockets.
-        # Let both use their ordinary host runtime scope instead.
-        environment.pop("ATM_TEST_RUNTIME_HOME", None)
-        return environment
 
     @staticmethod
     def _binary(environment_name: str, default: Path) -> Path:
@@ -277,18 +273,6 @@ def _parity_enabled() -> bool:
     return bool(os.environ.get("ATM_CLI_PARITY_FIXTURE")) or os.environ.get(
         "ATM_CLI_PARITY_CI"
     ) == "1"
-
-
-class GeneratedParityFixtureTests(unittest.TestCase):
-    def test_environment_removes_debug_runtime_override_for_release_wheel_parity(self) -> None:
-        with mock.patch.dict(
-            os.environ, {"ATM_TEST_RUNTIME_HOME": "/tmp/inherited-test-scope"}
-        ):
-            fixture = _GeneratedParityFixture()
-            try:
-                self.assertNotIn("ATM_TEST_RUNTIME_HOME", fixture._environment())
-            finally:
-                fixture.close()
 
 
 @unittest.skipUnless(

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+from unittest import mock
 
 # Bounded wait for the daemon readiness handshake and for every CLI
 # subprocess invocation. Every blocking call in this module must be bounded
@@ -93,15 +94,11 @@ class _GeneratedParityFixture:
         temp_dir = self.root / "tmp"
         for directory in (home, atm_home, log_dir, temp_dir):
             directory.mkdir(parents=True, exist_ok=True)
-        return {
+        environment = {
             **os.environ,
             "HOME": str(home),
             "ATM_HOME": str(atm_home),
             "ATM_CONFIG_HOME": str(atm_home),
-            # current_host_runtime_scope intentionally ignores HOME and
-            # ATM_HOME for real processes. This debug/test-only override is
-            # the explicit isolation boundary for the paired CLI/daemon.
-            "ATM_TEST_RUNTIME_HOME": str(home),
             "ATM_TEAM": self.team,
             "ATM_CHAT_ID": self.chat_id,
             "ATM_LOG_DIR": str(log_dir),
@@ -109,6 +106,13 @@ class _GeneratedParityFixture:
             "TMP": str(temp_dir),
             "TEMP": str(temp_dir),
         }
+        # The mandatory parity lane loads a release atm-graft wheel. Release
+        # artifacts intentionally ignore ATM_TEST_RUNTIME_HOME, while the
+        # checked-out debug daemon would honor it; retaining the override
+        # would split the paired native client and daemon across two sockets.
+        # Let both use their ordinary host runtime scope instead.
+        environment.pop("ATM_TEST_RUNTIME_HOME", None)
+        return environment
 
     @staticmethod
     def _binary(environment_name: str, default: Path) -> Path:
@@ -273,6 +277,18 @@ def _parity_enabled() -> bool:
     return bool(os.environ.get("ATM_CLI_PARITY_FIXTURE")) or os.environ.get(
         "ATM_CLI_PARITY_CI"
     ) == "1"
+
+
+class GeneratedParityFixtureTests(unittest.TestCase):
+    def test_environment_removes_debug_runtime_override_for_release_wheel_parity(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"ATM_TEST_RUNTIME_HOME": "/tmp/inherited-test-scope"}
+        ):
+            fixture = _GeneratedParityFixture()
+            try:
+                self.assertNotIn("ATM_TEST_RUNTIME_HOME", fixture._environment())
+            finally:
+                fixture.close()
 
 
 @unittest.skipUnless(

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -282,6 +282,31 @@ def _parity_enabled() -> bool:
 class CliParityTests(unittest.TestCase):
     """Compare native tool JSON with CLI JSON on one disposable daemon."""
 
+    @staticmethod
+    def _assert_debug_native_scope(environment: dict[str, str]) -> None:
+        """Reject a release extension before it can connect outside the fixture."""
+
+        runtime_home = environment.get("ATM_TEST_RUNTIME_HOME")
+        if not runtime_home:
+            raise RuntimeError("generated parity fixture requires ATM_TEST_RUNTIME_HOME")
+
+        import atm_graft._atm_graft as extension
+
+        try:
+            actual_runtime_root = Path(extension._debug_runtime_scope()).resolve()
+        except AttributeError as error:
+            raise RuntimeError(
+                "CLI/native parity requires a debug atm-graft extension; "
+                "a release wheel ignores ATM_TEST_RUNTIME_HOME"
+            ) from error
+
+        expected_runtime_root = (Path(runtime_home) / ".atm" / "daemon").resolve()
+        if actual_runtime_root != expected_runtime_root:
+            raise RuntimeError(
+                "CLI/native parity native runtime is outside the disposable fixture: "
+                f"expected {expected_runtime_root}, got {actual_runtime_root}"
+            )
+
     @classmethod
     def setUpClass(cls) -> None:
         fixture_path = os.environ.get("ATM_CLI_PARITY_FIXTURE")
@@ -303,6 +328,9 @@ class CliParityTests(unittest.TestCase):
         cls._prior_environment = os.environ.copy()
         os.environ.clear()
         os.environ.update(cls.environment)
+
+        if cls._generated is not None:
+            cls._assert_debug_native_scope(cls.environment)
 
         from hermes_atm import native_tools
 

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -808,15 +808,14 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
             let mut committed = self.commit_write(request, deadline).await?;
-            if ingress == AuthenticatedIngress::Local
-                && committed.newly_persisted
+            let is_remote_recipient = ingress == AuthenticatedIngress::Local
                 && committed
                     .canonical_request
                     .to
                     .as_ref()
                     .and_then(|recipient| recipient.host())
-                    .is_some()
-            {
+                    .is_some();
+            if committed.newly_persisted && is_remote_recipient {
                 self.dispatch_resolved_peer_write(
                     &committed.canonical_request,
                     committed.message_id,
@@ -826,7 +825,10 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 )
                 .await?;
             }
-            if committed.newly_persisted {
+            if committed.newly_persisted && !is_remote_recipient {
+                // A host-qualified local admission has already been handed to
+                // its peer above. Its receiver hook belongs to that peer's
+                // ingress, not to this sender's local roster.
                 let hook = self.clone();
                 let hook_task = async move {
                     hook.emit_received_hook(committed.received_hook_dispatches, deadline)
@@ -4219,7 +4221,9 @@ mod tests {
             .expect("ephemeral remote direct peer listener is bound")
             .port();
 
-        let mut local = fixture(true, None, None);
+        // The sender need not carry a local roster entry for a recipient
+        // resolved to a remote host. That peer owns receiver-hook selection.
+        let mut local = fixture(false, None, None);
         local.router = local
             .router
             .clone()
@@ -4242,10 +4246,23 @@ mod tests {
             )
             .await
             .expect("local daemon owns host-qualified delivery");
-        assert!(matches!(
-            response.into_inner(),
-            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
-        ));
+        let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response.into_inner()
+        else {
+            panic!("local daemon must own host-qualified delivery");
+        };
+        assert!(
+            outcome.warnings.is_empty(),
+            "a sender-local missing roster entry is not a failed remote receiver hook"
+        );
+        assert!(
+            local
+                .received_hook
+                .emitted_ids
+                .lock()
+                .expect("inspect local hook emissions")
+                .is_empty(),
+            "the sender must not run a receiver hook for a remote recipient"
+        );
         assert_eq!(
             remote
                 .message_store
@@ -4266,6 +4283,16 @@ mod tests {
             .finish()
             .await
             .expect("remote runtime drains");
+        assert_eq!(
+            remote
+                .received_hook
+                .emitted_ids
+                .lock()
+                .expect("inspect remote hook emissions")
+                .len(),
+            1,
+            "the peer ingress owns exactly one receiver hook"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Fixes the cross-host sender warning by skipping local receiver-hook emission after a host-qualified local write is handed to its peer.

The receiver-side peer ingress remains the sole hook owner. Adds a loopback peer regression covering a sender without a local recipient roster entry.

Validation: `just ci`, `cargo test --workspace`.