### PR TITLE
fix(tooling): support Windows daemon-switch lifecycle

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -90,22 +90,36 @@ binary identifier and certificate common name. A changed or mismatched leaf
 fails closed. Apple-issued `Apple Development` identities continue to use the
 team-identifier verification path.
 
-## Windows selector provisioning
+## Windows selector and task provisioning
 
-The script never replaces ordinary `.exe` files. Provision two user-writable
-selector symlinks named `atm.exe` and `atm-daemon.exe` in one directory placed
-before the installed release directory on `PATH`, then pass them explicitly:
+The script never replaces ordinary `.exe` files. Windows uses one
+**interactive-user Scheduled Task**, not an SCM service: SCM services commonly
+run as `LocalSystem` and would select a different `ATM_HOME` and durable store.
+Provision two user-writable selector symlinks named `atm.exe` and
+`atm-daemon.exe` in one directory placed before the installed release directory
+on `PATH`, then register the task to invoke the daemon selector:
 
 ```powershell
+python .claude/skills/daemon-switch/scripts/daemon-switch.py windows-provision `
+  --cli-link C:\\atm-active\\atm.exe --daemon-link C:\\atm-active\\atm-daemon.exe `
+  --service atm-daemon --yes
+
 python .claude/skills/daemon-switch/scripts/daemon-switch.py switch `
   --cli-link C:\\atm-active\\atm.exe --daemon-link C:\\atm-active\\atm-daemon.exe `
   --cli target\\release\\atm.exe --daemon target\\release\\atm-daemon.exe --yes `
   --service atm-daemon
 ```
 
-Creating those symlinks may require Developer Mode or an elevated shell. If
-they are unavailable, the script fails closed; do not replace installed
-executables or introduce a second daemon.
+`windows-provision` creates an on-logon, interactive-user task whose only
+executable action is `C:\\atm-active\\atm-daemon.exe`. `switch`, `restart`,
+and `quiesce` refuse a task whose action names a worktree or any other direct
+binary. Corporate policy may require running only `windows-provision` from an
+elevated terminal; do not work around that policy by registering an SCM service
+or launching a second daemon.
+
+The typed `temporary-launch` overlay is not supported by this task backend.
+It fails closed instead of modifying a task action outside its scoped
+pair-switch contract.
 
 ## Default scratch root (ADR-055)
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import time
 from typing import Protocol, Sequence
+from xml.etree import ElementTree
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -48,14 +49,13 @@ from temporary_launch import (  # noqa: E402
 )
 from temporary_launch_macos import MacosLaunchAgentAdapter  # noqa: E402
 from temporary_launch_windows import (  # noqa: E402
-    WindowsScmAdapter,
+    WindowsScmAdapter,  # noqa: F401 - adapter contract tests import this through the tool module.
     parse_windows_command_line,
     quote_windows_command_line,
 )
 from temporary_launch_linux import LinuxSystemdUserAdapter  # noqa: E402
 
 
-WINDOWS_SERVICE_NOT_FOUND = 1060
 LIVE_PAIR_READINESS_ATTEMPTS = 200
 MACOS_LAUNCH_AGENT_PATH = re.compile(r"^path = (.+)$")
 # [cass: helpful starter-rust-logging] - retains the bounded readiness state
@@ -121,7 +121,10 @@ def temporary_launch_adapter(_args: argparse.Namespace) -> TemporaryLaunchAdapte
             temporary_launch_journal().path.parent / "temporary-launch-overlays"
         )
     if platform.system() == "Windows":
-        return WindowsScmAdapter(lambda command, timeout: run(command, timeout=timeout))
+        raise SwitchError(
+            "temporary-launch is not supported by the Windows per-user scheduled-task backend; "
+            "do not substitute an SCM service because it would run under a different account"
+        )
     if platform.system() == "Linux":
         return LinuxSystemdUserAdapter(
             systemd_user_config_directory(),
@@ -421,30 +424,129 @@ def service_commands(args: argparse.Namespace, action: str) -> list[str]:
         plist = str(Path(args.launch_agent_plist).expanduser())
         return ["launchctl", "bootstrap", domain, plist]
     if system == "Windows":
-        return ["sc.exe", action, args.service]
+        return ["schtasks.exe", "/End" if action == "stop" else "/Run", "/TN", args.service]
     return ["systemctl", "--user", action, args.service]
 
 
-def windows_service_missing(result: subprocess.CompletedProcess[str]) -> bool:
-    """Recognize only SCM's missing-service result for an optional stop."""
-    if result.returncode == WINDOWS_SERVICE_NOT_FOUND:
-        return True
+def windows_task_missing(result: subprocess.CompletedProcess[str]) -> bool:
+    """Recognize Task Scheduler's absent-task diagnostics without masking other failures."""
     output = f"{result.stdout}\n{result.stderr}".lower()
-    return "1060" in output and "openservice" in output
+    return "cannot find the file specified" in output or "does not exist" in output
+
+
+def windows_task_status(task: str) -> dict[str, object]:
+    """Return the registered task's state and one exact executable action."""
+    result = run(["schtasks.exe", "/Query", "/TN", task, "/XML"], timeout=5.0)
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0:
+        return {
+            "registered": False,
+            "state": "absent" if windows_task_missing(result) else "unknown",
+            "detail": output.strip() or f"schtasks.exe exited with {result.returncode}",
+        }
+    try:
+        root = ElementTree.fromstring(result.stdout)
+    except ElementTree.ParseError:
+        return {"registered": True, "state": "unknown", "detail": "task XML was invalid"}
+    commands = [
+        command.text.strip()
+        for command in root.findall(".//{*}Actions/{*}Exec/{*}Command")
+        if command.text and command.text.strip()
+    ]
+    if len(commands) != 1:
+        return {
+            "registered": True,
+            "state": "unknown",
+            "detail": "task must define exactly one executable action",
+        }
+    state_result = run(["schtasks.exe", "/Query", "/TN", task, "/FO", "LIST", "/V"], timeout=5.0)
+    state_output = (state_result.stdout or "") + (state_result.stderr or "")
+    state = "unknown"
+    if state_result.returncode == 0:
+        for line in state_output.splitlines():
+            if line.lower().startswith("status:"):
+                state = line.split(":", 1)[1].strip().lower()
+                break
+    return {"registered": True, "state": state, "command": commands[0]}
+
+
+def require_windows_task_selector(args: argparse.Namespace) -> None:
+    """Ensure the scheduled task follows the selector rather than a mutable worktree build."""
+    assert args.service is not None
+    task = windows_task_status(args.service)
+    if not task.get("registered"):
+        detail = task.get("detail", "task is absent")
+        raise SwitchError(f"Windows scheduled task {args.service!r} is not registered: {detail}")
+    expected = str(selected_links(args)[1])
+    command = task.get("command")
+    if command != expected:
+        raise SwitchError(
+            f"Windows scheduled task {args.service!r} launches {command!r}, not the daemon selector {expected!r}"
+        )
+
+
+def provision_windows_task(args: argparse.Namespace) -> None:
+    """Register the current user's one managed daemon task with the daemon selector action."""
+    if platform.system() != "Windows":
+        raise SwitchError("windows-provision is only available on Windows")
+    if not args.yes:
+        raise SwitchError("windows-provision registers a logon task; re-run with --yes")
+    if not args.service:
+        raise SwitchError("--service is required; never create an unnamed daemon task")
+    _cli, daemon = selected_links(args)
+    require_executable(daemon, "selected atm daemon")
+    account = os.environ.get("USERDOMAIN", "") + "\\" + os.environ.get("USERNAME", "")
+    if account == "\\":
+        raise SwitchError("cannot identify the current Windows account for the daemon task")
+    command = [
+        "schtasks.exe",
+        "/Create",
+        "/TN",
+        args.service,
+        "/TR",
+        str(daemon),
+        "/SC",
+        "ONLOGON",
+        "/RU",
+        account,
+        "/IT",
+        "/RL",
+        "LIMITED",
+        "/F",
+    ]
+    result = run(command, timeout=20.0)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise SwitchError(f"Windows task provisioning failed: {' '.join(command)}: {detail}")
+    require_windows_task_selector(args)
 
 
 def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = False) -> None:
+    if platform.system() == "Windows":
+        if not args.service:
+            raise SwitchError("--service is required; never switch an unmanaged daemon")
+        task = windows_task_status(args.service)
+        if not task.get("registered"):
+            if action == "stop" and allow_absent:
+                return
+            detail = task.get("detail", "task is absent")
+            raise SwitchError(f"Windows scheduled task {args.service!r} is not registered: {detail}")
+        if action == "stop" and task.get("state") in {"ready", "disabled"}:
+            return
+        if action == "start":
+            require_windows_task_selector(args)
+        command = service_commands(args, action)
+        result = run(command, timeout=20.0)
+        if result.returncode == 0:
+            return
+        detail = (result.stderr or result.stdout).strip()
+        if action == "stop" and "not currently running" in detail.lower():
+            return
+        raise SwitchError(f"Windows task {action} failed: {' '.join(command)}: {detail}")
     command = service_commands(args, action)
     if platform.system() != "Darwin":
         result = run(command, timeout=20.0)
-        if result.returncode == 0 or (
-            allow_absent
-            and action == "stop"
-            and (
-                platform.system() != "Windows"
-                or windows_service_missing(result)
-            )
-        ):
+        if result.returncode == 0 or (allow_absent and action == "stop"):
             return
         detail = (result.stderr or result.stdout).strip()
         raise SwitchError(f"service {action} failed: {' '.join(command)}: {detail}")
@@ -1110,33 +1212,13 @@ def wait_for_live_pair(cli: Path, daemon: Path | None = None) -> tuple[bool, str
     return False, detail
 
 
-def windows_service_status(service: str) -> dict[str, object]:
-    """Expose SCM state so status cannot imply an absent service is managed."""
-    result = run(["sc.exe", "query", service], timeout=5.0)
-    output = (result.stdout or "") + (result.stderr or "")
-    if result.returncode != 0:
-        return {
-            "installed": False,
-            "state": "absent" if windows_service_missing(result) else "unknown",
-            "detail": output.strip() or f"sc.exe exited with {result.returncode}",
-        }
-
-    state = "unknown"
-    for line in output.splitlines():
-        if "STATE" not in line or ":" not in line:
-            continue
-        state = line.split(":", 1)[1].strip().split(maxsplit=1)[-1].lower()
-        break
-    return {"installed": True, "state": state}
-
-
 def status(args: argparse.Namespace) -> None:
     cli, daemon = selected_links(args)
     service = {"platform": platform.system(), "service": args.service}
     if platform.system() == "Darwin" and args.service:
         service["launch_agent_plist"] = args.launch_agent_plist
     if platform.system() == "Windows" and args.service:
-        service["windows"] = windows_service_status(args.service)
+        service["windows_task"] = windows_task_status(args.service)
     result: dict[str, object] = {
         "atm": {"selector": str(cli), "target": str(cli.resolve()), "version": version(cli)},
         "atm_daemon": {"selector": str(daemon), "target": str(daemon.resolve())},
@@ -1158,7 +1240,10 @@ def parser() -> argparse.ArgumentParser:
     selectors = argparse.ArgumentParser(add_help=False)
     selectors.add_argument("--cli-link", help="system selector symlink for atm")
     selectors.add_argument("--daemon-link", help="system selector symlink for atm-daemon")
-    selectors.add_argument("--service", help="LaunchAgent label or system service name")
+    selectors.add_argument(
+        "--service",
+        help="LaunchAgent label, systemd unit, or Windows scheduled-task name",
+    )
     selectors.add_argument("--launch-agent-plist", help="macOS LaunchAgent plist used to restart the singleton")
     selectors.add_argument(
         "--repair-orphan",
@@ -1196,6 +1281,8 @@ def parser() -> argparse.ArgumentParser:
         command = temporary_sub.add_parser(name)
         command.add_argument("--session", required=True)
         command.add_argument("--yes", action="store_true")
+    windows_provision = sub.add_parser("windows-provision", parents=[selectors])
+    windows_provision.add_argument("--yes", action="store_true")
     return result
 
 
@@ -1221,6 +1308,8 @@ def main() -> int:
                 restart_temporary_launch(args)
             else:
                 restore_temporary_launch(args, recovery=args.temporary_command == "recover")
+        elif args.command == "windows-provision":
+            provision_windows_task(args)
         else:
             quiesce(args)
     except SwitchError as error:

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -527,7 +527,7 @@ def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = F
             raise SwitchError("--service is required; never switch an unmanaged daemon")
         task = windows_task_status(args.service)
         if not task.get("registered"):
-            if action == "stop" and allow_absent:
+            if action == "stop" and allow_absent and task.get("state") == "absent":
                 return
             detail = task.get("detail", "task is absent")
             raise SwitchError(f"Windows scheduled task {args.service!r} is not registered: {detail}")

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -118,6 +118,79 @@ class QuiesceTests(unittest.TestCase):
                 DAEMON_SWITCH.run_service(args, "start")
 
 
+class WindowsScheduledTaskTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.args = argparse.Namespace(
+            service="atm-daemon",
+            cli_link=r"C:\atm-active\atm.exe",
+            daemon_link=r"C:\atm-active\atm-daemon.exe",
+            yes=True,
+        )
+        self.selector = Path(self.args.daemon_link)
+        self.xml = """<?xml version=\"1.0\"?><Task xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"><Actions><Exec><Command>C:\\atm-active\\atm-daemon.exe</Command></Exec></Actions></Task>"""
+
+    def test_task_status_reads_one_executable_action_and_running_state(self) -> None:
+        with mock.patch.object(
+            DAEMON_SWITCH,
+            "run",
+            side_effect=[
+                subprocess.CompletedProcess(["schtasks.exe"], 0, self.xml, ""),
+                subprocess.CompletedProcess(["schtasks.exe"], 0, "Status: Running\n", ""),
+            ],
+        ):
+            self.assertEqual(
+                DAEMON_SWITCH.windows_task_status("atm-daemon"),
+                {
+                    "registered": True,
+                    "state": "running",
+                    "command": r"C:\atm-active\atm-daemon.exe",
+                },
+            )
+
+    def test_task_status_reports_absent_task(self) -> None:
+        missing = subprocess.CompletedProcess(
+            ["schtasks.exe"], 1, "", "ERROR: The system cannot find the file specified."
+        )
+        with mock.patch.object(DAEMON_SWITCH, "run", return_value=missing):
+            self.assertEqual(DAEMON_SWITCH.windows_task_status("atm-daemon")["state"], "absent")
+
+    def test_start_requires_the_task_to_launch_the_daemon_selector(self) -> None:
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "windows_task_status",
+                return_value={"registered": True, "state": "ready", "command": r"C:\old\atm-daemon.exe"},
+            ),
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(Path(self.args.cli_link), self.selector)),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "not the daemon selector"):
+                DAEMON_SWITCH.run_service(self.args, "start")
+
+    def test_start_runs_only_after_task_selector_validation(self) -> None:
+        completed = subprocess.CompletedProcess(["schtasks.exe"], 0, "SUCCESS", "")
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "windows_task_status",
+                return_value={"registered": True, "state": "ready", "command": str(self.selector)},
+            ),
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(Path(self.args.cli_link), self.selector)),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=completed) as run,
+        ):
+            DAEMON_SWITCH.run_service(self.args, "start")
+
+        self.assertEqual(run.call_args.args[0], ["schtasks.exe", "/Run", "/TN", "atm-daemon"])
+
+    def test_temporary_launch_rejects_windows_scm_fallback(self) -> None:
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "scheduled-task backend"),
+        ):
+            DAEMON_SWITCH.temporary_launch_adapter(self.args)
+
+
 class MacosDevelopmentSigningTests(unittest.TestCase):
     def test_identity_discovery_uses_the_shared_apple_resolver(self) -> None:
         with (

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -289,33 +289,35 @@ class DaemonSwitchTests(unittest.TestCase):
         self.assertEqual(parsed.service, "atm-daemon")
         self.assertEqual(parsed.launch_agent_plist, "/tmp/atm-daemon.plist")
 
-    def test_windows_status_reports_absent_service(self) -> None:
+    def test_windows_status_reports_absent_task(self) -> None:
         missing = subprocess.CompletedProcess(
-            ["sc.exe", "query", "atm-daemon"],
-            self.module.WINDOWS_SERVICE_NOT_FOUND,
+            ["schtasks.exe", "/Query", "/TN", "atm-daemon", "/XML"],
+            1,
             "",
-            "[SC] OpenService FAILED 1060:\r\nThe specified service does not exist.\r\n",
+            "ERROR: The system cannot find the file specified.\r\n",
         )
         with (
             mock.patch.object(self.module.platform, "system", return_value="Windows"),
             mock.patch.object(self.module, "run", return_value=missing) as run,
         ):
             self.assertEqual(
-                self.module.windows_service_status("atm-daemon"),
+                self.module.windows_task_status("atm-daemon"),
                 {
-                    "installed": False,
+                    "registered": False,
                     "state": "absent",
-                    "detail": "[SC] OpenService FAILED 1060:\r\nThe specified service does not exist.",
+                    "detail": "ERROR: The system cannot find the file specified.",
                 },
             )
-        run.assert_called_once_with(["sc.exe", "query", "atm-daemon"], timeout=5.0)
+        run.assert_called_once_with(
+            ["schtasks.exe", "/Query", "/TN", "atm-daemon", "/XML"], timeout=5.0
+        )
 
     def test_windows_optional_stop_does_not_hide_access_denied(self) -> None:
         denied = subprocess.CompletedProcess(
-            ["sc.exe", "stop", "atm-daemon"],
-            5,
+            ["schtasks.exe", "/Query", "/TN", "atm-daemon", "/XML"],
+            1,
             "",
-            "[SC] OpenSCManager FAILED 5: Access is denied.",
+            "ERROR: Access is denied.",
         )
         args = argparse.Namespace(service="atm-daemon")
         with (


### PR DESCRIPTION
## Windows daemon-switch support

### Root cause
The existing Windows lifecycle path used `sc.exe`. ATM runs per-user and derives state from the user's `ATM_HOME`; an SCM service normally runs as LocalSystem, so it cannot safely manage the user-owned daemon or its state. This left Windows `daemon-switch` unsupported in practice.

### Resolution
- Manage the Windows daemon through a per-user interactive Scheduled Task instead of SCM.
- Add `windows-provision` to create the logon task with the configured daemon selector.
- Verify that the task action points exactly at the configured selector before starting it; reject direct worktree binaries and absent/mismatched tasks.
- Add Windows status, start, and stop handling through `schtasks.exe`.
- Fail `temporary-launch` closed on Windows because the Scheduled Task backend intentionally owns lifecycle.
- Document the Windows provisioning and selector requirements.

### Validation
- `py -3.12 .claude/skills/daemon-switch/tests/test_daemon_switch.py WindowsScheduledTaskTests` (5 passed)
- Live verification on FastPC4: provisioned `atm-daemon`, switched the paired selectors to installed ATM 1.5.0, and `daemon-switch.py status --doctor` reported a matched 1.5.0 CLI/daemon pair with a healthy daemon.

The all-platform test module contains pre-existing POSIX-only cases (`AF_UNIX`, `os.getuid`, POSIX permissions); this PR adds only Windows-specific lifecycle coverage and does not change Unix service paths.