### PR TITLE
test: bound HTTP runtime gate waits

### DIFF
--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -818,8 +818,8 @@ fn json_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
-    use std::sync::{Arc, Condvar, Mutex};
-    use std::time::Duration;
+    use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+    use std::time::{Duration, Instant};
 
     use atm_core::api::HttpRequest;
     use atm_core::error::{AtmError, AtmErrorCode};
@@ -936,21 +936,19 @@ mod tests {
         scheduler_progressed: bool,
     }
 
+    const GATE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
     impl Gate {
         fn wait_until_released(&self) {
             let mut state = self.state.lock().expect("lock gate");
             state.entered = true;
             self.changed.notify_all();
-            while !state.released {
-                state = self.changed.wait(state).expect("wait gate");
-            }
+            self.wait_until(state, "release", |state| state.released);
         }
 
         fn wait_until_entered(&self) {
-            let mut state = self.state.lock().expect("lock gate");
-            while !state.entered {
-                state = self.changed.wait(state).expect("wait gate");
-            }
+            let state = self.state.lock().expect("lock gate");
+            self.wait_until(state, "entry", |state| state.entered);
         }
 
         fn release(&self) {
@@ -964,9 +962,35 @@ mod tests {
         }
 
         fn wait_until_scheduler_progresses(&self) {
-            let mut state = self.state.lock().expect("lock gate");
-            while !state.scheduler_progressed {
-                state = self.changed.wait(state).expect("wait gate");
+            let state = self.state.lock().expect("lock gate");
+            self.wait_until(state, "scheduler progress", |state| {
+                state.scheduler_progressed
+            });
+        }
+
+        fn wait_until(
+            &self,
+            mut state: MutexGuard<'_, GateState>,
+            condition: &str,
+            ready: impl Fn(&GateState) -> bool,
+        ) {
+            let deadline = Instant::now() + GATE_WAIT_TIMEOUT;
+            while !ready(&state) {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(
+                    !remaining.is_zero(),
+                    "test gate timed out waiting for {condition} after {GATE_WAIT_TIMEOUT:?}"
+                );
+                let (next_state, wait_result) = self
+                    .changed
+                    .wait_timeout(state, remaining)
+                    .expect("wait gate");
+                state = next_state;
+                if wait_result.timed_out() && !ready(&state) {
+                    panic!(
+                        "test gate timed out waiting for {condition} after {GATE_WAIT_TIMEOUT:?}"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Closes FTQ-AW-P1-003. The cfg(test) Gate now uses wait_timeout against a fixed 5-second deadline for entry, release, and scheduler-progress waits, with actionable timeout panics. Production code and legacy daemon code are unchanged. Validation: cargo fmt --check; cargo clippy --workspace --all-targets -- -D warnings; cargo test -p atm-http-runtime (211 tests + 2 doctests).