### PR TITLE
fix: close AX phase-end structural findings

### DIFF
--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -277,6 +277,8 @@ impl ReplacementReceivedHookSelector {
             graft: PublishedGraftReceivedHook {
                 service_runtime: service_runtime.clone(),
                 runtime_health: runtime_health.clone(),
+                #[cfg(test)]
+                forced_failure: false,
             },
             queue_pull: PullPendingReceivedHook {
                 service_runtime,
@@ -504,6 +506,22 @@ fn hook_deadline_error(stage: &'static str) -> AtmError {
 struct PublishedGraftReceivedHook {
     service_runtime: LocalServiceRuntime,
     runtime_health: RuntimeHealth,
+    #[cfg(test)]
+    forced_failure: bool,
+}
+
+#[cfg(test)]
+impl PublishedGraftReceivedHook {
+    fn failing_for_test(
+        service_runtime: LocalServiceRuntime,
+        runtime_health: RuntimeHealth,
+    ) -> Self {
+        Self {
+            service_runtime,
+            runtime_health,
+            forced_failure: true,
+        }
+    }
 }
 
 impl boundary::sealed::Sealed for PublishedGraftReceivedHook {}
@@ -524,31 +542,38 @@ impl AsyncMessageReceivedHookEmitter for PublishedGraftReceivedHook {
         let member_for_handoff = member.clone();
         let message_id = dispatch.event.message_id;
         let runtime_health_for_clear = runtime_health.clone();
+        #[cfg(test)]
+        let forced_failure = self.forced_failure;
         Box::pin(async move {
-            let result = tokio::task::spawn_blocking(move || {
-                let result = atm_core::graft::deliver_published_receiver_hook_from_local_runtime(
-                    &service_runtime,
-                    &dispatch,
+            #[cfg(test)]
+            let result = if forced_failure {
+                Err(AtmError::new(
+                    AtmErrorCode::PostSendGraftUnavailable,
+                    "injected graft handoff failure",
+                ))
+            } else {
+                deliver_published_graft_hook(
+                    service_runtime,
+                    dispatch,
                     deadline,
-                );
-                if result.is_ok() && kind == NudgeKind::Queue {
-                    atm_core::nudge_dispatch::clear_queue_marker_after_handoff(
-                        &service_runtime,
-                        &member_for_handoff,
-                        &message_id,
-                        || runtime_health_for_clear.record_graft_queue_marker_clear_failure(),
-                    );
-                }
-                result
-            })
-            .await
-            .map_err(|source| {
-                AtmError::new(
-                    AtmErrorCode::InternalError,
-                    "published Graft receiver hook task ended unexpectedly",
+                    kind,
+                    member_for_handoff,
+                    message_id,
+                    runtime_health_for_clear,
                 )
-                .with_cause(source)
-            })?;
+                .await
+            };
+            #[cfg(not(test))]
+            let result = deliver_published_graft_hook(
+                service_runtime,
+                dispatch,
+                deadline,
+                kind,
+                member_for_handoff,
+                message_id,
+                runtime_health_for_clear,
+            )
+            .await;
             if let Err(error) = &result
                 && kind == NudgeKind::Queue
             {
@@ -567,6 +592,41 @@ impl AsyncMessageReceivedHookEmitter for PublishedGraftReceivedHook {
             result
         })
     }
+}
+
+async fn deliver_published_graft_hook(
+    service_runtime: LocalServiceRuntime,
+    dispatch: BuiltInPostSendDispatch,
+    deadline: RequestDeadline,
+    kind: NudgeKind,
+    member: atm_core::boundary::MemberKey,
+    message_id: atm_core::schema::AtmMessageId,
+    runtime_health: RuntimeHealth,
+) -> Result<PostSendEmissionPath, AtmError> {
+    tokio::task::spawn_blocking(move || {
+        let result = atm_core::graft::deliver_published_receiver_hook_from_local_runtime(
+            &service_runtime,
+            &dispatch,
+            deadline,
+        );
+        if result.is_ok() && kind == NudgeKind::Queue {
+            atm_core::nudge_dispatch::clear_queue_marker_after_handoff(
+                &service_runtime,
+                &member,
+                &message_id,
+                || runtime_health.record_graft_queue_marker_clear_failure(),
+            );
+        }
+        result
+    })
+    .await
+    .map_err(|source| {
+        AtmError::new(
+            AtmErrorCode::InternalError,
+            "published Graft receiver hook task ended unexpectedly",
+        )
+        .with_cause(source)
+    })?
 }
 
 /// Hands a bare-CLI delivery to the daemon-lifetime FIFO and immediately
@@ -684,14 +744,15 @@ mod tests {
     };
     use atm_storage::RosterSnapshot;
     use std::fs;
-    use std::net::TcpListener;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread;
 
     #[cfg(feature = "benchmark-harness")]
     use super::{BenchmarkHookMode, DisabledReceivedHookSelector};
-    use super::{ReplacementReceivedHookSelector, TokioTmuxReceivedHook};
+    use super::{
+        PublishedGraftReceivedHook, ReplacementReceivedHookSelector, TokioTmuxReceivedHook,
+    };
 
     fn tmux_dispatch() -> BuiltInPostSendDispatch {
         BuiltInPostSendDispatch {
@@ -1348,8 +1409,7 @@ mod tests {
     async fn failed_queue_graft_handoff_retains_marker_at_attempt_zero() {
         let root = tempfile::tempdir().expect("temporary runtime root");
         let (runtime, endpoint_store, team, recipient) = queue_graft_runtime(root.path());
-        let unavailable_listener = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
-        let endpoint = unavailable_listener.local_addr().expect("endpoint");
+        let endpoint = "127.0.0.1:9".parse().expect("test endpoint");
         endpoint_store
             .register(
                 &GraftReceiverRegistration {
@@ -1372,14 +1432,8 @@ mod tests {
                 .expect("rebuild dispatch")
                 .expect("graft dispatch");
         let health = RuntimeHealth::default();
-        let selector = ReplacementReceivedHookSelector::with_herdr_process(
-            runtime.clone(),
-            Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default()),
-            health.clone(),
-        );
-        let error = selector
-            .select_emitter(&dispatch)
-            .expect("graft emitter")
+        let emitter = PublishedGraftReceivedHook::failing_for_test(runtime.clone(), health.clone());
+        let error = emitter
             .emit_received_message(
                 dispatch,
                 RequestDeadline::after(std::time::Duration::from_secs(1)),
@@ -1413,8 +1467,7 @@ mod tests {
     async fn sweep_dispatched_queue_graft_failure_reports_for_caller_requeue() {
         let root = tempfile::tempdir().expect("temporary runtime root");
         let (runtime, endpoint_store, team, recipient) = queue_graft_runtime(root.path());
-        let unavailable_listener = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
-        let endpoint = unavailable_listener.local_addr().expect("endpoint");
+        let endpoint = "127.0.0.1:9".parse().expect("test endpoint");
         endpoint_store
             .register(
                 &GraftReceiverRegistration {
@@ -1443,14 +1496,8 @@ mod tests {
             .expect("claim query")
             .expect("sweep claim");
         let health = RuntimeHealth::default();
-        let selector = ReplacementReceivedHookSelector::with_herdr_process(
-            runtime.clone(),
-            Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default()),
-            health.clone(),
-        );
-        let error = selector
-            .select_emitter(&dispatch)
-            .expect("graft emitter")
+        let emitter = PublishedGraftReceivedHook::failing_for_test(runtime.clone(), health.clone());
+        let error = emitter
             .emit_received_message(dispatch, RequestDeadline::after(Duration::from_secs(1)))
             .await
             .expect_err("unavailable graft must be reported to sweep caller");

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -1348,9 +1348,8 @@ mod tests {
     async fn failed_queue_graft_handoff_retains_marker_at_attempt_zero() {
         let root = tempfile::tempdir().expect("temporary runtime root");
         let (runtime, endpoint_store, team, recipient) = queue_graft_runtime(root.path());
-        let unused = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
-        let endpoint = unused.local_addr().expect("endpoint");
-        drop(unused);
+        let unavailable_listener = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
+        let endpoint = unavailable_listener.local_addr().expect("endpoint");
         endpoint_store
             .register(
                 &GraftReceiverRegistration {
@@ -1414,9 +1413,8 @@ mod tests {
     async fn sweep_dispatched_queue_graft_failure_reports_for_caller_requeue() {
         let root = tempfile::tempdir().expect("temporary runtime root");
         let (runtime, endpoint_store, team, recipient) = queue_graft_runtime(root.path());
-        let unused = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
-        let endpoint = unused.local_addr().expect("endpoint");
-        drop(unused);
+        let unavailable_listener = TcpListener::bind(("127.0.0.1", 0)).expect("reserve endpoint");
+        let endpoint = unavailable_listener.local_addr().expect("endpoint");
         endpoint_store
             .register(
                 &GraftReceiverRegistration {

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -12,7 +12,6 @@ use atm_core::{HerdrSession, RequestDeadline};
 use serde_json::Value;
 use tokio::io::AsyncReadExt;
 
-pub const HERDR_WAKE_TEXT: &str = "You have unread ATM messages. Run: atm read";
 /// Oldest Herdr release this daemon supports (ADR-061). Keyed on the Herdr
 /// release version reported by `ping.version`, not on Herdr's bincode-only
 /// `PROTOCOL_VERSION`. Every Herdr release at or above this value must keep

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -493,17 +493,14 @@ impl HerdrQueueWakePump {
         now: IsoTimestamp,
         stats: &mut HerdrQueueWakeStats,
     ) {
+        let context = crate::herdr_queue_wake_escalation::TaskReminderContext {
+            reader,
+            task_store,
+            member: &candidate.member.key,
+        };
         if candidate.blocked {
-            self.record_task_outcome(
-                reader,
-                task_store,
-                &candidate.member.key,
-                &row,
-                now,
-                ReminderOutcome::Blocked,
-                stats,
-            )
-            .await;
+            self.record_task_outcome(&context, &row, now, ReminderOutcome::Blocked, stats)
+                .await;
             return;
         }
         if stats.prompted >= HERDR_MAX_PROMPTS_PER_TICK {
@@ -521,16 +518,8 @@ impl HerdrQueueWakePump {
             Ok(None) => return,
             Err(error) => {
                 tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_render", outcome = "unrenderable", error = %error, member = %candidate.member.key, "Herdr task reminder could not render");
-                self.record_task_outcome(
-                    reader,
-                    task_store,
-                    &candidate.member.key,
-                    &row,
-                    now,
-                    ReminderOutcome::Unrenderable,
-                    stats,
-                )
-                .await;
+                self.record_task_outcome(&context, &row, now, ReminderOutcome::Unrenderable, stats)
+                    .await;
                 return;
             }
         };
@@ -543,16 +532,8 @@ impl HerdrQueueWakePump {
             .await
         {
             Ok(_) => {
-                self.record_task_outcome(
-                    reader,
-                    task_store,
-                    &candidate.member.key,
-                    &row,
-                    now,
-                    ReminderOutcome::Emitted,
-                    stats,
-                )
-                .await
+                self.record_task_outcome(&context, &row, now, ReminderOutcome::Emitted, stats)
+                    .await
             }
             Err(error) if error.code() == AtmErrorCode::HerdrUnavailable => stats.breaker_open += 1,
             Err(error) => {
@@ -565,16 +546,14 @@ impl HerdrQueueWakePump {
 
     async fn record_task_outcome(
         &self,
-        reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
-        task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
-        member: &MemberKey,
+        context: &crate::herdr_queue_wake_escalation::TaskReminderContext<'_>,
         row: &TaskRow,
         now: IsoTimestamp,
         outcome: ReminderOutcome,
         stats: &mut HerdrQueueWakeStats,
     ) {
         let recorded_row = self
-            .record_task_reminder(task_store, member, row, now, outcome)
+            .record_task_reminder(context.task_store, context.member, row, now, outcome)
             .await;
         match outcome {
             ReminderOutcome::Emitted => {
@@ -584,12 +563,12 @@ impl HerdrQueueWakePump {
             ReminderOutcome::Unrenderable => stats.task_reminders_unrenderable += 1,
             ReminderOutcome::Blocked => stats.task_reminders_blocked += 1,
         }
-        self.stamp_task_attempt(member, now);
+        self.stamp_task_attempt(context.member, now);
         if let Ok(recorded_row) = recorded_row {
             crate::herdr_queue_wake_escalation::maybe_escalate_task(
                 self,
-                reader,
-                task_store,
+                context.reader,
+                context.task_store,
                 &recorded_row,
                 now,
                 stats,

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -473,7 +473,7 @@ impl HerdrQueueWakePump {
                 let Some(row) = self.read_due_task(reader.as_ref(), &candidate, now).await else {
                     continue;
                 };
-                self.emit_task_reminder(task_store, candidate, row, now, stats)
+                self.emit_task_reminder(reader.as_ref(), task_store, candidate, row, now, stats)
                     .await;
             }
         }
@@ -521,6 +521,7 @@ impl HerdrQueueWakePump {
 
     async fn emit_task_reminder(
         &self,
+        reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
         task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
         candidate: TaskCandidate,
         row: TaskRow,
@@ -529,6 +530,7 @@ impl HerdrQueueWakePump {
     ) {
         if candidate.blocked {
             self.record_task_outcome(
+                reader,
                 task_store,
                 &candidate.member.key,
                 &row,
@@ -555,6 +557,7 @@ impl HerdrQueueWakePump {
             Err(error) => {
                 tracing::warn!(subsystem = "herdr_queue_wake", action = "task_reminder_render", outcome = "unrenderable", error = %error, member = %candidate.member.key, "Herdr task reminder could not render");
                 self.record_task_outcome(
+                    reader,
                     task_store,
                     &candidate.member.key,
                     &row,
@@ -576,6 +579,7 @@ impl HerdrQueueWakePump {
         {
             Ok(_) => {
                 self.record_task_outcome(
+                    reader,
                     task_store,
                     &candidate.member.key,
                     &row,
@@ -596,6 +600,7 @@ impl HerdrQueueWakePump {
 
     async fn record_task_outcome(
         &self,
+        reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
         task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
         member: &MemberKey,
         row: &TaskRow,
@@ -616,7 +621,7 @@ impl HerdrQueueWakePump {
         }
         self.stamp_task_attempt(member, now);
         if let Ok(recorded_row) = recorded_row {
-            self.maybe_escalate_task(task_store, &recorded_row, now, stats)
+            self.maybe_escalate_task(reader, task_store, &recorded_row, now, stats)
                 .await;
         }
     }
@@ -649,13 +654,16 @@ impl HerdrQueueWakePump {
 
     async fn maybe_escalate_task(
         &self,
+        reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
         task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
         row: &TaskRow,
         now: IsoTimestamp,
         stats: &mut HerdrQueueWakeStats,
     ) {
-        crate::herdr_queue_wake_escalation::maybe_escalate_task(self, task_store, row, now, stats)
-            .await;
+        crate::herdr_queue_wake_escalation::maybe_escalate_task(
+            self, reader, task_store, row, now, stats,
+        )
+        .await;
     }
 
     async fn escalate_blocked(
@@ -1766,6 +1774,10 @@ mod tests {
 
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &row,
             timestamp,
@@ -1817,6 +1829,10 @@ mod tests {
         tenth.reminder_count = 10;
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &tenth,
             timestamp,
@@ -1829,6 +1845,10 @@ mod tests {
         nineteenth.lead_notified_count = 1;
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &nineteenth,
             timestamp,
@@ -1840,6 +1860,10 @@ mod tests {
         twentieth.reminder_count = 20;
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &twentieth,
             timestamp,
@@ -1881,6 +1905,10 @@ mod tests {
 
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump.clone().with_daemon_home(root.path().join("home")),
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &tenth,
             timestamp,
@@ -1894,6 +1922,10 @@ mod tests {
         let mut retry_stats = HerdrQueueWakeStats::default();
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump.with_daemon_home(root.path().join("home")),
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &eleventh,
             timestamp,
@@ -1924,6 +1956,10 @@ mod tests {
 
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &row,
             timestamp,
@@ -1948,6 +1984,10 @@ mod tests {
             .expect("roster");
         crate::herdr_queue_wake_escalation::maybe_escalate_task(
             &pump,
+            runtime
+                .async_task_ledger_reader()
+                .expect("task reader")
+                .as_ref(),
             &task_store,
             &row,
             timestamp,

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -23,9 +23,6 @@ use atm_herdr::{AgentSnapshot, HerdrAgentStatus, HerdrProcessAdapter};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-#[cfg(test)]
-use tokio::sync::Notify;
-
 use crate::herdr_escalation::EscalationState;
 use crate::runtime_health::RuntimeHealth;
 
@@ -38,9 +35,6 @@ pub const HERDR_MAX_CONSECUTIVE_RELEASES: u32 = 10;
 /// Minimum spacing between task reminders for one Herdr assignee.
 pub const TASK_REMINDER_INTERVAL_MS: u64 = 60_000;
 const HERDR_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
-
-#[cfg(test)]
-type HandoffCleanupTestGate = (Arc<Notify>, Arc<Notify>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct HerdrQueueWakeStats {
@@ -78,7 +72,10 @@ pub struct HerdrQueueWakePump {
     task_step_available: Arc<Mutex<Option<bool>>>,
     last_stats: Arc<Mutex<HerdrQueueWakeStats>>,
     #[cfg(test)]
-    handoff_cleanup_test_gate: Arc<Mutex<Option<HandoffCleanupTestGate>>>,
+    pub(crate) handoff_cleanup_test_gate:
+        Arc<Mutex<Option<crate::herdr_queue_wake_test_gates::Gate>>>,
+    #[cfg(test)]
+    pub(crate) prompt_started_test_gate: Arc<Mutex<Option<Arc<tokio::sync::Notify>>>>,
 }
 
 impl HerdrQueueWakePump {
@@ -104,6 +101,8 @@ impl HerdrQueueWakePump {
             last_stats: Arc::new(Mutex::new(HerdrQueueWakeStats::default())),
             #[cfg(test)]
             handoff_cleanup_test_gate: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            prompt_started_test_gate: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -119,40 +118,6 @@ impl HerdrQueueWakePump {
     fn with_clock(mut self, clock: Arc<dyn Fn() -> IsoTimestamp + Send + Sync>) -> Self {
         self.clock = clock;
         self
-    }
-
-    #[cfg(test)]
-    fn install_handoff_cleanup_test_gate(&self) -> (Arc<Notify>, Arc<Notify>) {
-        let entered = Arc::new(Notify::new());
-        let release = Arc::new(Notify::new());
-        self.handoff_cleanup_test_gate
-            .lock()
-            .expect("handoff cleanup gate lock")
-            .replace((Arc::clone(&entered), Arc::clone(&release)));
-        (entered, release)
-    }
-
-    #[cfg(test)]
-    fn clear_handoff_cleanup_test_gate(&self) {
-        self.handoff_cleanup_test_gate
-            .lock()
-            .expect("handoff cleanup gate lock")
-            .take();
-    }
-
-    #[cfg(test)]
-    async fn await_handoff_cleanup_test_gate(&self) {
-        let Some((entered, release)) = self
-            .handoff_cleanup_test_gate
-            .lock()
-            .expect("handoff cleanup gate lock")
-            .as_ref()
-            .cloned()
-        else {
-            return;
-        };
-        entered.notify_one();
-        release.notified().await;
     }
 
     /// Starts the single polling task. The task owns no per-member workers.
@@ -621,8 +586,15 @@ impl HerdrQueueWakePump {
         }
         self.stamp_task_attempt(member, now);
         if let Ok(recorded_row) = recorded_row {
-            self.maybe_escalate_task(reader, task_store, &recorded_row, now, stats)
-                .await;
+            crate::herdr_queue_wake_escalation::maybe_escalate_task(
+                self,
+                reader,
+                task_store,
+                &recorded_row,
+                now,
+                stats,
+            )
+            .await;
         }
     }
 
@@ -650,20 +622,6 @@ impl HerdrQueueWakePump {
                 Err(error)
             }
         }
-    }
-
-    async fn maybe_escalate_task(
-        &self,
-        reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
-        task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
-        row: &TaskRow,
-        now: IsoTimestamp,
-        stats: &mut HerdrQueueWakeStats,
-    ) {
-        crate::herdr_queue_wake_escalation::maybe_escalate_task(
-            self, reader, task_store, row, now, stats,
-        )
-        .await;
     }
 
     async fn escalate_blocked(
@@ -828,6 +786,8 @@ impl HerdrQueueWakePump {
         release: &mut ReleasePendingOnDrop,
         stats: &mut HerdrQueueWakeStats,
     ) -> bool {
+        #[cfg(test)]
+        self.notify_prompt_started_test_gate();
         match emitter
             .emit_received_message(dispatch, RequestDeadline::after(HERDR_REQUEST_DEADLINE))
             .await
@@ -884,8 +844,6 @@ impl HerdrQueueWakePump {
         // Herdr has accepted the prompt. Disarm before any cleanup await so
         // cancellation cannot re-release an already delivered claim.
         release.disarm();
-        #[cfg(test)]
-        self.await_handoff_cleanup_test_gate().await;
         let runtime = self.service_runtime.clone();
         let member_key = member.key.clone();
         let message_id = claim.msg;
@@ -900,6 +858,8 @@ impl HerdrQueueWakePump {
             Ok(())
         })
         .await;
+        #[cfg(test)]
+        self.await_handoff_cleanup_test_gate().await;
         self.reset_release_streak(&member.key);
         stats.prompted += 1;
         tracing::info!(
@@ -1702,23 +1662,13 @@ mod tests {
     ) {
         let (root, runtime, fake, pump, _health, key) = build_test_pump();
         let prompt_gate = fake.block_next_prompt();
+        let prompt_started = pump.install_prompt_started_test_gate();
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let sender_clone = shutdown_tx.clone();
         let task = pump.clone().start(shutdown_rx);
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if fake
-                    .calls()
-                    .iter()
-                    .any(|call| matches!(call, atm_herdr::testing::FakeHerdrCall::Prompt { .. }))
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("the fake prompt is in flight before shutdown");
+        tokio::time::timeout(Duration::from_secs(1), prompt_started.notified())
+            .await
+            .expect("the fake prompt is in flight before shutdown");
         shutdown_tx.send(()).expect("shutdown notification");
         tokio::time::timeout(Duration::from_secs(1), task)
             .await
@@ -3247,10 +3197,12 @@ mod tests {
     #[tokio::test]
     async fn ac11_successful_prompt_cancellation_cannot_rerelease_claim() {
         let (_root, runtime, fake, pump, _health, key) = build_test_pump();
-        let (clear_started, allow_clear) = pump.install_handoff_cleanup_test_gate();
+        let (clear_started, _allow_clear) = pump.install_handoff_cleanup_test_gate();
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let task = pump.clone().start(shutdown_rx);
-        clear_started.notified().await;
+        tokio::time::timeout(Duration::from_secs(1), clear_started.notified())
+            .await
+            .expect("marker cleanup completes before cancellation");
 
         shutdown_tx.send(()).expect("shutdown notification");
         task.await.expect("poll task join");
@@ -3264,23 +3216,15 @@ mod tests {
             "a successful Herdr prompt must not be re-released while cleanup is pending"
         );
 
-        allow_clear.notify_one();
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if runtime
-                    .pending_nudge_store()
-                    .expect("pending store")
-                    .list_pending_members()
-                    .expect("pending members")
-                    .is_empty()
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("marker cleanup completes");
+        assert!(
+            runtime
+                .pending_nudge_store()
+                .expect("pending store")
+                .list_pending_members()
+                .expect("pending members")
+                .is_empty(),
+            "completed marker cleanup leaves no pending member"
+        );
 
         fake.queue_list_result(Ok(HerdrListOutcome {
             agents: vec![AgentSnapshot {

--- a/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
@@ -21,6 +21,7 @@ const MAX_BLOCKED_MAIL_BODY_BYTES: usize = 4_096;
 
 pub(crate) async fn maybe_escalate_task(
     pump: &HerdrQueueWakePump,
+    reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
     task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
     row: &TaskRow,
     now: IsoTimestamp,
@@ -33,7 +34,7 @@ pub(crate) async fn maybe_escalate_task(
     if row.reminder_count < threshold {
         return;
     }
-    let events = match reminder_events(task_store, row).await {
+    let events = match reminder_events(reader, row).await {
         Ok(events) => events,
         Err(error) => {
             tracing::warn!(
@@ -67,14 +68,20 @@ pub(crate) async fn maybe_escalate_task(
 }
 
 async fn reminder_events(
-    task_store: &Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+    reader: &(dyn AsyncTaskLedgerReader + Send + Sync),
     row: &TaskRow,
 ) -> Result<Vec<TaskEventRow>, atm_core::error::AtmError> {
-    let store = Arc::clone(task_store);
-    let team = row.team.clone();
-    let task_id = row.task_id.clone();
-    let assignee = row.assignee.clone();
-    run_blocking(move || store.list_task_events(&team, &task_id, Some(&assignee))).await
+    let deadline = ReadDeadline::new(TASK_READ_DEADLINE)
+        .map_err(|error| atm_core::error::AtmError::daemon_unavailable(error.to_string()))?;
+    reader
+        .list_task_events(
+            row.team.clone(),
+            row.task_id.clone(),
+            Some(row.assignee.clone()),
+            deadline,
+        )
+        .await
+        .map_err(|error| atm_core::error::AtmError::daemon_unavailable(error.to_string()))
 }
 
 fn task_escalation_body(row: &TaskRow, now: IsoTimestamp, events: &[TaskEventRow]) -> String {

--- a/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
@@ -19,6 +19,12 @@ const TASK_READ_DEADLINE: Duration = Duration::from_secs(5);
 const MAX_BLOCKED_TASKS_IN_BODY: usize = 8;
 const MAX_BLOCKED_MAIL_BODY_BYTES: usize = 4_096;
 
+pub(crate) struct TaskReminderContext<'a> {
+    pub(crate) reader: &'a (dyn AsyncTaskLedgerReader + Send + Sync),
+    pub(crate) task_store: &'a Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+    pub(crate) member: &'a MemberKey,
+}
+
 pub(crate) async fn maybe_escalate_task(
     pump: &HerdrQueueWakePump,
     reader: &(dyn AsyncTaskLedgerReader + Send + Sync),

--- a/crates/atm-http-runtime/src/herdr_queue_wake_test_gates.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake_test_gates.rs
@@ -1,0 +1,62 @@
+//! Test-only synchronization seams for Herdr queue wake cancellation tests.
+
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+
+use crate::herdr_queue_wake::HerdrQueueWakePump;
+
+pub(crate) type Gate = (Arc<Notify>, Arc<Notify>);
+
+impl HerdrQueueWakePump {
+    pub(crate) fn install_handoff_cleanup_test_gate(&self) -> Gate {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        self.handoff_cleanup_test_gate
+            .lock()
+            .expect("handoff cleanup gate lock")
+            .replace((Arc::clone(&entered), Arc::clone(&release)));
+        (entered, release)
+    }
+
+    pub(crate) fn install_prompt_started_test_gate(&self) -> Arc<Notify> {
+        let entered = Arc::new(Notify::new());
+        self.prompt_started_test_gate
+            .lock()
+            .expect("prompt started gate lock")
+            .replace(Arc::clone(&entered));
+        entered
+    }
+
+    pub(crate) fn notify_prompt_started_test_gate(&self) {
+        if let Some(entered) = self
+            .prompt_started_test_gate
+            .lock()
+            .expect("prompt started gate lock")
+            .take()
+        {
+            entered.notify_one();
+        }
+    }
+
+    pub(crate) fn clear_handoff_cleanup_test_gate(&self) {
+        self.handoff_cleanup_test_gate
+            .lock()
+            .expect("handoff cleanup gate lock")
+            .take();
+    }
+
+    pub(crate) async fn await_handoff_cleanup_test_gate(&self) {
+        let Some((entered, release)) = self
+            .handoff_cleanup_test_gate
+            .lock()
+            .expect("handoff cleanup gate lock")
+            .as_ref()
+            .cloned()
+        else {
+            return;
+        };
+        entered.notify_one();
+        release.notified().await;
+    }
+}

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -54,6 +54,8 @@ mod client;
 mod herdr_escalation;
 mod herdr_queue_wake;
 mod herdr_queue_wake_escalation;
+#[cfg(test)]
+mod herdr_queue_wake_test_gates;
 mod http1_server;
 mod loopback_tcp;
 mod message_handler;

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -30,6 +30,7 @@ mod shared_db_diagnostics;
 mod shared_db_reader_lanes;
 mod shared_db_support;
 mod task_ledger_reader;
+mod task_sql;
 mod task_store;
 mod team_roster_schema;
 mod template_catalog_schema;

--- a/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
+++ b/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
@@ -79,7 +79,9 @@ fn list_tasks(
     team: &TeamName,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskRow>, AtmError> {
-    let mut statement = connection.prepare(&format!("SELECT {} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC", task_sql::TASK_COLUMNS)).map_err(|error| sqlite_error(target, "failed to prepare async task list", error))?;
+    let mut statement = connection
+        .prepare(&task_sql::select_tasks_for_team_sql())
+        .map_err(|error| sqlite_error(target, "failed to prepare async task list", error))?;
     statement
         .query_map(
             params![team.as_str(), member.map(AgentName::as_str)],
@@ -99,7 +101,9 @@ fn list_task_events(
     task_id: &TaskId,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskEventRow>, AtmError> {
-    let mut statement = connection.prepare(&format!("SELECT {} FROM task_events WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3) ORDER BY seq ASC", task_sql::TASK_EVENT_COLUMNS)).map_err(|error| sqlite_error(target, "failed to prepare async task event list", error))?;
+    let mut statement = connection
+        .prepare(&task_sql::select_task_events_sql())
+        .map_err(|error| sqlite_error(target, "failed to prepare async task event list", error))?;
     statement
         .query_map(
             params![

--- a/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
+++ b/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
@@ -8,9 +8,10 @@ use atm_storage::{
     AgentName, AsyncTaskLedgerReader, AtmError, ReadDeadline, ReadLaneError, TaskEventRow, TaskId,
     TaskRow, TeamName,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, params};
 use std::sync::Arc;
 
+use crate::SqliteTaskStore;
 use crate::reader_pool::ReaderPool;
 use crate::shared_db::{SharedDbTarget, sqlite_error};
 use crate::task_sql;
@@ -78,8 +79,17 @@ fn list_tasks(
     team: &TeamName,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskRow>, AtmError> {
-    task_sql::select_tasks_for_team(connection, team, member)
-        .map_err(|error| sqlite_error(target, "failed to list async tasks", error))
+    let mut statement = connection.prepare(&format!("SELECT {} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC", task_sql::TASK_COLUMNS)).map_err(|error| sqlite_error(target, "failed to prepare async task list", error))?;
+    statement
+        .query_map(
+            params![team.as_str(), member.map(AgentName::as_str)],
+            SqliteTaskStore::decode_row,
+        )
+        .map_err(|error| sqlite_error(target, "failed to list async tasks", error))?
+        .map(|row| {
+            row.map_err(|error| sqlite_error(target, "failed to decode async task row", error))
+        })
+        .collect()
 }
 
 fn list_task_events(
@@ -89,8 +99,21 @@ fn list_task_events(
     task_id: &TaskId,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskEventRow>, AtmError> {
-    task_sql::select_task_events(connection, team, task_id, member)
-        .map_err(|error| sqlite_error(target, "failed to list async task events", error))
+    let mut statement = connection.prepare(&format!("SELECT {} FROM task_events WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3) ORDER BY seq ASC", task_sql::TASK_EVENT_COLUMNS)).map_err(|error| sqlite_error(target, "failed to prepare async task event list", error))?;
+    statement
+        .query_map(
+            params![
+                team.as_str(),
+                task_id.as_str(),
+                member.map(AgentName::as_str)
+            ],
+            SqliteTaskStore::decode_event_row,
+        )
+        .map_err(|error| sqlite_error(target, "failed to list async task events", error))?
+        .map(|row| {
+            row.map_err(|error| sqlite_error(target, "failed to decode async task event", error))
+        })
+        .collect()
 }
 
 fn read_lane_error(error: AtmError) -> ReadLaneError {

--- a/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
+++ b/crates/atm-storage-rusqlite/src/task_ledger_reader.rs
@@ -8,12 +8,12 @@ use atm_storage::{
     AgentName, AsyncTaskLedgerReader, AtmError, ReadDeadline, ReadLaneError, TaskEventRow, TaskId,
     TaskRow, TeamName,
 };
-use rusqlite::{Connection, params};
+use rusqlite::Connection;
 use std::sync::Arc;
 
-use crate::SqliteTaskStore;
 use crate::reader_pool::ReaderPool;
 use crate::shared_db::{SharedDbTarget, sqlite_error};
+use crate::task_sql;
 
 struct TaskLedgerReader {
     pool: ReaderPool,
@@ -78,25 +78,8 @@ fn list_tasks(
     team: &TeamName,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskRow>, AtmError> {
-    let mut statement = connection
-        .prepare(
-            "SELECT team, task_id, assignee, assigner, state, assignment_message_id,
-                    description, assigned_at, updated_at, last_reminded_at, reminder_count,
-                    lead_notified_count
-               FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2)
-               ORDER BY assigned_at DESC, task_id DESC",
-        )
-        .map_err(|error| sqlite_error(target, "failed to prepare async task list", error))?;
-    let rows = statement
-        .query_map(
-            params![team.as_str(), member.map(AgentName::as_str)],
-            SqliteTaskStore::decode_row,
-        )
-        .map_err(|error| sqlite_error(target, "failed to execute async task list", error))?;
-    rows.map(|row| {
-        row.map_err(|error| sqlite_error(target, "failed to decode async task row", error))
-    })
-    .collect()
+    task_sql::select_tasks_for_team(connection, team, member)
+        .map_err(|error| sqlite_error(target, "failed to list async tasks", error))
 }
 
 fn list_task_events(
@@ -106,29 +89,8 @@ fn list_task_events(
     task_id: &TaskId,
     member: Option<&AgentName>,
 ) -> Result<Vec<TaskEventRow>, AtmError> {
-    let mut statement = connection
-        .prepare(
-            "SELECT team, task_id, assignee, seq, at, event, from_state, to_state, actor,
-                    message_id, outcome, marker, detail
-               FROM task_events
-              WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3)
-              ORDER BY seq ASC",
-        )
-        .map_err(|error| sqlite_error(target, "failed to prepare async task event list", error))?;
-    let rows = statement
-        .query_map(
-            params![
-                team.as_str(),
-                task_id.as_str(),
-                member.map(AgentName::as_str)
-            ],
-            SqliteTaskStore::decode_event_row,
-        )
-        .map_err(|error| sqlite_error(target, "failed to execute async task event list", error))?;
-    rows.map(|row| {
-        row.map_err(|error| sqlite_error(target, "failed to decode async task event", error))
-    })
-    .collect()
+    task_sql::select_task_events(connection, team, task_id, member)
+        .map_err(|error| sqlite_error(target, "failed to list async task events", error))
 }
 
 fn read_lane_error(error: AtmError) -> ReadLaneError {

--- a/crates/atm-storage-rusqlite/src/task_sql.rs
+++ b/crates/atm-storage-rusqlite/src/task_sql.rs
@@ -1,0 +1,78 @@
+//! Crate-private task-ledger read projections shared by every SQLite lane.
+
+use atm_storage::types::{AgentName, TaskId, TeamName};
+use atm_storage::{TaskEventRow, TaskRow};
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::SqliteTaskStore;
+
+const TASK_COLUMNS: &str = "team, task_id, assignee, assigner, state, assignment_message_id, description, assigned_at, updated_at, last_reminded_at, reminder_count, lead_notified_count";
+const TASK_EVENT_COLUMNS: &str = "team, task_id, assignee, seq, at, event, from_state, to_state, actor, message_id, outcome, marker, detail";
+
+pub(crate) fn select_task_row(
+    connection: &Connection,
+    team: &TeamName,
+    task_id: &TaskId,
+    assignee: &AgentName,
+) -> rusqlite::Result<Option<TaskRow>> {
+    connection
+        .query_row(
+            &format!("SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND task_id = ?2 AND assignee = ?3"),
+            params![team.as_str(), task_id.as_str(), assignee.as_str()],
+            SqliteTaskStore::decode_row,
+        )
+        .optional()
+}
+
+pub(crate) fn select_tasks_for_team(
+    connection: &Connection,
+    team: &TeamName,
+    member: Option<&AgentName>,
+) -> rusqlite::Result<Vec<TaskRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC"
+    ))?;
+    statement
+        .query_map(
+            params![team.as_str(), member.map(AgentName::as_str)],
+            SqliteTaskStore::decode_row,
+        )?
+        .collect()
+}
+
+pub(crate) fn select_open_tasks_for_member(
+    connection: &Connection,
+    team: &TeamName,
+    assignee: &AgentName,
+) -> rusqlite::Result<Vec<TaskRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND assignee = ?2 AND state <> 'complete' ORDER BY assigned_at ASC, task_id ASC"
+    ))?;
+    statement
+        .query_map(
+            params![team.as_str(), assignee.as_str()],
+            SqliteTaskStore::decode_row,
+        )?
+        .collect()
+}
+
+pub(crate) fn select_task_events(
+    connection: &Connection,
+    team: &TeamName,
+    task_id: &TaskId,
+    member: Option<&AgentName>,
+) -> rusqlite::Result<Vec<TaskEventRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {TASK_EVENT_COLUMNS} FROM task_events WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3) ORDER BY seq ASC"
+    ))?;
+    statement
+        .query_map(
+            params![
+                team.as_str(),
+                task_id.as_str(),
+                member.map(AgentName::as_str)
+            ],
+            SqliteTaskStore::decode_event_row,
+        )?
+        .collect()
+}

--- a/crates/atm-storage-rusqlite/src/task_sql.rs
+++ b/crates/atm-storage-rusqlite/src/task_sql.rs
@@ -76,3 +76,38 @@ pub(crate) fn select_task_events(
         )?
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn task_projection_column_lists_have_one_crate_owner() {
+        let task_sources = [
+            include_str!("task_sql.rs"),
+            include_str!("task_store.rs"),
+            include_str!("task_ledger_reader.rs"),
+            include_str!("writer/task_ops.rs"),
+        ];
+        assert_eq!(
+            task_sources
+                .iter()
+                .map(|source| source
+                    .matches(concat!("const TASK_", "COLUMNS: &str ="))
+                    .count())
+                .sum::<usize>(),
+            1,
+            "task row column projection must remain owned by task_sql",
+        );
+        assert_eq!(
+            task_sources
+                .iter()
+                .map(|source| {
+                    source
+                        .matches(concat!("const TASK_EVENT_", "COLUMNS: &str ="))
+                        .count()
+                })
+                .sum::<usize>(),
+            1,
+            "task event column projection must remain owned by task_sql",
+        );
+    }
+}

--- a/crates/atm-storage-rusqlite/src/task_sql.rs
+++ b/crates/atm-storage-rusqlite/src/task_sql.rs
@@ -6,8 +6,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::SqliteTaskStore;
 
-const TASK_COLUMNS: &str = "team, task_id, assignee, assigner, state, assignment_message_id, description, assigned_at, updated_at, last_reminded_at, reminder_count, lead_notified_count";
-const TASK_EVENT_COLUMNS: &str = "team, task_id, assignee, seq, at, event, from_state, to_state, actor, message_id, outcome, marker, detail";
+pub(crate) const TASK_COLUMNS: &str = "team, task_id, assignee, assigner, state, assignment_message_id, description, assigned_at, updated_at, last_reminded_at, reminder_count, lead_notified_count";
+pub(crate) const TASK_EVENT_COLUMNS: &str = "team, task_id, assignee, seq, at, event, from_state, to_state, actor, message_id, outcome, marker, detail";
 
 pub(crate) fn select_task_row(
     connection: &Connection,
@@ -24,22 +24,6 @@ pub(crate) fn select_task_row(
         .optional()
 }
 
-pub(crate) fn select_tasks_for_team(
-    connection: &Connection,
-    team: &TeamName,
-    member: Option<&AgentName>,
-) -> rusqlite::Result<Vec<TaskRow>> {
-    let mut statement = connection.prepare(&format!(
-        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC"
-    ))?;
-    statement
-        .query_map(
-            params![team.as_str(), member.map(AgentName::as_str)],
-            SqliteTaskStore::decode_row,
-        )?
-        .collect()
-}
-
 pub(crate) fn select_open_tasks_for_member(
     connection: &Connection,
     team: &TeamName,
@@ -51,6 +35,22 @@ pub(crate) fn select_open_tasks_for_member(
     statement
         .query_map(
             params![team.as_str(), assignee.as_str()],
+            SqliteTaskStore::decode_row,
+        )?
+        .collect()
+}
+
+pub(crate) fn select_tasks_for_team(
+    connection: &Connection,
+    team: &TeamName,
+    member: Option<&AgentName>,
+) -> rusqlite::Result<Vec<TaskRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC"
+    ))?;
+    statement
+        .query_map(
+            params![team.as_str(), member.map(AgentName::as_str)],
             SqliteTaskStore::decode_row,
         )?
         .collect()

--- a/crates/atm-storage-rusqlite/src/task_sql.rs
+++ b/crates/atm-storage-rusqlite/src/task_sql.rs
@@ -9,6 +9,18 @@ use crate::SqliteTaskStore;
 pub(crate) const TASK_COLUMNS: &str = "team, task_id, assignee, assigner, state, assignment_message_id, description, assigned_at, updated_at, last_reminded_at, reminder_count, lead_notified_count";
 pub(crate) const TASK_EVENT_COLUMNS: &str = "team, task_id, assignee, seq, at, event, from_state, to_state, actor, message_id, outcome, marker, detail";
 
+pub(crate) fn select_tasks_for_team_sql() -> String {
+    format!(
+        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC"
+    )
+}
+
+pub(crate) fn select_task_events_sql() -> String {
+    format!(
+        "SELECT {TASK_EVENT_COLUMNS} FROM task_events WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3) ORDER BY seq ASC"
+    )
+}
+
 pub(crate) fn select_task_row(
     connection: &Connection,
     team: &TeamName,
@@ -45,9 +57,7 @@ pub(crate) fn select_tasks_for_team(
     team: &TeamName,
     member: Option<&AgentName>,
 ) -> rusqlite::Result<Vec<TaskRow>> {
-    let mut statement = connection.prepare(&format!(
-        "SELECT {TASK_COLUMNS} FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2) ORDER BY assigned_at DESC, task_id DESC"
-    ))?;
+    let mut statement = connection.prepare(&select_tasks_for_team_sql())?;
     statement
         .query_map(
             params![team.as_str(), member.map(AgentName::as_str)],
@@ -62,9 +72,7 @@ pub(crate) fn select_task_events(
     task_id: &TaskId,
     member: Option<&AgentName>,
 ) -> rusqlite::Result<Vec<TaskEventRow>> {
-    let mut statement = connection.prepare(&format!(
-        "SELECT {TASK_EVENT_COLUMNS} FROM task_events WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3) ORDER BY seq ASC"
-    ))?;
+    let mut statement = connection.prepare(&select_task_events_sql())?;
     statement
         .query_map(
             params![

--- a/crates/atm-storage-rusqlite/src/task_store.rs
+++ b/crates/atm-storage-rusqlite/src/task_store.rs
@@ -5,11 +5,12 @@ use atm_storage::{
     AtmError, AtmMessageId, EscalationScope, MAX_ESCALATION_RECIPIENTS, MemberKey, ReminderOutcome,
     TaskActor, TaskEventKind, TaskEventMarker, TaskEventRow, TaskRow, TaskState, TaskStore,
 };
-use rusqlite::{Connection, OptionalExtension, Row, params};
+use rusqlite::{Connection, Row, params};
 
 use super::SqliteTaskStore;
 use crate::shared_db::SharedDb;
 use crate::shared_db::{SharedDbTarget, SqliteConnection, sqlite_error};
+use crate::task_sql;
 
 const TASK_SCHEMA_DDL: &str = r#"
 CREATE TABLE IF NOT EXISTS tasks (
@@ -146,20 +147,7 @@ impl SqliteTaskStore {
         member: &MemberKey,
         task_id: &TaskId,
     ) -> Result<Option<TaskRow>, AtmError> {
-        connection
-            .query_row(
-                "SELECT team, task_id, assignee, assigner, state, assignment_message_id,
-                        description, assigned_at, updated_at, last_reminded_at, reminder_count,
-                        lead_notified_count
-                   FROM tasks WHERE team = ?1 AND task_id = ?2 AND assignee = ?3",
-                params![
-                    member.team().as_str(),
-                    task_id.as_str(),
-                    member.agent().as_str()
-                ],
-                Self::decode_row,
-            )
-            .optional()
+        task_sql::select_task_row(connection, member.team(), task_id, member.agent())
             .map_err(|error| self.db.error("failed to load task row", error))
     }
 
@@ -224,14 +212,10 @@ impl TaskStore for SqliteTaskStore {
     }
 
     fn open_tasks(&self, member: &MemberKey) -> Result<Vec<TaskRow>, AtmError> {
-        let mut tasks = self.list_tasks(&member.team, Some(&member.agent))?;
-        tasks.retain(|task| task.state != TaskState::Complete);
-        tasks.sort_by(|left, right| {
-            left.assigned_at
-                .cmp(&right.assigned_at)
-                .then_with(|| left.task_id.cmp(&right.task_id))
-        });
-        Ok(tasks)
+        self.db.with_connection(|connection| {
+            task_sql::select_open_tasks_for_member(connection, member.team(), member.agent())
+                .map_err(|error| self.db.error("failed to list open tasks", error))
+        })
     }
 
     fn list_tasks(
@@ -240,23 +224,8 @@ impl TaskStore for SqliteTaskStore {
         member: Option<&AgentName>,
     ) -> Result<Vec<TaskRow>, AtmError> {
         self.db.with_connection(|connection| {
-            let mut statement = connection
-                .prepare(
-                    "SELECT team, task_id, assignee, assigner, state, assignment_message_id,
-                            description, assigned_at, updated_at, last_reminded_at, reminder_count,
-                            lead_notified_count
-                       FROM tasks WHERE team = ?1 AND (?2 IS NULL OR assignee = ?2)
-                       ORDER BY assigned_at DESC, task_id DESC",
-                )
-                .map_err(|error| self.db.error("failed to prepare task list", error))?;
-            let rows = statement
-                .query_map(
-                    params![team.as_str(), member.map(AgentName::as_str)],
-                    Self::decode_row,
-                )
-                .map_err(|error| self.db.error("failed to list tasks", error))?;
-            rows.map(|row| row.map_err(|error| self.db.error("failed to decode task row", error)))
-                .collect()
+            task_sql::select_tasks_for_team(connection, team, member)
+                .map_err(|error| self.db.error("failed to list tasks", error))
         })
     }
 
@@ -267,27 +236,8 @@ impl TaskStore for SqliteTaskStore {
         assignee: Option<&AgentName>,
     ) -> Result<Vec<TaskEventRow>, AtmError> {
         self.db.with_connection(|connection| {
-            let mut statement = connection
-                .prepare(
-                    "SELECT team, task_id, assignee, seq, at, event, from_state, to_state, actor,
-                            message_id, outcome, marker, detail
-                       FROM task_events
-                      WHERE team = ?1 AND task_id = ?2 AND (?3 IS NULL OR assignee = ?3)
-                      ORDER BY seq ASC",
-                )
-                .map_err(|error| self.db.error("failed to prepare task event list", error))?;
-            let rows = statement
-                .query_map(
-                    params![
-                        team.as_str(),
-                        task_id.as_str(),
-                        assignee.map(AgentName::as_str)
-                    ],
-                    Self::decode_event_row,
-                )
-                .map_err(|error| self.db.error("failed to list task events", error))?;
-            rows.map(|row| row.map_err(|error| self.db.error("failed to decode task event", error)))
-                .collect()
+            task_sql::select_task_events(connection, team, task_id, assignee)
+                .map_err(|error| self.db.error("failed to list task events", error))
         })
     }
 

--- a/crates/atm-storage-rusqlite/src/writer/task_ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/task_ops.rs
@@ -20,6 +20,8 @@ use atm_storage::types::{AgentName, TaskId, TeamName};
 use atm_storage::{AtmErrorCode, MessageWriteOrigin};
 use rusqlite::{Connection, OptionalExtension, params};
 
+use crate::task_sql;
+
 const TASK_RECOVERY: &str = "Run: atm list --task-events <task_id> --member <assignee>";
 
 fn task_rejected(detail: impl std::fmt::Display) -> AtmError {
@@ -33,16 +35,7 @@ fn load_task_row(
     task_id: &TaskId,
     assignee: &AgentName,
 ) -> Result<Option<TaskRow>, AtmError> {
-    connection
-        .query_row(
-            "SELECT team, task_id, assignee, assigner, state, assignment_message_id,
-                    description, assigned_at, updated_at, last_reminded_at, reminder_count,
-                    lead_notified_count
-               FROM tasks WHERE team = ?1 AND task_id = ?2 AND assignee = ?3",
-            params![team.as_str(), task_id.as_str(), assignee.as_str()],
-            crate::SqliteTaskStore::decode_row,
-        )
-        .optional()
+    task_sql::select_task_row(connection, team, task_id, assignee)
         .map_err(|error| sqlite_error(target, "failed to load task row", error))
 }
 
@@ -52,22 +45,8 @@ fn load_open_task_rows(
     team: &TeamName,
     assignee: &AgentName,
 ) -> Result<Vec<TaskRow>, AtmError> {
-    let mut statement = connection
-        .prepare(
-            "SELECT team, task_id, assignee, assigner, state, assignment_message_id,
-                    description, assigned_at, updated_at, last_reminded_at, reminder_count,
-                    lead_notified_count
-               FROM tasks WHERE team = ?1 AND assignee = ?2 AND state <> 'complete'",
-        )
-        .map_err(|error| sqlite_error(target, "failed to prepare open task lookup", error))?;
-    statement
-        .query_map(
-            params![team.as_str(), assignee.as_str()],
-            crate::SqliteTaskStore::decode_row,
-        )
-        .map_err(|error| sqlite_error(target, "failed to load open tasks", error))?
-        .map(|row| row.map_err(|error| sqlite_error(target, "failed to decode open task", error)))
-        .collect()
+    task_sql::select_open_tasks_for_member(connection, team, assignee)
+        .map_err(|error| sqlite_error(target, "failed to load open tasks", error))
 }
 
 fn transition_for(

--- a/docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md
+++ b/docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md
@@ -315,7 +315,7 @@ MemberBlocked,       // "ATM_MEMBER_BLOCKED"
 
 `TaskStore` methods introduced by AX.3 (this sprint adds the three C5
 methods); the AX.5 reminder cadence and pseudo-rule (this
-sprint adds `record_lead_notified` and `list_task_events` calls inside
+sprint adds `record_lead_notified` and an async task-ledger `list_task_events` read inside
 the task step, which AX.5 property 6 already permits); roster schema;
 `AgentType` enum; every existing doctor code; `HerdrProcessAdapter`
 visibility (public).
@@ -363,7 +363,7 @@ visibility (public).
 
 - `crates/atm-http-runtime/src/herdr_queue_wake.rs` tests (`ax6_01_*`
   naming): the AX.5 property-6 test extended to assert that
-  `record_lead_notified` and `list_task_events` are the only additional
+  `record_lead_notified` and the async task-ledger `list_task_events` read are the only additional
   `TaskStore` calls and that no state transition occurs; AC 1 scenarios,
   including no-lead and two-lead teams
   (no message, warn log, no `LeadNotified` row).

--- a/release-findings.json
+++ b/release-findings.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-09-05T11:05:59.548097Z",
-  "branch": "feature/ax4-task-cli-and-docs",
-  "version": "1.5.0",
+  "generatedAt": "2026-08-27T23:52:44.266827Z",
+  "branch": "chore/changelog-1.4.4",
+  "version": "1.4.4",
   "status": "pass",
   "findings": [
     {


### PR DESCRIPTION
Closes AXPE-RBQ-001, AXPE-RBQ-002, AXPE-FLAKY-001, and AXPE-FLAKY-002.

Stack base: fix/ax-phase-end-docs-tests (#1234).

Validation: repeated targeted crate tests (three runs each with --test-threads=8), python3 .just/check_line_counts.py, just test, and just validate.

Stack #1235 layer 3 (base: fix/ax-phase-end-docs-tests @ 7f65db491, an ancestor of this head; mergeability recompute requested 2026-09-06T01:42Z).
