### PR TITLE
fix(ax): phase-end review easy set (AXPE-BG-001/002, CPR-001/M1, ARCH-002)

### DIFF
--- a/boundaries/atm-storage-rusqlite/task-store-sqlite.toml
+++ b/boundaries/atm-storage-rusqlite/task-store-sqlite.toml
@@ -22,7 +22,7 @@ io_forbidden = ["message_delivery", "process_spawn"]
 [dependencies]
 allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime-test-support"]
 allowed_dependencies = ["atm-storage", "rusqlite"]
-forbidden_edges = ["atm-storage-rusqlite -> atm-core", "atm-storage-rusqlite -> atm-runtime"]
+forbidden_edges = ["atm-storage-rusqlite -> atm-core", "atm-storage-rusqlite -> atm-runtime", "atm-daemon -> atm-storage-rusqlite"]
 
 [references]
 scope = "outside_owner_crate"

--- a/crates/atm/tests/cli_surface.rs
+++ b/crates/atm/tests/cli_surface.rs
@@ -68,9 +68,14 @@ fn live_surface_json() -> Value {
 
 #[test]
 fn legacy_environment_variable_cannot_bypass_clap_parsing() {
+    let fixture = tempfile::tempdir().expect("temporary ATM environment");
     let atm_bin = env!("CARGO_BIN_EXE_atm");
     let output = Command::new(atm_bin)
         .env("ATM_CLI_SURFACE_DUMP", "json")
+        .env("ATM_HOME", fixture.path())
+        .env("ATM_CONFIG_HOME", fixture.path().join("config"))
+        .env("ATM_LOG_DIR", fixture.path().join("logs"))
+        .env("ATM_TEAMS_DIR", fixture.path().join("teams"))
         .arg("--version")
         .output()
         .expect("failed to run `atm --version`");

--- a/docs/plans/phase-ax/.audit/qa-evidence-master.json
+++ b/docs/plans/phase-ax/.audit/qa-evidence-master.json
@@ -5,7 +5,7 @@
     "start": "2026-09-05T05:00:31Z",
     "end": "2026-09-05T16:56:30Z"
   },
-  "scope": "phase-ax sprints AX.1-AX.7 (graph-orchestration cursor over .sprints/AX; sprint PRs #1185 AX.1, #1186 AX.2, #1191 AX.3, #1194 AX.4, #1201 AX.5 all merged into integrate/phase-ax). Every QA round quality-mgr reported for AX.1-AX.5 is listed; the latest run_type qa per sprint is the authoritative verdict. AX.6 (feature/ax6-lead-notification-doctor, cipher, Assignment a21) is in development with no QA run yet; AX.7 has not started. This master is extended with each authoritative verdict message as quality-mgr reports it.",
+  "scope": "phase-ax sprints AX.1-AX.6 (AX.1-AX.6 merged into integrate/phase-ax). AX.7 was superseded on 2026-09-05, with live proof moved to release readiness.",
   "count_basis": "headline/reviewer",
   "path_notes": "Built by fenix (phase AX orchestrator, sole .triage/.sprints writer) directly from ATM messages in the fenix and quality-mgr queues (team atm-dev): every assignment_message_id is the first fenix->quality-mgr message carrying that QA task id (atm list quality-mgr --all --json); every result_message_id is quality-mgr's verdict message in fenix's queue (atm list --all --json); Final Quality Report comment ids come from the GitHub issue-comments API for each PR. No verdict, run, or message id was fabricated; null means the value is not carried by the source message.",
   "runs": [

--- a/docs/plans/phase-ax/sprint-AX.3-task-state-machine.md
+++ b/docs/plans/phase-ax/sprint-AX.3-task-state-machine.md
@@ -36,6 +36,13 @@ boundary record, and ADR-062. The CLI and user docs are AX.4; the
 reminder cycle is AX.5. This sprint **executes in parallel with AX.1 and
 AX.2** on its own gh-stack rooted on `integrate/phase-ax`.
 
+### Frozen-file rulings
+
+The additive changes to `.just/lint-config.toml` and
+`.just/lint_boundaries.py` are approved frozen-file changes for AX.3:
+they preserve the existing rules and add the AX.3 false-positive regression
+test in `.just/tests/test_lint_boundaries.py:1426`.
+
 ## State machine
 
 One row per (`team`, `task_id`, `assignee`). States and events are
@@ -753,8 +760,8 @@ paths; `atm read` / `atm ack` argument shapes; `DeliveryRecipientSnapshot`;
    unchanged allowlist; `boundary-guard` review of `task-store.toml`
    and `task-store-sqlite.toml` passes; ADR-062, the ADR-054 amendment, and requirements §7 merged;
    `just validate` green; contract.rs size gate:
-   `awk '/^#\[cfg\(test\)\]/{exit} {n++} END{exit n>1000}' crates/atm-storage/src/contract.rs`
-   succeeds (non-test lines ≤ 1000); backend neutrality:
+   `python3 .just/check_line_counts.py` succeeds (non-test lines ≤ 1000);
+   backend neutrality:
    `cargo tree -p atm-storage -e normal | grep -c rusqlite` prints 0 and
    `cargo check -p atm-storage-sqlserver-proof` passes with that crate
    unchanged (it keeps the provenance defaults and `DummyTaskStore`).

--- a/docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md
+++ b/docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md
@@ -356,10 +356,8 @@ visibility (public).
    escalation whose lead write, every recipient write and `notify` all
    fail leaves `last_blocked_notice` unset and is retried on the next
    tick; one that reaches anyone is stamped.
-8. `awk '/^#\[cfg\(test\)\]/{exit} {n++} END{exit n>1000}'` passes for
-   `crates/atm-http-runtime/src/herdr_queue_wake.rs` and
-   `crates/atm-http-runtime/src/herdr_escalation.rs`; `docs/requirements.md`
-   §1 lists `atm escalation` as the Phase `AX` additive CLI feature.
+8. `python3 .just/check_line_counts.py` passes; `docs/requirements.md` §1
+   lists `atm escalation` as the Phase `AX` additive CLI feature.
 
 ## Required validation
 


### PR DESCRIPTION
Closes the phase-end EASY review set.\n\n- AXPE-BG-001: add the approved daemon-to-rusqlite forbidden edge.\n- AXPE-BG-002: document the additive frozen-file ruling.\n- AXPE-CPR-001: replace hand-rolled RULE-003 awk checks with the authoritative Python gate.\n- AXPE-CPR-M1: update only the QA evidence scope narrative.\n- AXPE-ARCH-002: isolate the --version CLI subprocess with the standard temporary ATM environment.\n\nValidation: focused CLI test 2/2, boundary lint, line-count gate, fmt, and clippy pass. just test and just lint spell/adr-index could not start because this worktree lacks .bootstrap-venv; CI should run those recipes.