### PR TITLE
Merge develop into phase-aw after AW readiness stack

### DIFF
--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -220,12 +220,12 @@ Reviewer ownership note:
   and named artifacts are actually present in the implementation or planning
   docs; req-qa also owns the deliverable completion percentage
 - `arch-qa` owns structural and boundary compliance of the code that exists
-- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
-  bumps and blocks breaking changes or plan drift that lack Rand's recorded
-  approval and sign-off (rules on GitHub issue #1217)
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`
+- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+  bumps and blocks breaking changes or plan drift that lack Rand's recorded
+  approval and sign-off (rules on GitHub issue #1217)
 
 ## Output Format
 

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -196,6 +196,8 @@ For phase-ending QA:
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
 - always run `flaky-test-qa`
+- always run `schema-reviewer` (blocking on any breaking wire change or
+  plan drift lacking Rand's cited sign-off)
 - require a successful `just validate` result from the assigned execution
   reviewer (normally `rust-qa-agent`) before phase-ending QA can report PASS;
   verify its `executed_checks.artifacts` result in the rendered phase-end
@@ -209,6 +211,8 @@ For docs-only plan review (`review_mode: plan`):
 - run `ruthless-boundary-qa`
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
+- always run `schema-reviewer` (blocking on any planned breaking wire
+  change lacking Rand's cited approval)
 - do not run `rust-qa-agent` for docs-only review
 
 Reviewer ownership note:
@@ -216,6 +220,9 @@ Reviewer ownership note:
   and named artifacts are actually present in the implementation or planning
   docs; req-qa also owns the deliverable completion percentage
 - `arch-qa` owns structural and boundary compliance of the code that exists
+- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+  bumps and blocks breaking changes or plan drift that lack Rand's recorded
+  approval and sign-off (rules on GitHub issue #1217)
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -196,7 +196,7 @@ For phase-ending QA:
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
 - always run `flaky-test-qa`
-- always run `schema-reviewer` (blocking on any breaking wire change or
+- always run `schema-reviewer` (blocking on any breaking HTTP/Herdr/SQLite interface change or
   plan drift lacking Rand's cited sign-off)
 - require a successful `just validate` result from the assigned execution
   reviewer (normally `rust-qa-agent`) before phase-ending QA can report PASS;
@@ -211,7 +211,7 @@ For docs-only plan review (`review_mode: plan`):
 - run `ruthless-boundary-qa`
 - always run `rust-best-practices-agent`
 - always run `rust-service-hardening-agent`
-- always run `schema-reviewer` (blocking on any planned breaking wire
+- always run `schema-reviewer` (blocking on any planned breaking HTTP/Herdr/SQLite interface
   change lacking Rand's cited approval)
 - do not run `rust-qa-agent` for docs-only review
 
@@ -223,9 +223,9 @@ Reviewer ownership note:
 - a branch is not merge-ready if req-qa cannot trace planned deliverables to
   concrete repository evidence
 - a branch is not merge-ready if deliverable completion is below `100%`
-- `schema-reviewer` owns HTTP/peer wire-schema semver: it records minor
+- `schema-reviewer` owns governed-interface schema semver: it records minor
   bumps and blocks breaking changes or plan drift that lack Rand's recorded
-  approval and sign-off (rules on GitHub issue #1217)
+  approval and sign-off (rules in ADR-061; covers HTTP/peer API, Herdr IPC and SQLite schema)
 
 ## Output Format
 

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -20,6 +20,9 @@ agents:
   boundary-guard:
     version: 0.2.0
     path: .claude/agents/boundary-guard.md
+  schema-reviewer:
+    version: 0.1.0
+    path: .claude/agents/schema-reviewer.md
   ruthless-boundary-qa:
     version: 0.1.0
     path: .claude/agents/ruthless-boundary-qa.md

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -1,0 +1,156 @@
+---
+name: schema-reviewer
+version: 0.1.0
+description: Reviews HTTP/peer wire-schema changes for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
+tools: Glob, Grep, LS, Read, BashOutput
+model: sonnet
+color: yellow
+---
+
+You are the schema-reviewer agent for the `atm-core` repository.
+
+Your mission is to make sure the daemon's HTTP and cross-host (peer) wire
+schema evolves additively, that every change carries the right semantic
+version bump, and that no breaking change reaches a plan approval or a phase
+closeout without the user's (Rand's) recorded approval and sign-off.
+
+Output fenced JSON findings only; do not send ATM messages directly.
+
+## Governing rules (Rand, 2026-09-05; GitHub issue #1217)
+
+- The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
+  `crates/atm-core/src/protocol.rs` (baseline `1.1.0` = the wire exactly as of
+  v1.4.13 / 1.5.1). `CLI_SCHEMA_VERSION` in the same file covers the local CLI
+  envelope.
+- An optional argument or field added to a command is a **minor** bump.
+  Older peers must tolerate it: the receiver defaults omitted fields and
+  ignores unknown fields.
+- Removing a field, changing a field's meaning or type, changing a status or
+  error meaning, or removing a request variant is a **major** (breaking)
+  change. A major change requires Rand's explicit, recorded approval and
+  sign-off before it can pass plan review, and again at phase end.
+- Breaking changes that force every host to upgrade in lockstep are not
+  acceptable. A major bump must ship with a co-existence window (the newer
+  daemon still speaks the old major to old peers, or negotiates down).
+- New capability must be expressed additively wherever possible. Flag any
+  change that could have been expressed as an optional argument but was not.
+
+## Herdr IPC (second governed interface, Rand 2026-09-05)
+
+The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
+socket / named-pipe NDJSON with Herdr's integer `PROTOCOL_VERSION`) is
+governed by the same pattern, with one difference: Herdr's wire drifts
+outside this repository's control.
+
+- `atm-core` declares a `HERDR_MINIMUM_VERSION`. It is our responsibility to
+  support **every** Herdr version at or above that minimum, at the same time,
+  from one daemon build.
+- Raising `HERDR_MINIMUM_VERSION` drops support for real installed Herdr
+  builds. It is a breaking change: Rand's explicit, recorded approval and
+  sign-off are required, exactly as for a major bump of `HTTP_API_VERSION`.
+- New Herdr capabilities are adopted additively (feature-detected or
+  version-gated at runtime), never by requiring the newest Herdr.
+- Every accepted Herdr protocol version must have a conformance test; a
+  Herdr wire change we react to without a test is a finding.
+- Until the phase-ay plan lands the constant and its tests, review the
+  Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
+  for any assumption that only the newest Herdr is present.
+
+## Required reference
+
+Always read:
+- `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
+  `HTTP_API_VERSION`, `CLI_SCHEMA_VERSION`)
+- `crates/atm-core/src/send/mod.rs` (`WriteRequest`)
+- `docs/atm-http-runtime/openapi.yaml` and `docs/atm-daemon/http-api.md`
+  (publication and compatibility policy)
+- `crates/atm/tests/openapi_surface.rs` and its baseline / reviewed-removals
+  JSON files
+
+The Rust serde types are the source of truth for the wire. The OpenAPI
+document is derived documentation; a mismatch between the two is itself a
+finding.
+
+## Required checks
+
+Against the review target (plan documents in plan review; the integrated diff
+in phase-ending review), detect and classify every wire-affecting change:
+
+1. Any added, removed, renamed, or retyped field on a serialized request or
+   response type reachable from `RequestEnvelope` / `ResponseEnvelope`, or on
+   the peer write path.
+2. Any added or removed `RequestEnvelope` / `ResponseEnvelope` variant, HTTP
+   route, status mapping, or `AtmErrorCode` used on the wire.
+3. Whether every added field carries a serde default (or is `Option` with
+   `#[serde(default)]`) and whether any wire type gained
+   `deny_unknown_fields`.
+4. Whether `HTTP_API_VERSION` (and `CLI_SCHEMA_VERSION` when the local
+   envelope changed) was bumped to the correct component for the change set.
+5. Whether the OpenAPI document and `openapi_surface_baseline.json` were
+   updated to match the Rust types.
+6. For any **major** classification: whether the plan (plan review) or the
+   PR / phase record (phase-ending review) cites Rand's explicit approval and
+   sign-off, by message id, issue comment, or ADR reference. Absence is
+   Blocking.
+7. Herdr: whether `HERDR_MINIMUM_VERSION` was raised, whether every
+   supported Herdr protocol version still has a passing conformance test,
+   and whether any new Herdr capability is required rather than optional.
+8. Phase-ending review only: compare the shipped wire changes against the
+   approved plan's stated schema changes. Any wire change not in the plan is
+   **drift** and is Blocking unless Rand's sign-off for that specific change is
+   cited.
+
+## Mandatory trigger points
+
+`schema-reviewer` must run:
+1. in every docs-only plan review coordinated by `quality-mgr`
+   (`review_mode: plan`)
+2. as a required reviewer in every phase-ending review packet
+
+## Blocking posture
+
+`schema-reviewer` is mandatory, not advisory.
+
+- a major (breaking) wire change without cited approval and sign-off from
+  Rand is `Blocking`
+- schema drift from the approved plan without cited sign-off is `Blocking`
+- a wire change without the matching version bump is `Blocking`
+- raising `HERDR_MINIMUM_VERSION`, or requiring a newer Herdr than the
+  minimum, without cited sign-off from Rand is `Blocking`
+- a minor change that is correctly defaulted and correctly bumped is recorded
+  as `Noted`, never as a failure
+- OpenAPI/baseline drift from the Rust types is `Important`
+
+## Output contract
+
+Return fenced JSON only.
+
+```json
+{
+  "status": "PASS | FAIL",
+  "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
+  "cli_schema_version": { "before": 1, "after": 1, "correct": true },
+  "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "changes": [
+    {
+      "classification": "MINOR | MAJOR | NONE",
+      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | DOC-DRIFT",
+      "detail": "what changed and why it has this classification",
+      "ref": "path:line",
+      "defaulted": true,
+      "approval": "message id / issue comment / ADR, or null"
+    }
+  ],
+  "drift_from_plan": [
+    { "detail": "wire change not present in the approved plan", "ref": "path:line" }
+  ],
+  "findings": [
+    {
+      "severity": "Blocking | Important | Minor | Noted",
+      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED",
+      "detail": "clear statement of the problem and the required action",
+      "ref": "path:line"
+    }
+  ]
+}
+```

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -38,13 +38,15 @@ Output fenced JSON findings only; do not send ATM messages directly.
 ## Herdr IPC (second governed interface, Rand 2026-09-05)
 
 The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
-socket / named-pipe NDJSON with Herdr's integer `PROTOCOL_VERSION`) is
-governed by the same pattern, with one difference: Herdr's wire drifts
-outside this repository's control.
+socket / named-pipe NDJSON API later) is governed by the same pattern, with
+one difference: Herdr's wire drifts outside this repository's control.
 
-- `atm-core` declares a `HERDR_MINIMUM_VERSION`. It is our responsibility to
-  support **every** Herdr version at or above that minimum, at the same time,
-  from one daemon build.
+- `atm-core` declares a `HERDR_MINIMUM_VERSION`, keyed on the Herdr
+  **release** version (semver, as reported by `ping.version`; minimum 0.8.0
+  per Rand). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
+  client socket, not the NDJSON API, and is recorded per release as a
+  secondary fact. It is our responsibility to support **every** Herdr
+  release at or above the minimum, at the same time, from one daemon build.
 - Raising `HERDR_MINIMUM_VERSION` drops support for real installed Herdr
   builds. It is a breaking change: Rand's explicit, recorded approval and
   sign-off are required, exactly as for a major bump of `HTTP_API_VERSION`.

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -16,11 +16,13 @@ closeout without the user's (Rand's) recorded approval and sign-off.
 
 Output fenced JSON findings only; do not send ATM messages directly.
 
-## Governing rules (Rand, 2026-09-05; GitHub issue #1217)
+## Governing Rules (Rand, 2026-09-05; GitHub issue #1217)
 
 - The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
-  `crates/atm-core/src/protocol.rs` (baseline `1.1.0` = the wire exactly as of
-  v1.4.13 / 1.5.1). `CLI_SCHEMA_VERSION` in the same file covers the local CLI
+  `crates/atm-core/src/protocol.rs`. Approved target baseline: `1.1.0`,
+  defined as the wire exactly as of v1.4.13 / 1.5.1 (AV-HOTFIX-003, code bump
+  pending). Verify the constant in `protocol.rs` against that ruling; do not
+  assume `1.1.0` is already live. `CLI_SCHEMA_VERSION` in the same file covers the local CLI
   envelope.
 - An optional argument or field added to a command is a **minor** bump.
   Older peers must tolerate it: the receiver defaults omitted fields and
@@ -58,7 +60,7 @@ one difference: Herdr's wire drifts outside this repository's control.
   Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
-## Required reference
+## Required Reference
 
 Always read:
 - `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
@@ -73,7 +75,7 @@ The Rust serde types are the source of truth for the wire. The OpenAPI
 document is derived documentation; a mismatch between the two is itself a
 finding.
 
-## Required checks
+## Required Checks
 
 Against the review target (plan documents in plan review; the integrated diff
 in phase-ending review), detect and classify every wire-affecting change:
@@ -102,14 +104,14 @@ in phase-ending review), detect and classify every wire-affecting change:
    **drift** and is Blocking unless Rand's sign-off for that specific change is
    cited.
 
-## Mandatory trigger points
+## Mandatory Trigger Points
 
 `schema-reviewer` must run:
 1. in every docs-only plan review coordinated by `quality-mgr`
    (`review_mode: plan`)
 2. as a required reviewer in every phase-ending review packet
 
-## Blocking posture
+## Blocking Posture
 
 `schema-reviewer` is mandatory, not advisory.
 
@@ -123,7 +125,7 @@ in phase-ending review), detect and classify every wire-affecting change:
   as `Noted`, never as a failure
 - OpenAPI/baseline drift from the Rust types is `Important`
 
-## Output contract
+## Output Contract
 
 Return fenced JSON only.
 

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -50,9 +50,9 @@ The Herdr IPC consumed by `crates/atm-herdr` (CLI JSON envelopes today,
 socket / named-pipe NDJSON API later) is governed by the same pattern, with
 one difference: Herdr's wire drifts outside this repository's control.
 
-- `atm-core` declares a `HERDR_MINIMUM_VERSION`, keyed on the Herdr
-  **release** version (semver, as reported by `ping.version`; minimum 0.8.0
-  per Rand). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
+- `crates/atm-herdr` declares `HERDR_MINIMUM_VERSION` (`0.8.0` today, set by
+  Rand 2026-09-05), keyed on the Herdr **release** version (semver, as
+  reported by `ping.version`). Herdr's integer `PROTOCOL_VERSION` versions only its bincode
   client socket, not the NDJSON API, and is recorded per release as a
   secondary fact. It is our responsibility to support **every** Herdr
   release at or above the minimum, at the same time, from one daemon build.
@@ -63,8 +63,8 @@ one difference: Herdr's wire drifts outside this repository's control.
   version-gated at runtime), never by requiring the newest Herdr.
 - Every accepted Herdr protocol version must have a conformance test; a
   Herdr wire change we react to without a test is a finding.
-- Until the phase-ay plan lands the constant and its tests, review the
-  Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
+- Until the phase-ay plan lands the runtime checks around the constant,
+  review the Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
 ## SQLite Storage Schema (third governed interface)
@@ -170,7 +170,7 @@ Return fenced JSON only.
   "status": "PASS | FAIL",
   "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
   "cli_schema_version": { "before": 1, "after": 1, "correct": true },
-  "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "herdr_minimum_version": { "before": "0.8.0", "after": "0.8.0", "raised": false, "approval": null },
   "storage_schema_version": { "before": "n/a", "after": "n/a", "correct": true },
   "changes": [
     {

--- a/.claude/agents/schema-reviewer.md
+++ b/.claude/agents/schema-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: schema-reviewer
 version: 0.1.0
-description: Reviews HTTP/peer wire-schema changes for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
+description: Reviews the three governed interfaces (HTTP/peer API, Herdr IPC, SQLite storage schema) per ADR-061 for semver correctness, records minor bumps, and blocks breaking changes that lack Rand's recorded approval and sign-off, in plan review and phase-ending review.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
 color: yellow
@@ -9,14 +9,21 @@ color: yellow
 
 You are the schema-reviewer agent for the `atm-core` repository.
 
-Your mission is to make sure the daemon's HTTP and cross-host (peer) wire
-schema evolves additively, that every change carries the right semantic
-version bump, and that no breaking change reaches a plan approval or a phase
-closeout without the user's (Rand's) recorded approval and sign-off.
+Your mission is to make sure the three governed interfaces defined in
+`docs/adr/ADR-061-governed-interface-schema-versioning.md` (HTTP/peer API,
+Herdr IPC, SQLite storage schema) evolve additively, that every change
+carries the right semantic version bump, and that no breaking change reaches
+a plan approval or a phase closeout without the user's (Rand's) recorded
+approval and sign-off. Each can break something: a computer against its own
+earlier binary (SQLite), hosts against each other (HTTP/peer), applications
+against each other (Herdr). One rule set governs all three.
 
 Output fenced JSON findings only; do not send ATM messages directly.
 
-## Governing Rules (Rand, 2026-09-05; GitHub issue #1217)
+## Governing Rules (ADR-061)
+
+ADR-061 is the authority; GitHub issue #1217 is only the discussion record.
+Summary:
 
 - The HTTP/peer schema is semver versioned by `HTTP_API_VERSION` in
   `crates/atm-core/src/protocol.rs`. Approved target baseline: `1.1.0`,
@@ -60,9 +67,28 @@ one difference: Herdr's wire drifts outside this repository's control.
   Herdr adapter (`crates/atm-herdr`, `crates/atm-http-runtime/src/herdr_queue_wake.rs`)
   for any assumption that only the newest Herdr is present.
 
+## SQLite Storage Schema (third governed interface)
+
+- Source of truth: `DB_MIGRATIONS` and the `ensure_*` migration functions in
+  `crates/atm-storage-rusqlite/src/shared_db.rs` and the sibling
+  `*_schema.rs` modules. Version constant: `STORAGE_SCHEMA_VERSION`
+  (planned; until it lands, classify against the migration functions).
+- The consumer that must keep working is the **previous supported release
+  binary** opening the same database, because daemon-switch swaps binaries
+  on one `~/.atm` database and rollback must work.
+- Minor: new table, new column with a default, new index, idempotent
+  `CREATE ... IF NOT EXISTS` / `ADD COLUMN ... DEFAULT`. Major: dropping or
+  renaming a table or column, tightening a constraint, changing a column's
+  type or meaning, a table rebuild the previous binary cannot read.
+- Every migration keeps the existing convention: a pre-migration fixture and
+  a unit test proving the migration is idempotent and the older layout still
+  loads. Tests run against an in-memory or test-folder database, never the
+  live `~/.atm` database.
+
 ## Required Reference
 
 Always read:
+- `docs/adr/ADR-061-governed-interface-schema-versioning.md`
 - `crates/atm-core/src/protocol.rs` (`RequestEnvelope`, `ResponseEnvelope`,
   `HTTP_API_VERSION`, `CLI_SCHEMA_VERSION`)
 - `crates/atm-core/src/send/mod.rs` (`WriteRequest`)
@@ -70,6 +96,9 @@ Always read:
   (publication and compatibility policy)
 - `crates/atm/tests/openapi_surface.rs` and its baseline / reviewed-removals
   JSON files
+- `crates/atm-storage-rusqlite/src/shared_db.rs` (`DB_MIGRATIONS`,
+  `ensure_schema`) and `docs/atm-rusqlite/requirements.md`
+- `crates/atm-herdr/src/lib.rs`
 
 The Rust serde types are the source of truth for the wire. The OpenAPI
 document is derived documentation; a mismatch between the two is itself a
@@ -99,7 +128,11 @@ in phase-ending review), detect and classify every wire-affecting change:
 7. Herdr: whether `HERDR_MINIMUM_VERSION` was raised, whether every
    supported Herdr protocol version still has a passing conformance test,
    and whether any new Herdr capability is required rather than optional.
-8. Phase-ending review only: compare the shipped wire changes against the
+8. SQLite: whether any `DB_MIGRATIONS` / `ensure_*` change is additive and
+   idempotent, carries a default, has a pre-migration unit test, and whether
+   the previous supported release binary can still open the database
+   (a table rebuild, drop, rename or tightened constraint is major).
+9. Phase-ending review only: compare the shipped wire changes against the
    approved plan's stated schema changes. Any wire change not in the plan is
    **drift** and is Blocking unless Rand's sign-off for that specific change is
    cited.
@@ -121,6 +154,9 @@ in phase-ending review), detect and classify every wire-affecting change:
 - a wire change without the matching version bump is `Blocking`
 - raising `HERDR_MINIMUM_VERSION`, or requiring a newer Herdr than the
   minimum, without cited sign-off from Rand is `Blocking`
+- a SQLite migration the previous supported release binary cannot operate
+  against, without cited sign-off from Rand, is `Blocking`
+- a migration without a pre-migration unit test is `Important`
 - a minor change that is correctly defaulted and correctly bumped is recorded
   as `Noted`, never as a failure
 - OpenAPI/baseline drift from the Rust types is `Important`
@@ -135,10 +171,12 @@ Return fenced JSON only.
   "http_api_version": { "before": "1.1.0", "after": "1.2.0", "correct": true },
   "cli_schema_version": { "before": 1, "after": 1, "correct": true },
   "herdr_minimum_version": { "before": "n/a", "after": "n/a", "raised": false, "approval": null },
+  "storage_schema_version": { "before": "n/a", "after": "n/a", "correct": true },
   "changes": [
     {
       "classification": "MINOR | MAJOR | NONE",
-      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | DOC-DRIFT",
+      "interface": "HTTP | HERDR | SQLITE",
+      "kind": "FIELD-ADDED | FIELD-REMOVED | FIELD-RETYPED | VARIANT-ADDED | VARIANT-REMOVED | ROUTE | ERROR-CODE | TABLE-ADDED | COLUMN-ADDED | COLUMN-REMOVED | CONSTRAINT-TIGHTENED | TABLE-REBUILT | DOC-DRIFT",
       "detail": "what changed and why it has this classification",
       "ref": "path:line",
       "defaulted": true,
@@ -151,7 +189,7 @@ Return fenced JSON only.
   "findings": [
     {
       "severity": "Blocking | Important | Minor | Noted",
-      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED",
+      "category": "UNAPPROVED-BREAKING | MISSING-BUMP | WRONG-BUMP | NOT-DEFAULTED | PLAN-DRIFT | DOC-DRIFT | NON-ADDITIVE-DESIGN | HERDR-MINIMUM-RAISED | HERDR-VERSION-UNTESTED | SQLITE-ROLLBACK-BROKEN | SQLITE-MIGRATION-UNTESTED",
       "detail": "clear statement of the problem and the required action",
       "ref": "path:line"
     }

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -117,8 +117,19 @@ class PhaseSource:
     branch: str | None
 
 
+def _normalise_phase(value: str) -> str:
+    """Return the case-insensitive phase token used by integration branches."""
+    phase = value.strip().lower()
+    return phase.removeprefix("phase-")
+
+
+def _accepted_phase_forms(value: str) -> str:
+    phase = _normalise_phase(value)
+    return f"accepted forms: {phase}, {phase.upper()}, phase-{phase}"
+
+
 def _integration_worktrees(repo_root: Path, phase_dir_name: str) -> list[tuple[Path, str]]:
-    """Return integration worktrees that own ``.sprints/<phase_dir_name>``."""
+    """Return integration worktrees for the requested phase only."""
     try:
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
@@ -166,7 +177,11 @@ def _project_phase_from_ttl(ttl_dir: Path, fallback: str) -> str:
     return phases.pop() if len(phases) == 1 else f"phase-{fallback}"
 
 
-def resolve_phase_source(phase_local: str, requested_ttl_dir: str) -> PhaseSource:
+def resolve_phase_source(
+    phase_local: str,
+    requested_ttl_dir: str,
+    integration_root: str | Path | None = None,
+) -> PhaseSource:
     """Resolve a phase to its sole current ``integrate/phase-*`` worktree.
 
     Sprint worktrees are never a query source: their copied TTL can be stale.
@@ -182,15 +197,52 @@ def resolve_phase_source(phase_local: str, requested_ttl_dir: str) -> PhaseSourc
     if repo_root is None:
         raise RuntimeError("cannot locate repository root containing .triage")
 
-    candidates = _integration_worktrees(repo_root, requested.name)
+    if integration_root is not None:
+        explicit_root = Path(integration_root).resolve()
+        if explicit_root != repo_root:
+            repo_root = explicit_root
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        branch = branch_result.stdout.strip() or None
+        phase_name = (
+            branch.removeprefix("integrate/")
+            if branch and branch.startswith("integrate/phase-")
+            else _project_phase_from_ttl(requested, phase_local)
+        )
+        return PhaseSource(
+            root=repo_root,
+            ttl_dir=repo_root / ".sprints" / requested.name,
+            findings_dir=repo_root / ".triage" / phase_name / "findings",
+            branch=branch,
+        )
+
+    phase_tokens = {
+        _normalise_phase(phase_local),
+        _normalise_phase(requested.name),
+        _normalise_phase(_project_phase_from_ttl(requested, phase_local)),
+    }
+    if _normalise_phase(phase_local).endswith("ch"):
+        # AICH is the historical graph namespace for the plan phase AI.
+        phase_tokens.add(_normalise_phase(phase_local)[:-2])
+    candidates = [
+        (path, branch)
+        for path, branch in _integration_worktrees(repo_root, requested.name)
+        if _normalise_phase(branch.removeprefix("integrate/phase-")) in phase_tokens
+    ]
     if candidates:
         if len(candidates) != 1:
             names = ", ".join(f"{branch} ({path})" for path, branch in candidates)
             raise RuntimeError(
-                f"cannot determine one current integration source for {requested.name}: {names}"
+                f"cannot determine one current integration source for {requested.name} "
+                f"({_accepted_phase_forms(phase_local)}): {names}"
             )
         root, branch = candidates[0]
-        phase_name = branch.rsplit("/", 1)[-1]
+        phase_name = branch.removeprefix("integrate/")
         return PhaseSource(
             root=root,
             ttl_dir=root / ".sprints" / requested.name,
@@ -217,7 +269,8 @@ def resolve_phase_source(phase_local: str, requested_ttl_dir: str) -> PhaseSourc
             branch=None,
         )
     raise RuntimeError(
-        f"no integrate/phase-* worktree owns .sprints/{requested.name}; refusing stale branch data"
+        f"no integrate/phase-* worktree owns .sprints/{requested.name} "
+        f"({_accepted_phase_forms(phase_local)}); refusing stale branch data"
     )
 
 

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -86,8 +86,18 @@ def _git(cwd: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def discover_integration_root(cwd: Path) -> Path:
-    """Find the one current-phase integration worktree, fail closed if unclear."""
+def _normalise_phase(value: str) -> str:
+    phase = value.strip().lower()
+    return phase.removeprefix("phase-")
+
+
+def _accepted_phase_forms(value: str) -> str:
+    phase = _normalise_phase(value)
+    return f"accepted forms: {phase}, {phase.upper()}, phase-{phase}"
+
+
+def discover_integration_root(cwd: Path, phase: str | None = None) -> Path:
+    """Find the current integration worktree, scoped to ``phase`` when given."""
     cwd = Path(_git(cwd, "rev-parse", "--show-toplevel"))
     branch = _git(cwd, "branch", "--show-current")
     if re.fullmatch(r"integrate/phase-.+", branch):
@@ -104,13 +114,25 @@ def discover_integration_root(cwd: Path) -> Path:
             if current_path is not None and current_branch is not None:
                 worktrees.append((current_path, current_branch))
             current_path = current_branch = None
-    if len(worktrees) != 1:
-        names = ", ".join(str(path) for path, _ in worktrees) or "none"
+    candidates = worktrees
+    if phase:
+        requested = _normalise_phase(phase)
+        candidates = [
+            (path, branch)
+            for path, branch in worktrees
+            if branch.lower().startswith("integrate/phase-")
+            and _normalise_phase(branch.rsplit("/", 1)[-1]) == requested
+        ]
+    if len(candidates) != 1:
+        names = ", ".join(
+            f"{branch} ({path})" for path, branch in candidates
+        ) or "none"
+        phase_detail = f" for {_accepted_phase_forms(phase)}" if phase else ""
         raise ReportError(
-            "cannot determine a unique integrate/phase-* worktree; "
-            f"found {len(worktrees)} ({names}); pass --integration-root"
+            "cannot determine a unique integrate/phase-* worktree"
+            f"{phase_detail}; found {len(candidates)} ({names}); pass --integration-root"
         )
-    return worktrees[0][0]
+    return candidates[0][0]
 
 
 def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
@@ -776,7 +798,9 @@ def build_report(
     phase_name, requested_phase_path = _phase_dir(root, phase)
     runner = _graph_runner()
     try:
-        source = runner.resolve_phase_source(phase_name, str(requested_phase_path))
+        source = runner.resolve_phase_source(
+            phase_name, str(requested_phase_path), integration_root=root
+        )
     except Exception as exc:  # noqa: BLE001 - normalize shared source errors
         raise ReportError(f"could not resolve current integration phase source: {exc}") from exc
     root = source.root
@@ -1163,7 +1187,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="alias for --format json")
     args = parser.parse_args(argv)
     try:
-        root = args.integration_root or discover_integration_root(Path.cwd())
+        root = args.integration_root or discover_integration_root(Path.cwd(), args.phase)
         report = build_report(root, args.phase, args.qa_master)
     except ReportError as exc:
         print(

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -139,10 +139,19 @@ def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
     sprints = root / ".sprints"
     if requested:
         phase = requested.removeprefix("phase-")
-        path = sprints / phase
-        if not (path / "structure.ttl").is_file():
-            raise ReportError(f"missing phase structure: {path / 'structure.ttl'}")
-        return phase, path
+        matches = []
+        if sprints.is_dir():
+            matches = [
+                path
+                for path in sprints.iterdir()
+                if path.is_dir()
+                and path.name.casefold() == phase.casefold()
+                and (path / "structure.ttl").is_file()
+            ]
+        if len(matches) != 1:
+            raise ReportError(f"missing phase structure: {sprints / phase / 'structure.ttl'}")
+        path = matches[0]
+        return path.name, path
     candidates = sorted(p.parent for p in sprints.glob("*/structure.ttl"))
     if len(candidates) != 1:
         raise ReportError(

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -307,6 +307,92 @@ def test_missing_integration_worktree_is_structured_error(tmp_path, monkeypatch)
     assert result == 2
 
 
+@pytest.mark.parametrize(
+    "requested",
+    ["av", "AV", "phase-av"],
+)
+def test_phase_scoped_worktree_resolution_is_case_insensitive(
+    tmp_path, monkeypatch, requested
+):
+    root = tmp_path / "repo"
+    av = tmp_path / "av"
+    aw = tmp_path / "aw"
+    porcelain = "\n".join(
+        [
+            f"worktree {av}",
+            "HEAD 1111111",
+            "branch refs/heads/integrate/phase-AV",
+            "",
+            f"worktree {aw}",
+            "HEAD 2222222",
+            "branch refs/heads/integrate/phase-aw",
+            "",
+        ]
+    )
+
+    def fake_git(_cwd, *args):
+        if args == ("rev-parse", "--show-toplevel"):
+            return str(root)
+        if args == ("branch", "--show-current"):
+            return "develop"
+        if args == ("worktree", "list", "--porcelain"):
+            return porcelain
+        raise AssertionError(args)
+
+    monkeypatch.setattr(triage_report, "_git", fake_git)
+    assert triage_report.discover_integration_root(root, requested) == av
+
+
+def test_explicit_integration_root_skips_worktree_discovery(tmp_path, monkeypatch, capsys):
+    root, qa = _inputs(tmp_path)
+    monkeypatch.setattr(
+        triage_report,
+        "discover_integration_root",
+        lambda *_args: pytest.fail("explicit integration root must not discover worktrees"),
+    )
+
+    result = triage_report.main(
+        [
+            "--integration-root",
+            str(root),
+            "--phase",
+            "AICH",
+            "--qa-master",
+            str(qa),
+            "--format",
+            "vars",
+        ]
+    )
+    assert result == 0
+    assert "sprint_rows" in json.loads(capsys.readouterr().out)
+
+
+def test_phase_resolution_error_names_accepted_forms(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    porcelain = "\n".join(
+        [
+            f"worktree {tmp_path / 'aw'}",
+            "HEAD 1111111",
+            "branch refs/heads/integrate/phase-aw",
+            "",
+        ]
+    )
+
+    def fake_git(_cwd, *args):
+        if args == ("rev-parse", "--show-toplevel"):
+            return str(root)
+        if args == ("branch", "--show-current"):
+            return "develop"
+        if args == ("worktree", "list", "--porcelain"):
+            return porcelain
+        raise AssertionError(args)
+
+    monkeypatch.setattr(triage_report, "_git", fake_git)
+    assert triage_report.main(["--phase", "AV"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "accepted forms: av, AV, phase-av" in payload["message"]
+
+
 def test_malformed_structure_is_report_error(tmp_path):
     root = tmp_path / "repo"
     phase = root / ".sprints" / "AICH"

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -343,6 +343,19 @@ def test_phase_scoped_worktree_resolution_is_case_insensitive(
     assert triage_report.discover_integration_root(root, requested) == av
 
 
+@pytest.mark.parametrize("requested", ["aw", "AW", "phase-aw"])
+def test_phase_directory_resolution_is_case_insensitive(tmp_path, requested):
+    root = tmp_path / "repo"
+    structure_dir = root / ".sprints" / "AW"
+    structure_dir.mkdir(parents=True)
+    (structure_dir / "structure.ttl").write_text(PREFIX)
+
+    phase_name, phase_path = triage_report._phase_dir(root, requested)
+
+    assert phase_name == "AW"
+    assert phase_path == structure_dir
+
+
 def test_explicit_integration_root_skips_worktree_discovery(tmp_path, monkeypatch, capsys):
     root, qa = _inputs(tmp_path)
     monkeypatch.setattr(

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -24,7 +24,7 @@ use base64::Engine as _;
 
 pub const MAX_HTTP_REQUEST_BODY_BYTES: usize = 1_048_576;
 /// Version of the daemon's HTTP request contract.
-pub const HTTP_API_VERSION: &str = crate::protocol::HTTP_API_VERSION;
+pub use crate::protocol::HTTP_API_VERSION;
 /// HTTP response header carrying the canonical clear outcome for the `204`
 /// clear route. Framework adapters use this shared contract instead of
 /// inventing a JSON body for a no-content response.

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -245,7 +245,7 @@ pub fn peer_config_doctor_report(
     store: &(dyn PeerConfigStore + Send + Sync),
 ) -> (PeerConfigDoctorReport, Vec<DoctorFinding>) {
     match peer_config_doctor_report_inner(store) {
-        Ok(report) => (report, Vec::new()),
+        Ok((report, findings)) => (report, findings),
         Err(error) => {
             let finding = DoctorFinding {
                 severity: DoctorSeverity::Error,
@@ -269,30 +269,77 @@ pub fn peer_config_doctor_report(
 
 fn peer_config_doctor_report_inner(
     store: &(dyn PeerConfigStore + Send + Sync),
-) -> Result<PeerConfigDoctorReport, crate::error::AtmError> {
+) -> Result<(PeerConfigDoctorReport, Vec<DoctorFinding>), crate::error::AtmError> {
     let interfaces = store.list_interfaces()?;
     let peers = store.list_trusted_peers()?;
     let certificate = store.local_certificate()?;
-    Ok(PeerConfigDoctorReport {
-        configured_interface_count: interfaces.len(),
-        enabled_interface_count: interfaces
-            .iter()
-            .filter(|interface| interface.enabled)
-            .count(),
-        certificate_fingerprint: certificate.map(|certificate| certificate.fingerprint.to_string()),
-        trusted_peer_count: peers.len(),
-        enabled_trusted_peer_count: peers.iter().filter(|peer| peer.enabled).count(),
-        trusted_peers: peers
-            .iter()
-            .map(|peer| PeerAuthorityDoctorReport {
-                host: peer.host.to_string(),
-                https_port: peer.https_port.get(),
-                enabled: peer.enabled,
-            })
-            .collect(),
-        legacy_literal_ip_peers: legacy_literal_ip_peer_reports(&peers),
-        validation_failure: None,
-    })
+    let findings = peer_config_doctor_warnings(&interfaces, &peers);
+    Ok((
+        PeerConfigDoctorReport {
+            configured_interface_count: interfaces.len(),
+            enabled_interface_count: interfaces
+                .iter()
+                .filter(|interface| interface.enabled)
+                .count(),
+            certificate_fingerprint: certificate
+                .map(|certificate| certificate.fingerprint.to_string()),
+            trusted_peer_count: peers.len(),
+            enabled_trusted_peer_count: peers.iter().filter(|peer| peer.enabled).count(),
+            trusted_peers: peers
+                .iter()
+                .map(|peer| PeerAuthorityDoctorReport {
+                    host: peer.host.to_string(),
+                    https_port: peer.https_port.get(),
+                    enabled: peer.enabled,
+                })
+                .collect(),
+            legacy_literal_ip_peers: legacy_literal_ip_peer_reports(&peers),
+            validation_failure: None,
+        },
+        findings,
+    ))
+}
+
+fn peer_config_doctor_warnings(
+    interfaces: &[atm_storage::HttpsInterface],
+    peers: &[atm_storage::TrustedPeer],
+) -> Vec<DoctorFinding> {
+    let malformed_fingerprint_findings = peers
+        .iter()
+        .filter(|peer| {
+            let fingerprint = peer.fingerprint.as_str();
+            fingerprint.len() != 64 || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+        .map(|peer| DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::PeerConfigValidationFailed,
+            message: format!(
+                "trusted peer '{}' has a malformed certificate fingerprint",
+                peer.host
+            ),
+            remediation: Some(
+                "Replace the trusted peer fingerprint with exactly 64 hexadecimal characters."
+                    .to_string(),
+            ),
+        });
+    let literal_advertise_host_findings = interfaces
+        .iter()
+        .filter(|interface| !interface.advertise_host.is_durable_hostname())
+        .map(|interface| DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::PeerConfigValidationFailed,
+            message: format!(
+                "peer interface {} advertises literal IP '{}' instead of a stable hostname",
+                interface.bind_addr, interface.advertise_host
+            ),
+            remediation: Some(
+                "Set --advertise-host to a stable hostname; literal IP addresses remain supported for compatibility."
+                    .to_string(),
+            ),
+        });
+    malformed_fingerprint_findings
+        .chain(literal_advertise_host_findings)
+        .collect()
 }
 
 /// Projects legacy literal-IP trusted-peer rows (enabled or disabled) with
@@ -890,18 +937,43 @@ mod tests {
 
     struct StubPeerConfigStore {
         failure: Option<AtmError>,
+        interfaces: Vec<HttpsInterface>,
+        peers: Vec<TrustedPeer>,
     }
 
     impl atm_storage::contract::sealed::Sealed for StubPeerConfigStore {}
 
     impl StubPeerConfigStore {
         fn healthy() -> Self {
-            Self { failure: None }
+            Self {
+                failure: None,
+                interfaces: vec![HttpsInterface {
+                    bind_addr: "127.0.0.1:43101".parse().expect("socket address"),
+                    advertise_host: "localhost".parse().expect("host name"),
+                    enabled: true,
+                }],
+                peers: vec![TrustedPeer {
+                    host: "peer.example".parse::<HostName>().expect("host name"),
+                    fingerprint: "a".repeat(64).parse().expect("fingerprint"),
+                    enabled: true,
+                    https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
+                }],
+            }
         }
 
         fn failing(error: AtmError) -> Self {
             Self {
                 failure: Some(error),
+                interfaces: Vec::new(),
+                peers: Vec::new(),
+            }
+        }
+
+        fn with_peer_config(interfaces: Vec<HttpsInterface>, peers: Vec<TrustedPeer>) -> Self {
+            Self {
+                failure: None,
+                interfaces,
+                peers,
             }
         }
 
@@ -912,11 +984,7 @@ mod tests {
 
     impl PeerConfigStore for StubPeerConfigStore {
         fn list_interfaces(&self) -> Result<Vec<HttpsInterface>, AtmError> {
-            self.result(vec![HttpsInterface {
-                bind_addr: "127.0.0.1:43101".parse().expect("socket address"),
-                advertise_host: "localhost".parse().expect("host name"),
-                enabled: true,
-            }])
+            self.result(self.interfaces.clone())
         }
 
         fn save_interface(&self, _interface: &HttpsInterface) -> Result<(), AtmError> {
@@ -943,14 +1011,7 @@ mod tests {
         }
 
         fn list_trusted_peers(&self) -> Result<Vec<TrustedPeer>, AtmError> {
-            self.result(vec![TrustedPeer {
-                host: "peer.example".parse::<HostName>().expect("host name"),
-                fingerprint: "sha256:peer"
-                    .parse::<CertificateFingerprint>()
-                    .expect("fingerprint"),
-                enabled: true,
-                https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
-            }])
+            self.result(self.peers.clone())
         }
 
         fn trusted_peer(&self, _host: &HostName) -> Result<Option<TrustedPeer>, AtmError> {
@@ -1931,6 +1992,41 @@ mod tests {
         let serialized = serde_json::to_string(&report).expect("serialize doctor projection");
         assert!(!serialized.contains("keychain:secret"));
         assert!(!serialized.contains("private_key_ref"));
+    }
+
+    #[test]
+    fn peer_config_doctor_warns_on_malformed_pins_and_literal_advertise_hosts() {
+        let store = StubPeerConfigStore::with_peer_config(
+            vec![HttpsInterface {
+                bind_addr: "0.0.0.0:43101".parse().expect("socket address"),
+                advertise_host: "192.168.128.82".parse().expect("literal IP host"),
+                enabled: true,
+            }],
+            vec![TrustedPeer {
+                host: "peer.example".parse().expect("host name"),
+                fingerprint: "sha256:test-peer".parse().expect("legacy fingerprint"),
+                enabled: true,
+                https_port: std::num::NonZeroU16::new(43101).expect("non-zero port"),
+            }],
+        );
+
+        let (_report, findings) = peer_config_doctor_report(&store);
+
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().all(|finding| {
+            finding.severity == DoctorSeverity::Warning
+                && finding.code == AtmErrorCode::PeerConfigValidationFailed
+        }));
+        assert!(findings.iter().any(|finding| {
+            finding
+                .message
+                .contains("malformed certificate fingerprint")
+        }));
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.message.contains("literal IP"))
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -93,7 +93,7 @@ pub enum ResponseEnvelope {
 }
 
 pub const CLI_SCHEMA_VERSION: u16 = 1;
-pub const HTTP_API_VERSION: &str = "1.0.0";
+pub const HTTP_API_VERSION: &str = "1.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -134,6 +134,11 @@ pub struct WriteRequest {
     /// persists an inbound record. It is not trusted from wire JSON.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authenticated_source_host: Option<HostName>,
+    /// Schema version attached by a locally admitted cross-host sender. Peer
+    /// ingress validates only the major version; absent values remain
+    /// compatible with the deployed 1.x baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_http_api_version: Option<crate::protocol::HttpApiVersion>,
     /// The immutable identity assigned by the origin canonical writer.
     /// Authenticated peer ingress preserves it so both hosts store one ULID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -193,6 +198,7 @@ impl WriteRequest {
             caller_team,
             activity_observation: None,
             authenticated_source_host: None,
+            peer_http_api_version: None,
             origin_message_id: None,
             origin_timestamp: None,
             to: Some(to.parse()?),
@@ -249,6 +255,12 @@ impl WriteRequest {
     #[must_use]
     pub fn with_origin_message_id(mut self, message_id: AtmMessageId) -> Self {
         self.origin_message_id = Some(message_id);
+        self
+    }
+
+    #[must_use]
+    pub fn with_peer_http_api_version(mut self) -> Self {
+        self.peer_http_api_version = Some(crate::protocol::HttpApiVersion::current());
         self
     }
 

--- a/crates/atm-core/src/write/acknowledgement.rs
+++ b/crates/atm-core/src/write/acknowledgement.rs
@@ -409,6 +409,7 @@ pub(crate) fn canonical_ack_write_request(
         caller_team: team.clone(),
         activity_observation: request.activity_observation.clone(),
         authenticated_source_host: None,
+        peer_http_api_version: None,
         origin_message_id: None,
         origin_timestamp: None,
         to: Some(crate::address::AgentAddress::new(

--- a/crates/atm-core/src/write/mod.rs
+++ b/crates/atm-core/src/write/mod.rs
@@ -60,6 +60,7 @@ impl AckRequest {
             caller_team: self.caller_team,
             activity_observation: self.activity_observation,
             authenticated_source_host: None,
+            peer_http_api_version: None,
             origin_message_id: None,
             origin_timestamp: None,
             to: None,

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -13,6 +13,13 @@ use serde_json::Value;
 use tokio::io::AsyncReadExt;
 
 pub const HERDR_WAKE_TEXT: &str = "You have unread ATM messages. Run: atm read";
+/// Oldest Herdr release this daemon supports (ADR-061). Keyed on the Herdr
+/// release version reported by `ping.version`, not on Herdr's bincode-only
+/// `PROTOCOL_VERSION`. Every Herdr release at or above this value must keep
+/// working from one daemon build; raising it is a breaking change that needs
+/// Rand's recorded approval and sign-off. Set to 0.8.0 by Rand on 2026-09-05
+/// from the M5 drift review of v0.8.0..v0.8.2.
+pub const HERDR_MINIMUM_VERSION: &str = "0.8.0";
 const HERDR_PROCESS_CAP: Duration = Duration::from_secs(5);
 const BREAKER_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
@@ -992,6 +999,26 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn herdr_minimum_version_is_three_part_semver_at_least_0_8_0() {
+        let parts: Vec<u64> = super::HERDR_MINIMUM_VERSION
+            .split('.')
+            .map(|part| {
+                part.parse()
+                    .expect("HERDR_MINIMUM_VERSION parts are integers")
+            })
+            .collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "HERDR_MINIMUM_VERSION must be MAJOR.MINOR.PATCH"
+        );
+        assert!(
+            (parts[0], parts[1], parts[2]) >= (0, 8, 0),
+            "HERDR_MINIMUM_VERSION may only be raised with Rand's recorded approval (ADR-061)"
+        );
+    }
+
     use super::*;
 
     /// A manually controlled clock used by tests that assert on the

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -59,6 +59,7 @@ mod peer_connection_pool;
 mod peer_dial;
 mod peer_stream;
 mod private_staging;
+mod router_support;
 mod runtime_health;
 mod runtime_maintenance;
 mod runtime_setup;

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -371,12 +371,23 @@ async fn post_messages_with_request_id(
         Ok(ingress) => ingress,
         Err(error) => return error_response(error),
     };
+    let peer_ingress = matches!(
+        ingress,
+        AuthenticatedIngress::Peer | AuthenticatedIngress::UntrustedSmoke(_)
+    );
     let deadline = RequestDeadline::after(state.request_timeout);
 
     let response = state
         .handler
         .write_with_request_id(request, ingress, deadline, request_id)
         .await;
+    if peer_ingress && let Err(error) = &response {
+        warn!(
+            %request_id,
+            error_code = %error.code(),
+            "rejected inbound peer write"
+        );
+    }
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -18,8 +18,8 @@ use atm_core::doctor::DoctorQuery;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::protocol::{
     CompatibilityPreflight, GraftReceiverLookupRequest, GraftReceiverRefreshRequest,
-    GraftReceiverRegistration, GraftReceiverUnregistration, QueueGetNextRequest, RequestId,
-    ResponseEnvelope, SendResponseEnvelope, TeamMemberHeartbeatRequest, next_request_id,
+    GraftReceiverRegistration, GraftReceiverUnregistration, HttpApiVersion, QueueGetNextRequest,
+    RequestId, ResponseEnvelope, SendResponseEnvelope, TeamMemberHeartbeatRequest, next_request_id,
 };
 use atm_core::read::{PeekQuery, ReadQuery};
 use atm_core::search::SearchRequest;
@@ -172,6 +172,7 @@ impl AuthenticatedConnector {
                 Ok(AuthenticatedIngress::Local)
             }
             Self::Peer { source_host } => {
+                validate_peer_write_version(request.peer_http_api_version.take())?;
                 request.authenticated_source_host = Some(source_host.clone());
                 if let Some(destination) = request.to.take() {
                     request.to = Some(destination.without_host());
@@ -197,6 +198,7 @@ impl AuthenticatedConnector {
                 // explicit plaintext test reply to the actual socket peer
                 // without accepting a JSON-forged value.
                 request.authenticated_source_host = Some(source_host.clone());
+                validate_peer_write_version(request.peer_http_api_version.take())?;
                 if let Some(destination) = request.to.take() {
                     request.to = Some(destination.without_host());
                 }
@@ -221,6 +223,20 @@ impl AuthenticatedConnector {
             },
         }
     }
+}
+
+fn validate_peer_write_version(peer_version: Option<HttpApiVersion>) -> Result<(), AtmError> {
+    let peer_version = peer_version.unwrap_or_else(HttpApiVersion::current);
+    let local_version = HttpApiVersion::current();
+    if peer_version.major() == local_version.major() {
+        return Ok(());
+    }
+    Err(AtmError::new(
+        AtmErrorCode::ClientDaemonVersionIncompatible,
+        format!(
+            "peer HTTP API major-version mismatch: sender {peer_version}, receiver {local_version}"
+        ),
+    ))
 }
 
 #[derive(Clone)]
@@ -792,7 +808,7 @@ mod tests {
 
     use atm_core::api::HttpRequest;
     use atm_core::error::{AtmError, AtmErrorCode};
-    use atm_core::protocol::ResponseEnvelope;
+    use atm_core::protocol::{HttpApiVersion, ResponseEnvelope};
     use atm_core::search::{SearchRequest, SearchResponse};
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
@@ -1699,6 +1715,22 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(serialization.code(), AtmErrorCode::SerializationFailed);
+    }
+
+    #[test]
+    fn peer_write_version_tolerates_minor_skew_and_rejects_major_skew() {
+        super::validate_peer_write_version(Some(
+            HttpApiVersion::parse("1.0.0").expect("minor-skew fixture"),
+        ))
+        .expect("same-major peer version is compatible");
+
+        let error = super::validate_peer_write_version(Some(
+            HttpApiVersion::parse("2.0.0").expect("major-skew fixture"),
+        ))
+        .expect_err("different-major peer version is incompatible");
+        assert_eq!(error.code(), AtmErrorCode::ClientDaemonVersionIncompatible);
+        assert!(error.message().contains("sender 2.0.0"));
+        assert!(error.message().contains("receiver 1.1.0"));
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/router_support.rs
+++ b/crates/atm-http-runtime/src/router_support.rs
@@ -1,0 +1,27 @@
+use atm_core::error::AtmError;
+use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+use atm_core::send::{WarningEntry, WriteOutcome};
+
+pub(super) fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
+    match outcome {
+        WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
+        WriteOutcome::Acknowledged(outcome) => outcome.warnings.extend(warnings),
+    }
+}
+
+pub(super) fn write_response(outcome: WriteOutcome) -> ResponseEnvelope {
+    match outcome {
+        WriteOutcome::Sent(outcome) => ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)),
+        WriteOutcome::Acknowledged(outcome) => {
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
+        }
+    }
+}
+
+pub(super) fn hook_warning(error: AtmError) -> WarningEntry {
+    WarningEntry::with_code(
+        error.code(),
+        format!("message received successfully, but its receiver hook did not run: {error}"),
+        Some("inspect the receiver hook endpoint or harness, then continue normally"),
+    )
+}

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -33,6 +33,7 @@ use crate::CanonicalWriteHandler;
 use crate::PeerConnectionPool;
 use crate::RuntimeHealth;
 use crate::bare_cli_fifo::{BareCliFifo, BareCliQueueFullDrops, drain_bare_cli_messages};
+use crate::router_support::{append_warnings, hook_warning, write_response};
 
 fn retry_deferred_marker<F>(health: &RuntimeHealth, mut mark: F) -> Result<(), AtmError>
 where
@@ -1132,30 +1133,6 @@ fn validate_graft_receiver_member(
         return Err(AtmError::agent_not_found(agent.as_str(), team.as_str()));
     }
     Ok(())
-}
-
-fn append_warnings(outcome: &mut WriteOutcome, warnings: Vec<WarningEntry>) {
-    match outcome {
-        WriteOutcome::Sent(outcome) => outcome.warnings.extend(warnings),
-        WriteOutcome::Acknowledged(outcome) => outcome.warnings.extend(warnings),
-    }
-}
-
-fn write_response(outcome: WriteOutcome) -> ResponseEnvelope {
-    match outcome {
-        WriteOutcome::Sent(outcome) => ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)),
-        WriteOutcome::Acknowledged(outcome) => {
-            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
-        }
-    }
-}
-
-fn hook_warning(error: AtmError) -> WarningEntry {
-    WarningEntry::with_code(
-        error.code(),
-        format!("message received successfully, but its receiver hook did not run: {error}"),
-        Some("inspect the receiver hook endpoint or harness, then continue normally"),
-    )
 }
 
 #[cfg(test)]

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -480,7 +480,17 @@ impl StorageAndNudgeRouter {
             .await?
             .into_inner()
         {
-            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => Ok(()),
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => {
+                tracing::info!(
+                    subsystem = "atm_core.peer",
+                    action = "peer_send",
+                    outcome = "delivered",
+                    peer_host = %host,
+                    message_id = %message_id,
+                    "host-qualified message delivered to peer"
+                );
+                Ok(())
+            }
             response => Err(AtmError::new(
                 atm_core::error_codes::AtmErrorCode::InternalError,
                 "cross-host daemon-owned delivery returned a non-write response",

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -973,6 +973,29 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;
+            // ACK replies may acquire their host-qualified recipient while the
+            // write is prepared.  These must be forwarded after their local
+            // durable record is created; raw host-qualified sends returned
+            // above and therefore never reach this post-commit path.
+            if ingress == AuthenticatedIngress::Local
+                && committed.newly_persisted
+                && committed
+                    .canonical_request
+                    .to
+                    .as_ref()
+                    .and_then(|recipient| recipient.host())
+                    .is_some()
+            {
+                let _ = self
+                    .dispatch_resolved_peer_write(
+                        &committed.canonical_request,
+                        committed.message_id,
+                        committed.persisted_timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
+            }
             if committed.newly_persisted {
                 let hook = self.clone();
                 let hook_task = async move {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -500,6 +500,33 @@ impl StorageAndNudgeRouter {
         }
     }
 
+    /// Routes a raw local host-qualified write before local admission.
+    ///
+    /// Prepared ACK replies are different: they acquire their recipient only
+    /// after commit and are handled by the post-commit branch in
+    /// `write_with_request_id`.
+    async fn dispatch_raw_host_qualified_local_write(
+        &self,
+        request: &atm_core::send::WriteRequest,
+        ingress: &AuthenticatedIngress,
+        deadline: RequestDeadline,
+        request_id: RequestId,
+    ) -> Result<Option<WriteOutcome>, AtmError> {
+        if *ingress != AuthenticatedIngress::Local
+            || request
+                .to
+                .as_ref()
+                .and_then(|recipient| recipient.host())
+                .is_none()
+        {
+            return Ok(None);
+        }
+        let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
+        self.dispatch_resolved_peer_write(request, message_id, timestamp, deadline, request_id)
+            .await
+            .map(Some)
+    }
+
     async fn emit_received_hook(
         &self,
         dispatches: Result<Vec<atm_core::boundary::BuiltInPostSendDispatch>, AtmError>,
@@ -953,23 +980,10 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             // shared writer uses them for its state and file-policy paths.
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
-            if ingress == AuthenticatedIngress::Local
-                && request
-                    .to
-                    .as_ref()
-                    .and_then(|recipient| recipient.host())
-                    .is_some()
+            if let Some(outcome) = self
+                .dispatch_raw_host_qualified_local_write(&request, &ingress, deadline, request_id)
+                .await?
             {
-                let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
-                let outcome = self
-                    .dispatch_resolved_peer_write(
-                        &request.with_origin_metadata(message_id, timestamp),
-                        message_id,
-                        timestamp,
-                        deadline,
-                        request_id,
-                    )
-                    .await?;
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -432,11 +432,11 @@ impl StorageAndNudgeRouter {
         })
     }
 
-    /// Delivers one locally admitted host-qualified write using the daemon's
-    /// selected peer-wire mode. The record is already durable at this point;
-    /// this method creates neither a second application route nor delivery
-    /// recovery state. Per ADR-057, connection reuse can redial only before
-    /// exchange; it never retries a request after handing it to the sender.
+    /// Delivers a host-qualified write through the selected peer-wire mode.
+    ///
+    /// Cross-host writes are intentionally not admitted into the local mailbox:
+    /// without the durable outbox design, a failed peer exchange must leave no
+    /// misleading local echo or local nudge behind.
     async fn dispatch_resolved_peer_write(
         &self,
         request: &atm_core::send::WriteRequest,
@@ -444,9 +444,11 @@ impl StorageAndNudgeRouter {
         timestamp: atm_core::types::IsoTimestamp,
         deadline: RequestDeadline,
         _request_id: RequestId,
-    ) -> Result<(), AtmError> {
+    ) -> Result<WriteOutcome, AtmError> {
         let Some(host) = request.to.as_ref().and_then(|recipient| recipient.host()) else {
-            return Ok(());
+            return Err(AtmError::validation(
+                "cross-host delivery requires a host-qualified recipient",
+            ));
         };
         let remaining = deadline.remaining().ok_or_else(|| {
             AtmError::daemon_unavailable(
@@ -480,7 +482,13 @@ impl StorageAndNudgeRouter {
             .await?
             .into_inner()
         {
-            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => Ok(()),
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
+                Ok(WriteOutcome::Sent(outcome))
+            }
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
+                Ok(WriteOutcome::Acknowledged(outcome))
+            }
+            ResponseEnvelope::Error(error) => Err(error),
             response => Err(AtmError::new(
                 atm_core::error_codes::AtmErrorCode::InternalError,
                 "cross-host daemon-owned delivery returned a non-write response",
@@ -942,6 +950,25 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
             // shared writer uses them for its state and file-policy paths.
             request.home_dir = self.daemon_home.clone();
             request.current_dir = self.daemon_home.clone();
+            if ingress == AuthenticatedIngress::Local
+                && request
+                    .to
+                    .as_ref()
+                    .and_then(|recipient| recipient.host())
+                    .is_some()
+            {
+                let (message_id, timestamp) = atm_core::schema::AtmMessageId::new_with_timestamp();
+                let outcome = self
+                    .dispatch_resolved_peer_write(
+                        &request.with_origin_metadata(message_id, timestamp),
+                        message_id,
+                        timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
+                return Ok(ApiResponse::new(write_response(outcome)));
+            }
             let mut committed = self.commit_write(request, deadline).await?;
             if ingress == AuthenticatedIngress::Local
                 && committed.newly_persisted
@@ -952,14 +979,15 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                     .and_then(|recipient| recipient.host())
                     .is_some()
             {
-                self.dispatch_resolved_peer_write(
-                    &committed.canonical_request,
-                    committed.message_id,
-                    committed.persisted_timestamp,
-                    deadline,
-                    request_id,
-                )
-                .await?;
+                let _ = self
+                    .dispatch_resolved_peer_write(
+                        &committed.canonical_request,
+                        committed.message_id,
+                        committed.persisted_timestamp,
+                        deadline,
+                        request_id,
+                    )
+                    .await?;
             }
             if committed.newly_persisted {
                 let hook = self.clone();
@@ -4331,6 +4359,20 @@ mod tests {
             response.into_inner(),
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
         ));
+        assert!(
+            local
+                .message_store
+                .list_messages(&MessageQuery {
+                    team: "test-team".parse().expect("team"),
+                    agent: "recipient".parse().expect("agent"),
+                    sender: None,
+                    task_id: None,
+                    limit: None,
+                })
+                .expect("read local recipient mailbox")
+                .is_empty(),
+            "a host-qualified send must not leave a local mailbox echo"
+        );
         assert_eq!(
             remote
                 .message_store
@@ -4344,7 +4386,7 @@ mod tests {
                 .expect("read remote recipient mailbox")
                 .len(),
             1,
-            "the peer listener receives exactly the locally admitted canonical write"
+            "the peer listener receives exactly one canonical write"
         );
         remote_runtime
             .begin_shutdown()

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -973,25 +973,6 @@ impl CanonicalWriteHandler for StorageAndNudgeRouter {
                 return Ok(ApiResponse::new(write_response(outcome)));
             }
             let mut committed = self.commit_write(request, deadline).await?;
-            if ingress == AuthenticatedIngress::Local
-                && committed.newly_persisted
-                && committed
-                    .canonical_request
-                    .to
-                    .as_ref()
-                    .and_then(|recipient| recipient.host())
-                    .is_some()
-            {
-                let _ = self
-                    .dispatch_resolved_peer_write(
-                        &committed.canonical_request,
-                        committed.message_id,
-                        committed.persisted_timestamp,
-                        deadline,
-                        request_id,
-                    )
-                    .await?;
-            }
             if committed.newly_persisted {
                 let hook = self.clone();
                 let hook_task = async move {

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -4663,6 +4663,107 @@ mod tests {
             .expect("remote direct peer runtime drains");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn local_ack_returns_peer_delivery_failure_after_the_local_commit() {
+        let remote = fixture(true, None, None);
+        let remote_runtime = HttpRuntimeBuilder::new(
+            direct_peer_runtime_config(&remote, crate::DirectPeerTcpConfig::ephemeral_for_test()),
+            Arc::new(remote.router.clone()),
+        )
+        .build()
+        .expect("valid remote direct peer configuration")
+        .start()
+        .await
+        .expect("remote direct peer runtime starts");
+        let remote_port = remote_runtime
+            .direct_peer_address()
+            .expect("ephemeral remote direct peer listener is bound")
+            .port();
+
+        let mut local = fixture(true, None, None);
+        local.router = local
+            .router
+            .clone()
+            .with_direct_peer_port(std::num::NonZeroU16::new(remote_port).expect("non-zero port"));
+        let local_runtime = HttpRuntimeBuilder::new(
+            direct_peer_runtime_config(&local, crate::DirectPeerTcpConfig::ephemeral_for_test()),
+            Arc::new(local.router.clone()),
+        )
+        .build()
+        .expect("valid local direct peer configuration")
+        .start()
+        .await
+        .expect("local direct peer runtime starts");
+        let local_port = local_runtime
+            .direct_peer_address()
+            .expect("ephemeral local direct peer listener is bound")
+            .port();
+
+        let received_id = AtmMessageId::new();
+        let mut incoming = write_request(remote.home_dir.clone(), remote.current_dir.clone())
+            .with_origin_metadata(received_id, atm_core::types::IsoTimestamp::now());
+        incoming.requires_ack = true;
+        let local_peer_client = direct_peer_tcp_client(
+            "127.0.0.1".parse().expect("loopback source host"),
+            std::num::NonZeroU16::new(local_port).expect("non-zero port"),
+            Duration::from_secs(5),
+        )
+        .expect("local direct peer client");
+        local_peer_client
+            .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(incoming))))
+            .await
+            .expect("incoming required message reaches local daemon");
+
+        remote_runtime
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("remote direct peer runtime drains before acknowledgement");
+
+        let acknowledgement = atm_core::ack::AckRequest {
+            home_dir: local.home_dir.clone(),
+            current_dir: local.current_dir.clone(),
+            caller_identity: "recipient".parse().expect("recipient"),
+            caller_chat_id: None,
+            caller_team: "test-team".parse().expect("team"),
+            activity_observation: None,
+            message_id: received_id,
+            reply_body: "received".to_owned(),
+        }
+        .into_write_request();
+        let error = local
+            .router
+            .dispatch(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(acknowledgement))),
+                atm_core::AuthenticatedIngress::Local,
+                RequestDeadline::after(TWO_RUNTIME_TEST_REQUEST_BUDGET),
+            )
+            .await
+            .expect_err("post-commit peer acknowledgement forwarding failure reaches the caller");
+        assert_eq!(
+            error.code(),
+            atm_core::error_codes::AtmErrorCode::RemoteDeliveryUnconfirmed,
+            "a committed acknowledgement still reports that peer acceptance was unconfirmed"
+        );
+        assert!(
+            local
+                .message_store
+                .load_message(&MessageKey::from(received_id))
+                .expect("read acknowledged local source")
+                .expect("received source remains durable")
+                .envelope
+                .acknowledged_at
+                .is_some(),
+            "the acknowledgement's local state transition commits before the failed peer forward"
+        );
+
+        local_runtime
+            .begin_shutdown()
+            .finish()
+            .await
+            .expect("local direct peer runtime drains");
+    }
+
     #[tokio::test]
     async fn direct_peer_hook_failure_keeps_the_write_successful_with_a_warning() {
         let fixture = fixture(

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -476,7 +476,10 @@ impl StorageAndNudgeRouter {
                 )?,
             },
         };
-        let request = request.clone().with_origin_metadata(message_id, timestamp);
+        let request = request
+            .clone()
+            .with_origin_metadata(message_id, timestamp)
+            .with_peer_http_api_version();
         match client
             .execute(ApiRequest::new(RequestEnvelope::Write(Box::new(request))))
             .await?

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -3421,6 +3421,59 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_acknowledgement_errors_explain_missing_and_non_pending_sources() {
+        struct UnusedReplyBuilder;
+
+        impl AcknowledgementReplyBuilder for UnusedReplyBuilder {
+            fn build_reply(&self, _source: &Message) -> Result<Message, atm_storage::AtmError> {
+                panic!("the builder must not run for rejected acknowledgement sources");
+            }
+        }
+
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.message_store();
+        let missing_id = AtmMessageId::new();
+        let source = AcknowledgementSource {
+            team: team(),
+            agent: agent(),
+            message_id: missing_id,
+        };
+        let missing = store
+            .acknowledge_message_atomically(&source, Arc::new(UnusedReplyBuilder))
+            .expect_err("unknown acknowledgement source");
+        assert!(missing.message().contains("was not found"));
+        assert!(missing.message().contains("not addressed to the caller"));
+        assert!(
+            !missing
+                .message()
+                .contains("Correct the invalid ATM request or state before retrying")
+        );
+
+        let not_pending_id = AtmMessageId::new();
+        let mut not_pending = message(&format!("atm:{not_pending_id}"), "already read");
+        not_pending.envelope.message_id = Some(not_pending_id);
+        store.save_message(&not_pending).expect("save source");
+        let source = AcknowledgementSource {
+            team: not_pending.team,
+            agent: not_pending.agent,
+            message_id: not_pending_id,
+        };
+        let not_pending = store
+            .acknowledge_message_atomically(&source, Arc::new(UnusedReplyBuilder))
+            .expect_err("non-pending acknowledgement source");
+        assert!(
+            not_pending
+                .message()
+                .contains("not pending acknowledgement")
+        );
+        assert!(
+            !not_pending
+                .message()
+                .contains("Correct the invalid ATM request or state before retrying")
+        );
+    }
+
+    #[test]
     fn sqlite_backend_saves_loads_and_lists_rosters() {
         let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
         let store = backend.roster_store();

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -492,10 +492,13 @@ fn load_acknowledgement_source_row(
             crate::shared_db::sqlite_error(target, "failed to load acknowledgement source", error)
         })?
         .ok_or_else(|| {
-            AtmError::validation(format!(
-                "message {} was not found in {}@{}",
-                source.message_id, source.agent, source.team
-            ))
+            AtmError::validation_with_recovery(
+                format!(
+                    "message {} was not found in {}@{}; it is unknown or not addressed to the caller",
+                    source.message_id, source.agent, source.team
+                ),
+                "verify the message ID belongs to the caller's mailbox before retrying `atm ack`",
+            )
         })
 }
 
@@ -551,10 +554,10 @@ fn decode_pending_acknowledgement_source(
         } else {
             "not pending acknowledgement"
         };
-        return Err(AtmError::validation(format!(
-            "message {} is {state}",
-            source.message_id
-        )));
+        return Err(AtmError::validation_with_recovery(
+            format!("message {} is {state}", source.message_id),
+            "only messages with a pending acknowledgement can be acknowledged; use `atm read --pending-ack` to inspect them",
+        ));
     }
     Ok(Message {
         team: source.team.clone(),

--- a/crates/atm/openapi.yaml
+++ b/crates/atm/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ATM daemon API
-  version: v1
+  version: 1.1.0
   description: HTTP contract shared by local UDS and future peer HTTPS adapters.
 servers:
   - url: /v1/atm
@@ -155,6 +155,9 @@ components:
         body: { type: string }
         requires_ack: { type: boolean }
         acknowledges_message_id: { type: string }
+        peer_http_api_version:
+          type: string
+          description: Optional cross-host wire API version. The current baseline is 1.1.0; receivers reject only a major-version mismatch.
     PeekQuery:
       type: object
       description: Canonical inspect query; fields are validated by the daemon.

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -450,6 +450,11 @@ fn peer(
     fingerprint: String,
     https_port: u16,
 ) -> std::result::Result<TrustedPeer, AtmError> {
+    if fingerprint.len() != 64 || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(AtmError::peer_config_validation(
+            "invalid --fingerprint: trusted-peer fingerprints must be exactly 64 hexadecimal characters",
+        ));
+    }
     Ok(TrustedPeer {
         host: trusted_peer_host(&host)?,
         fingerprint: fingerprint
@@ -679,7 +684,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "--yes",
             ],
             vec![
@@ -689,7 +694,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:replacement",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 "--yes",
             ],
             vec!["atm", "trust", "revoke", "--host", "peer.example", "--yes"],
@@ -777,7 +782,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer-one",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "--yes",
             ],
         )
@@ -792,7 +797,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer-two",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 "--yes",
             ],
         )
@@ -802,7 +807,7 @@ mod tests {
                 .trusted_peer(&"peer.example".parse().expect("host"))
                 .expect("read replaced peer")
                 .map(|peer| peer.fingerprint.to_string()),
-            Some("sha256:peer-two".to_string())
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string())
         );
         run_peer(
             &store,
@@ -830,12 +835,36 @@ mod tests {
                     "--host",
                     host,
                     "--fingerprint",
-                    "sha256:peer",
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "--yes",
                 ],
             )
             .expect_err("literal IP host must be rejected");
             assert!(error.message().contains("not stable peer identities"));
+        }
+        assert!(store.list_trusted_peers().expect("list peers").is_empty());
+    }
+
+    #[test]
+    fn trust_add_and_replace_require_exactly_64_hex_fingerprint_characters() {
+        let store = InMemoryPeerConfigStore::default();
+        for command in ["add", "replace"] {
+            let error = run_peer(
+                &store,
+                &[
+                    "atm",
+                    "trust",
+                    command,
+                    "--host",
+                    "peer.example",
+                    "--fingerprint",
+                    "sha256:test-peer",
+                    "--yes",
+                ],
+            )
+            .expect_err("malformed trusted-peer fingerprint must be rejected");
+            assert_eq!(error.code(), AtmErrorCode::PeerConfigValidationFailed);
+            assert!(error.message().contains("exactly 64 hexadecimal"));
         }
         assert!(store.list_trusted_peers().expect("list peers").is_empty());
     }
@@ -999,7 +1028,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ],
             vec![
                 "atm",
@@ -1008,7 +1037,7 @@ mod tests {
                 "--host",
                 "peer.example",
                 "--fingerprint",
-                "sha256:peer",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ],
             vec!["atm", "trust", "revoke", "--host", "peer.example"],
         ];

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -17,6 +17,12 @@ use crate::output;
 #[derive(Debug, Args)]
 /// Read one ATM mailbox message and optionally update read state.
 pub struct ReadCommand {
+    /// Positional message IDs are rejected with a migration hint. Keeping
+    /// this parser slot lets the CLI explain the supported option instead of
+    /// returning clap's generic unexpected-argument error.
+    #[arg(index = 1, value_name = "MESSAGE_ID")]
+    message_id_positional: Option<String>,
+
     #[arg(long)]
     team: Option<String>,
 
@@ -74,6 +80,9 @@ pub struct ReadCommand {
 
 impl ReadCommand {
     pub async fn run(self, observability: &CliObservability) -> Result<()> {
+        if let Some(message_id) = self.message_id_positional.as_deref() {
+            return Err(positional_message_id_error(message_id).into());
+        }
         let warnings = self.deprecation_warnings();
         let (home_dir, current_dir) = resolve_command_runtime_context("read")?;
         let json = self.json;
@@ -182,6 +191,13 @@ impl ReadCommand {
         }
         warnings
     }
+}
+
+fn positional_message_id_error(message_id: &str) -> atm_core::error::AtmError {
+    atm_core::error::AtmError::validation_with_recovery(
+        format!("positional message ID `{message_id}` is not supported by `atm read`"),
+        "use `atm read --message-id <id>`",
+    )
 }
 
 #[cfg(test)]
@@ -321,19 +337,23 @@ mod tests {
 
     #[test]
     fn cli_rejects_positional_mailbox_target_for_owner_only_read() {
-        let error = crate::commands::Cli::try_parse_from(["atm", "read", "recipient@test-team"])
-            .expect_err("owner-only read must reject positional target");
+        let parsed =
+            crate::commands::Cli::try_parse_from(["atm", "read", "01KX5TEST00000000000000001"])
+                .expect("positional message ID is parsed for an actionable error");
+        let rendered = format!("{parsed:?}");
+        assert!(rendered.contains("message_id_positional"), "{rendered}");
+    }
 
-        let rendered = error.to_string();
-        assert!(
-            rendered.contains("unexpected argument 'recipient@test-team'")
-                || rendered.contains("unexpected argument"),
-            "{rendered}"
-        );
+    #[test]
+    fn positional_message_id_error_points_to_message_id_option() {
+        let error = super::positional_message_id_error("01KX5TEST00000000000000001");
+        assert!(error.message().contains("positional message ID"));
+        assert!(error.message().contains("atm read --message-id <id>"));
     }
 
     fn base_command() -> ReadCommand {
         ReadCommand {
+            message_id_positional: None,
             team: None,
             chat_id: None,
             actor: None,

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -197,6 +197,11 @@ impl SendCommand {
             nudge_mode,
             attachment_note,
         )?;
+        let peer_host = request
+            .to
+            .as_ref()
+            .and_then(|recipient| recipient.host())
+            .cloned();
         let composition = CliComposition::bootstrap(
             command_name,
             observability,
@@ -211,7 +216,10 @@ impl SendCommand {
             outcome.warnings.push(warning);
         }
 
-        output::print_send_result(&outcome, json)
+        match peer_host.as_ref() {
+            Some(peer_host) => output::print_send_result_to_peer(&outcome, json, peer_host),
+            None => output::print_send_result(&outcome, json),
+        }
     }
 
     /// Lands this invocation's `--attach` files (if any) for the single

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -18,10 +18,23 @@ use atm_core::team_admin::{
     DisableNudgeTemplateOverrideOutcome, RemoveMemberOutcome, RestoreOutcome, RestorePlan,
     SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
 };
+use atm_core::types::HostName;
 
 /// Print one send result in human-readable or JSON form.
 pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
-    print!("{}", render_send_stdout(outcome, json)?);
+    print!("{}", render_send_stdout(outcome, json, None)?);
+    print_warnings_to_stderr(&outcome.warnings);
+
+    Ok(())
+}
+
+/// Print a send result with the peer host confirmed by the transport.
+pub fn print_send_result_to_peer(
+    outcome: &SendOutcome,
+    json: bool,
+    peer_host: &HostName,
+) -> Result<()> {
+    print!("{}", render_send_stdout(outcome, json, Some(peer_host))?);
     print_warnings_to_stderr(&outcome.warnings);
 
     Ok(())
@@ -162,15 +175,27 @@ pub fn print_ack_result(outcome: &AckOutcome, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn render_send_stdout(outcome: &SendOutcome, json: bool) -> Result<String> {
+fn render_send_stdout(
+    outcome: &SendOutcome,
+    json: bool,
+    peer_host: Option<&HostName>,
+) -> Result<String> {
     if json {
-        return Ok(format!("{}\n", serde_json::to_string_pretty(outcome)?));
+        let mut value = serde_json::to_value(outcome)?;
+        if let Some(peer_host) = peer_host {
+            value["delivered_to_peer_host"] = serde_json::Value::String(peer_host.to_string());
+        }
+        return Ok(format!("{}\n", serde_json::to_string_pretty(&value)?));
     }
 
-    Ok(format!(
+    let mut rendered = format!(
         "Sent to {}@{} [message_id: {}]\n",
         outcome.agent, outcome.team, outcome.message_id
-    ))
+    );
+    if let Some(peer_host) = peer_host {
+        rendered.push_str(&format!("Delivered to peer host: {peer_host}\n"));
+    }
+    Ok(rendered)
 }
 
 fn print_warnings_to_stderr(warnings: &[WarningEntry]) {
@@ -909,6 +934,7 @@ mod tests {
         BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
         BootstrapTraceReport, PeerConfigDoctorReport,
     };
+    use atm_core::types::HostName;
     use serde_json::json;
 
     use super::{
@@ -963,7 +989,7 @@ mod tests {
         }))
         .expect("send outcome");
 
-        let stdout = render_send_stdout(&outcome, true).expect("JSON stdout");
+        let stdout = render_send_stdout(&outcome, true, None).expect("JSON stdout");
         let stderr = render_warnings_to_stderr(&outcome.warnings);
 
         let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON stdout");
@@ -974,6 +1000,29 @@ mod tests {
         assert!(!stdout.contains("Recovery:"));
         assert!(stderr.contains("Recovery:"));
         assert!(stderr.contains("unregistered-tool@test-team"));
+    }
+
+    #[test]
+    fn peer_send_output_names_confirmed_peer_host_in_both_formats() {
+        let outcome: atm_core::send::SendOutcome = serde_json::from_value(json!({
+            "action": "send",
+            "team": "test-team",
+            "agent": "recipient",
+            "sender": "sender",
+            "outcome": "sent",
+            "message_id": "01KX5TEST00000000000000001",
+            "requires_ack": false
+        }))
+        .expect("send outcome");
+        let peer_host: HostName = "peer.example.test".parse().expect("peer host");
+
+        let human = render_send_stdout(&outcome, false, Some(&peer_host)).expect("human output");
+        assert!(human.contains("Delivered to peer host: peer.example.test"));
+
+        let json_output =
+            render_send_stdout(&outcome, true, Some(&peer_host)).expect("JSON output");
+        let parsed: serde_json::Value = serde_json::from_str(&json_output).expect("JSON output");
+        assert_eq!(parsed["delivered_to_peer_host"], "peer.example.test");
     }
 
     #[test]

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -1992,6 +1992,17 @@
           "short": null
         },
         {
+          "has_default": false,
+          "id": "message_id_positional",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
           "has_default": true,
           "id": "no_since_last_seen",
           "long": "no-since-last-seen",

--- a/crates/atm/tests/openapi_surface_baseline.json
+++ b/crates/atm/tests/openapi_surface_baseline.json
@@ -487,6 +487,7 @@
         "body",
         "from",
         "message_id",
+        "peer_http_api_version",
         "requires_ack",
         "to"
       ],

--- a/docs/adr/ADR-020-rule001-observability-adapter-exception.md
+++ b/docs/adr/ADR-020-rule001-observability-adapter-exception.md
@@ -11,20 +11,34 @@
 
 ---
 
+> **Amendment (2026-09-05, docs-only, team-lead):** the `atm-daemon` crate
+> was split and the daemon runtime moved to `atm-daemon-bootstrap`; the
+> sanctioned adapter module was carried forward as
+> `crates/atm-daemon-bootstrap/src/daemon_observability.rs`. Path references
+> below are updated to the current location. No policy content changed —
+> `.just/allowlists/scb_observability_allowlist.toml` (rule
+> `SCB-OBSERVABILITY-001`) already enforces the exception at this current
+> path, and a repo-wide grep confirms it remains the only non-`main.rs`
+> daemon source importing `sc_observability_types` directly.
+
+---
+
 ## Context
 
 `RULE-001` forbids direct `sc_observability_types` imports from arbitrary
 daemon library modules. During the `AD.25` through `AD.30` follow-up planning
 review, arch-qa re-verified the actual `atm-daemon` module graph and found:
 
-- `crates/atm-daemon/src/daemon_runtime_observability.rs` is declared via
-  `mod daemon_runtime_observability;` in `crates/atm-daemon/src/lib.rs`
+- `crates/atm-daemon-bootstrap/src/daemon_observability.rs` is declared via
+  `mod daemon_observability;` in `crates/atm-daemon-bootstrap/src/lib.rs`
 - `lib.rs` publicly re-exports daemon observability surface items from that
   module
 - therefore the file is a real library module, not a binary-internal file
-- `runtime_sqlite_observer.rs` and `test_observability.rs` still need access to
-  the same `ActionName` / `OutcomeLabel` types to call
-  `DaemonRuntimeObservability`
+- at the time of this decision, `runtime_sqlite_observer.rs` and
+  `test_observability.rs` needed access to the same `ActionName` /
+  `OutcomeLabel` types to call `DaemonRuntimeObservability` (those specific
+  consumer files have since been reorganized; the adapter module itself is
+  the load-bearing exception surface, not the specific consumer file names)
 
 The earlier "binary-internal seam" framing was factually wrong against the
 source tree and could not support a truthful exception.
@@ -40,7 +54,7 @@ conditions.
 Accept one sanctioned library-internal adapter exception to `RULE-001` for the
 `atm-daemon` crate:
 
-- `crates/atm-daemon/src/daemon_runtime_observability.rs` is the only
+- `crates/atm-daemon-bootstrap/src/daemon_observability.rs` is the only
   sanctioned non-`main.rs` daemon source file allowed to import
   `sc_observability_types::{ActionName, OutcomeLabel}` directly
 - that adapter module must expose a concrete achievable crate-visible
@@ -48,10 +62,9 @@ Accept one sanctioned library-internal adapter exception to `RULE-001` for the
   - `pub(crate)` aliases
   - `pub(crate)` constructor helpers
   - another equally narrow crate-visible adapter surface
-- `runtime_sqlite_observer.rs` and `test_observability.rs` must consume that
-  crate-visible adapter surface instead of importing `sc_observability_types`
-  directly
-- no other file under `crates/atm-daemon/src/` may add a new direct import of
+- every other daemon-internal consumer must consume that crate-visible
+  adapter surface instead of importing `sc_observability_types` directly
+- no other file under `crates/atm-daemon-bootstrap/src/` may add a new direct import of
   `ActionName` or `OutcomeLabel`
 
 ## Enforcement
@@ -60,7 +73,7 @@ This exception is valid only with mechanical enforcement:
 
 - `AD.26` must wire `.just/lint_boundaries.py` to reject direct
   `sc_observability_types::{ActionName, OutcomeLabel}` imports anywhere under
-  `crates/atm-daemon/src/` except the sanctioned adapter module and `main.rs`
+  `crates/atm-daemon-bootstrap/src/` except the sanctioned adapter module and `main.rs`
 - the lint rule must use the repository's existing TOML allowlist pattern
   rather than a one-off hard-coded path check
 - because the sanctioned import lives at module root, the allowlist mechanism
@@ -103,7 +116,7 @@ depends on crate-local aliases/helpers.
 The exception remains acceptable only while all of the following stay true:
 
 - the direct imports remain confined to
-  `crates/atm-daemon/src/daemon_runtime_observability.rs`
+  `crates/atm-daemon-bootstrap/src/daemon_observability.rs`
 - downstream daemon modules consume only the sanctioned crate-visible adapter
   surface
 - `.just/lint_boundaries.py` and its fixture/allowlist keep enforcing the

--- a/docs/adr/ADR-061-governed-interface-schema-versioning.md
+++ b/docs/adr/ADR-061-governed-interface-schema-versioning.md
@@ -1,0 +1,105 @@
+# ADR-061 — Governed Interface Schema Versioning And Breaking-Change Approval
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-061 |
+| Status | Accepted (Rand, 2026-09-05) |
+| Scope | The three managed interfaces: HTTP/peer API, Herdr IPC, SQLite storage schema |
+| Relates to | ADR-036, ADR-057, ADR-060, `docs/atm-daemon/http-api.md`, `docs/atm-rusqlite/requirements.md`, phase-ay plan, GitHub issue #1217 (discussion record only) |
+
+## Context
+
+`HTTP_API_VERSION` was set to `1.0.0` on 2026-07-24 and never bumped while
+the wire gained new request variants and optional fields. Nothing in the
+process required a bump, nothing required approval for a breaking change,
+and nothing checked shipped wire changes against the approved plan. The
+Herdr IPC adapter (`crates/atm-herdr`) has no version constant at all and
+reports any mismatch as a bare protocol-mismatch error. The SQLite schema is
+migrated by idempotent additive DDL in
+`crates/atm-storage-rusqlite/src/shared_db.rs` with pre-migration unit
+tests, but has no declared version and no rule for what a breaking change is.
+
+Rand's rulings (2026-09-05): the interfaces are semver versioned; adding an
+optional parameter is a minor bump; breaking changes need explicit recorded
+approval; breaking changes that force every host to upgrade in lockstep are
+unacceptable; new capability must be expressed as optional arguments
+wherever possible; there is no 2.0, the HTTP wire as of v1.4.13 / 1.5.1 is
+defined as `1.1.0`; Herdr drifts outside our control and every Herdr
+release at or above `HERDR_MINIMUM_VERSION` must stay supported; the SQLite
+schema gets the same scrutiny; "all should be managed by the same
+gates/rules"; "all have the potential to cause breaking changes on
+computers or between computers or between applications".
+
+## Decision
+
+### D1. Three governed interfaces, one rule set
+
+Each interface can break something different: the SQLite schema breaks a
+computer against its own earlier binary, the HTTP/peer API breaks hosts
+against each other, and the Herdr IPC breaks applications against each
+other. They are governed identically because the failure is the same kind:
+a consumer that worked yesterday stops working without anyone having
+approved that.
+
+| Interface | Version constant | Source of truth | Consumer that must keep working |
+| --- | --- | --- | --- |
+| HTTP/peer API | `HTTP_API_VERSION` (semver), `CLI_SCHEMA_VERSION` (local envelope) in `crates/atm-core/src/protocol.rs` | Rust serde types (`RequestEnvelope`, `ResponseEnvelope`, `WriteRequest`); `openapi.yaml` is derived documentation | Every deployed daemon and CLI speaking the same major |
+| Herdr IPC | `HERDR_MINIMUM_VERSION` (Herdr release semver from `ping.version`; Herdr `PROTOCOL_VERSION` recorded per release as a secondary fact) in `crates/atm-herdr` | Herdr's published wire, outside our control | Every Herdr release `>= HERDR_MINIMUM_VERSION`, simultaneously, from one daemon build |
+| SQLite storage schema | `STORAGE_SCHEMA_VERSION` (semver) declared by `atm-storage-rusqlite` and persisted in the database | `DB_MIGRATIONS` and the `ensure_*` migration functions | The previous supported release binary opening the same database (daemon-switch rollback) |
+
+`HERDR_MINIMUM_VERSION` and `STORAGE_SCHEMA_VERSION` do not exist yet. The
+phase-ay plan lands the Herdr constant (AY.1, AY.3). The storage constant
+needs its own planned sprint; until it lands, the SQLite rules below are
+applied against the migration functions directly.
+
+### D2. Classification
+
+- **Minor (additive):** a new optional field, argument, request variant,
+  route, table, column with a default, or index. Older consumers must keep
+  working unchanged: receivers default omitted fields and ignore unknown
+  fields; an older binary opening a newer database must still be able to
+  read and write the rows it understands.
+- **Major (breaking):** removing or renaming a field, variant, route, table,
+  or column; changing a type, constraint, status, or meaning; tightening
+  validation an older peer would fail; raising `HERDR_MINIMUM_VERSION`;
+  any storage change the previous supported release binary cannot operate
+  against.
+- **Patch:** documentation or test-only change with no wire or DDL effect.
+
+### D3. Approval gate
+
+- A minor change requires the matching version bump in the same change set,
+  updated documentation (`openapi.yaml` and surface baseline; the storage
+  schema document; the Herdr version matrix) and a test proving the older
+  consumer still works.
+- A major change requires Rand's explicit, recorded approval and sign-off
+  before plan approval, cited by message id, issue comment, or ADR, and
+  cited again at phase end. It must ship with a co-existence window: the new
+  build still serves the previous major (or negotiates down) for the
+  duration Rand approves. No change may require every host to upgrade
+  together.
+- Design rule: before proposing a major change, the author must show why the
+  capability cannot be expressed additively.
+
+### D4. Enforcement
+
+- `schema-reviewer` (`.claude/agents/schema-reviewer.md`) is a mandatory
+  reviewer in every `quality-mgr` plan review and every phase-ending review.
+  It classifies every change to the three interfaces, verifies the bump,
+  documentation and tests, and at phase end diffs shipped changes against
+  the approved plan. Unapproved major changes and unapproved drift are
+  Blocking.
+- Every interface change is documented and tested the same way SQLite
+  migrations already are: a pre-change fixture, the change, and a test that
+  the older consumer still works.
+
+## Consequences
+
+- `HTTP_API_VERSION` moves to `1.1.0` as the first act of the versioning
+  plan, defined as the current wire, and is bumped on every later change.
+- Herdr support becomes a matrix, not a single version; per-release
+  conformance fixtures are required.
+- SQLite migrations gain a declared version and an explicit rollback test
+  against the previous release binary.
+- Plan documents must list their intended interface changes so phase-end
+  drift review has something to diff against.

--- a/docs/adr/ADR-061-governed-interface-schema-versioning.md
+++ b/docs/adr/ADR-061-governed-interface-schema-versioning.md
@@ -47,10 +47,12 @@ approved that.
 | Herdr IPC | `HERDR_MINIMUM_VERSION` (Herdr release semver from `ping.version`; Herdr `PROTOCOL_VERSION` recorded per release as a secondary fact) in `crates/atm-herdr` | Herdr's published wire, outside our control | Every Herdr release `>= HERDR_MINIMUM_VERSION`, simultaneously, from one daemon build |
 | SQLite storage schema | `STORAGE_SCHEMA_VERSION` (semver) declared by `atm-storage-rusqlite` and persisted in the database | `DB_MIGRATIONS` and the `ensure_*` migration functions | The previous supported release binary opening the same database (daemon-switch rollback) |
 
-`HERDR_MINIMUM_VERSION` and `STORAGE_SCHEMA_VERSION` do not exist yet. The
-phase-ay plan lands the Herdr constant (AY.1, AY.3). The storage constant
-needs its own planned sprint; until it lands, the SQLite rules below are
-applied against the migration functions directly.
+`HERDR_MINIMUM_VERSION` is `0.8.0` today (`crates/atm-herdr/src/lib.rs`),
+set by Rand on 2026-09-05 from the M5 agents' drift review of Herdr
+v0.8.0..v0.8.2. The phase-ay plan lands the runtime checks around it (AY.1,
+AY.3). `STORAGE_SCHEMA_VERSION` does not exist yet and needs its own planned
+sprint; until it lands, the SQLite rules below are applied against the
+migration functions directly.
 
 ### D2. Classification
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -67,6 +67,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-058 — Herdr Local Steer Backend Contract](./ADR-058-herdr-local-steer-backend-contract.md)
 - [ADR-059 — Async Mailbox-Read Concurrency And State Handoff](./ADR-059-async-mailbox-read-concurrency.md)
 - [ADR-060 — Peer Dial Order And Address Cache](./ADR-060-peer-dial-and-address-cache.md)
+- [ADR-061 — Governed Interface Schema Versioning And Breaking-Change Approval](./ADR-061-governed-interface-schema-versioning.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/atm-daemon/http-api.md
+++ b/docs/atm-daemon/http-api.md
@@ -9,7 +9,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Proposed — Phase AI target |
-| HTTP API SemVer | `1.0.0`; major is `/v1/atm` |
+| HTTP API SemVer | `1.1.0`; major is `/v1/atm` |
 | Authoritative ADR | ADR-033 |
 | Machine-readable publication | checked-in OpenAPI 3.1 and `atm api spec` |
 
@@ -122,7 +122,10 @@ OpenAPI document against route schemas and tests every documented route. The
 embedded document is published by `atm api spec --format json|yaml`; no daemon
 network endpoint is needed merely to retrieve documentation.
 
-The v1 resource paths are durable. Same-major additive fields, error details,
+The v1 resource paths are durable. The current `1.1.0` baseline adds the
+optional `peer_http_api_version` to cross-host write envelopes; receivers
+reject only a peer major-version mismatch and tolerate minor skew. Same-major
+additive fields, error details,
 and endpoints require a minor version: servers default omitted additive request
 fields and ignore unknown additive fields; clients tolerate additive response
 fields. Patch versions are corrective only. A new operation may require an

--- a/docs/atm-http-runtime/openapi.yaml
+++ b/docs/atm-http-runtime/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: ATM daemon API
-  version: v1
+  version: 1.1.0
   description: HTTP contract shared by local UDS and future peer HTTPS adapters.
 servers:
   - url: /v1/atm
@@ -155,6 +155,9 @@ components:
         body: { type: string }
         requires_ack: { type: boolean }
         acknowledges_message_id: { type: string }
+        peer_http_api_version:
+          type: string
+          description: Optional cross-host wire API version. The current baseline is 1.1.0; receivers reject only a major-version mismatch.
     PeekQuery:
       type: object
       description: Canonical inspect query; fields are validated by the daemon.

--- a/site/announcements/atm-core-v1.5.0.md
+++ b/site/announcements/atm-core-v1.5.0.md
@@ -1,0 +1,59 @@
+# atm-core v1.5.0 — Queued Steering, Send-To Attachments, and Reader-Lane Scaling
+
+**Released:** September 4, 2026 · **Install:** `cargo install agent-team-mail` (crates.io), `brew install randlee/tap/agent-team-mail` (Homebrew), `pip install hermes-atm atm-graft` (PyPI), or binary archives from [releases](https://github.com/randlee/atm-core/releases) (now including a native `aarch64-unknown-linux-gnu` arm64-Linux archive)
+
+[Changelog](https://github.com/randlee/atm-core/blob/main/CHANGELOG.md) · [Release notes](https://github.com/randlee/atm-core/releases/tag/v1.5.0)
+
+---
+
+## Agent Orchestrator
+
+**As an agent orchestrator, I want to route work across a fleet of agents and track who is doing what, so that a multi-agent campaign stays coordinated without me hand-wiring every message.**
+
+v1.5.0 turns ATM from fire-and-forget messaging into a work-routing system. The new `atm queue` verb mirrors `atm send`'s full surface — including `--attach` — but defers the recipient nudge instead of firing it immediately, so you can stage work and have it delivered on your terms. Underneath it sits the nudge taxonomy and `PendingNudgeStore` contract (ADR-054) that every queued delivery builds on.
+
+That deferred delivery is now *guaranteed* to drain, not merely queued. Dual-channel graft delivery wires queue messages to a real trigger: harness idle-signal heartbeats and a bare-CLI Stop-pull path, backed by a bounded per-member FIFO. On top of that, the Herdr poll-gated wake pump drains pending queue messages on roster-wide idle transitions, and tmux idle-drain plus a kind-agnostic recovery sweep catch any drain that missed or crashed. For an orchestrator, this means deferred work actually lands — without you polling or hand-holding.
+
+---
+
+## Agent (agent-first design)
+
+**As an agent, I want messaging that treats me as the first-class user — my own identity, a simple send/read contract, and no plumbing knowledge required — so that I can message peers reliably without understanding the transport.**
+
+The headline for agents is ATM Send-To. `atm send --attach` and `--from-json` let you attach files and send structured payloads directly, with the `ATM_TEMP` scratch-directory contract (30-day TTL sweeper) and per-host cross-host transfer scripts (`sftp.sh` / `sftp.ps1`) handling the plumbing. One-gesture per-OS shell entry points for Finder/Explorer/Nautilus plus native member pickers mean you can hand a file to a teammate without learning any transport internals.
+
+Reads also get dramatically faster. Phase AV's dedicated reader lanes for mailbox and search queries mean your `atm read` no longer queues behind the writer lane, so inbox reads stay responsive even when the daemon is under write load. Identity, auto-start, and the singleton daemon contract are all unchanged — the "just works" ergonomics stay intact.
+
+---
+
+## Harness Integrator
+
+**As a harness integrator, I want a stable transport and persistence layer to embed, so that my runtime inherits inter-agent messaging instead of building its own IPC.**
+
+The persistence and transport layer gets a hardening pass aimed squarely at embedders. Phase AV adds bounded reader pools and queue depth for mailbox/search reads; Phase AQ enforces request-budget ordering between SQLite storage, the replacement daemon, and same-host clients, and rebuilds local TCP/Unix transports after a daemon generation change. `fix(peer-tls)` fails closed on legacy literal-IP trusted-peer rows, and storage errors now preserve the raw SQLite cause with a `Cause:` line in the CLI.
+
+Distribution also widens: a native `aarch64-unknown-linux-gnu` release archive ships arm64-Linux binaries (Apple-Silicon colima/docker without emulation), and a one-time storage rebuild relaxes the legacy `mail_messages.message_text NOT NULL` constraint so template sends work on pre-2026-08-11 databases. `fix(http-runtime)` dials direct peers by routable address with a short-lived resolution cache and surfaces the connect cause in the CLI.
+
+---
+
+## Ops Engineer
+
+**As an ops engineer, I want observability into messaging and the ability to improve and refine agent prompts out-of-band, so that a running fleet stays healthy and steerable without restarts.**
+
+`atm doctor --json` now publishes the effective `reader_lanes` contract, so you can confirm read-lane configuration directly. Out-of-band steering gains a second, selector-gated backend: `atm-herdr` (Herdr) now sits alongside retained tmux, with its own health and circuit breaker (ADR-058), letting you steer agents through a poll-gated session model rather than only tmux panes.
+
+The 1.5.0 bump itself is the first to run through the hardened release-readiness gate — the 1.4.7–1.4.13 readiness campaign on the isolated atmbench host and Windows, with smoke/benchmark evidence and benchmark floors recorded under `site/reports/`. Fleet health fixes round it out: retained-log startup failures keep their OS cause, the daemon observability boundary is hardened in `atm-observability`, a pinned self-signed daemon-dev signing identity is supported (Phase AS), and the sc-ecosystem dependency release-preflight gate checks Wyvern/sc-compose/sc-observability pins before every release.
+
+---
+
+## Agent-Graph / DAG Coordinator
+
+**As a workflow author, I want to express agent graphs and DAGs over ATM, so that multi-step agent pipelines pass messages between nodes deterministically.**
+
+The queue/steer delivery surface is the DAG-relevant piece: deferred nudges with guaranteed drain give pipeline authors a typed "stage work, deliver later" primitive on top of the existing pending-ack reliability backbone. Cross-team addressing and mailbox persistence are unchanged, so graph nodes keep the same deterministic hand-off guarantees while gaining a queued, deferred-delivery path.
+
+---
+
+## What's Next
+
+With queued steering and Send-To landed, subsequent work extends the queue/steer taxonomy (Phase AQ follow-ups), completes the arm-linux Homebrew wiring, and finishes the live m5 restart-matrix verification for the `hermes-atm` wheel.

--- a/site/announcements/atm-core-v1.5.0.md
+++ b/site/announcements/atm-core-v1.5.0.md
@@ -1,4 +1,4 @@
-# atm-core v1.5.0 — Queued Steering, Send-To Attachments, and Reader-Lane Scaling
+# atm-core v1.5.0 — Queued Steering, Cross-Platform Herdr Steering, Send-To Attachments, and Reader-Lane Scaling
 
 **Released:** September 4, 2026 · **Install:** `cargo install agent-team-mail` (crates.io), `brew install randlee/tap/agent-team-mail` (Homebrew), `pip install hermes-atm atm-graft` (PyPI), or binary archives from [releases](https://github.com/randlee/atm-core/releases) (now including a native `aarch64-unknown-linux-gnu` arm64-Linux archive)
 
@@ -12,7 +12,7 @@
 
 v1.5.0 turns ATM from fire-and-forget messaging into a work-routing system. The new `atm queue` verb mirrors `atm send`'s full surface — including `--attach` — but defers the recipient nudge instead of firing it immediately, so you can stage work and have it delivered on your terms. Underneath it sits the nudge taxonomy and `PendingNudgeStore` contract (ADR-054) that every queued delivery builds on.
 
-That deferred delivery is now *guaranteed* to drain, not merely queued. Dual-channel graft delivery wires queue messages to a real trigger: harness idle-signal heartbeats and a bare-CLI Stop-pull path, backed by a bounded per-member FIFO. On top of that, the Herdr poll-gated wake pump drains pending queue messages on roster-wide idle transitions, and tmux idle-drain plus a kind-agnostic recovery sweep catch any drain that missed or crashed. For an orchestrator, this means deferred work actually lands — without you polling or hand-holding.
+That deferred delivery is now *guaranteed* to drain, not merely queued — and it drains at the right moment, not just eventually. The Herdr poll-gated wake pump watches the fleet's real lifecycle state and releases each pending queue message the instant its recipient agent finishes a task and returns to `idle`. Dual-channel graft delivery wires queue messages to a real trigger (harness idle-signal heartbeats and a bare-CLI Stop-pull path, backed by a bounded per-member FIFO), and tmux idle-drain plus a kind-agnostic recovery sweep catch any drain that missed or crashed. For an orchestrator, this means deferred work lands precisely when an agent is free to take it — without you polling or hand-holding.
 
 ---
 
@@ -21,6 +21,8 @@ That deferred delivery is now *guaranteed* to drain, not merely queued. Dual-cha
 **As an agent, I want messaging that treats me as the first-class user — my own identity, a simple send/read contract, and no plumbing knowledge required — so that I can message peers reliably without understanding the transport.**
 
 The headline for agents is ATM Send-To. `atm send --attach` and `--from-json` let you attach files and send structured payloads directly, with the `ATM_TEMP` scratch-directory contract (30-day TTL sweeper) and per-host cross-host transfer scripts (`sftp.sh` / `sftp.ps1`) handling the plumbing. One-gesture per-OS shell entry points for Finder/Explorer/Nautilus plus native member pickers mean you can hand a file to a teammate without learning any transport internals.
+
+Nudges now reach Hermes agents on both of ATM's two delivery modes. The `hermes-atm` gateway hook fully supports `/steer` — immediate injection mid-turn — and `/queue` — injection deferred until your current turn completes, handled by Hermes' own busy-session queueing. A teammate (or your orchestrator) decides whether a message interrupts you now or waits until you've finished the task in flight, and `hermes-atm` honors that decision end to end.
 
 Reads also get dramatically faster. Phase AV's dedicated reader lanes for mailbox and search queries mean your `atm read` no longer queues behind the writer lane, so inbox reads stay responsive even when the daemon is under write load. Identity, auto-start, and the singleton daemon contract are all unchanged — the "just works" ergonomics stay intact.
 
@@ -32,6 +34,8 @@ Reads also get dramatically faster. Phase AV's dedicated reader lanes for mailbo
 
 The persistence and transport layer gets a hardening pass aimed squarely at embedders. Phase AV adds bounded reader pools and queue depth for mailbox/search reads; Phase AQ enforces request-budget ordering between SQLite storage, the replacement daemon, and same-host clients, and rebuilds local TCP/Unix transports after a daemon generation change. `fix(peer-tls)` fails closed on legacy literal-IP trusted-peer rows, and storage errors now preserve the raw SQLite cause with a `Cause:` line in the CLI.
 
+The steer/queue delivery backend is now selector-gated rather than tmux-only. A sealed emitter boundary (`AsyncMessageReceivedHookEmitter`) dispatches to **tmux (retained)** or **Herdr**, so a runtime plugs into either without forking the delivery path. Herdr itself is a sealed, alternate trait implementation — never a replacement — and the `atm-herdr` crate isolates the entire Herdr wire contract (argv construction, exit/error-code mapping, a per-host spawn circuit breaker) behind one process-adapter trait, so no other crate parses a Herdr response or constructs a Herdr command. The fixed wake text means a sender's message body is never injected as terminal input on any code path.
+
 Distribution also widens: a native `aarch64-unknown-linux-gnu` release archive ships arm64-Linux binaries (Apple-Silicon colima/docker without emulation), and a one-time storage rebuild relaxes the legacy `mail_messages.message_text NOT NULL` constraint so template sends work on pre-2026-08-11 databases. `fix(http-runtime)` dials direct peers by routable address with a short-lived resolution cache and surfaces the connect cause in the CLI.
 
 ---
@@ -40,7 +44,11 @@ Distribution also widens: a native `aarch64-unknown-linux-gnu` release archive s
 
 **As an ops engineer, I want observability into messaging and the ability to improve and refine agent prompts out-of-band, so that a running fleet stays healthy and steerable without restarts.**
 
-`atm doctor --json` now publishes the effective `reader_lanes` contract, so you can confirm read-lane configuration directly. Out-of-band steering gains a second, selector-gated backend: `atm-herdr` (Herdr) now sits alongside retained tmux, with its own health and circuit breaker (ADR-058), letting you steer agents through a poll-gated session model rather than only tmux panes.
+Herdr becomes the headline here, because it changes how much you have to install and maintain to steer an agent fleet. tmux steering works, but on Windows it meant standing up WSL — a separate Linux environment carrying its own CLI tools, skills, and config just to receive a nudge. Herdr is a cross-platform, agent-aware terminal multiplexer: it natively detects the agents running in its panes (the popular coding CLIs) and tracks their lifecycle state (`idle` / `working` / `blocked` / `done` / `unknown`) **without any per-agent hook**. That state is what the queue pump reads — via a roster-wide `herdr agent list` poll — to decide *when* to deliver, so an agent's status flows into the ATM daemon continuously with zero hook installation on the agent side.
+
+Because Herdr is one backend with one config surface (`--backend herdr [--session <name>]` on the roster row), the user experience and ATM configuration unify across operating systems instead of diverging into a tmux path and a WSL path. The nudge itself is delivered through Herdr's `agent prompt` — a lifecycle-aware primitive, not a blind keystroke injector like tmux `send-keys`. That same prompt powers both of ATM's nudge kinds: **steer**, written immediately to interrupt an agent mid-turn, and **queue**, held until the queue pump observes the agent `idle` after finishing a task and only then written. `agent prompt` refuses to write into a `blocked` agent before any byte lands, and it targets the agent by name inside a Herdr session — the agent's own pane on macOS, Linux, or Windows alike — so steering an agent on Windows works natively through Herdr, with no WSL layer standing between the fleet and its nudges.
+
+Steering is safe by construction and observable by default. The `atm-herdr` circuit breaker (ADR-058) trips open on infrastructure failure — `server_not_running`, `protocol_mismatch`, an external-timeout kill, or a failed `agent list` — with exponential backoff (`1s × 2ⁿ`, capped at 30s) and a half-open recovery probe, so a hung or restarted Herdr server degrades to "held" instead of spamming or wedging. `herdr agent prompt` refuses to write into a `blocked` agent before any byte is injected, and `atm doctor --json` now publishes both the effective `reader_lanes` contract and the live `herdr_breaker` state (plus the queue pump's own health), so you can confirm read-lane configuration and Herdr health directly.
 
 The 1.5.0 bump itself is the first to run through the hardened release-readiness gate — the 1.4.7–1.4.13 readiness campaign on the isolated atmbench host and Windows, with smoke/benchmark evidence and benchmark floors recorded under `site/reports/`. Fleet health fixes round it out: retained-log startup failures keep their OS cause, the daemon observability boundary is hardened in `atm-observability`, a pinned self-signed daemon-dev signing identity is supported (Phase AS), and the sc-ecosystem dependency release-preflight gate checks Wyvern/sc-compose/sc-observability pins before every release.
 
@@ -50,7 +58,7 @@ The 1.5.0 bump itself is the first to run through the hardened release-readiness
 
 **As a workflow author, I want to express agent graphs and DAGs over ATM, so that multi-step agent pipelines pass messages between nodes deterministically.**
 
-The queue/steer delivery surface is the DAG-relevant piece: deferred nudges with guaranteed drain give pipeline authors a typed "stage work, deliver later" primitive on top of the existing pending-ack reliability backbone. Cross-team addressing and mailbox persistence are unchanged, so graph nodes keep the same deterministic hand-off guarantees while gaining a queued, deferred-delivery path.
+The queue/steer delivery surface is the DAG-relevant piece: deferred nudges with guaranteed drain give pipeline authors a typed "stage work, deliver later" primitive on top of the existing pending-ack reliability backbone — and because delivery is now lifecycle-gated through Herdr (deliver on `idle`), a graph node's output can be handed off the moment the next node is actually free, not merely when a timer fires. Cross-team addressing and mailbox persistence are unchanged, so graph nodes keep the same deterministic hand-off guarantees while gaining a queued, deferred-delivery path across both Herdr and Hermes (`/steer` and `/queue`).
 
 ---
 

--- a/site/announcements/index.html
+++ b/site/announcements/index.html
@@ -14,6 +14,7 @@
   <h1>Announcements</h1>
   <p>Press releases and release announcements for atm-core.</p>
   <ul>
+    <li><a href="atm-core-v1.5.0.md">atm-core v1.5.0</a> — Queued Steering, Send-To Attachments, Reader-Lane Scaling</li>
     <li><a href="atm-core-v1.4.4.md">atm-core v1.4.4</a> — mTLS Peer-Wire Transport, First Kit-Era Release</li>
     <li><a href="atm-core-v1.4.3.md">atm-core v1.4.3</a> — Tokio HTTP Runtime, Template Messages, First PyPI Publish (recovery of abandoned v1.4.2)</li>
   </ul>

--- a/site/announcements/index.html
+++ b/site/announcements/index.html
@@ -14,7 +14,7 @@
   <h1>Announcements</h1>
   <p>Press releases and release announcements for atm-core.</p>
   <ul>
-    <li><a href="atm-core-v1.5.0.md">atm-core v1.5.0</a> — Queued Steering, Send-To Attachments, Reader-Lane Scaling</li>
+    <li><a href="atm-core-v1.5.0.md">atm-core v1.5.0</a> — Queued Steering, Cross-Platform Herdr Steering, Send-To Attachments, Reader-Lane Scaling</li>
     <li><a href="atm-core-v1.4.4.md">atm-core v1.4.4</a> — mTLS Peer-Wire Transport, First Kit-Era Release</li>
     <li><a href="atm-core-v1.4.3.md">atm-core v1.4.3</a> — Tokio HTTP Runtime, Template Messages, First PyPI Publish (recovery of abandoned v1.4.2)</li>
   </ul>


### PR DESCRIPTION
Merge-forward for PR #1199 after develop advanced. Resolves the router_support add/add union and storage_and_nudge_router conflict while preserving both peer-delivery assertion sets. Validation: cargo build; cargo test -p atm-http-runtime (211 tests + 2 doctests); just lint (36 checks).