### PR TITLE
docs(ax): reconcile phase plan status

### DIFF
--- a/docs/plans/phase-ax/.audit/qa-evidence-master.json
+++ b/docs/plans/phase-ax/.audit/qa-evidence-master.json
@@ -557,7 +557,7 @@
       "important": 4,
       "minor": 2,
       "count_basis": "headline/reviewer",
-      "evidence": "Sprint AX.6 QA-2: FAIL (5 blocking / 4 important / 2 minor), PR #1204 @ c3268df8a. Final Quality Report: https://github.com/randlee/atm-core/pull/1204#issuecomment-5554091903. 22/25 carry-forward findings CLOSED (AX6-QA1-001,004,006-024, AX5-QA4-001); STILL OPEN 002 (partial), 003, 005 (partial). New: ARCH-001/002 RULE-008 atm-dev literals, ARCH-003 RULE-011 run_atm lacks ATM_CONFIG_HOME, ATM-QA-005 cli-reference not regenerated, QA-2-001 vacuous HR-SAFE-003 guard, ATM-QA-004 project-plan row, QA-2-002 TOCTOU cap check. RULE-003 confirmed by fenix with .just/check_line_counts.py at c3268df8a: herdr_queue_wake.rs 997 prod lines (pass). CI: windows-latest Test FAILURE (escalation_cli exit 5 vs 3)."
+      "evidence": "Sprint AX.6 QA-2: FAIL (5 blocking / 4 important / 2 minor), PR #1204 @ c3268df8a. Final Quality Report: https://github.com/randlee/atm-core/pull/1204#issuecomment-5554091903. 22/25 carry-forward findings CLOSED (AX6-QA1-001,004,006-024, AX5-QA4-001); STILL OPEN 002 (partial), 003, 005 (partial). New: ARCH-001/002 RULE-008 atm-dev literals, ARCH-003 RULE-011 run_atm lacks ATM_CONFIG_HOME, ATM-QA-005 cli-reference not regenerated, QA-2-001 vacuous HR-SAFE-003 guard, AX6-QA2-009 project-plan row, QA-2-002 TOCTOU cap check. RULE-003 confirmed by fenix with .just/check_line_counts.py at c3268df8a: herdr_queue_wake.rs 997 prod lines (pass). CI: windows-latest Test FAILURE (escalation_cli exit 5 vs 3)."
     },
     {
       "run_id": "AX6-QA3",
@@ -640,6 +640,6 @@
     "AX5-QA1 headline counts (4/8/7) differ from the deduplicated triage records (4/8/5); the triage records are the lifecycle source.",
     "AX.6: closed at QA-5 PASS (PR #1204).",
     "AX.7: superseded 2026-09-05; live Windows/macOS Herdr proof moved to release readiness (docs/plans/phase-ay/release-readiness-herdr-live-proof.md).",
-    "Nine AXPE phase-end findings are tracked in .triage/phase-ax/findings and fixed on stack #1235."
+    "AXPE-* phase-end findings are tracked in .triage/phase-ax/findings on integrate/phase-ax; fixes land via stack #1235 and closure (record status plus Resolution events) is recorded by fenix at stack merge."
   ]
 }

--- a/docs/plans/phase-ax/phase-ax-plan.md
+++ b/docs/plans/phase-ax/phase-ax-plan.md
@@ -2,7 +2,7 @@
 title: "Phase AX — Nudge templates on every backend and task-state tracking"
 phase: AX
 branch: integrate/phase-ax
-status: draft
+status: closeout
 owner: fenix (plan author); team-lead (dispatch); arch-ctm / Cipher-311d (implementation)
 base_revision: 5b1baacef (develop)
 integration_branch: integrate/phase-ax
@@ -40,10 +40,6 @@ dependency_relations:
     dependent: AX.6
     relation: must_follow
     rationale: the lead notification is triggered from the reminder counter AX.5 maintains inside the same pump function, and doctor ATM_TASK_STALLED reads it.
-  - prerequisite: AX.6
-    dependent: AX.7
-    relation: must_follow
-    rationale: AX.7 is a proof sprint on the merged integrate head.
 execution_tracks:
   - track: A
     sprints: [AX.1, AX.2]

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1591,7 +1591,7 @@ Phase AV sprint status:
 | `AV.3` | `complete` (PR #1113 merged) | `feature/av3-read-concurrency-gates` | `docs/plans/phase-av/sprint-AV.3-mechanical-hard-gates.md` |
 | `AV.4` | `complete` (PR #1114 merged) | `feature/av4-read-query-benchmarks` | `docs/plans/phase-av/sprint-AV.4-read-query-benchmarks.md` |
 
-## 55. Phase AX — Nudge Templates On Every Backend And Task-State Tracking [PLANNING — PLAN HARDENING]
+## 55. Phase AX — Nudge Templates On Every Backend And Task-State Tracking [EXECUTING — PHASE CLOSEOUT]
 
 Phase AX closes three delivery defects found in the 2026-09-04 Herdr
 dogfood run (issue #1173): the Herdr sink bypasses the built-in nudge
@@ -1608,6 +1608,9 @@ AX.2→AX.5, AX.4→AX.5, AX.5→AX.6, AX.6→AX.7. Branches are worktrees via
 `sc-git-worktree`; PR bases and merges via `gh stack` (sequence in the
 phase plan §6).
 
+Current phase status: AX.1-AX.6 merged into `integrate/phase-ax`; AX.7
+superseded 2026-09-05.
+
 The authoritative plan is
 [phase-ax-plan](./plans/phase-ax/phase-ax-plan.md) with per-sprint docs
 under `docs/plans/phase-ax/`, authored on branch `integrate/phase-ax`.
@@ -1622,7 +1625,7 @@ Phase AX sprint status:
 | `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `complete` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |
 | `AX.5` | C | after A and B merge | `complete` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-062 reminder-cycle section |
 | `AX.6` | C | after AX.5 | `complete` | `feature/ax6-lead-notification-doctor` | `docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md` |
-| `AX.7` | D | after AX.6 merges | `planned` | none (proof on `integrate/phase-ax`) | `docs/plans/phase-ax/ax7-live-proof.md` |
+| `AX.7` | D | after AX.6 merges | `superseded` (2026-09-05) | none (proof moved to `docs/plans/phase-ay/release-readiness-herdr-live-proof.md`) | `docs/plans/phase-ax/sprint-AX.7-herdr-dogfood-evidence.md` |
 
 ## Daemon-Switch Scope Reduction
 


### PR DESCRIPTION
Closes AXPE-QA-106, AXPE-QA-107, AXPE-QA-108, and AXPE-QA-109.\n\n- Retags Phase AX as EXECUTING - PHASE CLOSEOUT and reconciles project-plan status/AX.7 artifact and release-readiness note.\n- Removes the superseded AX.6 -> AX.7 dependency from plan frontmatter without changing the authoritative body.\n- Corrects only the AX6-QA2 evidence field's project-plan finding reference to AX6-QA2-009.\n\nValidation: JSON parse and python3 .just/check_line_counts.py both passed with exit 0; no dedicated plan-frontmatter lint exists.