### PR TITLE
docs(adr): ADR-053 amendment — Windows out of temporary-launch scope; REQ-P-DAEMON-SWITCH-002

### DIFF
--- a/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
+++ b/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
@@ -70,9 +70,9 @@ Platform adapters provide the same contract while preserving native ownership:
 - **macOS:** read/hash the controlled source LaunchAgent plist, write an owned
   overlay copy with one typed `ProgramArguments` addition, bootstrap that
   overlay, and bootstrap the untouched original plist on restore.
-- **Windows:** capture the named SCM service's exact `BINARY_PATH_NAME`, use a
-  round-trip-tested Windows argv codec to form an owned typed overlay, and
-  restore the exact captured scalar through SCM.
+- **Windows:** no temporary-launch backend (amended 2026-09-05, see below).
+  `temporary-launch` on Windows fails closed with an explicit error; it must
+  not substitute an SCM service for the per-user scheduled task.
 - **Linux:** accept only an unambiguous systemd `--user` unit command shape,
   install an owned drop-in that resets/replaces `ExecStart` with one typed
   addition, and remove only that owned drop-in on restoration.
@@ -97,8 +97,9 @@ Apple Development signing checks remain mandatory before lifecycle mutation.
   normal daemon launch remains mTLS.
 - A crash is diagnosable and safe to recover; it cannot silently replace an
   operator's current service configuration with a synthesized default.
-- macOS, Windows, and Linux share product semantics but may reject a service
+- macOS and Linux share product semantics but may reject a service
   configuration that their narrow adapter cannot preserve losslessly.
+  Windows has no temporary-launch adapter.
 - Lifecycle/setup work stays outside benchmark samples, preserving the
   plaintext admission pipeline and its performance evidence.
 
@@ -126,16 +127,36 @@ Apple Development signing checks remain mandatory before lifecycle mutation.
 
 - Unit/failure-injection tests prove journal-before-mutation, exact restoration,
   and refusal of a second session/normal mutation while recovery is pending.
-- macOS plist, Windows argv/SCM, and Linux unit/drop-in contract tests reject
+- macOS plist and Linux unit/drop-in contract tests reject
   malformed, ambiguous, duplicate-mode, and changed-source configurations
   before service mutation.
 - Each supported operating system has a real managed-service proof using the
   selected signed release pair: mTLS begin/restore and plaintext-test
   begin/restore both pass doctor, curl receiver, CLI loopback, and same-host
-  send/read checks.  Windows and Linux are not considered complete on fake
-  boundaries alone.
+  send/read checks.  Linux is not considered complete on fake boundaries
+  alone.  Windows is out of scope for this evidence.
 - Architecture evidence proves this feature is absent from `atm-http-runtime`,
   router, persistence, direct-peer connector, and benchmark `run_profile`.
 - Session evidence records selected pair identity, adapter, mode, phase timing,
   redacted configuration digests, and recovery disposition.  It records no
   primary-database mutation.
+
+## Amendment 2026-09-05 — Windows removed from the temporary-launch scope
+
+Rand's ruling: `daemon-switch` is a tool that switches the daemon and CLI
+pair; what it switches to depends on the situation (benchmarks run on a
+dedicated fixture, integration testing runs in Colima).  It was carrying too
+many requirements.  The Windows managed daemon is a per-user scheduled task
+(`windows-provision`, PR #1223), not an SCM service; an SCM service would run
+under a different account, so the exact `BINARY_PATH_NAME` round trip this
+ADR originally required no longer describes a supported backend.
+
+Effect:
+
+- The typed temporary-launch overlay is a macOS LaunchAgent and Linux systemd
+  `--user` capability only.
+- On Windows, `temporary-launch` fails closed with an explicit `SwitchError`
+  and never creates or edits an SCM service as a fallback.
+- `REQ-P-DAEMON-SWITCH-001` is narrowed to match.  The Windows argv codec
+  remains in the codebase only as a tested utility; it carries no service
+  contract.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -309,13 +309,25 @@ Satisfied by:
     captured original configuration; ambiguous, missing, changed, or
     unsupported service configuration fails closed before an unsafe mutation
   - adapters must preserve platform-native ownership: an owned macOS
-    LaunchAgent plist copy, exact Windows SCM `BINARY_PATH_NAME` round trip,
-    or an owned systemd `--user` drop-in.  They must not rewrite an unknown
-    source configuration or start a direct child daemon as fallback
+    LaunchAgent plist copy or an owned systemd `--user` drop-in.  They must
+    not rewrite an unknown source configuration or start a direct child
+    daemon as fallback.  Windows has no temporary-launch adapter: the managed
+    daemon is a per-user scheduled task and `temporary-launch` fails closed
+    (ADR-053 amendment 2026-09-05)
   - after successful restoration, the same selected pair starts through the
     ordinary managed service without the temporary argument and doctor proves
     normal mTLS/default state; selected-pair and applicable signing gates
     remain mandatory for every lifecycle-changing operation
+- `REQ-P-DAEMON-SWITCH-002` `daemon-switch` switches the matched CLI/daemon
+  pair between a released build and a locally built pair; which pair is
+  selected depends on the situation (benchmarks run on a dedicated fixture,
+  integration testing runs in Colima).  Switching to a locally built pair
+  must require that the build is tagged for reproducibility and traceability
+  (a patch-bumped prerelease tag on the integration branch, `just
+  prerelease-tag`), and the switch/restart/status/doctor lifecycle must work
+  correctly on macOS, Linux, and Windows.  Beyond tagging and the platform
+  lifecycle, the tool carries no additional service-management requirements
+  (Rand, 2026-09-05; ADR-053 amendment).
   - evidence may expose redacted service metadata, pair identity, mode,
     digests, phase durations, and recovery outcome, but never private keys,
     certificate contents, raw trust records, or primary-database state


### PR DESCRIPTION
Stacked on #1225 → #1223. Docs only.

Records Rand's ruling that `daemon-switch` switches the matched CLI/daemon pair and carries only two requirements beyond that: a local build must be prerelease-tagged for traceability, and the lifecycle must work on macOS, Linux, and Windows. The Windows managed daemon is a per-user scheduled task (#1223), so the SCM `BINARY_PATH_NAME` temporary-launch clause is removed from ADR-053 and `REQ-P-DAEMON-SWITCH-001`; `temporary-launch` on Windows fails closed.

Clears the two Blocking findings from qa-pr1223-r1 (capability removal against an Accepted ADR without amendment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK