### PR TITLE
fix(aw-pool-v7): write-through RAM roster with ephemeral member state

### DIFF
--- a/boundaries/atm-storage-rusqlite/roster-runtime-mirror.toml
+++ b/boundaries/atm-storage-rusqlite/roster-runtime-mirror.toml
@@ -70,4 +70,6 @@ notes = [
   "backend-agnostic: the decorator wraps any RosterStore, not only SqliteRosterStore, but is authorized to live only in this crate per this boundary",
   "build_write_through_roster is the sole composition entrypoint; every caller (production SqliteStorageFactory::open or a test-support fixture) must go through it instead of hand-rolling an equivalent write-through wrapper",
   "hydration is fail-closed: build_write_through_roster propagates a durable read failure instead of returning a partially-populated mirror",
+  "AW-RAM-I4: the intra-crate bypass is now closed by type, not only by review. StorageHandleParts carries one atm_storage::WriteThroughRosterStore instead of separate roster_store/roster_runtime_mirror fields; its sole constructor (WriteThroughRosterStore::from_write_through_view) requires a value implementing both RosterStore and RosterRuntimeMirror, which only WriteThroughRosterView does, so passing backend.roster_store() at a composition site is a compile error",
+  "crates/atm-storage-rusqlite/tests/roster_write_through_production_path.rs proves the property on the real production path: SqliteStorageFactory::open() on a temp database, then an out-of-band durable write through a second backend that the production roster read must not observe until an explicit reload_from_durable",
 ]

--- a/boundaries/atm-storage-rusqlite/roster-runtime-mirror.toml
+++ b/boundaries/atm-storage-rusqlite/roster-runtime-mirror.toml
@@ -1,0 +1,73 @@
+boundary_id = "BOUNDARY-RosterStore-Sqlite-WriteThrough"
+owner_package = "atm-storage-rusqlite"
+owner_crate_path = "atm_storage_rusqlite"
+name = "RosterRuntimeMirror"
+
+[public]
+trait = "RosterStore"
+notes = "write-through RAM roster mirror decorator relocated here from atm-core (FTQ-AW finding 1 on PR #1240); wraps any atm-storage RosterStore (SqliteRosterStore in production) and keeps the paired atm_storage::contract::RosterRuntimeMirror synchronized with every durable roster write in the same operation"
+
+[implementation]
+type = "WriteThroughRosterView"
+module = "atm_storage_rusqlite::roster_runtime"
+visibility = "private"
+constructor = "private"
+
+[composition]
+roots = ["atm_storage_rusqlite::roster_runtime::build_write_through_roster"]
+
+[ownership]
+io_owns = ["roster_runtime_ram_mirror"]
+io_forbidden = ["socket_io", "process_spawn"]
+
+[dependencies]
+# Same authorized dependents as the sibling SqliteRosterStore boundary: only
+# the composition roots that assemble a durable SQLite backend for
+# production or for test-support fixtures may reach this module directly.
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime-test-support"]
+allowed_dependencies = ["atm-storage"]
+forbidden_edges = [
+  "atm -> atm-storage-rusqlite",
+  "atm-daemon -> atm-storage-rusqlite",
+  "atm-graft -> atm-storage-rusqlite",
+  "atm-runtime -> atm-storage-rusqlite",
+  "atm-core -> atm-storage-rusqlite",
+  "atm-storage-rusqlite -> atm-runtime",
+]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = [
+  "WriteThroughRosterView",
+  "RosterRuntimeState",
+  "TeamRosterRecord",
+]
+
+[contracts]
+request_types = ["RosterStore method inputs", "RosterRuntimeMirror method inputs"]
+response_types = ["atm-storage roster DTOs"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["rusqlite::Connection"]
+
+[enforcement]
+lint_rules = [
+  "LINT-BOUNDARY-ROSTERRUNTIMEMIRROR-EDGES",
+  "LINT-BOUNDARY-ROSTERRUNTIMEMIRROR-REFERENCES",
+]
+review_gates = [
+  "no_public_impl",
+  "no_public_constructor",
+  "single_write_through_impl_site",
+]
+
+[status]
+state = "active"
+notes = [
+  "relocated from crates/atm-core/src/service_runtime.rs (RosterRuntimeView/RosterRuntimeState/TeamRosterRecord) per team-lead boundary ruling on PR #1240 finding 1",
+  "backend-agnostic: the decorator wraps any RosterStore, not only SqliteRosterStore, but is authorized to live only in this crate per this boundary",
+  "build_write_through_roster is the sole composition entrypoint; every caller (production SqliteStorageFactory::open or a test-support fixture) must go through it instead of hand-rolling an equivalent write-through wrapper",
+  "hydration is fail-closed: build_write_through_roster propagates a durable read failure instead of returning a partially-populated mirror",
+]

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -371,7 +371,10 @@ impl atm_storage::RosterStore for SingleMemberRoster {
     }
 
     fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
-        unreachable!("admission entry tests never enumerate teams")
+        // Runtime construction hydrates the RAM roster from the durable
+        // store exactly once at startup, exercising `list_teams` even though
+        // admission tests otherwise never enumerate teams themselves.
+        Ok(vec![TeamName::from_validated(TEST_TEAM)])
     }
 }
 

--- a/crates/atm-core/src/ack/admission_tests.rs
+++ b/crates/atm-core/src/ack/admission_tests.rs
@@ -418,9 +418,13 @@ impl crate::boundary::NudgeTemplateOverrideStore for NoopNudgeTemplateOverrideSt
 }
 
 fn local_runtime(store: Arc<InMemoryAsyncStore>, attach_async_store: bool) -> LocalServiceRuntime {
+    let (roster_store, roster_runtime_mirror) =
+        atm_runtime_test_support::build_write_through_roster_for_test(Arc::new(SingleMemberRoster))
+            .expect("write-through roster fixture hydrates from the in-memory fake");
     let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
         store.clone(),
-        Arc::new(SingleMemberRoster),
+        roster_store,
+        roster_runtime_mirror,
         Arc::new(NoopNudgeTemplateOverrideStore),
         Arc::new(crate::LocalFileNonClaudeOutbound::new()),
     );

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -379,8 +379,8 @@ mod tests {
             &self,
             team: &TeamName,
             agent: &AgentName,
-        ) -> Result<Option<boundary::RosterEntry>, AtmError> {
-            Ok(self.roster_present.then(|| boundary::RosterEntry {
+        ) -> Option<boundary::RosterEntry> {
+            self.roster_present.then(|| boundary::RosterEntry {
                 team_name: team.clone(),
                 agent_name: agent.clone(),
                 member_kind: RosterMemberKind::Permanent,
@@ -389,14 +389,11 @@ mod tests {
                 model: crate::types::ModelName::default(),
                 recipient_pane_id: None,
                 metadata_json: Map::new(),
-            }))
+            })
         }
 
-        fn load_team_roster(
-            &self,
-            _team: &TeamName,
-        ) -> Result<Vec<boundary::RosterEntry>, AtmError> {
-            Ok(Vec::new())
+        fn load_team_roster(&self, _team: &TeamName) -> Vec<boundary::RosterEntry> {
+            Vec::new()
         }
     }
 

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -353,7 +353,7 @@ impl DeliveryPolicyCoordinator {
         agent: &AgentName,
     ) -> Result<DeliveryRecipientSnapshot, AtmError> {
         let member = runtime
-            .load_roster_member(team, agent)?
+            .load_roster_member(team, agent)
             .ok_or_else(|| AtmError::agent_not_found(agent, team))?;
         let lease = runtime.graft_receiver_lease(team, agent)?;
         Ok(DeliveryRecipientSnapshot::from_roster(
@@ -670,16 +670,12 @@ mod tests {
             Ok(())
         }
 
-        fn load_roster_member(
-            &self,
-            _team: &TeamName,
-            _agent: &AgentName,
-        ) -> Result<Option<RosterEntry>, AtmError> {
-            Ok(None)
+        fn load_roster_member(&self, _team: &TeamName, _agent: &AgentName) -> Option<RosterEntry> {
+            None
         }
 
-        fn load_team_roster(&self, _team: &TeamName) -> Result<Vec<RosterEntry>, AtmError> {
-            Ok(Vec::new())
+        fn load_team_roster(&self, _team: &TeamName) -> Vec<RosterEntry> {
+            Vec::new()
         }
     }
 

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -443,13 +443,7 @@ fn graft_receivers_doctor_report(
     team: &TeamName,
     findings: &mut Vec<DoctorFinding>,
 ) -> GraftReceiversDoctorReport {
-    let roster = match runtime.load_team_roster(team) {
-        Ok(roster) => roster,
-        Err(error) => {
-            push_doctor_error(findings, DoctorSeverity::Error, error);
-            return GraftReceiversDoctorReport::default();
-        }
-    };
+    let roster = runtime.load_team_roster(team);
     let now = chrono::Utc::now();
     let receivers = roster
         .into_iter()
@@ -728,16 +722,9 @@ fn load_member_roster(
         push_doctor_error(findings, DoctorSeverity::Error, error);
         return None;
     }
-    let members = match runtime.load_team_roster(team) {
-        Ok(roster) => {
-            push_mixed_local_backend_warning(team, &roster, findings);
-            ordered_roster_member_summaries(&roster, caller_identity, live_cwd)
-        }
-        Err(error) => {
-            push_doctor_error(findings, DoctorSeverity::Error, error);
-            return None;
-        }
-    };
+    let roster = runtime.load_team_roster(team);
+    push_mixed_local_backend_warning(team, &roster, findings);
+    let members = ordered_roster_member_summaries(&roster, caller_identity, live_cwd);
 
     Some(MembersList {
         team: team.clone(),
@@ -1344,9 +1331,15 @@ mod tests {
     }
 
     fn test_runtime_with_roster(members: &[&str]) -> LocalServiceRuntime {
+        let (roster_store, roster_runtime_mirror) =
+            atm_runtime_test_support::build_write_through_roster_for_test(Arc::new(roster_store(
+                members,
+            )))
+            .expect("write-through roster fixture hydrates from the in-memory fake");
         LocalServiceRuntime::new_with_delivery_boundaries(
             Arc::new(UnusedMailStore),
-            Arc::new(roster_store(members)),
+            roster_store,
+            roster_runtime_mirror,
             Arc::new(NoopNudgeTemplateOverrideStore),
             Arc::new(crate::LocalFileNonClaudeOutbound::new()),
         )
@@ -1779,11 +1772,17 @@ mod tests {
             HOME_DIR_METADATA_KEY.to_string(),
             serde_json::json!("/repo/roster"),
         );
+        let (roster_store, roster_runtime_mirror) =
+            atm_runtime_test_support::build_write_through_roster_for_test(Arc::new(
+                TestRosterStore {
+                    members: vec![roster_member],
+                },
+            ))
+            .expect("write-through roster fixture hydrates from the in-memory fake");
         let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
             Arc::new(UnusedMailStore),
-            Arc::new(TestRosterStore {
-                members: vec![roster_member],
-            }),
+            roster_store,
+            roster_runtime_mirror,
             Arc::new(NoopNudgeTemplateOverrideStore),
             Arc::new(crate::LocalFileNonClaudeOutbound::new()),
         );

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1076,11 +1076,23 @@ mod tests {
         }
 
         fn save_roster(&self, _roster: &atm_storage::RosterSnapshot) -> Result<(), AtmError> {
-            unreachable!("doctor tests do not touch the roster store boundary")
+            unreachable!("doctor tests do not mutate the roster store boundary")
         }
 
         fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
-            unreachable!("doctor tests do not touch the roster store boundary")
+            // Runtime construction hydrates the RAM roster from the durable
+            // store exactly once at startup, so a real durable store's
+            // `list_teams` is exercised here even though doctor itself never
+            // mutates rosters. Mirror that by returning the distinct team
+            // names present in the fixture data.
+            let mut teams: Vec<TeamName> = self
+                .members
+                .iter()
+                .map(|member| member.team_name.clone())
+                .collect();
+            teams.sort();
+            teams.dedup();
+            Ok(teams)
         }
     }
 

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -104,7 +104,7 @@ where
         ));
     };
     if runtime
-        .load_roster_member(recipient_team, recipient)?
+        .load_roster_member(recipient_team, recipient)
         .is_none()
     {
         return Err(AtmError::new(
@@ -1045,19 +1045,12 @@ mod tests {
             Ok(())
         }
 
-        fn load_roster_member(
-            &self,
-            team: &TeamName,
-            agent: &AgentName,
-        ) -> Result<Option<RosterEntry>, AtmError> {
-            Ok(Some(roster_entry(team, agent)))
+        fn load_roster_member(&self, team: &TeamName, agent: &AgentName) -> Option<RosterEntry> {
+            Some(roster_entry(team, agent))
         }
 
-        fn load_team_roster(&self, team: &TeamName) -> Result<Vec<RosterEntry>, AtmError> {
-            Ok(vec![roster_entry(
-                team,
-                &AgentName::from_validated(TEST_QA),
-            )])
+        fn load_team_roster(&self, team: &TeamName) -> Vec<RosterEntry> {
+            vec![roster_entry(team, &AgentName::from_validated(TEST_QA))]
         }
     }
 

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -361,7 +361,7 @@ fn validate_target_member_in_roster<R: RetainedServiceRuntime>(
     }
 
     if runtime
-        .load_roster_member(&target.team, &target.agent)?
+        .load_roster_member(&target.team, &target.agent)
         .is_none()
     {
         return Err(AtmError::agent_not_found(&target.agent, &target.team));
@@ -587,8 +587,8 @@ mod tests {
             &self,
             team: &TeamName,
             agent: &AgentName,
-        ) -> Result<Option<boundary::RosterEntry>, AtmError> {
-            Ok(self.roster_present.then(|| boundary::RosterEntry {
+        ) -> Option<boundary::RosterEntry> {
+            self.roster_present.then(|| boundary::RosterEntry {
                 team_name: team.clone(),
                 agent_name: agent.clone(),
                 member_kind: RosterMemberKind::Permanent,
@@ -597,14 +597,11 @@ mod tests {
                 model: crate::types::ModelName::default(),
                 recipient_pane_id: None,
                 metadata_json: Map::new(),
-            }))
+            })
         }
 
-        fn load_team_roster(
-            &self,
-            _team: &TeamName,
-        ) -> Result<Vec<boundary::RosterEntry>, AtmError> {
-            Ok(Vec::new())
+        fn load_team_roster(&self, _team: &TeamName) -> Vec<boundary::RosterEntry> {
+            Vec::new()
         }
     }
 

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -570,7 +570,7 @@ fn validate_target_member_in_roster<R: RetainedServiceRuntime>(
     }
 
     if runtime
-        .load_roster_member(&target.team, &target.agent)?
+        .load_roster_member(&target.team, &target.agent)
         .is_none()
     {
         return Err(AtmError::agent_not_found(&target.agent, &target.team));
@@ -1101,8 +1101,8 @@ mod tests {
             &self,
             team: &TeamName,
             agent: &AgentName,
-        ) -> Result<Option<boundary::RosterEntry>, crate::error::AtmError> {
-            Ok(self.roster_present.then(|| boundary::RosterEntry {
+        ) -> Option<boundary::RosterEntry> {
+            self.roster_present.then(|| boundary::RosterEntry {
                 team_name: team.clone(),
                 agent_name: agent.clone(),
                 member_kind: RosterMemberKind::Permanent,
@@ -1111,14 +1111,11 @@ mod tests {
                 model: crate::types::ModelName::default(),
                 recipient_pane_id: None,
                 metadata_json: Map::new(),
-            }))
+            })
         }
 
-        fn load_team_roster(
-            &self,
-            _team: &TeamName,
-        ) -> Result<Vec<boundary::RosterEntry>, crate::error::AtmError> {
-            Ok(Vec::new())
+        fn load_team_roster(&self, _team: &TeamName) -> Vec<boundary::RosterEntry> {
+            Vec::new()
         }
     }
 

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -172,15 +172,11 @@ impl RetainedServiceRuntime for TestRuntime {
         Ok(())
     }
 
-    fn load_roster_member(
-        &self,
-        team: &TeamName,
-        agent: &AgentName,
-    ) -> Result<Option<crate::boundary::RosterEntry>, AtmError> {
+    fn load_roster_member(&self, team: &TeamName, agent: &AgentName) -> Option<RosterEntry> {
         if self.roster_member_missing {
-            return Ok(None);
+            return None;
         }
-        Ok(Some(RosterEntry {
+        Some(RosterEntry {
             team_name: team.clone(),
             agent_name: agent.clone(),
             member_kind: RosterMemberKind::Permanent,
@@ -192,17 +188,14 @@ impl RetainedServiceRuntime for TestRuntime {
             model: crate::types::ModelName::default(),
             recipient_pane_id: None,
             metadata_json: Map::new(),
-        }))
+        })
     }
 
-    fn load_team_roster(
-        &self,
-        team: &TeamName,
-    ) -> Result<Vec<crate::boundary::RosterEntry>, AtmError> {
+    fn load_team_roster(&self, team: &TeamName) -> Vec<RosterEntry> {
         if self.roster_member_missing {
-            return Ok(Vec::new());
+            return Vec::new();
         }
-        Ok(vec![RosterEntry {
+        vec![RosterEntry {
             team_name: team.clone(),
             agent_name: AgentName::from_validated("recipient"),
             member_kind: RosterMemberKind::Permanent,
@@ -214,7 +207,7 @@ impl RetainedServiceRuntime for TestRuntime {
             model: crate::types::ModelName::default(),
             recipient_pane_id: None,
             metadata_json: Map::new(),
-        }])
+        }]
     }
 }
 

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant};
 use atm_storage::{
     AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore, GraftEndpointStoreError,
     GraftReceiverEndpointStore, GraftReceiverLease, MessageStore as SharedMessageStore,
-    OwnerGeneration, PendingNudgeStore, RosterStore as SharedRosterStore, TemplateCatalogStore,
+    OwnerGeneration, PendingNudgeStore, RosterMemberEphemeralState, RosterRuntimeMirror,
+    RosterStore as SharedRosterStore, TemplateCatalogStore,
 };
 
 use crate::boundary::TemplateComposer;
@@ -32,268 +33,6 @@ enum WorkspaceConfigAccess {
     #[default]
     Client,
     Disabled,
-}
-
-/// Ephemeral per-member roster state that never round-trips through the
-/// durable roster store. This struct is deliberately small and extensible:
-/// every field here is mutated in RAM only, through explicit
-/// [`LocalServiceRuntime`] methods, on an observed state change. Nothing here
-/// is ever read from or written to SQLite.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct RosterMemberEphemeralState {
-    /// Set/cleared by Herdr queue-wake bookkeeping when a member's steer
-    /// target is pending a wake attempt.
-    pub herdr_wake_pending: bool,
-}
-
-/// One team's write-through roster mirror: the durable roster columns plus
-/// the ephemeral per-member state layered on top of them. The whole record is
-/// replaced as one `Arc` on every mutation, so readers observe either the
-/// entries-before or the entries-after a write, never a torn mix of the two.
-#[derive(Clone, Debug, Default)]
-struct TeamRosterRecord {
-    entries: Arc<[crate::boundary::RosterEntry]>,
-    ephemeral: Arc<BTreeMap<AgentName, RosterMemberEphemeralState>>,
-}
-
-impl TeamRosterRecord {
-    fn from_durable(entries: Vec<crate::boundary::RosterEntry>) -> Self {
-        let ephemeral = entries
-            .iter()
-            .map(|entry| {
-                (
-                    entry.agent_name.clone(),
-                    RosterMemberEphemeralState::default(),
-                )
-            })
-            .collect();
-        Self {
-            entries: entries.into(),
-            ephemeral: Arc::new(ephemeral),
-        }
-    }
-
-    /// Builds the record a durable roster replacement produces: retained
-    /// members keep their ephemeral state, new members start with the
-    /// default (empty) ephemeral state, and removed members' ephemeral state
-    /// is dropped with them.
-    fn replaced_with(&self, members: &[crate::boundary::RosterEntry]) -> Self {
-        let ephemeral = members
-            .iter()
-            .map(|member| {
-                let state = self
-                    .ephemeral
-                    .get(&member.agent_name)
-                    .copied()
-                    .unwrap_or_default();
-                (member.agent_name.clone(), state)
-            })
-            .collect();
-        Self {
-            entries: members.to_vec().into(),
-            ephemeral: Arc::new(ephemeral),
-        }
-    }
-}
-
-/// Runtime-owned, write-through in-memory roster mirror: one record per
-/// team, holding durable roster columns plus the ephemeral state columns
-/// that never appear in the database.
-///
-/// This is hydrated from the durable roster store once at runtime startup
-/// (see [`LocalServiceRuntime::new_with_delivery_boundaries`]) and is
-/// updated in the same operation as every durable roster write thereafter
-/// (see [`RosterRuntimeView`]). No consumer reads the durable store after
-/// startup; a control-plane reload only re-hydrates this mirror, it is never
-/// the only synchronization mechanism.
-///
-/// Race ordering between a reader and a concurrent add/update/remove is
-/// intentionally not guaranteed beyond memory safety: the only invariant
-/// enforced is that one durable write and its RAM update happen in the same
-/// operation.
-#[derive(Default)]
-struct RosterRuntimeState {
-    teams: RwLock<BTreeMap<TeamName, Arc<TeamRosterRecord>>>,
-}
-
-impl RosterRuntimeState {
-    /// Seeds one team's record straight from a durable read. Used only at
-    /// startup hydration and at an explicit reload re-hydration; never on a
-    /// per-request or per-tick path.
-    fn hydrate(&self, team: TeamName, entries: Vec<crate::boundary::RosterEntry>) {
-        let mut teams = self
-            .teams
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        teams.insert(team, Arc::new(TeamRosterRecord::from_durable(entries)));
-    }
-
-    /// Replaces one team's *durable* roster columns in RAM in the same
-    /// operation as the durable write that produced `members`. An empty
-    /// roster drops the team entirely, mirroring the durable store's
-    /// `list_teams` semantics (a team with zero roster rows is not
-    /// enumerable).
-    fn replace_roster(&self, team: &TeamName, members: &[crate::boundary::RosterEntry]) {
-        let mut teams = self
-            .teams
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if members.is_empty() {
-            teams.remove(team);
-            return;
-        }
-        let next = match teams.get(team) {
-            Some(existing) => existing.replaced_with(members),
-            None => TeamRosterRecord::from_durable(members.to_vec()),
-        };
-        teams.insert(team.clone(), Arc::new(next));
-    }
-
-    fn team_record(&self, team: &TeamName) -> Option<Arc<TeamRosterRecord>> {
-        let teams = self
-            .teams
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        teams.get(team).cloned()
-    }
-
-    fn load_team_roster(&self, team: &TeamName) -> Vec<crate::boundary::RosterEntry> {
-        self.team_record(team)
-            .map(|record| record.entries.to_vec())
-            .unwrap_or_default()
-    }
-
-    fn load_roster_member(
-        &self,
-        team: &TeamName,
-        agent: &AgentName,
-    ) -> Option<crate::boundary::RosterEntry> {
-        self.team_record(team)?
-            .entries
-            .iter()
-            .find(|member| &member.agent_name == agent)
-            .cloned()
-    }
-
-    fn list_teams(&self) -> Vec<TeamName> {
-        let teams = self
-            .teams
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        teams.keys().cloned().collect()
-    }
-
-    fn ephemeral_state(
-        &self,
-        team: &TeamName,
-        agent: &AgentName,
-    ) -> Option<RosterMemberEphemeralState> {
-        self.team_record(team)?.ephemeral.get(agent).copied()
-    }
-
-    /// Mutates one member's ephemeral state in RAM only. Returns `false`
-    /// without effect when the member is not present in the current
-    /// snapshot; there is nothing durable to attach ephemeral state to.
-    fn set_ephemeral_state(
-        &self,
-        team: &TeamName,
-        agent: &AgentName,
-        mutate: impl FnOnce(&mut RosterMemberEphemeralState),
-    ) -> bool {
-        let mut teams = self
-            .teams
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(record) = teams.get(team) else {
-            return false;
-        };
-        if !record
-            .entries
-            .iter()
-            .any(|member| &member.agent_name == agent)
-        {
-            return false;
-        }
-        let mut ephemeral = (*record.ephemeral).clone();
-        let state = ephemeral.entry(agent.clone()).or_default();
-        mutate(state);
-        let next = TeamRosterRecord {
-            entries: Arc::clone(&record.entries),
-            ephemeral: Arc::new(ephemeral),
-        };
-        teams.insert(team.clone(), Arc::new(next));
-        true
-    }
-}
-
-/// The single write-through seam for the durable roster store: every write
-/// updates the runtime-owned RAM mirror in the same operation, and every
-/// read is served from RAM. This is what [`LocalServiceRuntime::shared_roster_store_arc`]
-/// returns; nothing downstream of it reaches SQLite except the one durable
-/// write this performs.
-#[derive(Clone)]
-struct RosterRuntimeView {
-    durable: std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
-    state: Arc<RosterRuntimeState>,
-}
-
-impl atm_storage::contract::sealed::Sealed for RosterRuntimeView {}
-
-impl SharedRosterStore for RosterRuntimeView {
-    fn load_roster(&self, team: &TeamName) -> Result<atm_storage::RosterSnapshot, AtmError> {
-        Ok(atm_storage::RosterSnapshot {
-            team_name: team.clone(),
-            members: self.state.load_team_roster(team),
-            refreshed_at: None,
-        })
-    }
-
-    fn save_roster(&self, roster: &atm_storage::RosterSnapshot) -> Result<(), AtmError> {
-        self.durable.save_roster(roster)?;
-        self.state
-            .replace_roster(&roster.team_name, &roster.members);
-        Ok(())
-    }
-
-    fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
-        Ok(self.state.list_teams())
-    }
-}
-
-/// Hydrates the RAM roster mirror from the durable roster store. This is the
-/// only place a roster read reaches SQLite outside of an explicit
-/// control-plane reload; every consumer after this call reads RAM.
-///
-/// Best-effort: a durable read failure during startup hydration is logged
-/// and leaves the affected team absent from RAM rather than failing runtime
-/// construction. A later write-through mutation (or an explicit reload)
-/// still recovers a correct RAM view for that team.
-fn hydrate_roster_runtime_from_durable(
-    durable: &std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
-    state: &Arc<RosterRuntimeState>,
-) {
-    let teams = match durable.list_teams() {
-        Ok(teams) => teams,
-        Err(error) => {
-            tracing::warn!(
-                error = %error,
-                "roster runtime hydration could not enumerate durable teams; RAM roster starts empty"
-            );
-            return;
-        }
-    };
-    for team in teams {
-        match durable.load_roster(&team) {
-            Ok(snapshot) => state.hydrate(team, snapshot.members),
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    team = %team,
-                    "roster runtime hydration could not load one team's durable roster"
-                );
-            }
-        }
-    }
 }
 
 /// Lease snapshots avoid a control-path SQLite lookup for every admitted
@@ -517,11 +256,8 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
         &self,
         team: &TeamName,
         agent: &AgentName,
-    ) -> Result<Option<crate::boundary::RosterEntry>, AtmError>;
-    fn load_team_roster(
-        &self,
-        team: &TeamName,
-    ) -> Result<Vec<crate::boundary::RosterEntry>, AtmError>;
+    ) -> Option<crate::boundary::RosterEntry>;
+    fn load_team_roster(&self, team: &TeamName) -> Vec<crate::boundary::RosterEntry>;
 }
 
 #[derive(Clone)]
@@ -550,12 +286,14 @@ pub struct LocalServiceRuntime {
         Option<std::sync::Arc<dyn TemplateCatalogStore + Send + Sync>>,
     /// The runtime-owned, write-through RAM roster mirror used by every
     /// roster consumer (admission, send/recipient resolution, Herdr
-    /// queue-wake, doctor/diagnostics, graft). Hydrated once from the
-    /// durable roster store at construction; every subsequent durable roster
-    /// write updates it in the same operation through
-    /// [`RosterRuntimeView`]. No consumer reads durable roster state on a
+    /// queue-wake, doctor/diagnostics, graft). Built and hydrated once by
+    /// the storage composition root (`atm-storage-rusqlite`'s
+    /// `roster_runtime::build_write_through_roster`, boundary
+    /// `BOUNDARY-RosterStore-Sqlite-WriteThrough`) before this runtime is
+    /// constructed; every subsequent durable roster write updates it in the
+    /// same operation. No consumer reads durable roster state on a
     /// per-request or per-tick path.
-    roster_runtime: Arc<RosterRuntimeState>,
+    roster_runtime: Arc<dyn RosterRuntimeMirror + Send + Sync>,
     /// Short-lived receiver endpoint snapshots keep the graft registry's
     /// control-path SQLite lookup out of the local write hot path.
     graft_receiver_lease_cache: Arc<GraftReceiverLeaseCache>,
@@ -563,16 +301,23 @@ pub struct LocalServiceRuntime {
 }
 
 impl LocalServiceRuntime {
+    ///
+    /// `roster_store` and `roster_runtime` must be the paired handles
+    /// returned by the storage composition root's write-through roster
+    /// factory (e.g. `atm_storage_rusqlite::roster_runtime::build_write_through_roster`):
+    /// `roster_store` is the write-through `RosterStore` decorator and
+    /// `roster_runtime` is its RAM mirror. Hydration already happened,
+    /// fail-closed, before either handle was constructed; this constructor
+    /// performs no further durable roster I/O.
     pub fn new_with_delivery_boundaries(
         message_store: std::sync::Arc<dyn SharedMessageStore + Send + Sync>,
         roster_store: std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
+        roster_runtime: Arc<dyn RosterRuntimeMirror + Send + Sync>,
         nudge_template_override_store: std::sync::Arc<
             dyn crate::boundary::NudgeTemplateOverrideStore + Send + Sync,
         >,
         non_claude_outbound: std::sync::Arc<dyn crate::boundary::NonClaudeOutbound + Send + Sync>,
     ) -> Self {
-        let roster_runtime = Arc::new(RosterRuntimeState::default());
-        hydrate_roster_runtime_from_durable(&roster_store, &roster_runtime);
         Self {
             message_store,
             async_message_store: None,
@@ -818,22 +563,22 @@ impl LocalServiceRuntime {
     }
 
     /// Reads one roster member from the RAM roster mirror. Never issues a
-    /// durable roster read.
+    /// durable roster read. Infallible: the RAM mirror is always populated
+    /// (construction fails closed on a hydration error), so there is no
+    /// error case left to report.
     pub fn load_roster_member(
         &self,
         team: &TeamName,
         agent: &AgentName,
-    ) -> Result<Option<crate::boundary::RosterEntry>, AtmError> {
-        Ok(self.roster_runtime.load_roster_member(team, agent))
+    ) -> Option<crate::boundary::RosterEntry> {
+        self.roster_runtime.load_roster_member(team, agent)
     }
 
     /// Reads one team's roster from the RAM roster mirror. Never issues a
-    /// durable roster read.
-    pub fn load_team_roster(
-        &self,
-        team: &TeamName,
-    ) -> Result<Vec<crate::boundary::RosterEntry>, AtmError> {
-        Ok(self.roster_runtime.load_team_roster(team))
+    /// durable roster read. Infallible for the same reason as
+    /// [`Self::load_roster_member`].
+    pub fn load_team_roster(&self, team: &TeamName) -> Vec<crate::boundary::RosterEntry> {
+        self.roster_runtime.load_team_roster(team)
     }
 
     /// Enumerates every team the RAM roster mirror currently holds. Never
@@ -863,20 +608,25 @@ impl LocalServiceRuntime {
         pending: bool,
     ) -> bool {
         self.roster_runtime
-            .set_ephemeral_state(team, agent, |state| state.herdr_wake_pending = pending)
+            .set_herdr_wake_pending(team, agent, pending)
     }
 
     /// Re-hydrates the RAM roster mirror from the durable roster store.
     ///
     /// This is *not* the write-through synchronization mechanism -- every
-    /// durable roster write already updates RAM in the same operation
-    /// through [`RosterRuntimeView`]. This method exists only for the
-    /// authenticated control-plane reload boundary, which may want to
-    /// re-derive RAM from durable state (e.g. after an out-of-band durable
-    /// migration); it is never required for correctness of the normal
-    /// mutation path.
-    pub fn reload_roster_from_durable_store(&self) {
-        hydrate_roster_runtime_from_durable(&self.roster_store, &self.roster_runtime);
+    /// durable roster write already updates RAM in the same operation. This
+    /// method exists only for the authenticated control-plane reload
+    /// boundary, which may want to re-derive RAM from durable state (e.g.
+    /// after an out-of-band durable migration); it is never required for
+    /// correctness of the normal mutation path.
+    ///
+    /// # Errors
+    /// Fails closed: a durable read failure leaves the RAM mirror as it was
+    /// before the reload was attempted (the mirror itself clears and
+    /// re-hydrates atomically per the implementation's own contract), and
+    /// the error is propagated to the caller rather than silently degrading.
+    pub fn reload_roster_from_durable_store(&self) -> Result<(), AtmError> {
+        self.roster_runtime.reload_from_durable()
     }
 
     /// Returns the single write-through roster seam used by every roster
@@ -886,15 +636,11 @@ impl LocalServiceRuntime {
     /// never SQLite. A write performed through this handle durably persists
     /// first, then updates the RAM mirror in the same operation. The only
     /// SQLite roster reads outside of this handle happen once, at
-    /// construction (see [`LocalServiceRuntime::new_with_delivery_boundaries`])
-    /// or at an explicit [`LocalServiceRuntime::reload_roster_from_durable_store`]
-    /// call.
+    /// construction (before this runtime exists) or at an explicit
+    /// [`LocalServiceRuntime::reload_roster_from_durable_store`] call.
     #[doc(hidden)]
     pub fn shared_roster_store_arc(&self) -> std::sync::Arc<dyn SharedRosterStore + Send + Sync> {
-        std::sync::Arc::new(RosterRuntimeView {
-            durable: self.roster_store.clone(),
-            state: Arc::clone(&self.roster_runtime),
-        })
+        std::sync::Arc::clone(&self.roster_store)
     }
 }
 
@@ -1094,14 +840,11 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
         &self,
         team: &TeamName,
         agent: &AgentName,
-    ) -> Result<Option<crate::boundary::RosterEntry>, AtmError> {
+    ) -> Option<crate::boundary::RosterEntry> {
         Self::load_roster_member(self, team, agent)
     }
 
-    fn load_team_roster(
-        &self,
-        team: &TeamName,
-    ) -> Result<Vec<crate::boundary::RosterEntry>, AtmError> {
+    fn load_team_roster(&self, team: &TeamName) -> Vec<crate::boundary::RosterEntry> {
         Self::load_team_roster(self, team)
     }
 
@@ -1195,14 +938,12 @@ mod workspace_config_tests {
 mod tests {
     use super::{
         GraftReceiverLeaseCache, LocalFileNonClaudeOutbound, MAX_NON_CLAUDE_PAYLOAD_BYTES,
-        RosterRuntimeState, RosterRuntimeView, append_notification_log_at_path,
+        append_notification_log_at_path,
     };
-    use crate::error::AtmError;
     use crate::error_codes::AtmErrorCode;
     use crate::protocol::{NotificationEvent, NotificationKind};
     use crate::schema::InboxMessage;
     use crate::types::{AgentName, IsoTimestamp, TeamName};
-    use atm_storage::RosterStore as SharedRosterStore;
     use chrono::Utc;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1295,245 +1036,6 @@ mod tests {
         assert!(error.message().contains("exceeded"));
         assert!(error.message().contains("Recovery:"));
         assert!(!output_path.exists());
-    }
-
-    /// A durable roster double that counts every `save_roster`/`load_roster`/
-    /// `list_teams` call, used to prove that RAM reads never fall through to
-    /// the durable store once hydrated.
-    #[derive(Default)]
-    struct CountingRosterStore {
-        rosters: std::sync::Mutex<
-            std::collections::BTreeMap<TeamName, Vec<crate::boundary::RosterEntry>>,
-        >,
-        save_calls: AtomicUsize,
-        load_calls: AtomicUsize,
-        list_calls: AtomicUsize,
-    }
-
-    impl atm_storage::contract::sealed::Sealed for CountingRosterStore {}
-
-    impl SharedRosterStore for CountingRosterStore {
-        fn load_roster(&self, team: &TeamName) -> Result<atm_storage::RosterSnapshot, AtmError> {
-            self.load_calls.fetch_add(1, Ordering::Relaxed);
-            let rosters = self
-                .rosters
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            Ok(atm_storage::RosterSnapshot {
-                team_name: team.clone(),
-                members: rosters.get(team).cloned().unwrap_or_default(),
-                refreshed_at: None,
-            })
-        }
-
-        fn save_roster(&self, roster: &atm_storage::RosterSnapshot) -> Result<(), AtmError> {
-            self.save_calls.fetch_add(1, Ordering::Relaxed);
-            let mut rosters = self
-                .rosters
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            rosters.insert(roster.team_name.clone(), roster.members.clone());
-            Ok(())
-        }
-
-        fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
-            self.list_calls.fetch_add(1, Ordering::Relaxed);
-            let rosters = self
-                .rosters
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            Ok(rosters.keys().cloned().collect())
-        }
-    }
-
-    fn test_roster_entry(team: &TeamName, agent: &str) -> crate::boundary::RosterEntry {
-        crate::boundary::RosterEntry {
-            team_name: team.clone(),
-            agent_name: agent.parse::<AgentName>().expect("agent"),
-            member_kind: crate::boundary::RosterMemberKind::Permanent,
-            harness: crate::boundary::RosterHarness::CodexCli,
-            agent_type: crate::schema::AgentType::default(),
-            model: Default::default(),
-            recipient_pane_id: None,
-            metadata_json: serde_json::Map::new(),
-        }
-    }
-
-    #[test]
-    fn write_through_updates_ram_in_the_same_operation_as_the_durable_write() {
-        let team = TeamName::from_validated("test-team");
-        let durable: Arc<dyn SharedRosterStore + Send + Sync> =
-            Arc::new(CountingRosterStore::default());
-        let state = Arc::new(RosterRuntimeState::default());
-        let view = RosterRuntimeView {
-            durable: durable.clone(),
-            state: Arc::clone(&state),
-        };
-
-        // add
-        view.save_roster(&atm_storage::RosterSnapshot {
-            team_name: team.clone(),
-            members: vec![test_roster_entry(&team, "agent-a")],
-            refreshed_at: None,
-        })
-        .expect("add member write-through");
-        assert_eq!(state.load_team_roster(&team).len(), 1);
-        assert!(
-            state
-                .load_roster_member(&team, &"agent-a".parse().expect("agent"))
-                .is_some()
-        );
-
-        // update (replace with a changed member set, same agent retained)
-        let mut updated = test_roster_entry(&team, "agent-a");
-        updated.harness = crate::boundary::RosterHarness::ClaudeCode;
-        view.save_roster(&atm_storage::RosterSnapshot {
-            team_name: team.clone(),
-            members: vec![updated],
-            refreshed_at: None,
-        })
-        .expect("update member write-through");
-        let after_update = state
-            .load_roster_member(&team, &"agent-a".parse().expect("agent"))
-            .expect("member retained after update");
-        assert_eq!(
-            after_update.harness,
-            crate::boundary::RosterHarness::ClaudeCode
-        );
-
-        // remove (empty roster drops the team from RAM entirely)
-        view.save_roster(&atm_storage::RosterSnapshot {
-            team_name: team.clone(),
-            members: vec![],
-            refreshed_at: None,
-        })
-        .expect("remove member write-through");
-        assert!(state.load_team_roster(&team).is_empty());
-        assert!(!state.list_teams().contains(&team));
-    }
-
-    #[test]
-    fn ram_read_after_hydration_never_calls_the_durable_store_again() {
-        let team = TeamName::from_validated("test-team");
-        let counting = Arc::new(CountingRosterStore::default());
-        counting
-            .save_roster(&atm_storage::RosterSnapshot {
-                team_name: team.clone(),
-                members: vec![test_roster_entry(&team, "agent-a")],
-                refreshed_at: None,
-            })
-            .expect("seed durable roster");
-
-        let durable: Arc<dyn SharedRosterStore + Send + Sync> = counting.clone();
-        let state = Arc::new(RosterRuntimeState::default());
-        super::hydrate_roster_runtime_from_durable(&durable, &state);
-        assert_eq!(counting.list_calls.load(Ordering::Relaxed), 1);
-        assert_eq!(counting.load_calls.load(Ordering::Relaxed), 1);
-
-        let view = RosterRuntimeView {
-            durable: durable.clone(),
-            state: Arc::clone(&state),
-        };
-        for _ in 0..64 {
-            view.load_roster(&team).expect("ram roster read");
-            view.list_teams().expect("ram team enumeration");
-        }
-
-        assert_eq!(
-            counting.load_calls.load(Ordering::Relaxed),
-            1,
-            "reads after hydration must never reach the durable store"
-        );
-        assert_eq!(
-            counting.list_calls.load(Ordering::Relaxed),
-            1,
-            "team enumeration after hydration must never reach the durable store"
-        );
-    }
-
-    #[test]
-    fn ram_roster_enumerates_every_team_without_a_durable_read() {
-        let counting = Arc::new(CountingRosterStore::default());
-        let team_a = TeamName::from_validated("team-a");
-        let team_b = TeamName::from_validated("team-b");
-        counting
-            .save_roster(&atm_storage::RosterSnapshot {
-                team_name: team_a.clone(),
-                members: vec![test_roster_entry(&team_a, "agent-a")],
-                refreshed_at: None,
-            })
-            .expect("seed team-a");
-        counting
-            .save_roster(&atm_storage::RosterSnapshot {
-                team_name: team_b.clone(),
-                members: vec![test_roster_entry(&team_b, "agent-b")],
-                refreshed_at: None,
-            })
-            .expect("seed team-b");
-
-        let durable: Arc<dyn SharedRosterStore + Send + Sync> = counting.clone();
-        let state = Arc::new(RosterRuntimeState::default());
-        super::hydrate_roster_runtime_from_durable(&durable, &state);
-
-        let mut teams = state.list_teams();
-        teams.sort_by(|left, right| left.as_str().cmp(right.as_str()));
-        assert_eq!(teams, vec![team_a, team_b]);
-    }
-
-    #[test]
-    fn ephemeral_state_mutates_in_ram_and_is_visible_to_readers() {
-        let team = TeamName::from_validated("test-team");
-        let agent: AgentName = "agent-a".parse().expect("agent");
-        let state = RosterRuntimeState::default();
-        state.hydrate(team.clone(), vec![test_roster_entry(&team, "agent-a")]);
-
-        assert_eq!(
-            state.ephemeral_state(&team, &agent),
-            Some(super::RosterMemberEphemeralState::default())
-        );
-
-        let updated = state.set_ephemeral_state(&team, &agent, |ephemeral| {
-            ephemeral.herdr_wake_pending = true;
-        });
-        assert!(updated);
-        assert!(
-            state
-                .ephemeral_state(&team, &agent)
-                .expect("member present")
-                .herdr_wake_pending
-        );
-
-        // Durable roster columns for the retained member are unaffected by
-        // the ephemeral-only mutation.
-        assert_eq!(state.load_team_roster(&team).len(), 1);
-
-        // A replace_roster that retains the member must retain its ephemeral
-        // state; a replace_roster that drops the member must drop it too.
-        state.replace_roster(&team, &[test_roster_entry(&team, "agent-a")]);
-        assert!(
-            state
-                .ephemeral_state(&team, &agent)
-                .expect("member retained")
-                .herdr_wake_pending,
-            "ephemeral state must survive a durable roster replace that retains the member"
-        );
-
-        state.replace_roster(&team, &[]);
-        assert_eq!(state.ephemeral_state(&team, &agent), None);
-    }
-
-    #[test]
-    fn ephemeral_mutation_on_an_unknown_member_is_a_no_op() {
-        let team = TeamName::from_validated("test-team");
-        let agent: AgentName = "ghost".parse().expect("agent");
-        let state = RosterRuntimeState::default();
-        state.hydrate(team.clone(), vec![]);
-
-        let updated = state.set_ephemeral_state(&team, &agent, |ephemeral| {
-            ephemeral.herdr_wake_pending = true
-        });
-        assert!(!updated);
-        assert_eq!(state.ephemeral_state(&team, &agent), None);
     }
 
     #[test]

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -34,10 +34,266 @@ enum WorkspaceConfigAccess {
     Disabled,
 }
 
-/// Reload-scoped cache for immutable roster snapshots used during admission.
+/// Ephemeral per-member roster state that never round-trips through the
+/// durable roster store. This struct is deliberately small and extensible:
+/// every field here is mutated in RAM only, through explicit
+/// [`LocalServiceRuntime`] methods, on an observed state change. Nothing here
+/// is ever read from or written to SQLite.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RosterMemberEphemeralState {
+    /// Set/cleared by Herdr queue-wake bookkeeping when a member's steer
+    /// target is pending a wake attempt.
+    pub herdr_wake_pending: bool,
+}
+
+/// One team's write-through roster mirror: the durable roster columns plus
+/// the ephemeral per-member state layered on top of them. The whole record is
+/// replaced as one `Arc` on every mutation, so readers observe either the
+/// entries-before or the entries-after a write, never a torn mix of the two.
+#[derive(Clone, Debug, Default)]
+struct TeamRosterRecord {
+    entries: Arc<[crate::boundary::RosterEntry]>,
+    ephemeral: Arc<BTreeMap<AgentName, RosterMemberEphemeralState>>,
+}
+
+impl TeamRosterRecord {
+    fn from_durable(entries: Vec<crate::boundary::RosterEntry>) -> Self {
+        let ephemeral = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.agent_name.clone(),
+                    RosterMemberEphemeralState::default(),
+                )
+            })
+            .collect();
+        Self {
+            entries: entries.into(),
+            ephemeral: Arc::new(ephemeral),
+        }
+    }
+
+    /// Builds the record a durable roster replacement produces: retained
+    /// members keep their ephemeral state, new members start with the
+    /// default (empty) ephemeral state, and removed members' ephemeral state
+    /// is dropped with them.
+    fn replaced_with(&self, members: &[crate::boundary::RosterEntry]) -> Self {
+        let ephemeral = members
+            .iter()
+            .map(|member| {
+                let state = self
+                    .ephemeral
+                    .get(&member.agent_name)
+                    .copied()
+                    .unwrap_or_default();
+                (member.agent_name.clone(), state)
+            })
+            .collect();
+        Self {
+            entries: members.to_vec().into(),
+            ephemeral: Arc::new(ephemeral),
+        }
+    }
+}
+
+/// Runtime-owned, write-through in-memory roster mirror: one record per
+/// team, holding durable roster columns plus the ephemeral state columns
+/// that never appear in the database.
+///
+/// This is hydrated from the durable roster store once at runtime startup
+/// (see [`LocalServiceRuntime::new_with_delivery_boundaries`]) and is
+/// updated in the same operation as every durable roster write thereafter
+/// (see [`RosterRuntimeView`]). No consumer reads the durable store after
+/// startup; a control-plane reload only re-hydrates this mirror, it is never
+/// the only synchronization mechanism.
+///
+/// Race ordering between a reader and a concurrent add/update/remove is
+/// intentionally not guaranteed beyond memory safety: the only invariant
+/// enforced is that one durable write and its RAM update happen in the same
+/// operation.
 #[derive(Default)]
-struct RosterSnapshotCache {
-    snapshots: RwLock<BTreeMap<TeamName, Arc<[crate::boundary::RosterEntry]>>>,
+struct RosterRuntimeState {
+    teams: RwLock<BTreeMap<TeamName, Arc<TeamRosterRecord>>>,
+}
+
+impl RosterRuntimeState {
+    /// Seeds one team's record straight from a durable read. Used only at
+    /// startup hydration and at an explicit reload re-hydration; never on a
+    /// per-request or per-tick path.
+    fn hydrate(&self, team: TeamName, entries: Vec<crate::boundary::RosterEntry>) {
+        let mut teams = self
+            .teams
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        teams.insert(team, Arc::new(TeamRosterRecord::from_durable(entries)));
+    }
+
+    /// Replaces one team's *durable* roster columns in RAM in the same
+    /// operation as the durable write that produced `members`. An empty
+    /// roster drops the team entirely, mirroring the durable store's
+    /// `list_teams` semantics (a team with zero roster rows is not
+    /// enumerable).
+    fn replace_roster(&self, team: &TeamName, members: &[crate::boundary::RosterEntry]) {
+        let mut teams = self
+            .teams
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if members.is_empty() {
+            teams.remove(team);
+            return;
+        }
+        let next = match teams.get(team) {
+            Some(existing) => existing.replaced_with(members),
+            None => TeamRosterRecord::from_durable(members.to_vec()),
+        };
+        teams.insert(team.clone(), Arc::new(next));
+    }
+
+    fn team_record(&self, team: &TeamName) -> Option<Arc<TeamRosterRecord>> {
+        let teams = self
+            .teams
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        teams.get(team).cloned()
+    }
+
+    fn load_team_roster(&self, team: &TeamName) -> Vec<crate::boundary::RosterEntry> {
+        self.team_record(team)
+            .map(|record| record.entries.to_vec())
+            .unwrap_or_default()
+    }
+
+    fn load_roster_member(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Option<crate::boundary::RosterEntry> {
+        self.team_record(team)?
+            .entries
+            .iter()
+            .find(|member| &member.agent_name == agent)
+            .cloned()
+    }
+
+    fn list_teams(&self) -> Vec<TeamName> {
+        let teams = self
+            .teams
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        teams.keys().cloned().collect()
+    }
+
+    fn ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Option<RosterMemberEphemeralState> {
+        self.team_record(team)?.ephemeral.get(agent).copied()
+    }
+
+    /// Mutates one member's ephemeral state in RAM only. Returns `false`
+    /// without effect when the member is not present in the current
+    /// snapshot; there is nothing durable to attach ephemeral state to.
+    fn set_ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        mutate: impl FnOnce(&mut RosterMemberEphemeralState),
+    ) -> bool {
+        let mut teams = self
+            .teams
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(record) = teams.get(team) else {
+            return false;
+        };
+        if !record
+            .entries
+            .iter()
+            .any(|member| &member.agent_name == agent)
+        {
+            return false;
+        }
+        let mut ephemeral = (*record.ephemeral).clone();
+        let state = ephemeral.entry(agent.clone()).or_default();
+        mutate(state);
+        let next = TeamRosterRecord {
+            entries: Arc::clone(&record.entries),
+            ephemeral: Arc::new(ephemeral),
+        };
+        teams.insert(team.clone(), Arc::new(next));
+        true
+    }
+}
+
+/// The single write-through seam for the durable roster store: every write
+/// updates the runtime-owned RAM mirror in the same operation, and every
+/// read is served from RAM. This is what [`LocalServiceRuntime::shared_roster_store_arc`]
+/// returns; nothing downstream of it reaches SQLite except the one durable
+/// write this performs.
+#[derive(Clone)]
+struct RosterRuntimeView {
+    durable: std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
+    state: Arc<RosterRuntimeState>,
+}
+
+impl atm_storage::contract::sealed::Sealed for RosterRuntimeView {}
+
+impl SharedRosterStore for RosterRuntimeView {
+    fn load_roster(&self, team: &TeamName) -> Result<atm_storage::RosterSnapshot, AtmError> {
+        Ok(atm_storage::RosterSnapshot {
+            team_name: team.clone(),
+            members: self.state.load_team_roster(team),
+            refreshed_at: None,
+        })
+    }
+
+    fn save_roster(&self, roster: &atm_storage::RosterSnapshot) -> Result<(), AtmError> {
+        self.durable.save_roster(roster)?;
+        self.state
+            .replace_roster(&roster.team_name, &roster.members);
+        Ok(())
+    }
+
+    fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
+        Ok(self.state.list_teams())
+    }
+}
+
+/// Hydrates the RAM roster mirror from the durable roster store. This is the
+/// only place a roster read reaches SQLite outside of an explicit
+/// control-plane reload; every consumer after this call reads RAM.
+///
+/// Best-effort: a durable read failure during startup hydration is logged
+/// and leaves the affected team absent from RAM rather than failing runtime
+/// construction. A later write-through mutation (or an explicit reload)
+/// still recovers a correct RAM view for that team.
+fn hydrate_roster_runtime_from_durable(
+    durable: &std::sync::Arc<dyn SharedRosterStore + Send + Sync>,
+    state: &Arc<RosterRuntimeState>,
+) {
+    let teams = match durable.list_teams() {
+        Ok(teams) => teams,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "roster runtime hydration could not enumerate durable teams; RAM roster starts empty"
+            );
+            return;
+        }
+    };
+    for team in teams {
+        match durable.load_roster(&team) {
+            Ok(snapshot) => state.hydrate(team, snapshot.members),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    team = %team,
+                    "roster runtime hydration could not load one team's durable roster"
+                );
+            }
+        }
+    }
 }
 
 /// Lease snapshots avoid a control-path SQLite lookup for every admitted
@@ -197,46 +453,6 @@ impl GraftReceiverLeaseCache {
     }
 }
 
-impl RosterSnapshotCache {
-    fn clear(&self) {
-        let mut snapshots = match self.snapshots.write() {
-            Ok(snapshots) => snapshots,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        snapshots.clear();
-    }
-
-    fn load(
-        &self,
-        team: &TeamName,
-        load: impl FnOnce() -> Result<Arc<[crate::boundary::RosterEntry]>, AtmError>,
-    ) -> Result<Arc<[crate::boundary::RosterEntry]>, AtmError> {
-        {
-            let snapshots = match self.snapshots.read() {
-                Ok(snapshots) => snapshots,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            if let Some(snapshot) = snapshots.get(team) {
-                return Ok(Arc::clone(snapshot));
-            }
-        }
-
-        // Hold the write lock across the one backing-store read. This makes a
-        // cold admission burst load a team once instead of creating one SQLite
-        // reader per concurrent request.
-        let mut snapshots = match self.snapshots.write() {
-            Ok(snapshots) => snapshots,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        if let Some(snapshot) = snapshots.get(team) {
-            return Ok(Arc::clone(snapshot));
-        }
-        let snapshot = load()?;
-        snapshots.insert(team.clone(), Arc::clone(&snapshot));
-        Ok(snapshot)
-    }
-}
-
 /// Invoke a closure with the installed retained local runtime.
 #[doc(hidden)]
 pub fn with_default_local_service_runtime<T>(
@@ -332,13 +548,14 @@ pub struct LocalServiceRuntime {
     /// template-registration-plus-decomposed-message operation.
     pub(crate) template_catalog_store:
         Option<std::sync::Arc<dyn TemplateCatalogStore + Send + Sync>>,
-    /// Immutable roster snapshots used by daemon-owned admission.
-    ///
-    /// A daemon reload clears this cache before publishing its replacement
-    /// admission view. Keeping the roster snapshot here prevents every local
-    /// message admission from opening another SQLite reader connection merely
-    /// to rediscover an unchanged recipient.
-    roster_cache: Arc<RosterSnapshotCache>,
+    /// The runtime-owned, write-through RAM roster mirror used by every
+    /// roster consumer (admission, send/recipient resolution, Herdr
+    /// queue-wake, doctor/diagnostics, graft). Hydrated once from the
+    /// durable roster store at construction; every subsequent durable roster
+    /// write updates it in the same operation through
+    /// [`RosterRuntimeView`]. No consumer reads durable roster state on a
+    /// per-request or per-tick path.
+    roster_runtime: Arc<RosterRuntimeState>,
     /// Short-lived receiver endpoint snapshots keep the graft registry's
     /// control-path SQLite lookup out of the local write hot path.
     graft_receiver_lease_cache: Arc<GraftReceiverLeaseCache>,
@@ -354,6 +571,8 @@ impl LocalServiceRuntime {
         >,
         non_claude_outbound: std::sync::Arc<dyn crate::boundary::NonClaudeOutbound + Send + Sync>,
     ) -> Self {
+        let roster_runtime = Arc::new(RosterRuntimeState::default());
+        hydrate_roster_runtime_from_durable(&roster_store, &roster_runtime);
         Self {
             message_store,
             async_message_store: None,
@@ -366,7 +585,7 @@ impl LocalServiceRuntime {
             graft_receiver_endpoint_store: None,
             template_composer: None,
             template_catalog_store: None,
-            roster_cache: Arc::new(RosterSnapshotCache::default()),
+            roster_runtime,
             graft_receiver_lease_cache: Arc::new(GraftReceiverLeaseCache::default()),
             workspace_config_access: WorkspaceConfigAccess::Client,
         }
@@ -598,46 +817,84 @@ impl LocalServiceRuntime {
         self
     }
 
+    /// Reads one roster member from the RAM roster mirror. Never issues a
+    /// durable roster read.
     pub fn load_roster_member(
         &self,
         team: &TeamName,
         agent: &AgentName,
     ) -> Result<Option<crate::boundary::RosterEntry>, AtmError> {
-        Ok(self
-            .load_cached_roster(team)?
-            .iter()
-            .find(|member| &member.agent_name == agent)
-            .cloned())
+        Ok(self.roster_runtime.load_roster_member(team, agent))
     }
 
+    /// Reads one team's roster from the RAM roster mirror. Never issues a
+    /// durable roster read.
     pub fn load_team_roster(
         &self,
         team: &TeamName,
     ) -> Result<Vec<crate::boundary::RosterEntry>, AtmError> {
-        Ok(self.load_cached_roster(team)?.as_ref().to_vec())
+        Ok(self.roster_runtime.load_team_roster(team))
     }
 
-    /// Drops roster data held by this runtime before a control-plane reload.
-    ///
-    /// Cache invalidation is deliberately explicit: mutable roster state is
-    /// observed only at the daemon's existing reload boundary, never through
-    /// a reader connection on the synchronous message-admission path.
-    pub fn clear_roster_cache(&self) {
-        self.roster_cache.clear();
+    /// Enumerates every team the RAM roster mirror currently holds. Never
+    /// issues a durable roster read.
+    pub fn list_roster_teams(&self) -> Vec<TeamName> {
+        self.roster_runtime.list_teams()
     }
 
-    fn load_cached_roster(
+    /// Reads one member's ephemeral (non-durable) roster state from RAM.
+    /// Returns `None` when the member is not present in the current roster
+    /// snapshot.
+    pub fn roster_ephemeral_state(
         &self,
         team: &TeamName,
-    ) -> Result<Arc<[crate::boundary::RosterEntry]>, AtmError> {
-        self.roster_cache.load(team, || {
-            Ok(self.roster_store.load_roster(team)?.members.into())
-        })
+        agent: &AgentName,
+    ) -> Option<RosterMemberEphemeralState> {
+        self.roster_runtime.ephemeral_state(team, agent)
     }
 
+    /// Sets one member's Herdr wake-pending ephemeral flag in RAM only.
+    /// Returns `false` without effect when the member is not present in the
+    /// current roster snapshot.
+    pub fn set_roster_herdr_wake_pending(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        pending: bool,
+    ) -> bool {
+        self.roster_runtime
+            .set_ephemeral_state(team, agent, |state| state.herdr_wake_pending = pending)
+    }
+
+    /// Re-hydrates the RAM roster mirror from the durable roster store.
+    ///
+    /// This is *not* the write-through synchronization mechanism -- every
+    /// durable roster write already updates RAM in the same operation
+    /// through [`RosterRuntimeView`]. This method exists only for the
+    /// authenticated control-plane reload boundary, which may want to
+    /// re-derive RAM from durable state (e.g. after an out-of-band durable
+    /// migration); it is never required for correctness of the normal
+    /// mutation path.
+    pub fn reload_roster_from_durable_store(&self) {
+        hydrate_roster_runtime_from_durable(&self.roster_store, &self.roster_runtime);
+    }
+
+    /// Returns the single write-through roster seam used by every roster
+    /// consumer.
+    ///
+    /// Reads served through this handle come from the RAM roster mirror,
+    /// never SQLite. A write performed through this handle durably persists
+    /// first, then updates the RAM mirror in the same operation. The only
+    /// SQLite roster reads outside of this handle happen once, at
+    /// construction (see [`LocalServiceRuntime::new_with_delivery_boundaries`])
+    /// or at an explicit [`LocalServiceRuntime::reload_roster_from_durable_store`]
+    /// call.
     #[doc(hidden)]
     pub fn shared_roster_store_arc(&self) -> std::sync::Arc<dyn SharedRosterStore + Send + Sync> {
-        self.roster_store.clone()
+        std::sync::Arc::new(RosterRuntimeView {
+            durable: self.roster_store.clone(),
+            state: Arc::clone(&self.roster_runtime),
+        })
     }
 }
 
@@ -938,12 +1195,14 @@ mod workspace_config_tests {
 mod tests {
     use super::{
         GraftReceiverLeaseCache, LocalFileNonClaudeOutbound, MAX_NON_CLAUDE_PAYLOAD_BYTES,
-        RosterSnapshotCache, append_notification_log_at_path,
+        RosterRuntimeState, RosterRuntimeView, append_notification_log_at_path,
     };
+    use crate::error::AtmError;
     use crate::error_codes::AtmErrorCode;
     use crate::protocol::{NotificationEvent, NotificationKind};
     use crate::schema::InboxMessage;
     use crate::types::{AgentName, IsoTimestamp, TeamName};
+    use atm_storage::RosterStore as SharedRosterStore;
     use chrono::Utc;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1038,35 +1297,243 @@ mod tests {
         assert!(!output_path.exists());
     }
 
+    /// A durable roster double that counts every `save_roster`/`load_roster`/
+    /// `list_teams` call, used to prove that RAM reads never fall through to
+    /// the durable store once hydrated.
+    #[derive(Default)]
+    struct CountingRosterStore {
+        rosters: std::sync::Mutex<
+            std::collections::BTreeMap<TeamName, Vec<crate::boundary::RosterEntry>>,
+        >,
+        save_calls: AtomicUsize,
+        load_calls: AtomicUsize,
+        list_calls: AtomicUsize,
+    }
+
+    impl atm_storage::contract::sealed::Sealed for CountingRosterStore {}
+
+    impl SharedRosterStore for CountingRosterStore {
+        fn load_roster(&self, team: &TeamName) -> Result<atm_storage::RosterSnapshot, AtmError> {
+            self.load_calls.fetch_add(1, Ordering::Relaxed);
+            let rosters = self
+                .rosters
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            Ok(atm_storage::RosterSnapshot {
+                team_name: team.clone(),
+                members: rosters.get(team).cloned().unwrap_or_default(),
+                refreshed_at: None,
+            })
+        }
+
+        fn save_roster(&self, roster: &atm_storage::RosterSnapshot) -> Result<(), AtmError> {
+            self.save_calls.fetch_add(1, Ordering::Relaxed);
+            let mut rosters = self
+                .rosters
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            rosters.insert(roster.team_name.clone(), roster.members.clone());
+            Ok(())
+        }
+
+        fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
+            self.list_calls.fetch_add(1, Ordering::Relaxed);
+            let rosters = self
+                .rosters
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            Ok(rosters.keys().cloned().collect())
+        }
+    }
+
+    fn test_roster_entry(team: &TeamName, agent: &str) -> crate::boundary::RosterEntry {
+        crate::boundary::RosterEntry {
+            team_name: team.clone(),
+            agent_name: agent.parse::<AgentName>().expect("agent"),
+            member_kind: crate::boundary::RosterMemberKind::Permanent,
+            harness: crate::boundary::RosterHarness::CodexCli,
+            agent_type: crate::schema::AgentType::default(),
+            model: Default::default(),
+            recipient_pane_id: None,
+            metadata_json: serde_json::Map::new(),
+        }
+    }
+
     #[test]
-    fn cached_roster_is_reused_until_explicit_reload_invalidation() {
-        let cache = RosterSnapshotCache::default();
+    fn write_through_updates_ram_in_the_same_operation_as_the_durable_write() {
         let team = TeamName::from_validated("test-team");
-        let loads = AtomicUsize::new(0);
-        let empty_roster: Arc<[crate::boundary::RosterEntry]> = Arc::from([]);
+        let durable: Arc<dyn SharedRosterStore + Send + Sync> =
+            Arc::new(CountingRosterStore::default());
+        let state = Arc::new(RosterRuntimeState::default());
+        let view = RosterRuntimeView {
+            durable: durable.clone(),
+            state: Arc::clone(&state),
+        };
 
-        cache
-            .load(&team, || {
-                loads.fetch_add(1, Ordering::Relaxed);
-                Ok(Arc::clone(&empty_roster))
-            })
-            .expect("first roster lookup");
-        cache
-            .load(&team, || {
-                loads.fetch_add(1, Ordering::Relaxed);
-                Ok(Arc::clone(&empty_roster))
-            })
-            .expect("cached roster lookup");
-        assert_eq!(loads.load(Ordering::Relaxed), 1);
+        // add
+        view.save_roster(&atm_storage::RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![test_roster_entry(&team, "agent-a")],
+            refreshed_at: None,
+        })
+        .expect("add member write-through");
+        assert_eq!(state.load_team_roster(&team).len(), 1);
+        assert!(
+            state
+                .load_roster_member(&team, &"agent-a".parse().expect("agent"))
+                .is_some()
+        );
 
-        cache.clear();
-        cache
-            .load(&team, || {
-                loads.fetch_add(1, Ordering::Relaxed);
-                Ok(empty_roster)
+        // update (replace with a changed member set, same agent retained)
+        let mut updated = test_roster_entry(&team, "agent-a");
+        updated.harness = crate::boundary::RosterHarness::ClaudeCode;
+        view.save_roster(&atm_storage::RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![updated],
+            refreshed_at: None,
+        })
+        .expect("update member write-through");
+        let after_update = state
+            .load_roster_member(&team, &"agent-a".parse().expect("agent"))
+            .expect("member retained after update");
+        assert_eq!(
+            after_update.harness,
+            crate::boundary::RosterHarness::ClaudeCode
+        );
+
+        // remove (empty roster drops the team from RAM entirely)
+        view.save_roster(&atm_storage::RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![],
+            refreshed_at: None,
+        })
+        .expect("remove member write-through");
+        assert!(state.load_team_roster(&team).is_empty());
+        assert!(!state.list_teams().contains(&team));
+    }
+
+    #[test]
+    fn ram_read_after_hydration_never_calls_the_durable_store_again() {
+        let team = TeamName::from_validated("test-team");
+        let counting = Arc::new(CountingRosterStore::default());
+        counting
+            .save_roster(&atm_storage::RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![test_roster_entry(&team, "agent-a")],
+                refreshed_at: None,
             })
-            .expect("reloaded roster lookup");
-        assert_eq!(loads.load(Ordering::Relaxed), 2);
+            .expect("seed durable roster");
+
+        let durable: Arc<dyn SharedRosterStore + Send + Sync> = counting.clone();
+        let state = Arc::new(RosterRuntimeState::default());
+        super::hydrate_roster_runtime_from_durable(&durable, &state);
+        assert_eq!(counting.list_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(counting.load_calls.load(Ordering::Relaxed), 1);
+
+        let view = RosterRuntimeView {
+            durable: durable.clone(),
+            state: Arc::clone(&state),
+        };
+        for _ in 0..64 {
+            view.load_roster(&team).expect("ram roster read");
+            view.list_teams().expect("ram team enumeration");
+        }
+
+        assert_eq!(
+            counting.load_calls.load(Ordering::Relaxed),
+            1,
+            "reads after hydration must never reach the durable store"
+        );
+        assert_eq!(
+            counting.list_calls.load(Ordering::Relaxed),
+            1,
+            "team enumeration after hydration must never reach the durable store"
+        );
+    }
+
+    #[test]
+    fn ram_roster_enumerates_every_team_without_a_durable_read() {
+        let counting = Arc::new(CountingRosterStore::default());
+        let team_a = TeamName::from_validated("team-a");
+        let team_b = TeamName::from_validated("team-b");
+        counting
+            .save_roster(&atm_storage::RosterSnapshot {
+                team_name: team_a.clone(),
+                members: vec![test_roster_entry(&team_a, "agent-a")],
+                refreshed_at: None,
+            })
+            .expect("seed team-a");
+        counting
+            .save_roster(&atm_storage::RosterSnapshot {
+                team_name: team_b.clone(),
+                members: vec![test_roster_entry(&team_b, "agent-b")],
+                refreshed_at: None,
+            })
+            .expect("seed team-b");
+
+        let durable: Arc<dyn SharedRosterStore + Send + Sync> = counting.clone();
+        let state = Arc::new(RosterRuntimeState::default());
+        super::hydrate_roster_runtime_from_durable(&durable, &state);
+
+        let mut teams = state.list_teams();
+        teams.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        assert_eq!(teams, vec![team_a, team_b]);
+    }
+
+    #[test]
+    fn ephemeral_state_mutates_in_ram_and_is_visible_to_readers() {
+        let team = TeamName::from_validated("test-team");
+        let agent: AgentName = "agent-a".parse().expect("agent");
+        let state = RosterRuntimeState::default();
+        state.hydrate(team.clone(), vec![test_roster_entry(&team, "agent-a")]);
+
+        assert_eq!(
+            state.ephemeral_state(&team, &agent),
+            Some(super::RosterMemberEphemeralState::default())
+        );
+
+        let updated = state.set_ephemeral_state(&team, &agent, |ephemeral| {
+            ephemeral.herdr_wake_pending = true;
+        });
+        assert!(updated);
+        assert!(
+            state
+                .ephemeral_state(&team, &agent)
+                .expect("member present")
+                .herdr_wake_pending
+        );
+
+        // Durable roster columns for the retained member are unaffected by
+        // the ephemeral-only mutation.
+        assert_eq!(state.load_team_roster(&team).len(), 1);
+
+        // A replace_roster that retains the member must retain its ephemeral
+        // state; a replace_roster that drops the member must drop it too.
+        state.replace_roster(&team, &[test_roster_entry(&team, "agent-a")]);
+        assert!(
+            state
+                .ephemeral_state(&team, &agent)
+                .expect("member retained")
+                .herdr_wake_pending,
+            "ephemeral state must survive a durable roster replace that retains the member"
+        );
+
+        state.replace_roster(&team, &[]);
+        assert_eq!(state.ephemeral_state(&team, &agent), None);
+    }
+
+    #[test]
+    fn ephemeral_mutation_on_an_unknown_member_is_a_no_op() {
+        let team = TeamName::from_validated("test-team");
+        let agent: AgentName = "ghost".parse().expect("agent");
+        let state = RosterRuntimeState::default();
+        state.hydrate(team.clone(), vec![]);
+
+        let updated = state.set_ephemeral_state(&team, &agent, |ephemeral| {
+            ephemeral.herdr_wake_pending = true
+        });
+        assert!(!updated);
+        assert_eq!(state.ephemeral_state(&team, &agent), None);
     }
 
     #[test]

--- a/crates/atm-core/src/write/acknowledgement.rs
+++ b/crates/atm-core/src/write/acknowledgement.rs
@@ -439,7 +439,7 @@ fn ensure_roster_member_exists<R: RetainedServiceRuntime>(
     agent: &AgentName,
     recovery: &str,
 ) -> Result<(), AtmError> {
-    if runtime.load_roster_member(team, agent)?.is_none() {
+    if runtime.load_roster_member(team, agent).is_none() {
         return Err(AtmError::new(
             crate::error_codes::AtmErrorCode::AgentNotFound,
             format!("agent '{agent}' was not found in team '{team}'\n  Recovery: {recovery}"),

--- a/crates/atm-daemon-bootstrap/src/queue_drain.rs
+++ b/crates/atm-daemon-bootstrap/src/queue_drain.rs
@@ -31,7 +31,7 @@ pub(crate) fn queue_drain_channel_allowed(
     runtime: &LocalServiceRuntime,
     member: &MemberKey,
 ) -> Result<bool, AtmError> {
-    let Some(roster) = runtime.load_roster_member(member.team(), member.agent())? else {
+    let Some(roster) = runtime.load_roster_member(member.team(), member.agent()) else {
         return Ok(false);
     };
     let local_backend = local_message_received_backend(&roster);

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -1330,7 +1330,6 @@ mod tests {
                 refreshed_at: None,
             })
             .expect("changed roster");
-        runtime.clear_roster_cache();
         queue_message(root.path(), &runtime, &team, "aq27-agent");
         queue_message(root.path(), &runtime, &team, "aq27-agent-20");
         queue_message(root.path(), &runtime, &team, "aq27-agent-21");
@@ -1385,6 +1384,175 @@ mod tests {
         assert_eq!(
             runtime_state(HerdrAgentStatus::Unknown),
             RuntimeMemberState::Unknown
+        );
+    }
+
+    struct UnusedMailStore;
+    impl atm_storage::contract::sealed::Sealed for UnusedMailStore {}
+    impl atm_storage::MessageStore for UnusedMailStore {
+        fn save_message(&self, _message: &atm_storage::Message) -> Result<(), AtmError> {
+            unreachable!("herdr candidate test never touches the mail store boundary")
+        }
+
+        fn save_messages_atomically(
+            &self,
+            _messages: &[atm_storage::Message],
+        ) -> Result<(), AtmError> {
+            unreachable!("herdr candidate test never touches the mail store boundary")
+        }
+
+        fn load_message(
+            &self,
+            _key: &atm_storage::MessageKey,
+        ) -> Result<Option<atm_storage::Message>, AtmError> {
+            unreachable!("herdr candidate test never touches the mail store boundary")
+        }
+
+        fn list_messages(
+            &self,
+            _query: &atm_storage::MessageQuery,
+        ) -> Result<Vec<atm_storage::Message>, AtmError> {
+            unreachable!("herdr candidate test never touches the mail store boundary")
+        }
+
+        fn delete_message(&self, _key: &atm_storage::MessageKey) -> Result<(), AtmError> {
+            unreachable!("herdr candidate test never touches the mail store boundary")
+        }
+    }
+
+    struct NoopNudgeTemplateOverrideStore;
+    impl atm_storage::contract::sealed::Sealed for NoopNudgeTemplateOverrideStore {}
+    impl atm_core::boundary::NudgeTemplateOverrideStore for NoopNudgeTemplateOverrideStore {
+        fn load_template_override(
+            &self,
+            _team: &TeamName,
+            _kind: atm_core::boundary::BuiltInNudgeTemplateKind,
+        ) -> Result<Option<atm_core::boundary::TeamNudgeTemplateOverrideRow>, AtmError> {
+            Ok(None)
+        }
+
+        fn save_template_override(
+            &self,
+            _team: &TeamName,
+            _kind: atm_core::boundary::BuiltInNudgeTemplateKind,
+            _template_body: &str,
+        ) -> Result<atm_core::boundary::TeamNudgeTemplateOverrideRow, AtmError> {
+            unreachable!("herdr candidate test never touches the override-store boundary")
+        }
+
+        fn disable_template_override(
+            &self,
+            _team: &TeamName,
+            _kind: atm_core::boundary::BuiltInNudgeTemplateKind,
+        ) -> Result<atm_core::boundary::TeamNudgeTemplateOverrideRow, AtmError> {
+            unreachable!("herdr candidate test never touches the override-store boundary")
+        }
+
+        fn clear_template_override(
+            &self,
+            _team: &TeamName,
+            _kind: atm_core::boundary::BuiltInNudgeTemplateKind,
+        ) -> Result<bool, AtmError> {
+            unreachable!("herdr candidate test never touches the override-store boundary")
+        }
+    }
+
+    struct UnusedNonClaudeOutbound;
+    impl atm_core::boundary::sealed::Sealed for UnusedNonClaudeOutbound {}
+    impl atm_core::boundary::NonClaudeOutbound for UnusedNonClaudeOutbound {
+        fn deliver_payloads(
+            &self,
+            _request: atm_core::boundary::NonClaudeOutboundDeliveryRequest,
+        ) -> Result<atm_core::boundary::NonClaudeOutboundDeliveryResponse, AtmError> {
+            unreachable!("herdr candidate test never touches the non-Claude outbound boundary")
+        }
+    }
+
+    /// Durable roster store that counts every call so the test can prove
+    /// `herdr_candidates` reads exclusively from the RAM roster after the
+    /// one hydration read performed at runtime construction.
+    struct CountingRosterStore {
+        roster: RosterSnapshot,
+        load_roster_calls: std::sync::atomic::AtomicUsize,
+        list_teams_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl atm_storage::contract::sealed::Sealed for CountingRosterStore {}
+    impl atm_storage::contract::RosterStore for CountingRosterStore {
+        fn load_roster(&self, team: &TeamName) -> Result<RosterSnapshot, AtmError> {
+            self.load_roster_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(team, &self.roster.team_name, "unexpected team requested");
+            Ok(self.roster.clone())
+        }
+
+        fn save_roster(&self, _roster: &RosterSnapshot) -> Result<(), AtmError> {
+            unreachable!("herdr candidate test never mutates the durable roster")
+        }
+
+        fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
+            self.list_teams_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(vec![self.roster.team_name.clone()])
+        }
+    }
+
+    #[test]
+    fn herdr_candidates_never_reads_the_durable_roster_store_after_hydration() {
+        let team: TeamName = "aq27-counting-team".parse().expect("team");
+        let member = herdr_member(&team, "aq27-counting-agent");
+        let durable = std::sync::Arc::new(CountingRosterStore {
+            roster: RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![member],
+                refreshed_at: None,
+            },
+            load_roster_calls: std::sync::atomic::AtomicUsize::new(0),
+            list_teams_calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
+            std::sync::Arc::new(UnusedMailStore),
+            durable.clone(),
+            std::sync::Arc::new(NoopNudgeTemplateOverrideStore),
+            std::sync::Arc::new(UnusedNonClaudeOutbound),
+        );
+        // Hydration at construction performs exactly one read of each kind.
+        assert_eq!(
+            durable
+                .list_teams_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            durable
+                .load_roster_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+
+        let pending = std::collections::HashSet::new();
+        for _ in 0..5 {
+            let roster_store = runtime.shared_roster_store_arc();
+            let candidates =
+                super::herdr_candidates(roster_store.as_ref(), &pending).expect("candidates");
+            assert_eq!(candidates.len(), 1);
+        }
+
+        // Five additional herdr_candidates calls must not touch the durable
+        // store again: RAM is the only read path once hydrated.
+        assert_eq!(
+            durable
+                .list_teams_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "herdr_candidates must not call list_teams on the durable store"
+        );
+        assert_eq!(
+            durable
+                .load_roster_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "herdr_candidates must not call load_roster on the durable store"
         );
     }
 }

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -286,11 +286,20 @@ impl HerdrQueueWakePump {
             Ok(Some(claim)) => claim,
             Ok(None) | Err(_) => return,
         };
+        // A claimed nudge is now a real, in-flight Herdr wake attempt for this
+        // member: mark the ephemeral roster state pending. `ReleasePendingOnDrop`
+        // clears it unconditionally when the attempt concludes below.
+        self.service_runtime.set_roster_herdr_wake_pending(
+            member.key.team(),
+            member.key.agent(),
+            true,
+        );
         let mut release = ReleasePendingOnDrop::new(
             Arc::clone(pending_store),
             member.key.clone(),
             claim.clone(),
             Arc::clone(&self.release_streaks),
+            self.service_runtime.clone(),
         );
         let dispatch = match self.rebuild_dispatch(member, claim.msg).await {
             Ok(Some(dispatch)) => dispatch,
@@ -540,6 +549,13 @@ struct ReleasePendingOnDrop {
     member: MemberKey,
     claim: atm_core::boundary::NudgeClaim,
     release_streaks: Arc<Mutex<HashMap<MemberKey, u32>>>,
+    /// Clears the member's ephemeral Herdr wake-pending roster flag when this
+    /// claim attempt concludes (success, requeue, or release), regardless of
+    /// which exit path was taken. Set alongside claiming a pending nudge in
+    /// [`HerdrQueueWakePump::process_candidate`]; this is the real production
+    /// transition the ephemeral roster state exists to track (FTQ-AW finding
+    /// 4 on PR #1240 -- previously this state had no production caller).
+    service_runtime: LocalServiceRuntime,
     armed: bool,
 }
 
@@ -549,12 +565,14 @@ impl ReleasePendingOnDrop {
         member: MemberKey,
         claim: atm_core::boundary::NudgeClaim,
         release_streaks: Arc<Mutex<HashMap<MemberKey, u32>>>,
+        service_runtime: LocalServiceRuntime,
     ) -> Self {
         Self {
             store,
             member,
             claim,
             release_streaks,
+            service_runtime,
             armed: true,
         }
     }
@@ -608,6 +626,11 @@ impl ReleasePendingOnDrop {
 impl Drop for ReleasePendingOnDrop {
     fn drop(&mut self) {
         self.release_without_input();
+        self.service_runtime.set_roster_herdr_wake_pending(
+            self.member.team(),
+            self.member.agent(),
+            false,
+        );
     }
 }
 
@@ -953,6 +976,55 @@ mod tests {
                 .expect("pending members")
                 .contains(&key)
         );
+    }
+
+    /// Proves the ephemeral roster wake-pending flag actually mutates on a
+    /// real Herdr wake attempt (FTQ-AW finding 4 on PR #1240): it is unset
+    /// before any attempt, set while a claim's prompt is in flight, and
+    /// clears again once the attempt concludes -- regardless of the claim
+    /// eventually succeeding.
+    #[tokio::test]
+    async fn ac13_herdr_wake_pending_ephemeral_state_tracks_the_in_flight_claim() {
+        let (root, runtime, fake, pump, _health, key) = build_test_pump();
+        assert_eq!(
+            runtime.roster_ephemeral_state(key.team(), key.agent()),
+            Some(atm_storage::RosterMemberEphemeralState::default()),
+            "no wake attempt is in flight before the first tick"
+        );
+
+        let prompt_gate = fake.block_next_prompt();
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let task = pump.start(shutdown_rx);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if runtime
+                    .roster_ephemeral_state(key.team(), key.agent())
+                    .expect("member present in RAM roster")
+                    .herdr_wake_pending
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("wake-pending ephemeral state must be set while a claim is in flight");
+
+        drop(prompt_gate);
+        shutdown_tx.send(()).expect("shutdown notification");
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("pump joins after shutdown notification")
+            .expect("poll task join");
+
+        assert!(
+            !runtime
+                .roster_ephemeral_state(key.team(), key.agent())
+                .expect("member present in RAM roster")
+                .herdr_wake_pending,
+            "wake-pending must clear once the claim attempt concludes"
+        );
+        let _ = root;
     }
 
     #[tokio::test]
@@ -1510,13 +1582,18 @@ mod tests {
             load_roster_calls: std::sync::atomic::AtomicUsize::new(0),
             list_teams_calls: std::sync::atomic::AtomicUsize::new(0),
         });
+        let (roster_store, roster_runtime_mirror) =
+            atm_runtime_test_support::build_write_through_roster_for_test(durable.clone())
+                .expect("write-through roster fixture hydrates from the counting fake");
         let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
             std::sync::Arc::new(UnusedMailStore),
-            durable.clone(),
+            roster_store,
+            roster_runtime_mirror,
             std::sync::Arc::new(NoopNudgeTemplateOverrideStore),
             std::sync::Arc::new(UnusedNonClaudeOutbound),
         );
-        // Hydration at construction performs exactly one read of each kind.
+        // Hydration (now performed by build_write_through_roster_for_test)
+        // performs exactly one read of each kind.
         assert_eq!(
             durable
                 .list_teams_calls

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -798,7 +798,11 @@ impl StorageAndNudgeRouter {
                 "runtime reload is available only through authenticated local HTTP adapters",
             ));
         }
-        self.service_runtime.clear_roster_cache();
+        // Write-through already keeps the RAM roster mirror synchronized
+        // with every durable mutation; this re-hydration is not the
+        // synchronization mechanism, it only re-derives RAM from durable
+        // state for the rare case of an out-of-band durable change.
+        self.service_runtime.reload_roster_from_durable_store();
         Ok(ApiResponse::new(ResponseEnvelope::RuntimeViewReloaded))
     }
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -802,7 +802,7 @@ impl StorageAndNudgeRouter {
         // with every durable mutation; this re-hydration is not the
         // synchronization mechanism, it only re-derives RAM from durable
         // state for the rare case of an out-of-band durable change.
-        self.service_runtime.reload_roster_from_durable_store();
+        self.service_runtime.reload_roster_from_durable_store()?;
         Ok(ApiResponse::new(ResponseEnvelope::RuntimeViewReloaded))
     }
 }
@@ -982,7 +982,7 @@ pub(crate) fn validate_heartbeat_member(
     team: &atm_core::types::TeamName,
     member: &atm_core::types::AgentName,
 ) -> Result<(), AtmError> {
-    if runtime.load_roster_member(team, member)?.is_none() {
+    if runtime.load_roster_member(team, member).is_none() {
         return Err(AtmError::agent_not_found(member.as_str(), team.as_str()));
     }
     Ok(())
@@ -1002,7 +1002,7 @@ pub(crate) fn validate_graft_receiver_member(
     team: &atm_core::types::TeamName,
     agent: &atm_core::types::AgentName,
 ) -> Result<(), AtmError> {
-    if runtime.load_roster_member(team, agent)?.is_none() {
+    if runtime.load_roster_member(team, agent).is_none() {
         return Err(AtmError::agent_not_found(agent.as_str(), team.as_str()));
     }
     Ok(())

--- a/crates/atm-runtime-test-support/src/lib.rs
+++ b/crates/atm-runtime-test-support/src/lib.rs
@@ -282,10 +282,21 @@ pub fn open_isolated_sqlite_boundary(root: impl AsRef<Path>) -> Result<RuntimeAs
 /// # Errors
 /// Fails closed: propagates a durable roster read failure encountered while
 /// hydrating the RAM mirror from `durable`.
+#[allow(
+    clippy::type_complexity,
+    reason = "test fixtures destructure the paired handles directly; the production seam uses the WriteThroughRosterStore newtype"
+)]
 pub fn build_write_through_roster_for_test(
     durable: Arc<dyn RosterStore + Send + Sync>,
-) -> Result<atm_storage_rusqlite::roster_runtime::WriteThroughRosterHandles, AtmError> {
-    atm_storage_rusqlite::roster_runtime::build_write_through_roster(durable)
+) -> Result<
+    (
+        Arc<dyn RosterStore + Send + Sync>,
+        Arc<dyn atm_storage::RosterRuntimeMirror + Send + Sync>,
+    ),
+    AtmError,
+> {
+    let roster = atm_storage_rusqlite::roster_runtime::build_write_through_roster(durable)?;
+    Ok((roster.store(), roster.mirror()))
 }
 
 /// Install the current test's isolated runtime path before composing a

--- a/crates/atm-runtime-test-support/src/lib.rs
+++ b/crates/atm-runtime-test-support/src/lib.rs
@@ -16,7 +16,7 @@ use atm_runtime::mailbox_runtime::StorageAsyncMailboxRuntime;
 use atm_runtime::{RuntimeAssembly, RuntimeAssemblyInputs, assemble_runtime};
 use atm_storage::{
     AsyncMailboxReader, AsyncMessageStore, IsoTimestamp, MailboxScope, Message, MessageKey,
-    MessageQuery, MessageStore,
+    MessageQuery, MessageStore, RosterStore,
 };
 use atm_storage_rusqlite::SqliteStorageFactory;
 
@@ -268,6 +268,24 @@ pub fn open_graft_receiver_endpoint_store(
 /// a transaction in the same process.
 pub fn open_isolated_sqlite_boundary(root: impl AsRef<Path>) -> Result<RuntimeAssembly, AtmError> {
     open_sqlite_boundary(root.as_ref().join("runtime").join("mail.sqlite3"))
+}
+
+/// Builds the paired write-through roster handles (`RosterStore` decorator
+/// plus its RAM mirror) that `LocalServiceRuntime::new_with_delivery_boundaries`
+/// requires, for tests that construct a runtime directly instead of going
+/// through [`assemble_runtime`]. This wraps
+/// `atm_storage_rusqlite::roster_runtime::build_write_through_roster`, which
+/// is the only authorized construction site (boundary
+/// `BOUNDARY-RosterStore-Sqlite-WriteThrough`); no caller outside this crate
+/// or `atm-daemon-bootstrap` may build an equivalent wrapper by hand.
+///
+/// # Errors
+/// Fails closed: propagates a durable roster read failure encountered while
+/// hydrating the RAM mirror from `durable`.
+pub fn build_write_through_roster_for_test(
+    durable: Arc<dyn RosterStore + Send + Sync>,
+) -> Result<atm_storage_rusqlite::roster_runtime::WriteThroughRosterHandles, AtmError> {
+    atm_storage_rusqlite::roster_runtime::build_write_through_roster(durable)
 }
 
 /// Install the current test's isolated runtime path before composing a

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -295,12 +295,24 @@ impl RuntimeAssembly {
         boundary_mail_store_view(self.storage_backends.messages.clone())
     }
 
+    /// Returns the write-through, RAM-backed roster boundary view.
+    ///
+    /// This must go through [`LocalServiceRuntime::shared_roster_store_arc`]
+    /// rather than the raw durable `storage_backends.rosters` handle: the
+    /// runtime's handle is what serves every read from the RAM roster
+    /// mirror and write-throughs every mutation into it in the same
+    /// operation. Reaching past it to the durable store directly would
+    /// silently reintroduce a SQLite roster read on this seam.
     pub fn roster_store_arc(&self) -> Arc<dyn boundary::RosterStore + Send + Sync> {
-        boundary_roster_store_view(self.storage_backends.rosters.clone())
+        boundary_roster_store_view(self.service_runtime.shared_roster_store_arc())
     }
 
+    /// Returns the write-through, RAM-backed roster store seam.
+    ///
+    /// See [`Self::roster_store_arc`] for why this must be sourced from the
+    /// runtime rather than `storage_backends.rosters` directly.
     pub fn shared_roster_store_arc(&self) -> Arc<dyn SharedRosterStore + Send + Sync> {
-        self.storage_backends.rosters.clone()
+        self.service_runtime.shared_roster_store_arc()
     }
 
     pub fn peer_config_store(&self) -> Arc<dyn PeerConfigStore + Send + Sync> {

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -172,6 +172,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
         messages: storage.message_store(),
         rosters: storage.roster_store(),
     };
+    let roster_runtime_mirror = storage.roster_runtime_mirror();
     let async_message_store = storage.async_message_store();
     let async_mailbox_reader = storage.async_mailbox_reader();
     let async_message_search_store = storage.async_message_search_store();
@@ -184,6 +185,7 @@ pub fn assemble_runtime(inputs: RuntimeAssemblyInputs) -> Result<RuntimeAssembly
     let service_runtime = LocalServiceRuntime::new_with_delivery_boundaries(
         storage_backends.messages.clone(),
         storage_backends.rosters.clone(),
+        roster_runtime_mirror,
         Arc::clone(&nudge_template_override_store),
         inputs.non_claude_outbound,
     )

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -23,6 +23,7 @@ mod observability;
 mod peer_config_store;
 mod pending_nudge_store;
 mod reader_pool;
+pub mod roster_runtime;
 mod roster_store;
 mod schema_support;
 mod search_reader;
@@ -692,11 +693,18 @@ impl StorageFactory for SqliteStorageFactory {
         if let Some(observer) = &self.timeline_observer {
             observer(backend.diagnostic_timeline());
         }
+        // The write-through roster seam hydrates its RAM mirror here, fail
+        // closed: a durable roster read failure at startup aborts backend
+        // construction instead of silently starting with an incomplete RAM
+        // roster for the process lifetime.
+        let (roster_store, roster_runtime_mirror) =
+            roster_runtime::build_write_through_roster(backend.roster_store())?;
         Ok(StorageHandles::from_parts(StorageHandleParts {
             message_store: backend.message_store(),
             async_message_store: backend.async_message_store(),
             async_mailbox_reader: backend.async_mailbox_reader(),
-            roster_store: backend.roster_store(),
+            roster_store,
+            roster_runtime_mirror,
             nudge_template_override_store: backend.nudge_template_override_store(),
             pending_nudge_store: backend.pending_nudge_store(),
             graft_receiver_endpoint_store: backend.graft_receiver_endpoint_store(),

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -697,14 +697,12 @@ impl StorageFactory for SqliteStorageFactory {
         // closed: a durable roster read failure at startup aborts backend
         // construction instead of silently starting with an incomplete RAM
         // roster for the process lifetime.
-        let (roster_store, roster_runtime_mirror) =
-            roster_runtime::build_write_through_roster(backend.roster_store())?;
+        let roster = roster_runtime::build_write_through_roster(backend.roster_store())?;
         Ok(StorageHandles::from_parts(StorageHandleParts {
             message_store: backend.message_store(),
             async_message_store: backend.async_message_store(),
             async_mailbox_reader: backend.async_mailbox_reader(),
-            roster_store,
-            roster_runtime_mirror,
+            roster,
             nudge_template_override_store: backend.nudge_template_override_store(),
             pending_nudge_store: backend.pending_nudge_store(),
             graft_receiver_endpoint_store: backend.graft_receiver_endpoint_store(),

--- a/crates/atm-storage-rusqlite/src/roster_runtime.rs
+++ b/crates/atm-storage-rusqlite/src/roster_runtime.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, RwLock};
 
 use atm_storage::contract::{RosterMember, RosterMemberEphemeralState, RosterRuntimeMirror};
 use atm_storage::types::{AgentName, TeamName};
-use atm_storage::{AtmError, RosterSnapshot, RosterStore};
+use atm_storage::{AtmError, RosterSnapshot, RosterStore, WriteThroughRosterStore};
 
 /// One team's write-through roster mirror: the durable roster columns plus
 /// the ephemeral per-member state layered on top of them. The whole record
@@ -301,18 +301,17 @@ impl RosterRuntimeMirror for WriteThroughRosterView {
     }
 }
 
-/// Paired write-through [`RosterStore`] handle and [`RosterRuntimeMirror`]
-/// read handle returned by [`build_write_through_roster`], over the same
-/// backing RAM state.
-pub type WriteThroughRosterHandles = (
-    Arc<dyn RosterStore + Send + Sync>,
-    Arc<dyn RosterRuntimeMirror + Send + Sync>,
-);
-
 /// Builds the write-through roster seam from a durable [`RosterStore`]:
 /// hydrates the RAM mirror once (fail-closed), then returns the paired
 /// write-through [`RosterStore`] handle and [`RosterRuntimeMirror`] read
-/// handle over the same backing state.
+/// handle over the same backing state, as one
+/// [`WriteThroughRosterStore`].
+///
+/// This is the only function in the workspace that can produce a
+/// [`WriteThroughRosterStore`]: its constructor requires a value
+/// implementing both `RosterStore` and `RosterRuntimeMirror`, which only
+/// [`WriteThroughRosterView`] does. Composition sites therefore cannot
+/// substitute a raw durable roster store -- it fails to compile.
 ///
 /// Every composition root that assembles a durable roster store --
 /// production or test -- must call this rather than handing the raw durable
@@ -324,11 +323,12 @@ pub type WriteThroughRosterHandles = (
 /// cannot be enumerated or read during hydration.
 pub fn build_write_through_roster(
     durable: Arc<dyn RosterStore + Send + Sync>,
-) -> Result<WriteThroughRosterHandles, AtmError> {
+) -> Result<WriteThroughRosterStore, AtmError> {
     let state = Arc::new(RosterRuntimeState::default());
     hydrate_roster_runtime_from_durable(&durable, &state)?;
-    let view = Arc::new(WriteThroughRosterView { durable, state });
-    Ok((view.clone(), view))
+    Ok(WriteThroughRosterStore::from_write_through_view(Arc::new(
+        WriteThroughRosterView { durable, state },
+    )))
 }
 
 #[cfg(test)]
@@ -336,6 +336,12 @@ mod tests {
     use super::*;
     use atm_storage::contract::{AgentType, RosterHarness, RosterMemberKind};
     use std::sync::Mutex;
+
+    /// Neutral fixture identifiers: the subject under test is the
+    /// write-through seam, not any particular team or agent. Production
+    /// team/agent names must never appear as test fixture data.
+    const TEST_TEAM: &str = "test-team";
+    const TEST_AGENT: &str = "test-agent";
 
     #[derive(Default)]
     struct FakeDurableRoster {
@@ -406,15 +412,15 @@ mod tests {
         let durable = Arc::new(FakeDurableRoster::default());
         durable
             .save_roster(&RosterSnapshot {
-                team_name: TeamName::from_validated("atm-dev"),
-                members: vec![member("atm-dev", "dev-1")],
+                team_name: TeamName::from_validated(TEST_TEAM),
+                members: vec![member(TEST_TEAM, TEST_AGENT)],
                 refreshed_at: None,
             })
             .unwrap();
-        let (_store, mirror) = build_write_through_roster(durable).unwrap();
+        let mirror = build_write_through_roster(durable).unwrap().mirror();
         assert_eq!(
-            mirror.load_team_roster(&TeamName::from_validated("atm-dev")),
-            vec![member("atm-dev", "dev-1")]
+            mirror.load_team_roster(&TeamName::from_validated(TEST_TEAM)),
+            vec![member(TEST_TEAM, TEST_AGENT)]
         );
     }
 
@@ -433,8 +439,8 @@ mod tests {
         let durable = Arc::new(FakeDurableRoster::default());
         durable
             .save_roster(&RosterSnapshot {
-                team_name: TeamName::from_validated("atm-dev"),
-                members: vec![member("atm-dev", "dev-1")],
+                team_name: TeamName::from_validated(TEST_TEAM),
+                members: vec![member(TEST_TEAM, TEST_AGENT)],
                 refreshed_at: None,
             })
             .unwrap();
@@ -448,18 +454,19 @@ mod tests {
     #[test]
     fn save_roster_updates_ram_in_the_same_operation() {
         let durable = Arc::new(FakeDurableRoster::default());
-        let (store, mirror) = build_write_through_roster(durable).unwrap();
-        let team = TeamName::from_validated("atm-dev");
+        let roster = build_write_through_roster(durable).unwrap();
+        let (store, mirror) = (roster.store(), roster.mirror());
+        let team = TeamName::from_validated(TEST_TEAM);
         store
             .save_roster(&RosterSnapshot {
                 team_name: team.clone(),
-                members: vec![member("atm-dev", "dev-1")],
+                members: vec![member(TEST_TEAM, TEST_AGENT)],
                 refreshed_at: None,
             })
             .unwrap();
         assert_eq!(
             mirror.load_team_roster(&team),
-            vec![member("atm-dev", "dev-1")]
+            vec![member(TEST_TEAM, TEST_AGENT)]
         );
     }
 
@@ -468,14 +475,14 @@ mod tests {
         let durable = Arc::new(FakeDurableRoster::default());
         durable
             .save_roster(&RosterSnapshot {
-                team_name: TeamName::from_validated("atm-dev"),
-                members: vec![member("atm-dev", "dev-1")],
+                team_name: TeamName::from_validated(TEST_TEAM),
+                members: vec![member(TEST_TEAM, TEST_AGENT)],
                 refreshed_at: None,
             })
             .unwrap();
-        let (_store, mirror) = build_write_through_roster(durable).unwrap();
-        let team = TeamName::from_validated("atm-dev");
-        let agent = AgentName::from_validated("dev-1");
+        let mirror = build_write_through_roster(durable).unwrap().mirror();
+        let team = TeamName::from_validated(TEST_TEAM);
+        let agent = AgentName::from_validated(TEST_AGENT);
         assert_eq!(
             mirror.ephemeral_state(&team, &agent),
             Some(RosterMemberEphemeralState::default())
@@ -492,26 +499,27 @@ mod tests {
     #[test]
     fn set_ephemeral_state_is_a_no_op_for_an_absent_member() {
         let durable = Arc::new(FakeDurableRoster::default());
-        let (_store, mirror) = build_write_through_roster(durable).unwrap();
-        let team = TeamName::from_validated("atm-dev");
-        let agent = AgentName::from_validated("dev-1");
+        let mirror = build_write_through_roster(durable).unwrap().mirror();
+        let team = TeamName::from_validated(TEST_TEAM);
+        let agent = AgentName::from_validated(TEST_AGENT);
         assert!(!mirror.set_herdr_wake_pending(&team, &agent, true));
     }
 
     #[test]
     fn reload_from_durable_re_derives_ram_and_drops_removed_teams() {
         let durable = Arc::new(FakeDurableRoster::default());
-        let team = TeamName::from_validated("atm-dev");
+        let team = TeamName::from_validated(TEST_TEAM);
         durable
             .save_roster(&RosterSnapshot {
                 team_name: team.clone(),
-                members: vec![member("atm-dev", "dev-1")],
+                members: vec![member(TEST_TEAM, TEST_AGENT)],
                 refreshed_at: None,
             })
             .unwrap();
-        let (store, mirror) =
+        let roster =
             build_write_through_roster(Arc::clone(&durable) as Arc<dyn RosterStore + Send + Sync>)
                 .unwrap();
+        let (store, mirror) = (roster.store(), roster.mirror());
         // Out-of-band durable mutation that bypasses the write-through seam.
         durable
             .save_roster(&RosterSnapshot {
@@ -522,7 +530,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             mirror.load_team_roster(&team),
-            vec![member("atm-dev", "dev-1")]
+            vec![member(TEST_TEAM, TEST_AGENT)]
         );
         store.list_teams().unwrap(); // exercise through the RosterStore facade too
         mirror.reload_from_durable().unwrap();
@@ -532,9 +540,10 @@ mod tests {
     #[test]
     fn reload_from_durable_fails_closed_on_durable_error() {
         let durable = Arc::new(FakeDurableRoster::default());
-        let (_store, mirror) =
+        let mirror =
             build_write_through_roster(Arc::clone(&durable) as Arc<dyn RosterStore + Send + Sync>)
-                .unwrap();
+                .unwrap()
+                .mirror();
         durable
             .fail_list_teams
             .store(true, std::sync::atomic::Ordering::SeqCst);

--- a/crates/atm-storage-rusqlite/src/roster_runtime.rs
+++ b/crates/atm-storage-rusqlite/src/roster_runtime.rs
@@ -1,0 +1,543 @@
+//! Write-through, RAM-backed roster mirror.
+//!
+//! This module owns the concrete [`RosterStore`] decorator that keeps a
+//! runtime-owned in-memory roster mirror synchronized with every durable
+//! roster write, plus the [`RosterRuntimeMirror`] handle every roster
+//! consumer reads through after startup hydration.
+//!
+//! Design ruling: every roster durable write updates RAM in the same
+//! operation; ephemeral per-member state (e.g. Herdr wake-pending) lives
+//! only in RAM and mutates on observed state changes; every roster consumer
+//! reads RAM, never the durable store, outside of startup hydration or an
+//! explicit control-plane reload. A read racing a concurrent mutation is
+//! intentionally not ordered beyond memory safety.
+//!
+//! This decorator is backend-agnostic (it wraps any `Arc<dyn RosterStore>`),
+//! but boundary policy (`boundaries/atm-storage-rusqlite/roster-store-sqlite.toml`)
+//! authorizes this crate as the sole implementation site for the write-through
+//! `RosterStore` impl; construct it only through
+//! [`build_write_through_roster`], which every composition root (including
+//! test-support callers) must use instead of hand-rolling an equivalent type.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use atm_storage::contract::{RosterMember, RosterMemberEphemeralState, RosterRuntimeMirror};
+use atm_storage::types::{AgentName, TeamName};
+use atm_storage::{AtmError, RosterSnapshot, RosterStore};
+
+/// One team's write-through roster mirror: the durable roster columns plus
+/// the ephemeral per-member state layered on top of them. The whole record
+/// is replaced as one `Arc` on every mutation, so readers observe either the
+/// entries-before or the entries-after a write, never a torn mix of the two.
+#[derive(Clone, Debug, Default)]
+struct TeamRosterRecord {
+    entries: Arc<[RosterMember]>,
+    ephemeral: Arc<BTreeMap<AgentName, RosterMemberEphemeralState>>,
+}
+
+impl TeamRosterRecord {
+    fn from_durable(entries: Vec<RosterMember>) -> Self {
+        let ephemeral = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.agent_name.clone(),
+                    RosterMemberEphemeralState::default(),
+                )
+            })
+            .collect();
+        Self {
+            entries: entries.into(),
+            ephemeral: Arc::new(ephemeral),
+        }
+    }
+
+    /// Builds the record a durable roster replacement produces: retained
+    /// members keep their ephemeral state, new members start with the
+    /// default (empty) ephemeral state, and removed members' ephemeral state
+    /// is dropped with them.
+    fn replaced_with(&self, members: &[RosterMember]) -> Self {
+        let ephemeral = members
+            .iter()
+            .map(|member| {
+                let state = self
+                    .ephemeral
+                    .get(&member.agent_name)
+                    .copied()
+                    .unwrap_or_default();
+                (member.agent_name.clone(), state)
+            })
+            .collect();
+        Self {
+            entries: members.to_vec().into(),
+            ephemeral: Arc::new(ephemeral),
+        }
+    }
+}
+
+/// Recovers from a poisoned lock by taking the guarded value as-is.
+///
+/// A panic while a roster lock is held can only happen from a bug in this
+/// module's own (infallible, non-panicking-by-design) critical sections; the
+/// data behind the lock is never left semantically inconsistent by a
+/// panic mid-mutation here, because every mutation builds its replacement
+/// value before installing it. Treating poison as recoverable keeps one
+/// caller's panic from wedging every other roster reader/writer for the rest
+/// of the process lifetime.
+fn recover_poison<T>(poisoned: std::sync::PoisonError<T>) -> T {
+    poisoned.into_inner()
+}
+
+/// Runtime-owned, write-through in-memory roster mirror: one record per
+/// team, holding durable roster columns plus the ephemeral state columns
+/// that never appear in the database.
+///
+/// Locking is two-level and per-team: the outer map lock is held only long
+/// enough to look up (or insert/remove) one team's record `Arc`; the actual
+/// mutation happens on that team's own inner lock. An ephemeral update, or a
+/// durable-write RAM sync, for one team therefore never blocks a read or
+/// mutation for any other team.
+#[derive(Default)]
+struct RosterRuntimeState {
+    teams: RwLock<BTreeMap<TeamName, Arc<RwLock<TeamRosterRecord>>>>,
+}
+
+impl RosterRuntimeState {
+    fn team_lock(&self, team: &TeamName) -> Option<Arc<RwLock<TeamRosterRecord>>> {
+        let teams = self.teams.read().unwrap_or_else(recover_poison);
+        teams.get(team).cloned()
+    }
+
+    fn team_lock_or_insert(&self, team: &TeamName) -> Arc<RwLock<TeamRosterRecord>> {
+        if let Some(existing) = self.team_lock(team) {
+            return existing;
+        }
+        let mut teams = self.teams.write().unwrap_or_else(recover_poison);
+        Arc::clone(
+            teams
+                .entry(team.clone())
+                .or_insert_with(|| Arc::new(RwLock::new(TeamRosterRecord::default()))),
+        )
+    }
+
+    /// Seeds one team's record straight from a durable read. Used only at
+    /// startup hydration and at an explicit reload re-hydration; never on a
+    /// per-request or per-tick path.
+    fn hydrate(&self, team: &TeamName, entries: Vec<RosterMember>) {
+        let lock = self.team_lock_or_insert(team);
+        let mut record = lock.write().unwrap_or_else(recover_poison);
+        *record = TeamRosterRecord::from_durable(entries);
+    }
+
+    /// Discards every team's RAM state. Used only immediately before a
+    /// reload re-hydration so a team removed durably out-of-band cannot
+    /// survive in RAM past the reload.
+    fn clear(&self) {
+        let mut teams = self.teams.write().unwrap_or_else(recover_poison);
+        teams.clear();
+    }
+
+    /// Replaces one team's *durable* roster columns in RAM in the same
+    /// operation as the durable write that produced `members`. An empty
+    /// roster drops the team entirely, mirroring the durable store's
+    /// `list_teams` semantics (a team with zero roster rows is not
+    /// enumerable).
+    fn replace_roster(&self, team: &TeamName, members: &[RosterMember]) {
+        if members.is_empty() {
+            let mut teams = self.teams.write().unwrap_or_else(recover_poison);
+            teams.remove(team);
+            return;
+        }
+        let lock = self.team_lock_or_insert(team);
+        let mut record = lock.write().unwrap_or_else(recover_poison);
+        *record = record.replaced_with(members);
+    }
+
+    fn load_team_roster(&self, team: &TeamName) -> Vec<RosterMember> {
+        self.team_lock(team)
+            .map(|lock| lock.read().unwrap_or_else(recover_poison).entries.to_vec())
+            .unwrap_or_default()
+    }
+
+    fn load_roster_member(&self, team: &TeamName, agent: &AgentName) -> Option<RosterMember> {
+        let lock = self.team_lock(team)?;
+        let record = lock.read().unwrap_or_else(recover_poison);
+        record
+            .entries
+            .iter()
+            .find(|member| &member.agent_name == agent)
+            .cloned()
+    }
+
+    fn list_teams(&self) -> Vec<TeamName> {
+        let teams = self.teams.read().unwrap_or_else(recover_poison);
+        teams.keys().cloned().collect()
+    }
+
+    fn ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Option<RosterMemberEphemeralState> {
+        let lock = self.team_lock(team)?;
+        let record = lock.read().unwrap_or_else(recover_poison);
+        record.ephemeral.get(agent).copied()
+    }
+
+    /// Mutates one member's ephemeral state in RAM only. Returns `false`
+    /// without effect when the team or member is not present in the current
+    /// snapshot; there is nothing durable to attach ephemeral state to.
+    fn set_ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        mutate: impl FnOnce(&mut RosterMemberEphemeralState),
+    ) -> bool {
+        let Some(lock) = self.team_lock(team) else {
+            return false;
+        };
+        let mut record = lock.write().unwrap_or_else(recover_poison);
+        if !record
+            .entries
+            .iter()
+            .any(|member| &member.agent_name == agent)
+        {
+            return false;
+        }
+        let mut ephemeral = (*record.ephemeral).clone();
+        let state = ephemeral.entry(agent.clone()).or_default();
+        mutate(state);
+        record.ephemeral = Arc::new(ephemeral);
+        true
+    }
+}
+
+/// Hydrates the RAM roster mirror from the durable roster store.
+///
+/// Fail-closed: a durable read failure aborts hydration and returns an
+/// error to the caller instead of leaving RAM silently short of a team for
+/// the process lifetime. A partially populated `state` on error is
+/// discarded by the caller (startup construction fails outright; an
+/// explicit reload clears RAM before retrying hydration, see
+/// [`WriteThroughRosterView::reload_from_durable`]).
+fn hydrate_roster_runtime_from_durable(
+    durable: &Arc<dyn RosterStore + Send + Sync>,
+    state: &RosterRuntimeState,
+) -> Result<(), AtmError> {
+    let teams = durable.list_teams()?;
+    for team in teams {
+        let snapshot = durable.load_roster(&team)?;
+        state.hydrate(&team, snapshot.members);
+    }
+    Ok(())
+}
+
+/// The single write-through seam for the durable roster store: every write
+/// updates the runtime-owned RAM mirror in the same operation, and every
+/// read is served from RAM. Construct through [`build_write_through_roster`].
+#[derive(Clone)]
+struct WriteThroughRosterView {
+    durable: Arc<dyn RosterStore + Send + Sync>,
+    state: Arc<RosterRuntimeState>,
+}
+
+impl atm_storage::contract::sealed::Sealed for WriteThroughRosterView {}
+
+impl RosterStore for WriteThroughRosterView {
+    fn load_roster(&self, team: &TeamName) -> Result<RosterSnapshot, AtmError> {
+        Ok(RosterSnapshot {
+            team_name: team.clone(),
+            members: self.state.load_team_roster(team),
+            refreshed_at: None,
+        })
+    }
+
+    fn save_roster(&self, roster: &RosterSnapshot) -> Result<(), AtmError> {
+        self.durable.save_roster(roster)?;
+        self.state
+            .replace_roster(&roster.team_name, &roster.members);
+        Ok(())
+    }
+
+    fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
+        Ok(self.state.list_teams())
+    }
+}
+
+impl RosterRuntimeMirror for WriteThroughRosterView {
+    fn load_team_roster(&self, team: &TeamName) -> Vec<RosterMember> {
+        self.state.load_team_roster(team)
+    }
+
+    fn load_roster_member(&self, team: &TeamName, agent: &AgentName) -> Option<RosterMember> {
+        self.state.load_roster_member(team, agent)
+    }
+
+    fn list_teams(&self) -> Vec<TeamName> {
+        self.state.list_teams()
+    }
+
+    fn ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Option<RosterMemberEphemeralState> {
+        self.state.ephemeral_state(team, agent)
+    }
+
+    fn set_herdr_wake_pending(&self, team: &TeamName, agent: &AgentName, pending: bool) -> bool {
+        self.state.set_ephemeral_state(team, agent, |ephemeral| {
+            ephemeral.herdr_wake_pending = pending
+        })
+    }
+
+    fn reload_from_durable(&self) -> Result<(), AtmError> {
+        // Fail-closed like startup hydration: clear first, so a caller that
+        // ignores an error is never left with a stale-but-plausible mix of
+        // pre-reload and partially-reloaded state.
+        self.state.clear();
+        hydrate_roster_runtime_from_durable(&self.durable, &self.state)
+    }
+}
+
+/// Paired write-through [`RosterStore`] handle and [`RosterRuntimeMirror`]
+/// read handle returned by [`build_write_through_roster`], over the same
+/// backing RAM state.
+pub type WriteThroughRosterHandles = (
+    Arc<dyn RosterStore + Send + Sync>,
+    Arc<dyn RosterRuntimeMirror + Send + Sync>,
+);
+
+/// Builds the write-through roster seam from a durable [`RosterStore`]:
+/// hydrates the RAM mirror once (fail-closed), then returns the paired
+/// write-through [`RosterStore`] handle and [`RosterRuntimeMirror`] read
+/// handle over the same backing state.
+///
+/// Every composition root that assembles a durable roster store --
+/// production or test -- must call this rather than handing the raw durable
+/// store to a roster consumer directly, so every roster read after startup
+/// comes from RAM.
+///
+/// # Errors
+/// Returns an error, and installs nothing, if the durable roster store
+/// cannot be enumerated or read during hydration.
+pub fn build_write_through_roster(
+    durable: Arc<dyn RosterStore + Send + Sync>,
+) -> Result<WriteThroughRosterHandles, AtmError> {
+    let state = Arc::new(RosterRuntimeState::default());
+    hydrate_roster_runtime_from_durable(&durable, &state)?;
+    let view = Arc::new(WriteThroughRosterView { durable, state });
+    Ok((view.clone(), view))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atm_storage::contract::{AgentType, RosterHarness, RosterMemberKind};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeDurableRoster {
+        rosters: Mutex<BTreeMap<TeamName, Vec<RosterMember>>>,
+        fail_list_teams: std::sync::atomic::AtomicBool,
+        fail_load_roster: std::sync::atomic::AtomicBool,
+    }
+
+    impl atm_storage::contract::sealed::Sealed for FakeDurableRoster {}
+
+    impl RosterStore for FakeDurableRoster {
+        fn load_roster(&self, team: &TeamName) -> Result<RosterSnapshot, AtmError> {
+            if self
+                .fail_load_roster
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(AtmError::validation(
+                    "simulated durable roster read failure",
+                ));
+            }
+            let rosters = self.rosters.lock().unwrap();
+            Ok(RosterSnapshot {
+                team_name: team.clone(),
+                members: rosters.get(team).cloned().unwrap_or_default(),
+                refreshed_at: None,
+            })
+        }
+
+        fn save_roster(&self, roster: &RosterSnapshot) -> Result<(), AtmError> {
+            let mut rosters = self.rosters.lock().unwrap();
+            if roster.members.is_empty() {
+                rosters.remove(&roster.team_name);
+            } else {
+                rosters.insert(roster.team_name.clone(), roster.members.clone());
+            }
+            Ok(())
+        }
+
+        fn list_teams(&self) -> Result<Vec<TeamName>, AtmError> {
+            if self
+                .fail_list_teams
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(AtmError::validation(
+                    "simulated durable roster list failure",
+                ));
+            }
+            let rosters = self.rosters.lock().unwrap();
+            Ok(rosters.keys().cloned().collect())
+        }
+    }
+
+    fn member(team: &str, agent: &str) -> RosterMember {
+        RosterMember {
+            team_name: TeamName::from_validated(team.to_string()),
+            agent_name: AgentName::from_validated(agent.to_string()),
+            member_kind: RosterMemberKind::Permanent,
+            harness: RosterHarness::ClaudeCode,
+            agent_type: AgentType::default(),
+            model: Default::default(),
+            recipient_pane_id: None,
+            metadata_json: Default::default(),
+        }
+    }
+
+    #[test]
+    fn hydrates_existing_durable_teams_at_construction() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        durable
+            .save_roster(&RosterSnapshot {
+                team_name: TeamName::from_validated("atm-dev"),
+                members: vec![member("atm-dev", "dev-1")],
+                refreshed_at: None,
+            })
+            .unwrap();
+        let (_store, mirror) = build_write_through_roster(durable).unwrap();
+        assert_eq!(
+            mirror.load_team_roster(&TeamName::from_validated("atm-dev")),
+            vec![member("atm-dev", "dev-1")]
+        );
+    }
+
+    #[test]
+    fn construction_fails_closed_when_durable_list_teams_errors() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        durable
+            .fail_list_teams
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let result = build_write_through_roster(durable);
+        assert!(result.is_err(), "startup hydration must fail closed");
+    }
+
+    #[test]
+    fn construction_fails_closed_when_durable_load_roster_errors() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        durable
+            .save_roster(&RosterSnapshot {
+                team_name: TeamName::from_validated("atm-dev"),
+                members: vec![member("atm-dev", "dev-1")],
+                refreshed_at: None,
+            })
+            .unwrap();
+        durable
+            .fail_load_roster
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let result = build_write_through_roster(durable);
+        assert!(result.is_err(), "startup hydration must fail closed");
+    }
+
+    #[test]
+    fn save_roster_updates_ram_in_the_same_operation() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        let (store, mirror) = build_write_through_roster(durable).unwrap();
+        let team = TeamName::from_validated("atm-dev");
+        store
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![member("atm-dev", "dev-1")],
+                refreshed_at: None,
+            })
+            .unwrap();
+        assert_eq!(
+            mirror.load_team_roster(&team),
+            vec![member("atm-dev", "dev-1")]
+        );
+    }
+
+    #[test]
+    fn ephemeral_state_mutates_independently_of_durable_columns() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        durable
+            .save_roster(&RosterSnapshot {
+                team_name: TeamName::from_validated("atm-dev"),
+                members: vec![member("atm-dev", "dev-1")],
+                refreshed_at: None,
+            })
+            .unwrap();
+        let (_store, mirror) = build_write_through_roster(durable).unwrap();
+        let team = TeamName::from_validated("atm-dev");
+        let agent = AgentName::from_validated("dev-1");
+        assert_eq!(
+            mirror.ephemeral_state(&team, &agent),
+            Some(RosterMemberEphemeralState::default())
+        );
+        assert!(mirror.set_herdr_wake_pending(&team, &agent, true));
+        assert_eq!(
+            mirror.ephemeral_state(&team, &agent),
+            Some(RosterMemberEphemeralState {
+                herdr_wake_pending: true
+            })
+        );
+    }
+
+    #[test]
+    fn set_ephemeral_state_is_a_no_op_for_an_absent_member() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        let (_store, mirror) = build_write_through_roster(durable).unwrap();
+        let team = TeamName::from_validated("atm-dev");
+        let agent = AgentName::from_validated("dev-1");
+        assert!(!mirror.set_herdr_wake_pending(&team, &agent, true));
+    }
+
+    #[test]
+    fn reload_from_durable_re_derives_ram_and_drops_removed_teams() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        let team = TeamName::from_validated("atm-dev");
+        durable
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: vec![member("atm-dev", "dev-1")],
+                refreshed_at: None,
+            })
+            .unwrap();
+        let (store, mirror) =
+            build_write_through_roster(Arc::clone(&durable) as Arc<dyn RosterStore + Send + Sync>)
+                .unwrap();
+        // Out-of-band durable mutation that bypasses the write-through seam.
+        durable
+            .save_roster(&RosterSnapshot {
+                team_name: team.clone(),
+                members: Vec::new(),
+                refreshed_at: None,
+            })
+            .unwrap();
+        assert_eq!(
+            mirror.load_team_roster(&team),
+            vec![member("atm-dev", "dev-1")]
+        );
+        store.list_teams().unwrap(); // exercise through the RosterStore facade too
+        mirror.reload_from_durable().unwrap();
+        assert!(mirror.load_team_roster(&team).is_empty());
+    }
+
+    #[test]
+    fn reload_from_durable_fails_closed_on_durable_error() {
+        let durable = Arc::new(FakeDurableRoster::default());
+        let (_store, mirror) =
+            build_write_through_roster(Arc::clone(&durable) as Arc<dyn RosterStore + Send + Sync>)
+                .unwrap();
+        durable
+            .fail_list_teams
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(mirror.reload_from_durable().is_err());
+    }
+}

--- a/crates/atm-storage-rusqlite/tests/roster_write_through_production_path.rs
+++ b/crates/atm-storage-rusqlite/tests/roster_write_through_production_path.rs
@@ -1,0 +1,153 @@
+//! Production-path proof for the write-through RAM roster seam
+//! (`BOUNDARY-RosterStore-Sqlite-WriteThrough`, PR #1240 finding AW-RAM-I4).
+//!
+//! The unit tests in `roster_runtime` exercise the decorator over an
+//! in-memory fake. This suite instead opens storage the way production does
+//! -- `SqliteStorageFactory::open()` against a real temp database -- and
+//! proves that the handles it hands back actually serve roster reads from
+//! RAM rather than from SQLite.
+
+use std::sync::Arc;
+
+use atm_storage::StorageFactory;
+use atm_storage::contract::{
+    AgentType, RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot,
+};
+use atm_storage::types::{AgentName, TeamName};
+use atm_storage_rusqlite::{SqliteStorageBackend, SqliteStorageFactory};
+
+const TEST_TEAM: &str = "test-team";
+const TEST_AGENT: &str = "test-agent";
+
+fn member(team: &str, agent: &str) -> RosterMember {
+    RosterMember {
+        team_name: TeamName::from_validated(team.to_string()),
+        agent_name: AgentName::from_validated(agent.to_string()),
+        member_kind: RosterMemberKind::Permanent,
+        harness: RosterHarness::ClaudeCode,
+        agent_type: AgentType::default(),
+        model: Default::default(),
+        recipient_pane_id: None,
+        metadata_json: Default::default(),
+    }
+}
+
+fn snapshot(team: &TeamName, members: Vec<RosterMember>) -> RosterSnapshot {
+    RosterSnapshot {
+        team_name: team.clone(),
+        members,
+        refreshed_at: None,
+    }
+}
+
+/// The production composition root must hand back a roster store whose reads
+/// are served from the RAM mirror, and a mirror that observes every durable
+/// write in the same operation.
+#[test]
+fn production_factory_open_serves_roster_reads_from_ram() {
+    let root = tempfile::tempdir().expect("temp durable state root");
+    let handles = SqliteStorageFactory::host_scoped()
+        .open(root.path())
+        .expect("production storage open");
+    let team = TeamName::from_validated(TEST_TEAM.to_string());
+
+    // A durable write through the production handle updates RAM in the same
+    // operation: the mirror observes it with no reload.
+    handles
+        .roster_store()
+        .save_roster(&snapshot(&team, vec![member(TEST_TEAM, TEST_AGENT)]))
+        .expect("durable roster write");
+    assert_eq!(
+        handles.roster_runtime_mirror().load_team_roster(&team),
+        vec![member(TEST_TEAM, TEST_AGENT)],
+        "the RAM mirror must observe a durable write without a reload"
+    );
+    assert_eq!(
+        handles.roster_runtime_mirror().list_teams(),
+        vec![team.clone()]
+    );
+
+    // Ephemeral (RAM-only) state exists for the member, which is only
+    // possible if the production handle is the write-through decorator and
+    // not the raw durable store.
+    let agent = AgentName::from_validated(TEST_AGENT.to_string());
+    assert!(
+        handles
+            .roster_runtime_mirror()
+            .set_herdr_wake_pending(&team, &agent, true),
+        "ephemeral RAM state must exist for a member written through the seam"
+    );
+
+    // Now mutate the database out-of-band, behind the mirror's back, through
+    // a second raw durable backend on the same file. If production roster
+    // reads went to SQLite, they would pick this up; because they are served
+    // from RAM, they must not.
+    let out_of_band = SqliteStorageBackend::new(root.path().join("mail.db"))
+        .expect("second raw durable backend on the same database file");
+    Arc::clone(&out_of_band.roster_store())
+        .save_roster(&snapshot(&team, Vec::new()))
+        .expect("out-of-band durable roster write");
+    assert_eq!(
+        out_of_band
+            .roster_store()
+            .load_roster(&team)
+            .unwrap()
+            .members,
+        Vec::new(),
+        "sanity: the out-of-band durable write really landed in SQLite"
+    );
+
+    assert_eq!(
+        handles
+            .roster_store()
+            .load_roster(&team)
+            .expect("roster read")
+            .members,
+        vec![member(TEST_TEAM, TEST_AGENT)],
+        "a production roster read must come from RAM, not from SQLite"
+    );
+    assert_eq!(
+        handles.roster_runtime_mirror().load_team_roster(&team),
+        vec![member(TEST_TEAM, TEST_AGENT)]
+    );
+
+    // The explicit control-plane reload is the only thing that re-derives RAM
+    // from durable state.
+    handles
+        .roster_runtime_mirror()
+        .reload_from_durable()
+        .expect("control-plane reload");
+    assert!(
+        handles
+            .roster_runtime_mirror()
+            .load_team_roster(&team)
+            .is_empty(),
+        "an explicit reload must re-derive RAM from the durable store"
+    );
+}
+
+/// Startup hydration on the production path populates RAM from durable state
+/// before any read is served.
+#[test]
+fn production_factory_open_hydrates_ram_from_durable_state() {
+    let root = tempfile::tempdir().expect("temp durable state root");
+    let team = TeamName::from_validated(TEST_TEAM.to_string());
+    {
+        let handles = SqliteStorageFactory::host_scoped()
+            .open(root.path())
+            .expect("production storage open");
+        handles
+            .roster_store()
+            .save_roster(&snapshot(&team, vec![member(TEST_TEAM, TEST_AGENT)]))
+            .expect("durable roster write");
+    }
+
+    let reopened = SqliteStorageFactory::host_scoped()
+        .open(root.path())
+        .expect("production storage reopen");
+    assert_eq!(
+        reopened.roster_runtime_mirror().load_team_roster(&team),
+        vec![member(TEST_TEAM, TEST_AGENT)],
+        "a fresh production open must hydrate RAM from the durable roster"
+    );
+}

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -755,6 +755,59 @@ pub trait RosterStore: sealed::Sealed + Send + Sync {
     fn list_teams(&self) -> Result<Vec<TeamName>, AtmError>;
 }
 
+/// Ephemeral per-member roster state that never round-trips through the
+/// durable roster store. Every field here is mutated in RAM only, on an
+/// observed state change; nothing here is ever read from or written to a
+/// durable backend.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RosterMemberEphemeralState {
+    /// Set/cleared by Herdr queue-wake bookkeeping when a member's steer
+    /// target is pending a wake attempt.
+    pub herdr_wake_pending: bool,
+}
+
+/// Cross-crate seam for the runtime-owned, write-through in-memory roster
+/// mirror. Every roster consumer reads through this handle after startup
+/// hydration; a durable roster write updates the backing mirror in the same
+/// operation through the paired [`RosterStore`] write-through implementation.
+///
+/// The concrete write-through implementation (the [`RosterStore`] impl and
+/// the state backing both this trait and that impl) is authorized only at
+/// the `atm-storage-rusqlite` composition boundary (see
+/// `boundaries/atm-storage-rusqlite/roster-store-sqlite.toml`). This trait
+/// exists so `atm-core` and other consumer crates can hold and call the
+/// mirror without depending on that concrete backend crate.
+pub trait RosterRuntimeMirror: Send + Sync {
+    /// Reads one team's roster from RAM. Never issues a durable read.
+    fn load_team_roster(&self, team: &TeamName) -> Vec<RosterMember>;
+    /// Reads one roster member from RAM. Never issues a durable read.
+    fn load_roster_member(&self, team: &TeamName, agent: &AgentName) -> Option<RosterMember>;
+    /// Enumerates every team currently held in RAM. Never issues a durable read.
+    fn list_teams(&self) -> Vec<TeamName>;
+    /// Reads one member's ephemeral (non-durable) roster state from RAM.
+    fn ephemeral_state(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Option<RosterMemberEphemeralState>;
+    /// Sets one member's Herdr wake-pending ephemeral flag in RAM only.
+    /// Returns `false` without effect when the member is not present in the
+    /// current roster snapshot.
+    fn set_herdr_wake_pending(&self, team: &TeamName, agent: &AgentName, pending: bool) -> bool;
+    /// Re-hydrates the RAM roster mirror from the durable roster store.
+    ///
+    /// This is *not* the write-through synchronization mechanism -- every
+    /// durable roster write already updates RAM in the same operation. This
+    /// exists only for an authenticated control-plane reload boundary that
+    /// wants to re-derive RAM from durable state (e.g. after an out-of-band
+    /// durable migration).
+    ///
+    /// # Errors
+    /// Returns an error if the durable roster store cannot be read; RAM is
+    /// left unchanged on failure.
+    fn reload_from_durable(&self) -> Result<(), AtmError>;
+}
+
 /// Registration payload for one loopback graft receiver lease.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GraftReceiverRegistration {

--- a/crates/atm-storage/src/factory.rs
+++ b/crates/atm-storage/src/factory.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use crate::{
     AsyncMailboxReader, AsyncMessageSearchStore, AsyncMessageStore, AtmError,
     DiagnosticTimelineStore, GraftReceiverEndpointStore, MessageSearchStore, MessageStore,
-    NudgeTemplateOverrideStore, PeerConfigStore, PendingNudgeStore, RosterStore,
-    TemplateCatalogStore,
+    NudgeTemplateOverrideStore, PeerConfigStore, PendingNudgeStore, RosterRuntimeMirror,
+    RosterStore, TemplateCatalogStore,
 };
 
 /// Effective capacity settings for one reader lane, selected by the backend
@@ -32,6 +32,10 @@ pub struct StorageHandles {
     async_message_store: Arc<dyn AsyncMessageStore + Send + Sync>,
     async_mailbox_reader: Arc<dyn AsyncMailboxReader + Send + Sync>,
     roster_store: Arc<dyn RosterStore + Send + Sync>,
+    /// Runtime-owned, write-through RAM roster mirror paired with
+    /// `roster_store`. Every roster consumer reads through this handle
+    /// after startup hydration; see [`RosterRuntimeMirror`].
+    roster_runtime_mirror: Arc<dyn RosterRuntimeMirror + Send + Sync>,
     nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     pending_nudge_store: Arc<dyn PendingNudgeStore + Send + Sync>,
     graft_receiver_endpoint_store: Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
@@ -54,6 +58,9 @@ pub struct StorageHandleParts {
     pub async_message_store: Arc<dyn AsyncMessageStore + Send + Sync>,
     pub async_mailbox_reader: Arc<dyn AsyncMailboxReader + Send + Sync>,
     pub roster_store: Arc<dyn RosterStore + Send + Sync>,
+    /// Runtime-owned, write-through RAM roster mirror paired with
+    /// `roster_store`. See [`RosterRuntimeMirror`].
+    pub roster_runtime_mirror: Arc<dyn RosterRuntimeMirror + Send + Sync>,
     pub nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     pub pending_nudge_store: Arc<dyn PendingNudgeStore + Send + Sync>,
     pub graft_receiver_endpoint_store: Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
@@ -71,6 +78,7 @@ impl fmt::Debug for StorageHandles {
             .field("message_store", &"dyn MessageStore")
             .field("async_message_store", &"dyn AsyncMessageStore")
             .field("roster_store", &"dyn RosterStore")
+            .field("roster_runtime_mirror", &"dyn RosterRuntimeMirror")
             .field(
                 "nudge_template_override_store",
                 &"dyn NudgeTemplateOverrideStore",
@@ -96,6 +104,7 @@ impl StorageHandles {
             async_message_store: parts.async_message_store,
             async_mailbox_reader: parts.async_mailbox_reader,
             roster_store: parts.roster_store,
+            roster_runtime_mirror: parts.roster_runtime_mirror,
             nudge_template_override_store: parts.nudge_template_override_store,
             pending_nudge_store: parts.pending_nudge_store,
             graft_receiver_endpoint_store: parts.graft_receiver_endpoint_store,
@@ -124,6 +133,13 @@ impl StorageHandles {
 
     pub fn roster_store(&self) -> Arc<dyn RosterStore + Send + Sync> {
         Arc::clone(&self.roster_store)
+    }
+
+    /// Returns the write-through RAM roster mirror paired with
+    /// [`Self::roster_store`]. Every roster consumer reads through this
+    /// handle after startup hydration.
+    pub fn roster_runtime_mirror(&self) -> Arc<dyn RosterRuntimeMirror + Send + Sync> {
+        Arc::clone(&self.roster_runtime_mirror)
     }
 
     pub fn nudge_template_override_store(

--- a/crates/atm-storage/src/factory.rs
+++ b/crates/atm-storage/src/factory.rs
@@ -25,6 +25,67 @@ pub struct EffectiveReaderLanes {
     pub search: EffectiveReaderLane,
 }
 
+/// A roster [`RosterStore`] handle proven, *by type*, to be the
+/// write-through RAM-mirroring seam -- paired with the
+/// [`RosterRuntimeMirror`] read handle over the same backing state.
+///
+/// # Why this is a newtype and not two plain fields
+///
+/// [`StorageHandleParts`] used to take `roster_store` and
+/// `roster_runtime_mirror` as two independent `Arc<dyn ...>` fields. Nothing
+/// stopped a future edit from passing a backend's *raw durable* roster store
+/// (e.g. `backend.roster_store()`) as `roster_store` while pairing it with an
+/// unrelated mirror: every roster read would then silently go back to hitting
+/// the database, defeating the RAM-roster design ruling, and no boundary lint
+/// would notice because the bypass is intra-crate.
+///
+/// This type closes that vector at the type level. Its only constructor,
+/// [`WriteThroughRosterStore::from_write_through_view`], requires a *single*
+/// value that implements **both** [`RosterStore`] and [`RosterRuntimeMirror`]
+/// -- i.e. a store that serves its own reads from its own RAM mirror. A
+/// durable-backed roster store implements only [`RosterStore`], and an
+/// `Arc<dyn RosterStore + Send + Sync>` cannot coerce into the bound at all,
+/// so the bypass is a compile error rather than a silent regression.
+#[derive(Clone)]
+pub struct WriteThroughRosterStore {
+    store: Arc<dyn RosterStore + Send + Sync>,
+    mirror: Arc<dyn RosterRuntimeMirror + Send + Sync>,
+}
+
+impl fmt::Debug for WriteThroughRosterStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriteThroughRosterStore").finish()
+    }
+}
+
+impl WriteThroughRosterStore {
+    /// The sole constructor: adopts one write-through view as both the
+    /// durable-write [`RosterStore`] handle and the [`RosterRuntimeMirror`]
+    /// read handle.
+    ///
+    /// The `V: RosterStore + RosterRuntimeMirror` bound is the enforcement
+    /// mechanism -- a raw durable roster store cannot satisfy it.
+    pub fn from_write_through_view<V>(view: Arc<V>) -> Self
+    where
+        V: RosterStore + RosterRuntimeMirror + 'static,
+    {
+        Self {
+            store: Arc::clone(&view) as Arc<dyn RosterStore + Send + Sync>,
+            mirror: view as Arc<dyn RosterRuntimeMirror + Send + Sync>,
+        }
+    }
+
+    /// The write-through durable-write handle.
+    pub fn store(&self) -> Arc<dyn RosterStore + Send + Sync> {
+        Arc::clone(&self.store)
+    }
+
+    /// The RAM mirror read handle paired with [`Self::store`].
+    pub fn mirror(&self) -> Arc<dyn RosterRuntimeMirror + Send + Sync> {
+        Arc::clone(&self.mirror)
+    }
+}
+
 /// Backend-neutral handles returned by the selected durable storage backend.
 #[derive(Clone)]
 pub struct StorageHandles {
@@ -57,10 +118,12 @@ pub struct StorageHandleParts {
     pub message_store: Arc<dyn MessageStore + Send + Sync>,
     pub async_message_store: Arc<dyn AsyncMessageStore + Send + Sync>,
     pub async_mailbox_reader: Arc<dyn AsyncMailboxReader + Send + Sync>,
-    pub roster_store: Arc<dyn RosterStore + Send + Sync>,
-    /// Runtime-owned, write-through RAM roster mirror paired with
-    /// `roster_store`. See [`RosterRuntimeMirror`].
-    pub roster_runtime_mirror: Arc<dyn RosterRuntimeMirror + Send + Sync>,
+    /// The write-through roster seam: the durable-write [`RosterStore`]
+    /// handle and its paired RAM [`RosterRuntimeMirror`], carried as one
+    /// value that only [`WriteThroughRosterStore::from_write_through_view`]
+    /// can construct. Handing a raw durable roster store here does not
+    /// compile.
+    pub roster: WriteThroughRosterStore,
     pub nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     pub pending_nudge_store: Arc<dyn PendingNudgeStore + Send + Sync>,
     pub graft_receiver_endpoint_store: Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
@@ -103,8 +166,8 @@ impl StorageHandles {
             message_store: parts.message_store,
             async_message_store: parts.async_message_store,
             async_mailbox_reader: parts.async_mailbox_reader,
-            roster_store: parts.roster_store,
-            roster_runtime_mirror: parts.roster_runtime_mirror,
+            roster_store: parts.roster.store(),
+            roster_runtime_mirror: parts.roster.mirror(),
             nudge_template_override_store: parts.nudge_template_override_store,
             pending_nudge_store: parts.pending_nudge_store,
             graft_receiver_endpoint_store: parts.graft_receiver_endpoint_store,

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -39,9 +39,10 @@ pub use contract::{
     LocalCertificate, MAX_NUDGE_ATTEMPTS, MailMessageState, MailboxBucketCounts, MailboxScope,
     Message, MessageFingerprint, MessageKey, MessageQuery, MessageReceivedEvent, MessageStore,
     NudgeClaim, NudgeTemplateOverrideStore, PeerConfigStore, PendingNudgeStore, PrivateKeyRef,
-    ReadDeadline, ReadLaneError, RosterChangedEvent, RosterHarness, RosterMember, RosterMemberKind,
-    RosterSnapshot, RosterStore, StorageNotifier, TaskState, TeamNudgeTemplateOverrideMode,
-    TeamNudgeTemplateOverrideRow, TrustedPeer, derive_ack_requirement,
+    ReadDeadline, ReadLaneError, RosterChangedEvent, RosterHarness, RosterMember,
+    RosterMemberEphemeralState, RosterMemberKind, RosterRuntimeMirror, RosterSnapshot, RosterStore,
+    StorageNotifier, TaskState, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
+    TrustedPeer, derive_ack_requirement,
 };
 pub use diagnostics::{
     DIAGNOSTIC_QUERY_DEFAULT_LIMIT, DIAGNOSTIC_QUERY_MAX_LIMIT, DiagnosticCursor, DiagnosticEvent,

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -52,6 +52,7 @@ pub use error::AtmError;
 pub use error_codes::AtmErrorCode;
 pub use factory::{
     EffectiveReaderLane, EffectiveReaderLanes, StorageFactory, StorageHandleParts, StorageHandles,
+    WriteThroughRosterStore,
 };
 pub use peer_catalog_audit::TrustedPeerCatalogAudit;
 pub use roles::ROLE_WORKER;


### PR DESCRIPTION
## Summary

Fix round phase-aw, Stack B1: **AW-POOL-V7** (write-through RAM roster). Root finding per Rand's ruling: every write to the roster DB must be reflected in RAM in the same operation; ephemeral per-member state lives only in RAM; every roster consumer reads RAM, never SQLite.

- `RosterSnapshotCache` (lazy DB projection, cleared only on reload) removed.
- `RosterRuntimeState` owned by `LocalServiceRuntime`, hydrated once from the durable store at construction.
- `RosterRuntimeView` implements the durable `RosterStore` trait: `save_roster` write-throughs SQLite first, then RAM in the same call; `load_roster`/`list_teams` are RAM-only.
- `RosterMemberEphemeralState { herdr_wake_pending }` carried per member, preserved/defaulted/dropped across `replace_roster`.
- `RuntimeAssembly::roster_store_arc` / `shared_roster_store_arc` now delegate through the service runtime, so herdr_queue_wake, doctor, CLI commands, graft receiver, admission all get the RAM view transparently (covers V8's roster lookup).
- HTTP reload endpoint uses `reload_roster_from_durable_store` (explicitly not a sync mechanism).

Roster read-vs-mutation races are ruled don't-care by Rand (send vs remove-member / add-member).

## Tests

New: `write_through_updates_ram_in_the_same_operation_as_the_durable_write`, `ram_read_after_hydration_never_calls_the_durable_store_again`, `ram_roster_enumerates_every_team_without_a_durable_read`, `ephemeral_state_mutates_in_ram_and_is_visible_to_readers`, `ephemeral_mutation_on_an_unknown_member_is_a_no_op`, `herdr_candidates_never_reads_the_durable_roster_store_after_hydration`.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` green locally at bf00512c1. Boundary lint (`sc-lint-boundary`) not run locally; CI covers it.

Triage: `.triage/phase-aw/findings/AW-POOL-V7.ttl` (closure by quality-mgr after QA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
