### PR TITLE
fix(tooling): daemon-switch optional stop honesty on Linux + canonical suite in CI

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -521,6 +521,12 @@ def provision_windows_task(args: argparse.Namespace) -> None:
     require_windows_task_selector(args)
 
 
+def systemd_unit_missing(detail: str) -> bool:
+    """Recognize only systemd's absent-unit diagnostics so an optional stop never hides a denial."""
+    lowered = detail.lower()
+    return "not loaded" in lowered or "not found" in lowered
+
+
 def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = False) -> None:
     if platform.system() == "Windows":
         if not args.service:
@@ -546,9 +552,11 @@ def run_service(args: argparse.Namespace, action: str, *, allow_absent: bool = F
     command = service_commands(args, action)
     if platform.system() != "Darwin":
         result = run(command, timeout=20.0)
-        if result.returncode == 0 or (allow_absent and action == "stop"):
+        if result.returncode == 0:
             return
         detail = (result.stderr or result.stdout).strip()
+        if allow_absent and action == "stop" and systemd_unit_missing(detail):
+            return
         raise SwitchError(f"service {action} failed: {' '.join(command)}: {detail}")
 
     domain = f"gui/{os.getuid()}"

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -154,6 +154,36 @@ class WindowsScheduledTaskTests(unittest.TestCase):
         with mock.patch.object(DAEMON_SWITCH, "run", return_value=missing):
             self.assertEqual(DAEMON_SWITCH.windows_task_status("atm-daemon")["state"], "absent")
 
+    def test_optional_stop_does_not_hide_a_denied_task_query(self) -> None:
+        denied = subprocess.CompletedProcess(["schtasks.exe"], 1, "", "ERROR: Access is denied.")
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=denied),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "Access is denied"):
+                DAEMON_SWITCH.run_service(self.args, "stop", allow_absent=True)
+
+    def test_optional_stop_skips_only_an_absent_task(self) -> None:
+        missing = subprocess.CompletedProcess(
+            ["schtasks.exe"], 1, "", "ERROR: The system cannot find the file specified."
+        )
+        with (
+            mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=missing),
+        ):
+            DAEMON_SWITCH.run_service(self.args, "stop", allow_absent=True)
+
+    def test_linux_optional_stop_does_not_hide_a_denied_unit(self) -> None:
+        args = argparse.Namespace(service="atm-daemon")
+        denied = subprocess.CompletedProcess(["systemctl"], 1, "", "Failed to stop atm-daemon.service: Access denied")
+        missing = subprocess.CompletedProcess(["systemctl"], 5, "", "Failed to stop atm-daemon.service: Unit atm-daemon.service not loaded.")
+        with mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Linux"):
+            with mock.patch.object(DAEMON_SWITCH, "run", return_value=denied):
+                with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "Access denied"):
+                    DAEMON_SWITCH.run_service(args, "stop", allow_absent=True)
+            with mock.patch.object(DAEMON_SWITCH, "run", return_value=missing):
+                DAEMON_SWITCH.run_service(args, "stop", allow_absent=True)
+
     def test_start_requires_the_task_to_launch_the_daemon_selector(self) -> None:
         with (
             mock.patch.object(DAEMON_SWITCH.platform, "system", return_value="Windows"),

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import argparse
 import json
+import os
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 import plistlib
@@ -23,6 +24,13 @@ DAEMON_SWITCH = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(DAEMON_SWITCH)
 
 
+POSIX_ONLY = unittest.skipUnless(
+    os.name == "posix",
+    "launchd/systemd/AF_UNIX backends and POSIX permission bits do not exist on Windows",
+)
+
+
+@POSIX_ONLY
 class StaleSocketCleanupTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -66,6 +74,7 @@ class StaleSocketCleanupTests(unittest.TestCase):
         self.assertTrue(self.socket_path.is_file())
 
 
+@POSIX_ONLY
 class QuiesceTests(unittest.TestCase):
     def test_requires_explicit_confirmation(self) -> None:
         with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "--yes"):
@@ -697,6 +706,7 @@ class ReadinessAndRollbackTests(unittest.TestCase):
         development.assert_called_once_with(candidate_cli, candidate_daemon)
 
 
+@POSIX_ONLY
 class TemporaryLaunchJournalTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -937,6 +947,7 @@ class TemporaryLaunchControlPlaneTests(unittest.TestCase):
         )
 
 
+@POSIX_ONLY
 class MacosTemporaryLaunchAdapterTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -1237,6 +1248,7 @@ class WindowsTemporaryLaunchAdapterTests(unittest.TestCase):
             self.adapter.restore_exact(self.args, session)
 
 
+@POSIX_ONLY
 class LinuxTemporaryLaunchAdapterTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()

--- a/.just/run_pytests.py
+++ b/.just/run_pytests.py
@@ -49,6 +49,7 @@ def build_suite(repo_root: Path) -> unittest.TestSuite:
     test_paths = sorted((repo_root / ".just/tests").glob("test_*.py"))
     test_paths.extend(sorted((repo_root / "scripts/smoke").glob("test_*.py")))
     test_paths.extend(sorted((repo_root / "scripts/phase-aq").glob("test_*.py")))
+    test_paths.extend(sorted((repo_root / ".claude/skills/daemon-switch/tests").glob("test_*.py")))
     for test_path in test_paths:
         relative = test_path.relative_to(repo_root)
         module_name = (


### PR DESCRIPTION
Stacked on #1223 (targets its branch). Addresses the non-blocking Important findings from qa-pr1223-r1:

- Linux/systemd `run_service`: optional stop skipped only when systemd reports the unit absent; access denied and other failures now raise (same bug class fixed for Windows in e624b0471).
- Regression tests mirrored into the canonical `.claude/skills/daemon-switch/tests` suite (Windows denied/absent, Linux denied/absent).
- `.just/run_pytests.py` now discovers the canonical suite, so `just lint pytests` and CI run it.

`just lint` 35/35 locally.

The two Blocking findings on #1223 (Windows temporary-launch removal vs ADR-053 / REQ-P-DAEMON-SWITCH-001) are not addressed here; they need Rand's ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK