### PR TITLE
fix(ci): AW-PARITY-ISOLATION-1 — debug atm-graft for CLI parity lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,8 @@ jobs:
         shell: bash
         env:
           ATM_CLI_PARITY_CI: "1"
-        run: "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
+        run: |
+          "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
 
       - name: Run ATM queue lifecycle hook tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,12 +350,32 @@ jobs:
           python -m pip install --disable-pip-version-check --requirement tools/bootstrap-requirements.txt
           python -m pip install --no-deps "$ATM_GRAFT_WHEEL" crates/hermes-atm
 
+      - name: Install isolated debug CLI/native parity packages
+        if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv_root="$GITHUB_WORKSPACE/.bootstrap-venv"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            venv_python="$venv_root/Scripts/python.exe"
+            venv_bin="$venv_root/Scripts"
+          else
+            venv_python="$venv_root/bin/python"
+            venv_bin="$venv_root/bin"
+          fi
+          export VIRTUAL_ENV="$venv_root"
+          export PATH="$venv_bin:$PATH"
+          "$venv_python" -m pip install --no-deps crates/hermes-atm
+          maturin develop --manifest-path crates/atm-graft-python/Cargo.toml
+          "$venv_python" -c 'import atm_graft._atm_graft as extension; assert hasattr(extension, "_debug_runtime_scope")'
+          echo "ATM_PARITY_PYTHON=$venv_python" >> "$GITHUB_ENV"
+
       - name: Run CLI/native parity test with a generated fixture
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}
         shell: bash
         env:
           ATM_CLI_PARITY_CI: "1"
-        run: python -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
+        run: "$ATM_PARITY_PYTHON" -m unittest discover -s crates/atm-graft-python/tests -p "test_cli_parity.py"
 
       - name: Run ATM queue lifecycle hook tests
         if: ${{ needs.ci-scope.outputs.runtime == 'true' }}

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -418,6 +418,19 @@ fn observability_paths() -> PyResult<PyObservabilityPaths> {
     })
 }
 
+/// Return the debug runtime root selected for process-pair integration tests.
+///
+/// This private diagnostic is deliberately compiled only into debug extension
+/// artifacts. The CLI/native parity fixture uses it to fail before opening a
+/// native session when a release wheel would ignore its isolated test scope.
+#[cfg(debug_assertions)]
+#[pyfunction]
+fn _debug_runtime_scope() -> PyResult<String> {
+    atm_core::home::current_host_runtime_scope()
+        .map(|scope| scope.runtime_root.as_ref().display().to_string())
+        .map_err(atm_error)
+}
+
 impl PyGraftSession {
     fn client(&self) -> PyResult<GraftClient> {
         self.client
@@ -866,6 +879,8 @@ impl PyGraftSession {
 fn _atm_graft(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("AtmGraftError", m.py().get_type::<AtmGraftError>())?;
     m.add_function(wrap_pyfunction!(observability_paths, m)?)?;
+    #[cfg(debug_assertions)]
+    m.add_function(wrap_pyfunction!(_debug_runtime_scope, m)?)?;
     m.add_class::<PyObservability>()?;
     m.add_class::<PyObservabilityPaths>()?;
     m.add_class::<PyAgentAddress>()?;

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -282,6 +282,31 @@ def _parity_enabled() -> bool:
 class CliParityTests(unittest.TestCase):
     """Compare native tool JSON with CLI JSON on one disposable daemon."""
 
+    @staticmethod
+    def _assert_debug_native_scope(environment: dict[str, str]) -> None:
+        """Reject a release extension before it can connect outside the fixture."""
+
+        runtime_home = environment.get("ATM_TEST_RUNTIME_HOME")
+        if not runtime_home:
+            raise RuntimeError("generated parity fixture requires ATM_TEST_RUNTIME_HOME")
+
+        import atm_graft._atm_graft as extension
+
+        try:
+            actual_runtime_root = Path(extension._debug_runtime_scope()).resolve()
+        except AttributeError as error:
+            raise RuntimeError(
+                "CLI/native parity requires a debug atm-graft extension; "
+                "a release wheel ignores ATM_TEST_RUNTIME_HOME"
+            ) from error
+
+        expected_runtime_root = (Path(runtime_home) / ".atm" / "daemon").resolve()
+        if actual_runtime_root != expected_runtime_root:
+            raise RuntimeError(
+                "CLI/native parity native runtime is outside the disposable fixture: "
+                f"expected {expected_runtime_root}, got {actual_runtime_root}"
+            )
+
     @classmethod
     def setUpClass(cls) -> None:
         fixture_path = os.environ.get("ATM_CLI_PARITY_FIXTURE")
@@ -303,6 +328,9 @@ class CliParityTests(unittest.TestCase):
         cls._prior_environment = os.environ.copy()
         os.environ.clear()
         os.environ.update(cls.environment)
+
+        if cls._generated is not None:
+            cls._assert_debug_native_scope(cls.environment)
 
         from hermes_atm import native_tools
 


### PR DESCRIPTION
Stacked on #1222 (fix/aw-readiness-followup). Layer 5 of the AW readiness stack.

Release builds compile out `ATM_TEST_RUNTIME_HOME`, so with runtime isolation restored in 9d9bcd0b1 the release atm-graft wheel and the debug daemon split sockets and the parity lane fails. CI keeps the release-wheel install/smoke and additionally installs a debug atm-graft into the bootstrap venv for behavioural parity. Generated-fixture setup now calls the debug-only runtime-scope helper and hard-fails before native-session creation unless it resolves under the fixture temp home.

Dev validation (arch-ctm, 9ca526035): parity PASS with `ATM_CLI_PARITY_CI=1`; `just lint` all checks pass; no `~/.atm` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK