### PR TITLE
skill: /gh-stack-view one-call stack coherence table

### DIFF
--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -62,8 +62,8 @@ VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its 
 |--------|--------|-------|
 | L | layer / stack depth, bottom first | |
 | rebase | `gh stack view --json` `head`/`base`/`needsRebase`, `origin/<branch>` after one fetch, PR `headRefOid` | ✅ not needed (base==parent head and local==origin==PR) · ⚠️ needed · 🔄 local tracking stale, fetch+reset before any sync · ❓ unknown (`--no-fetch`) · 🏁 merged |
-| merge | one GraphQL query: `mergeable`, `mergeStateStatus`, `isDraft`; gh stack `isMerged`/`isQueued` | 🚀 clean · 🚧 blocked/unstable · ⏪ behind · ❌ conflicting/dirty · ⏳ computing · 📝 draft · ◎ queued · 🏁 merged |
-| CI | same query, `statusCheckRollup.state` of the head commit | ✅ success · ❌ failure · 🌀 pending · — none |
+| merge | one GraphQL query: `mergeable`, `mergeStateStatus`, `isDraft`; gh stack `isMerged`/`isQueued` | ✅ mergeable now · 🚧 blocked (conflicting, behind, draft, queued, required checks, still computing) · 🏁 merged |
+| CI | same query, `statusCheckRollup.state` of the head commit | ✅ green · 🌀 running · ⛔ failed, do not enter · — none |
 
 `VERDICT` names the branch and the owner action for every problem (SHAs
 appear there, not in the table). A bottom layer merely behind trunk is a note,

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: gh-stack-view
+version: 1.0.0
+description: One-call coherence and mergeability table for a gh stack (head/base SHAs, origin vs local, needsRebase, mergeable, mergeStateStatus, CI). Use for any stacked-PR status question, before/after a rebase or merge, or `/gh-stack-view`. Never check stack layers one branch at a time.
+---
+
+# gh-stack-view
+
+Read-only stack status. One command replaces the "one `gh pr view` per branch"
+habit, which never shows the two things that actually break stacks:
+
+1. **Base coherence** - is each layer's base SHA the head SHA of the layer
+   below (and the bottom layer's base the trunk head)? Only
+   `gh stack view --json` exposes `head` and `base`; `gh pr view` does not.
+2. **Rebase / mergeability** - `needsRebase` from gh stack plus GitHub's
+   `mergeable` and `mergeStateStatus` (`CONFLICTING`, `BEHIND`, `DIRTY`,
+   `BLOCKED`, `CLEAN`). `gh pr list` and `gh pr checks` do not return
+   `needsRebase`, and `gh pr checks` output must never be text-parsed.
+
+The script also compares every local head against `origin/<branch>` and the
+PR's `headRefOid`, so stale local tracking (someone else rebased the stack) is
+caught before anyone runs `gh stack sync` on top of it.
+
+## Usage
+
+```
+/gh-stack-view [--no-fetch] [--no-pr] [--json]
+```
+
+Run from a worktree checked out on any branch of the stack (the main repo on
+`develop` is never part of a stack and will error; never `git checkout` there).
+
+```bash
+cd ../atm-core-worktrees/<any-stack-layer>
+python3 "$(git rev-parse --show-toplevel)/.claude/skills/gh-stack-view/scripts/gh_stack_view.py"
+```
+
+The script path resolves inside the current worktree; if the skill is not on
+that branch yet, point at the main repo's copy instead:
+`python3 <main-repo>/.claude/skills/gh-stack-view/scripts/gh_stack_view.py`.
+
+Exit code: `0` coherent, `1` problems listed, `2` not in a stack.
+
+## Output
+
+The script renders everything. **Paste its output verbatim.** The agent makes
+no rendering decisions: no reformatting, no re-summarising the table, no
+substituting its own per-branch lookups.
+
+```
+stack: integrate/phase-aw @ 0f4ab1be2  (current: fix/aw-pool-read-migration)
+
+| L | branch | PR | head | base | sync | merge | CI |
+|---|---|---|---|---|---|---|---|
+| 1 | fix/aw-pool-consolidate | #1242 | a60779787 | 0f4ab1be2 | ✅ | 🚧 | 🌀 |
+| 2 | fix/aw-pool-read-migration | #1244 | 913dc9413 | a60779787 | ✅ | 🚧 | 🌀 |
+
+VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its PR
+```
+
+| Column | Source | Icons |
+|--------|--------|-------|
+| head / base | `gh stack view --json` | local stack-tracking SHAs |
+| sync | computed from `base`, `origin/<branch>` (one fetch) and PR `headRefOid` | ✅ base==parent head and local==origin==PR · 🔄 local/origin/PR heads differ · ⚠️ needs rebase · ❓ unknown (`--no-fetch`) |
+| merge | one GraphQL query: `mergeable`, `mergeStateStatus`, `isDraft`; gh stack `isMerged`/`isQueued` | 🚀 clean · 🚧 blocked/unstable · ⏪ behind · ❌ conflicting/dirty · ⏳ computing · 📝 draft · ◎ queued · 🏁 merged |
+| CI | same query, `statusCheckRollup.state` of the head commit | ✅ success · ❌ failure · 🌀 pending · — none |
+
+`VERDICT` lists every problem with the owner action. A bottom layer merely
+behind trunk is a note, not a problem: do not rebase a layer whose CI could go
+green just to catch up with trunk. The legend is printed under every table.
+
+## Rules the skill enforces by convention
+
+- This is **the** status call for stacks. Do not fan out `gh pr view` per
+  branch; that costs N calls and still misses base coherence and needsRebase.
+- The script is read-only. `gh stack sync` and `gh stack rebase` rewrite and
+  force-push every layer; only the stack owner runs them, and only after this
+  table shows `origin ok` on every layer (otherwise sync re-rebases stale local
+  heads over someone else's push and turns PRs CONFLICTING).
+- After ANY merge or rebase on a stack, run this again and reconcile before
+  dispatching dev or QA against a layer.
+- `--json` emits the merged rows (`rows[]`, `problems[]`, `notes[]`,
+  `coherent`) for agents that need to branch on the result.
+- Draft PRs block `gh stack merge`; the table flags them.

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -41,9 +41,28 @@ trunk, `--all` shows everything.
 python3 .claude/skills/gh-stack-view/scripts/gh_stack_view.py --phase aw
 ```
 
-Exit code: `0` all coherent, `1` problems listed, `2` no stack found (a stack
-needs at least one layer checked out in a worktree; never `git checkout` in
-the main repo to get one).
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | every shown stack coherent |
+| 1 | problems listed under a VERDICT |
+| 2 | nothing to show or the environment failed; stderr says which (see Errors) |
+
+## Errors
+
+Every failure is one `gh-stack-view: ...` line on stderr with the next action,
+never a traceback. Exit 2 covers all of these, so read the line:
+
+- `git`/`gh` not on PATH, gh-stack extension missing (`gh extension install github/gh-stack`), not inside a git repository.
+- `gh repo view` / `gh api graphql` failure: run `gh auth status`; `--no-pr` gives a local-only view meanwhile.
+- GraphQL errors, null data or non-JSON output: same, with the PR numbers named.
+- `gh stack view --json` returning an unexpected shape: upgrade gh-stack.
+- No open stack for the current phase or develop: the line reports how many merged/closed/other-phase stacks were hidden; use `--phase`, `--trunk` or `--all`.
+
+Non-fatal: a failed `git fetch origin` is warned once and the rebase column
+shows ❓ instead of comparing against stale refs. Pruned or unreadable
+worktrees are skipped silently (`git worktree prune` cleans them up).
 
 ## Output
 

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -31,7 +31,11 @@ Run from anywhere in the repo, normally the main checkout on `develop`. The
 script discovers every stack by running `gh stack view --json` in each
 worktree from `git worktree list` (concurrently), keeps the longest view of
 each stack (a lower-layer worktree only sees the layers linked from it), and
-joins them into one report. Fully merged stacks are hidden unless `--all`.
+joins them into one report. The default view is strict: only stacks whose
+trunk is the current phase (highest `integrate/phase-*` seen) or `develop`,
+and only stacks that still have an open layer. Merged, closed and other-phase
+stacks are counted on a `hidden:` line; `--phase`/`--trunk` selects another
+trunk, `--all` shows everything.
 
 ```bash
 python3 .claude/skills/gh-stack-view/scripts/gh_stack_view.py --phase aw

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -24,50 +24,53 @@ caught before anyone runs `gh stack sync` on top of it.
 ## Usage
 
 ```
-/gh-stack-view [--no-fetch] [--no-pr] [--json]
+/gh-stack-view [--phase aw | --trunk <branch>] [--all] [--no-fetch] [--no-pr] [--json]
 ```
 
-Run from a worktree checked out on any branch of the stack (the main repo on
-`develop` is never part of a stack and will error; never `git checkout` there).
+Run from anywhere in the repo, normally the main checkout on `develop`. The
+script discovers every stack by running `gh stack view --json` in each
+worktree from `git worktree list` (concurrently), keeps the longest view of
+each stack (a lower-layer worktree only sees the layers linked from it), and
+joins them into one report. Fully merged stacks are hidden unless `--all`.
 
 ```bash
-cd ../atm-core-worktrees/<any-stack-layer>
-python3 "$(git rev-parse --show-toplevel)/.claude/skills/gh-stack-view/scripts/gh_stack_view.py"
+python3 .claude/skills/gh-stack-view/scripts/gh_stack_view.py --phase aw
 ```
 
-The script path resolves inside the current worktree; if the skill is not on
-that branch yet, point at the main repo's copy instead:
-`python3 <main-repo>/.claude/skills/gh-stack-view/scripts/gh_stack_view.py`.
-
-Exit code: `0` coherent, `1` problems listed, `2` not in a stack.
+Exit code: `0` all coherent, `1` problems listed, `2` no stack found (a stack
+needs at least one layer checked out in a worktree; never `git checkout` in
+the main repo to get one).
 
 ## Output
 
 The script renders everything. **Paste its output verbatim.** The agent makes
-no rendering decisions: no reformatting, no re-summarising the table, no
-substituting its own per-branch lookups.
+no rendering decisions: no reformatting, no re-summarising, no substituting
+its own per-branch lookups.
 
 ```
-stack: integrate/phase-aw @ 0f4ab1be2  (current: fix/aw-pool-read-migration)
+stack: fix/aw-pool-read-migration -> integrate/phase-aw @ 0e640b20a
 
-| L | branch | PR | head | base | sync | merge | CI |
-|---|---|---|---|---|---|---|---|
-| 1 | fix/aw-pool-consolidate | #1242 | a60779787 | 0f4ab1be2 | ✅ | 🚧 | 🌀 |
-| 2 | fix/aw-pool-read-migration | #1244 | 913dc9413 | a60779787 | ✅ | 🚧 | 🌀 |
+| L | PR | sync | merge | CI |
+|---|---|---|---|---|
+| 1/2 | #1242 | ✅ | 🚧 | 🌀 |
+| 2/2 | #1244 | ✅ | 🚧 | 🌀 |
 
 VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its PR
 ```
 
 | Column | Source | Icons |
 |--------|--------|-------|
-| head / base | `gh stack view --json` | local stack-tracking SHAs |
-| sync | computed from `base`, `origin/<branch>` (one fetch) and PR `headRefOid` | ✅ base==parent head and local==origin==PR · 🔄 local/origin/PR heads differ · ⚠️ needs rebase · ❓ unknown (`--no-fetch`) |
+| L | layer / stack depth, bottom first | |
+| sync | `gh stack view --json` `head`/`base`/`needsRebase`, `origin/<branch>` after one fetch, PR `headRefOid` | ✅ base==parent head and local==origin==PR · 🔄 local/origin/PR heads differ · ⚠️ needs rebase · ❓ unknown (`--no-fetch`) · 🏁 merged |
 | merge | one GraphQL query: `mergeable`, `mergeStateStatus`, `isDraft`; gh stack `isMerged`/`isQueued` | 🚀 clean · 🚧 blocked/unstable · ⏪ behind · ❌ conflicting/dirty · ⏳ computing · 📝 draft · ◎ queued · 🏁 merged |
 | CI | same query, `statusCheckRollup.state` of the head commit | ✅ success · ❌ failure · 🌀 pending · — none |
 
-`VERDICT` lists every problem with the owner action. A bottom layer merely
-behind trunk is a note, not a problem: do not rebase a layer whose CI could go
-green just to catch up with trunk. The legend is printed under every table.
+`VERDICT` names the branch and the owner action for every problem (SHAs
+appear there, not in the table). A bottom layer merely behind trunk is a note,
+not a problem: do not rebase a layer whose CI could go green just to catch up
+with trunk. The legend is printed once at the end. `--json` emits
+`stacks[].rows[]`, `problems[]`, `notes[]`, `coherent` for agents that need to
+branch on the result.
 
 ## Rules the skill enforces by convention
 
@@ -79,6 +82,4 @@ green just to catch up with trunk. The legend is printed under every table.
   heads over someone else's push and turns PRs CONFLICTING).
 - After ANY merge or rebase on a stack, run this again and reconcile before
   dispatching dev or QA against a layer.
-- `--json` emits the merged rows (`rows[]`, `problems[]`, `notes[]`,
-  `coherent`) for agents that need to branch on the result.
 - Draft PRs block `gh stack merge`; the table flags them.

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -43,11 +43,11 @@ the main repo to get one).
 
 ## Output
 
-The script renders everything. **Paste its output verbatim.** The agent makes
-no rendering decisions: no reformatting, no re-summarising, no substituting
-its own per-branch lookups.
+The script renders everything. **Paste its output verbatim and unfenced**
+(no ``` around it) so the markdown table renders in the terminal. The agent
+makes no rendering decisions: no reformatting, no re-summarising, no
+substituting its own per-branch lookups. Example (as it should appear):
 
-```
 stack: fix/aw-pool-read-migration -> integrate/phase-aw @ 0e640b20a
 
 | L | PR | rebase | merge | CI |
@@ -56,7 +56,6 @@ stack: fix/aw-pool-read-migration -> integrate/phase-aw @ 0e640b20a
 | 2/2 | #1244 | ✅ | 🚧 | 🌀 |
 
 VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its PR
-```
 
 | Column | Source | Icons |
 |--------|--------|-------|

--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -50,7 +50,7 @@ its own per-branch lookups.
 ```
 stack: fix/aw-pool-read-migration -> integrate/phase-aw @ 0e640b20a
 
-| L | PR | sync | merge | CI |
+| L | PR | rebase | merge | CI |
 |---|---|---|---|---|
 | 1/2 | #1242 | ✅ | 🚧 | 🌀 |
 | 2/2 | #1244 | ✅ | 🚧 | 🌀 |
@@ -61,7 +61,7 @@ VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its 
 | Column | Source | Icons |
 |--------|--------|-------|
 | L | layer / stack depth, bottom first | |
-| sync | `gh stack view --json` `head`/`base`/`needsRebase`, `origin/<branch>` after one fetch, PR `headRefOid` | ✅ base==parent head and local==origin==PR · 🔄 local/origin/PR heads differ · ⚠️ needs rebase · ❓ unknown (`--no-fetch`) · 🏁 merged |
+| rebase | `gh stack view --json` `head`/`base`/`needsRebase`, `origin/<branch>` after one fetch, PR `headRefOid` | ✅ not needed (base==parent head and local==origin==PR) · ⚠️ needed · 🔄 local tracking stale, fetch+reset before any sync · ❓ unknown (`--no-fetch`) · 🏁 merged |
 | merge | one GraphQL query: `mergeable`, `mergeStateStatus`, `isDraft`; gh stack `isMerged`/`isQueued` | 🚀 clean · 🚧 blocked/unstable · ⏪ behind · ❌ conflicting/dirty · ⏳ computing · 📝 draft · ◎ queued · 🏁 merged |
 | CI | same query, `statusCheckRollup.state` of the head commit | ✅ success · ❌ failure · 🌀 pending · — none |
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -203,13 +203,9 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
 
 
 ICON_SYNC = {"ok": "✅", "stale": "🔄", "rebase": "⚠️", "unknown": "❓"}
-ICON_MERGE = {
-    "MERGED": "🏁", "QUEUED": "◎", "CLEAN": "🚀", "HAS_HOOKS": "🚀",
-    "UNSTABLE": "🚧", "BLOCKED": "🚧", "BEHIND": "⏪", "DIRTY": "❌",
-    "CONFLICTING": "❌", "UNKNOWN": "⏳", "DRAFT": "📝",
-}
-ICON_CI = {"SUCCESS": "✅", "FAILURE": "❌", "ERROR": "❌", "PENDING": "🌀",
-           "EXPECTED": "🌀", "NONE": "—"}
+ICON_MERGE = {"MERGED": "\U0001f3c1", "OK": "✅", "BLOCKED": "\U0001f6a7"}
+ICON_CI = {"SUCCESS": "✅", "FAILURE": "⛔", "ERROR": "⛔", "PENDING": "\U0001f300",
+           "EXPECTED": "\U0001f300", "NONE": "—"}
 
 
 def sync_icon(r: dict) -> str:
@@ -225,15 +221,12 @@ def sync_icon(r: dict) -> str:
 
 
 def merge_icon(r: dict) -> str:
+    """✅ only when GitHub says the PR can merge now; anything else is 🚧."""
     if r["merged"]:
         return ICON_MERGE["MERGED"]
-    if r["queued"]:
-        return ICON_MERGE["QUEUED"]
-    if r["draft"]:
-        return ICON_MERGE["DRAFT"]
-    if r["mergeable"] == "CONFLICTING":
-        return ICON_MERGE["CONFLICTING"]
-    return ICON_MERGE.get(r["merge_state"] or "UNKNOWN", ICON_MERGE["UNKNOWN"])
+    if r["draft"] or r["queued"] or r["mergeable"] != "MERGEABLE":
+        return ICON_MERGE["BLOCKED"]
+    return ICON_MERGE["OK"] if r["merge_state"] in ("CLEAN", "HAS_HOOKS", "UNSTABLE") else ICON_MERGE["BLOCKED"]
 
 
 def ci_icon(r: dict) -> str:

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -65,7 +65,14 @@ def stack_json_at(path: str) -> dict | None:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError:
         return None
-    return data if data.get("branches") else None
+    if not isinstance(data, dict) or not isinstance(data.get("branches"), list) or not data["branches"]:
+        return None
+    if not isinstance(data.get("trunk"), str) or not all(
+        isinstance(b, dict) and isinstance(b.get("name"), str) for b in data["branches"]
+    ):
+        raise ToolError(f"gh stack view --json in {path} returned an unexpected shape; "
+                        "upgrade gh-stack (`gh extension upgrade stack`) or report the output")
+    return data
 
 
 def worktree_paths() -> list[str]:
@@ -350,7 +357,8 @@ def run_report(args: argparse.Namespace, trunk_filter: str | None) -> int:
     if fetched:
         fetch = run(["git", "fetch", "--quiet", "origin"], check=False)
         if fetch.returncode != 0:
-            sys.stderr.write("gh-stack-view: git fetch origin failed; origin comparison uses the last fetched state\n")
+            fetched = False
+            sys.stderr.write("gh-stack-view: git fetch origin failed; rebase column reported as unknown (❓)\n")
     numbers = sorted({b["pr"]["number"] for st in stacks for b in st["branches"] if b.get("pr")})
     prs = {} if args.no_pr else pr_details(numbers)
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -256,8 +256,8 @@ def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list
 def legend() -> str:
     lines = []
     lines.append("rebase: ✅ not needed (base==parent head, local==origin==PR)  ⚠️ needed  🔄 local tracking stale: fetch+reset before any sync  ❓ unknown (--no-fetch)  🏁 merged")
-    lines.append("merge: 🚀 clean  🚧 blocked/unstable  ⏪ behind  ❌ conflicting/dirty  ⏳ computing  📝 draft  ◎ queued  🏁 merged")
-    lines.append("CI: ✅ success  ❌ failure  🌀 pending  — none")
+    lines.append("merge: ✅ mergeable now  🚧 blocked (conflicting, behind, draft, queued, required checks, or still computing)  🏁 merged")
+    lines.append("CI: ✅ green  🌀 running  ⛔ failed, do not enter  — none")
     return "\n".join(lines)
 
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -23,13 +23,30 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
 
-def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, text=True, capture_output=True, check=check)
+class ToolError(Exception):
+    """A required external command is missing or failed; message is actionable."""
+
+
+def run(cmd: list[str], *, check: bool = True, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    try:
+        proc = subprocess.run(cmd, text=True, capture_output=True, cwd=cwd)
+    except FileNotFoundError as exc:
+        missing = cmd[0] if exc.filename in (None, cmd[0]) else f"directory {exc.filename}"
+        raise ToolError(f"cannot run {' '.join(cmd[:3])}: {missing} not found "
+                        f"(install gh + gh-stack extension and git; prune stale worktrees with `git worktree prune`)") from exc
+    except OSError as exc:
+        raise ToolError(f"cannot run {' '.join(cmd[:3])}: {exc}") from exc
+    if check and proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip().splitlines()
+        raise ToolError(f"{' '.join(cmd[:3])} failed (exit {proc.returncode}): {detail[-1] if detail else 'no output'}"
+                        + ("; run `gh auth status`" if "auth" in " ".join(detail).lower() or "401" in " ".join(detail) else ""))
+    return proc
 
 
 def short(sha: str | None) -> str:
@@ -37,7 +54,11 @@ def short(sha: str | None) -> str:
 
 
 def stack_json_at(path: str) -> dict | None:
-    proc = subprocess.run(["gh", "stack", "view", "--json"], cwd=path, text=True, capture_output=True)
+    """None when this worktree is not on a stack (or is pruned/unreadable)."""
+    try:
+        proc = run(["gh", "stack", "view", "--json"], check=False, cwd=path)
+    except ToolError:
+        return None
     if proc.returncode != 0:
         return None
     try:
@@ -100,6 +121,7 @@ def discover_stacks(trunk_filter: str | None, *, include_merged: bool) -> list[d
 
 
 def origin_sha(ref: str) -> str | None:
+    """None when the branch is not on origin (unpushed or deleted after merge)."""
     proc = run(["git", "rev-parse", "--verify", "--quiet", f"origin/{ref}"], check=False)
     return proc.stdout.strip() or None
 
@@ -109,7 +131,10 @@ def pr_details(numbers: list[int]) -> dict[int, dict]:
     if not numbers:
         return {}
     remote = run(["gh", "repo", "view", "--json", "owner,name"]).stdout
-    repo = json.loads(remote)
+    try:
+        repo = json.loads(remote)
+    except json.JSONDecodeError as exc:
+        raise ToolError(f"gh repo view returned non-JSON: {remote[:200]!r}") from exc
     owner, name = repo["owner"]["login"], repo["name"]
     fields = (
         "number isDraft mergeable mergeStateStatus baseRefName headRefOid "
@@ -119,7 +144,16 @@ def pr_details(numbers: list[int]) -> dict[int, dict]:
     aliases = " ".join(f"pr{n}: pullRequest(number:{n}) {{ {fields} }}" for n in numbers)
     query = f'query($owner:String!,$name:String!){{ repository(owner:$owner,name:$name) {{ {aliases} }} }}'
     proc = run(["gh", "api", "graphql", "-f", f"query={query}", "-F", f"owner={owner}", "-F", f"name={name}"])
-    data = json.loads(proc.stdout)["data"]["repository"]
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ToolError(f"gh api graphql returned non-JSON: {proc.stdout[:200]!r}") from exc
+    if payload.get("errors"):
+        msgs = "; ".join(e.get("message", "?") for e in payload["errors"][:3])
+        raise ToolError(f"GraphQL errors: {msgs} (PRs {numbers}; use --no-pr for a local-only view)")
+    data = (payload.get("data") or {}).get("repository")
+    if not data:
+        raise ToolError("GraphQL returned no repository data; run `gh auth status` or use --no-pr")
     out: dict[int, dict] = {}
     for n in numbers:
         pr = data.get(f"pr{n}") or {}
@@ -272,6 +306,25 @@ def main() -> int:
     args = ap.parse_args()
     trunk_filter = args.trunk or (f"integrate/phase-{args.phase.lower()}" if args.phase else None)
 
+    try:
+        return run_report(args, trunk_filter)
+    except ToolError as exc:
+        sys.stderr.write(f"gh-stack-view: {exc}\n")
+        return 2
+
+
+def preflight() -> None:
+    for tool in ("git", "gh"):
+        if not shutil.which(tool):
+            raise ToolError(f"`{tool}` not on PATH")
+    if run(["gh", "stack", "--help"], check=False).returncode != 0:
+        raise ToolError("gh-stack extension missing: `gh extension install github/gh-stack`")
+    if run(["git", "rev-parse", "--git-dir"], check=False).returncode != 0:
+        raise ToolError("not inside a git repository")
+
+
+def run_report(args: argparse.Namespace, trunk_filter: str | None) -> int:
+    preflight()
     stacks = discover_stacks(trunk_filter, include_merged=args.all)
     if not stacks:
         where = f" with trunk {trunk_filter}" if trunk_filter else ""
@@ -282,7 +335,9 @@ def main() -> int:
         return 2
     fetched = not args.no_fetch
     if fetched:
-        run(["git", "fetch", "--quiet", "origin"], check=False)
+        fetch = run(["git", "fetch", "--quiet", "origin"], check=False)
+        if fetch.returncode != 0:
+            sys.stderr.write("gh-stack-view: git fetch origin failed; origin comparison uses the last fetched state\n")
     numbers = sorted({b["pr"]["number"] for st in stacks for b in st["branches"] if b.get("pr")})
     prs = {} if args.no_pr else pr_details(numbers)
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -86,38 +86,50 @@ def worktree_paths() -> list[str]:
     return paths
 
 
-def discover_stacks(trunk_filter: str | None, *, include_merged: bool) -> list[dict]:
+def discover_stacks(trunk_filter: str | None, *, include_all: bool) -> tuple[list[dict], int]:
     """Run `gh stack view --json` once per worktree, dedupe by branch set.
 
     Works from develop/main (not part of any stack): every stack that has at
     least one worktree checked out is found. Concurrent, read-only.
+
+    Default view is strict: trunk must be the current phase (highest
+    integrate/phase-* seen) or develop, and the stack must still have an open
+    layer. Returns (stacks, hidden_count).
     """
     paths = worktree_paths()
     with ThreadPoolExecutor(max_workers=8) as pool:
         results = list(pool.map(stack_json_at, paths))
-    stacks: list[dict] = []
+    found: list[dict] = []
     for path, data in zip(paths, results):
-        if not data:
-            continue
-        if trunk_filter and data["trunk"] != trunk_filter:
-            continue
-        if not include_merged and all(b.get("isMerged") for b in data["branches"]):
-            continue
-        data["worktree"] = path
-        stacks.append(data)
+        if data:
+            data["worktree"] = path
+            found.append(data)
+
     # Each worktree only knows the layers linked from it; the same stack seen
     # from a lower layer is a prefix of the view from the top. Keep the longest.
     def names(d: dict) -> tuple[str, ...]:
         return tuple(b["name"] for b in d["branches"])
-    stacks = [d for d in stacks if not any(
+    found = [d for d in found if not any(
         o is not d and len(names(o)) > len(names(d)) and names(o)[: len(names(d))] == names(d)
-        for o in stacks)]
+        for o in found)]
     uniq: dict[tuple[str, ...], dict] = {}
-    for d in stacks:
+    for d in found:
         uniq.setdefault(names(d), d)
-    stacks = list(uniq.values())
+    found = list(uniq.values())
+
+    phases = sorted(d["trunk"] for d in found if d["trunk"].startswith("integrate/phase-"))
+    allowed_trunks = {trunk_filter} if trunk_filter else ({phases[-1]} if phases else set()) | {"develop"}
+
+    def is_open(d: dict) -> bool:
+        return any(not b.get("isMerged") and (b.get("pr") or {}).get("state", "OPEN") != "CLOSED"
+                   for b in d["branches"])
+
+    if include_all and not trunk_filter:
+        stacks = found
+    else:
+        stacks = [d for d in found if d["trunk"] in allowed_trunks and (include_all or is_open(d))]
     stacks.sort(key=lambda d: (not d["trunk"].startswith("integrate/"), d["trunk"], d["branches"][0]["name"]))
-    return stacks
+    return stacks, len(found) - len(stacks)
 
 
 def origin_sha(ref: str) -> str | None:
@@ -299,7 +311,7 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--trunk", help="only stacks whose trunk is this branch (e.g. integrate/phase-aw)")
     ap.add_argument("--phase", help="shorthand for --trunk integrate/phase-<PHASE>")
-    ap.add_argument("--all", action="store_true", help="include stacks whose every layer is already merged")
+    ap.add_argument("--all", action="store_true", help="show every stack, including merged/closed ones and other phases")
     ap.add_argument("--no-fetch", action="store_true", help="skip `git fetch origin` and origin comparison")
     ap.add_argument("--no-pr", action="store_true", help="skip the GraphQL PR query (offline / local-only view)")
     ap.add_argument("--json", action="store_true", help="emit the merged rows as JSON instead of tables")
@@ -325,11 +337,12 @@ def preflight() -> None:
 
 def run_report(args: argparse.Namespace, trunk_filter: str | None) -> int:
     preflight()
-    stacks = discover_stacks(trunk_filter, include_merged=args.all)
+    stacks, hidden = discover_stacks(trunk_filter, include_all=args.all)
     if not stacks:
-        where = f" with trunk {trunk_filter}" if trunk_filter else ""
+        where = f" with trunk {trunk_filter}" if trunk_filter else " for the current phase or develop"
+        hint = f" ({hidden} merged/closed/other-phase stack(s) hidden; --all to show)" if hidden else ""
         sys.stderr.write(
-            f"no gh stack found{where}. Stacks are discovered through `git worktree list`; a stack "
+            f"no open gh stack found{where}{hint}. Stacks are discovered through `git worktree list`; a stack "
             "needs at least one of its layers checked out in a worktree (never `git checkout` in the main repo).\n"
         )
         return 2
@@ -352,10 +365,12 @@ def run_report(args: argparse.Namespace, trunk_filter: str | None) -> int:
                        "rows": rows, "problems": problems, "notes": notes, "coherent": not problems})
         blocks.append(render_table(st, rows, problems, notes, trunk_origin=trunk_origin))
     if args.json:
-        print(json.dumps({"stacks": report, "coherent": not any_problem}, indent=2))
+        print(json.dumps({"stacks": report, "hidden": hidden, "coherent": not any_problem}, indent=2))
     else:
         print("\n\n".join(blocks))
         print()
+        if hidden:
+            print(f"hidden: {hidden} merged/closed/other-phase stack(s); --all to show")
         print(legend())
     return 1 if any_problem else 0
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -241,7 +241,7 @@ def ci_icon(r: dict) -> str:
 
 
 def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list[str], *, trunk_origin: str | None) -> str:
-    hdr = ["L", "PR", "sync", "merge", "CI"]
+    hdr = ["L", "PR", "rebase", "merge", "CI"]
     lines = [f"stack: {stack['branches'][-1]['name']} -> {stack['trunk']} @ {short(trunk_origin)}", ""]
     lines.append("| " + " | ".join(hdr) + " |")
     lines.append("|" + "|".join("---" for _ in hdr) + "|")
@@ -262,7 +262,7 @@ def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list
 
 def legend() -> str:
     lines = []
-    lines.append("sync: ✅ base==parent head & local==origin==PR  🔄 local/origin/PR heads differ  ⚠️ needs rebase  ❓ unknown (--no-fetch)")
+    lines.append("rebase: ✅ not needed (base==parent head, local==origin==PR)  ⚠️ needed  🔄 local tracking stale: fetch+reset before any sync  ❓ unknown (--no-fetch)  🏁 merged")
     lines.append("merge: 🚀 clean  🚧 blocked/unstable  ⏪ behind  ❌ conflicting/dirty  ⏳ computing  📝 draft  ◎ queued  🏁 merged")
     lines.append("CI: ✅ success  ❌ failure  🌀 pending  — none")
     return "\n".join(lines)

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""One-call status table for a `gh stack`.
+
+Combines exactly three data sources into one table:
+
+1. ``gh stack view --json``  - local stack tracking: layer order, head/base
+   SHAs, needsRebase, PR number.
+2. ``git rev-parse origin/<branch>`` (after one ``git fetch``) - what is
+   actually pushed.
+3. One batched GraphQL query - per-PR ``mergeable``, ``mergeStateStatus``,
+   ``baseRefName``, ``headRefOid``, ``isDraft`` and CI rollup.
+
+Coherence checks (the two metrics conventional per-branch calls never show):
+
+* ``base ok``  - each layer's base == the layer below's head (bottom == trunk).
+* ``origin ok`` - local head == origin head == PR head.
+* ``needsRebase`` straight from gh stack, plus GitHub's ``mergeable`` /
+  ``mergeStateStatus`` which reveal CONFLICTING / BEHIND / DIRTY layers.
+
+Read-only. Never runs ``gh stack sync`` or ``gh stack rebase``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, capture_output=True, check=check)
+
+
+def short(sha: str | None) -> str:
+    return (sha or "")[:9] or "-"
+
+
+def stack_json() -> dict:
+    proc = run(["gh", "stack", "view", "--json"], check=False)
+    if proc.returncode != 0:
+        msg = (proc.stderr or proc.stdout).strip()
+        sys.stderr.write(
+            f"gh stack view --json failed: {msg}\n"
+            "Hint: run from a worktree checked out on a stack branch "
+            "(develop/main/detached HEAD are not part of any stack). "
+            "Never `git checkout` in the main repo; cd into the layer's worktree.\n"
+        )
+        sys.exit(2)
+    return json.loads(proc.stdout)
+
+
+def origin_sha(ref: str) -> str | None:
+    proc = run(["git", "rev-parse", "--verify", "--quiet", f"origin/{ref}"], check=False)
+    return proc.stdout.strip() or None
+
+
+def pr_details(numbers: list[int]) -> dict[int, dict]:
+    """One GraphQL round-trip for every PR in the stack."""
+    if not numbers:
+        return {}
+    remote = run(["gh", "repo", "view", "--json", "owner,name"]).stdout
+    repo = json.loads(remote)
+    owner, name = repo["owner"]["login"], repo["name"]
+    fields = (
+        "number isDraft mergeable mergeStateStatus baseRefName headRefOid "
+        "reviewDecision state "
+        "commits(last:1){nodes{commit{statusCheckRollup{state}}}}"
+    )
+    aliases = " ".join(f"pr{n}: pullRequest(number:{n}) {{ {fields} }}" for n in numbers)
+    query = f'query($owner:String!,$name:String!){{ repository(owner:$owner,name:$name) {{ {aliases} }} }}'
+    proc = run(["gh", "api", "graphql", "-f", f"query={query}", "-F", f"owner={owner}", "-F", f"name={name}"])
+    data = json.loads(proc.stdout)["data"]["repository"]
+    out: dict[int, dict] = {}
+    for n in numbers:
+        pr = data.get(f"pr{n}") or {}
+        nodes = ((pr.get("commits") or {}).get("nodes") or [{}])
+        rollup = ((nodes[0].get("commit") or {}).get("statusCheckRollup") or {}).get("state")
+        pr["ci"] = rollup or "NONE"
+        out[n] = pr
+    return out
+
+
+def is_ancestor(older: str, newer: str) -> bool:
+    return run(["git", "merge-base", "--is-ancestor", older, newer], check=False).returncode == 0
+
+
+def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[list[dict], list[str], list[str]]:
+    trunk = stack["trunk"]
+    trunk_origin = origin_sha(trunk) if fetched else None
+    rows: list[dict] = []
+    problems: list[str] = []
+    notes: list[str] = []
+    expected_base = trunk_origin
+    for idx, br in enumerate(stack["branches"], start=1):
+        name = br["name"]
+        pr = prs.get((br.get("pr") or {}).get("number") or -1, {})
+        origin = origin_sha(name) if fetched else None
+        base_ok = (br["base"] == expected_base) if expected_base else None
+        origin_ok = None
+        if origin:
+            origin_ok = br["head"] == origin and (not pr or pr.get("headRefOid") == origin)
+        row = {
+            "layer": idx,
+            "branch": name,
+            "pr": (br.get("pr") or {}).get("number"),
+            "head": br["head"],
+            "origin": origin,
+            "pr_head": pr.get("headRefOid"),
+            "base": br["base"],
+            "expected_base": expected_base,
+            "base_ok": base_ok,
+            "origin_ok": origin_ok,
+            "needs_rebase": br.get("needsRebase"),
+            "merged": br.get("isMerged"),
+            "queued": br.get("isQueued"),
+            "draft": pr.get("isDraft"),
+            "mergeable": pr.get("mergeable"),
+            "merge_state": pr.get("mergeStateStatus"),
+            "ci": pr.get("ci"),
+            "pr_base": pr.get("baseRefName"),
+        }
+        parent = trunk if idx == 1 else stack["branches"][idx - 2]["name"]
+        if pr and pr.get("baseRefName") not in (None, parent):
+            problems.append(f"L{idx} {name}: PR #{row['pr']} base is {pr['baseRefName']}, expected {parent}")
+        if base_ok is False:
+            if idx == 1 and is_ancestor(br["base"], expected_base):
+                notes.append(f"L1 {name}: behind trunk ({short(br['base'])} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
+            else:
+                problems.append(f"L{idx} {name}: base {short(br['base'])} != parent head {short(expected_base)} -> needs rebase")
+        if origin_ok is False:
+            problems.append(
+                f"L{idx} {name}: local {short(br['head'])} / origin {short(origin)} / PR {short(pr.get('headRefOid'))} differ"
+                " -> local tracking stale or unpushed; owner must fetch+reset or push"
+            )
+        if br.get("needsRebase"):
+            problems.append(f"L{idx} {name}: gh stack reports needsRebase")
+        if pr.get("mergeable") == "CONFLICTING":
+            problems.append(f"L{idx} {name}: PR #{row['pr']} CONFLICTING")
+        if pr.get("isDraft"):
+            problems.append(f"L{idx} {name}: PR #{row['pr']} is DRAFT (blocks stack merge)")
+        rows.append(row)
+        # The next layer must be based on THIS layer's pushed head (fall back to local).
+        expected_base = origin or br["head"]
+    return rows, problems, notes
+
+
+ICON_SYNC = {"ok": "✅", "stale": "🔄", "rebase": "⚠️", "unknown": "❓"}
+ICON_MERGE = {
+    "MERGED": "🏁", "QUEUED": "◎", "CLEAN": "🚀", "HAS_HOOKS": "🚀",
+    "UNSTABLE": "🚧", "BLOCKED": "🚧", "BEHIND": "⏪", "DIRTY": "❌",
+    "CONFLICTING": "❌", "UNKNOWN": "⏳", "DRAFT": "📝",
+}
+ICON_CI = {"SUCCESS": "✅", "FAILURE": "❌", "ERROR": "❌", "PENDING": "🌀",
+           "EXPECTED": "🌀", "NONE": "—"}
+
+
+def sync_icon(r: dict) -> str:
+    if r["origin_ok"] is False:
+        return ICON_SYNC["stale"]
+    if r["base_ok"] is False or r["needs_rebase"]:
+        return ICON_SYNC["rebase"]
+    if r["base_ok"] is None or r["origin_ok"] is None:
+        return ICON_SYNC["unknown"]
+    return ICON_SYNC["ok"]
+
+
+def merge_icon(r: dict) -> str:
+    if r["merged"]:
+        return ICON_MERGE["MERGED"]
+    if r["queued"]:
+        return ICON_MERGE["QUEUED"]
+    if r["draft"]:
+        return ICON_MERGE["DRAFT"]
+    if r["mergeable"] == "CONFLICTING":
+        return ICON_MERGE["CONFLICTING"]
+    return ICON_MERGE.get(r["merge_state"] or "UNKNOWN", ICON_MERGE["UNKNOWN"])
+
+
+def ci_icon(r: dict) -> str:
+    return ICON_CI.get(r["ci"] or "NONE", ICON_CI["NONE"])
+
+
+def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list[str], *, trunk_origin: str | None) -> str:
+    hdr = ["L", "branch", "PR", "head", "base", "sync", "merge", "CI"]
+    lines = [f"stack: {stack['trunk']} @ {short(trunk_origin)}  (current: {stack['currentBranch']})", ""]
+    lines.append("| " + " | ".join(hdr) + " |")
+    lines.append("|" + "|".join("---" for _ in hdr) + "|")
+    for r in rows:
+        pr = f"#{r['pr']}" if r["pr"] else "-"
+        lines.append("| " + " | ".join([
+            str(r["layer"]), r["branch"], pr, short(r["head"]), short(r["base"]),
+            sync_icon(r), merge_icon(r), ci_icon(r),
+        ]) + " |")
+    lines.append("")
+    if problems:
+        lines.append(f"VERDICT: ❌ NOT COHERENT ({len(problems)} issue(s))")
+        lines.extend(f"- {p}" for p in problems)
+    else:
+        lines.append("VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its PR")
+    lines.extend(f"- note: {n}" for n in notes)
+    lines.append("")
+    lines.append("sync: ✅ base==parent head & local==origin==PR  🔄 local/origin/PR heads differ  ⚠️ needs rebase  ❓ unknown (--no-fetch)")
+    lines.append("merge: 🚀 clean  🚧 blocked/unstable  ⏪ behind  ❌ conflicting/dirty  ⏳ computing  📝 draft  ◎ queued  🏁 merged")
+    lines.append("CI: ✅ success  ❌ failure  🌀 pending  — none")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--no-fetch", action="store_true", help="skip `git fetch origin` and origin comparison")
+    ap.add_argument("--no-pr", action="store_true", help="skip the GraphQL PR query (offline / local-only view)")
+    ap.add_argument("--json", action="store_true", help="emit the merged rows as JSON instead of a table")
+    args = ap.parse_args()
+
+    stack = stack_json()
+    fetched = not args.no_fetch
+    if fetched:
+        run(["git", "fetch", "--quiet", "origin"], check=False)
+    numbers = [b["pr"]["number"] for b in stack["branches"] if b.get("pr")]
+    prs = {} if args.no_pr else pr_details(numbers)
+    rows, problems, notes = build_rows(stack, prs, fetched=fetched)
+    trunk_origin = origin_sha(stack["trunk"]) if fetched else None
+    if args.json:
+        print(json.dumps({"trunk": stack["trunk"], "trunk_origin": trunk_origin, "current": stack["currentBranch"],
+                          "rows": rows, "problems": problems, "notes": notes, "coherent": not problems}, indent=2))
+    else:
+        print(render_table(stack, rows, problems, notes, trunk_origin=trunk_origin))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 
 def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -35,18 +36,67 @@ def short(sha: str | None) -> str:
     return (sha or "")[:9] or "-"
 
 
-def stack_json() -> dict:
-    proc = run(["gh", "stack", "view", "--json"], check=False)
+def stack_json_at(path: str) -> dict | None:
+    proc = subprocess.run(["gh", "stack", "view", "--json"], cwd=path, text=True, capture_output=True)
     if proc.returncode != 0:
-        msg = (proc.stderr or proc.stdout).strip()
-        sys.stderr.write(
-            f"gh stack view --json failed: {msg}\n"
-            "Hint: run from a worktree checked out on a stack branch "
-            "(develop/main/detached HEAD are not part of any stack). "
-            "Never `git checkout` in the main repo; cd into the layer's worktree.\n"
-        )
-        sys.exit(2)
-    return json.loads(proc.stdout)
+        return None
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    return data if data.get("branches") else None
+
+
+def worktree_paths() -> list[str]:
+    """Every worktree of this repo that is checked out on a branch (cwd first)."""
+    out = run(["git", "worktree", "list", "--porcelain"]).stdout
+    paths: list[str] = []
+    cur: str | None = None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            cur = line[len("worktree "):]
+        elif line.startswith("branch ") and cur:
+            paths.append(cur)
+            cur = None
+        elif line == "" :
+            cur = None
+    cwd = run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
+    paths.sort(key=lambda p: p != cwd)
+    return paths
+
+
+def discover_stacks(trunk_filter: str | None, *, include_merged: bool) -> list[dict]:
+    """Run `gh stack view --json` once per worktree, dedupe by branch set.
+
+    Works from develop/main (not part of any stack): every stack that has at
+    least one worktree checked out is found. Concurrent, read-only.
+    """
+    paths = worktree_paths()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(stack_json_at, paths))
+    stacks: list[dict] = []
+    for path, data in zip(paths, results):
+        if not data:
+            continue
+        if trunk_filter and data["trunk"] != trunk_filter:
+            continue
+        if not include_merged and all(b.get("isMerged") for b in data["branches"]):
+            continue
+        data["worktree"] = path
+        stacks.append(data)
+    # Each worktree only knows the layers linked from it; the same stack seen
+    # from a lower layer is a prefix of the view from the top. Keep the longest.
+    def names(d: dict) -> tuple[str, ...]:
+        return tuple(b["name"] for b in d["branches"])
+    stacks = [d for d in stacks if not any(
+        o is not d and len(names(o)) > len(names(d)) and names(o)[: len(names(d))] == names(d)
+        for o in stacks)]
+    uniq: dict[tuple[str, ...], dict] = {}
+    for d in stacks:
+        uniq.setdefault(names(d), d)
+    stacks = list(uniq.values())
+    stacks.sort(key=lambda d: (not d["trunk"].startswith("integrate/"), d["trunk"], d["branches"][0]["name"]))
+    return stacks
 
 
 def origin_sha(ref: str) -> str | None:
@@ -94,19 +144,27 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
     for idx, br in enumerate(stack["branches"], start=1):
         name = br["name"]
         pr = prs.get((br.get("pr") or {}).get("number") or -1, {})
+        if br.get("isMerged"):
+            rows.append({"layer": idx, "branch": name, "pr": (br.get("pr") or {}).get("number"),
+                         "head": br.get("head"), "base": br.get("base"), "merged": True, "queued": False,
+                         "draft": False, "mergeable": None, "merge_state": "MERGED", "ci": pr.get("ci"),
+                         "base_ok": None, "origin_ok": None, "needs_rebase": False, "origin": None,
+                         "pr_head": pr.get("headRefOid"), "expected_base": expected_base, "pr_base": pr.get("baseRefName")})
+            expected_base = br.get("head") or expected_base
+            continue
         origin = origin_sha(name) if fetched else None
-        base_ok = (br["base"] == expected_base) if expected_base else None
+        base_ok = (br.get("base") == expected_base) if (expected_base and br.get("base")) else None
         origin_ok = None
         if origin:
-            origin_ok = br["head"] == origin and (not pr or pr.get("headRefOid") == origin)
+            origin_ok = br.get("head") == origin and (not pr or pr.get("headRefOid") == origin)
         row = {
             "layer": idx,
             "branch": name,
             "pr": (br.get("pr") or {}).get("number"),
-            "head": br["head"],
+            "head": br.get("head"),
             "origin": origin,
             "pr_head": pr.get("headRefOid"),
-            "base": br["base"],
+            "base": br.get("base"),
             "expected_base": expected_base,
             "base_ok": base_ok,
             "origin_ok": origin_ok,
@@ -123,7 +181,7 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
         if pr and pr.get("baseRefName") not in (None, parent):
             problems.append(f"L{idx} {name}: PR #{row['pr']} base is {pr['baseRefName']}, expected {parent}")
         if base_ok is False:
-            if idx == 1 and is_ancestor(br["base"], expected_base):
+            if idx == 1 and is_ancestor(br.get("base", ""), expected_base):
                 notes.append(f"L1 {name}: behind trunk ({short(br['base'])} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
             else:
                 problems.append(f"L{idx} {name}: base {short(br['base'])} != parent head {short(expected_base)} -> needs rebase")
@@ -140,7 +198,7 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
             problems.append(f"L{idx} {name}: PR #{row['pr']} is DRAFT (blocks stack merge)")
         rows.append(row)
         # The next layer must be based on THIS layer's pushed head (fall back to local).
-        expected_base = origin or br["head"]
+        expected_base = origin or br.get("head")
     return rows, problems, notes
 
 
@@ -155,6 +213,8 @@ ICON_CI = {"SUCCESS": "✅", "FAILURE": "❌", "ERROR": "❌", "PENDING": "🌀"
 
 
 def sync_icon(r: dict) -> str:
+    if r["merged"]:
+        return ICON_MERGE["MERGED"]
     if r["origin_ok"] is False:
         return ICON_SYNC["stale"]
     if r["base_ok"] is False or r["needs_rebase"]:
@@ -181,15 +241,14 @@ def ci_icon(r: dict) -> str:
 
 
 def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list[str], *, trunk_origin: str | None) -> str:
-    hdr = ["L", "branch", "PR", "head", "base", "sync", "merge", "CI"]
-    lines = [f"stack: {stack['trunk']} @ {short(trunk_origin)}  (current: {stack['currentBranch']})", ""]
+    hdr = ["L", "PR", "sync", "merge", "CI"]
+    lines = [f"stack: {stack['branches'][-1]['name']} -> {stack['trunk']} @ {short(trunk_origin)}", ""]
     lines.append("| " + " | ".join(hdr) + " |")
     lines.append("|" + "|".join("---" for _ in hdr) + "|")
     for r in rows:
         pr = f"#{r['pr']}" if r["pr"] else "-"
         lines.append("| " + " | ".join([
-            str(r["layer"]), r["branch"], pr, short(r["head"]), short(r["base"]),
-            sync_icon(r), merge_icon(r), ci_icon(r),
+            f"{r['layer']}/{len(rows)}", pr, sync_icon(r), merge_icon(r), ci_icon(r),
         ]) + " |")
     lines.append("")
     if problems:
@@ -198,7 +257,11 @@ def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list
     else:
         lines.append("VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its PR")
     lines.extend(f"- note: {n}" for n in notes)
-    lines.append("")
+    return "\n".join(lines)
+
+
+def legend() -> str:
+    lines = []
     lines.append("sync: ✅ base==parent head & local==origin==PR  🔄 local/origin/PR heads differ  ⚠️ needs rebase  ❓ unknown (--no-fetch)")
     lines.append("merge: 🚀 clean  🚧 blocked/unstable  ⏪ behind  ❌ conflicting/dirty  ⏳ computing  📝 draft  ◎ queued  🏁 merged")
     lines.append("CI: ✅ success  ❌ failure  🌀 pending  — none")
@@ -207,25 +270,46 @@ def render_table(stack: dict, rows: list[dict], problems: list[str], notes: list
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--trunk", help="only stacks whose trunk is this branch (e.g. integrate/phase-aw)")
+    ap.add_argument("--phase", help="shorthand for --trunk integrate/phase-<PHASE>")
+    ap.add_argument("--all", action="store_true", help="include stacks whose every layer is already merged")
     ap.add_argument("--no-fetch", action="store_true", help="skip `git fetch origin` and origin comparison")
     ap.add_argument("--no-pr", action="store_true", help="skip the GraphQL PR query (offline / local-only view)")
-    ap.add_argument("--json", action="store_true", help="emit the merged rows as JSON instead of a table")
+    ap.add_argument("--json", action="store_true", help="emit the merged rows as JSON instead of tables")
     args = ap.parse_args()
+    trunk_filter = args.trunk or (f"integrate/phase-{args.phase.lower()}" if args.phase else None)
 
-    stack = stack_json()
+    stacks = discover_stacks(trunk_filter, include_merged=args.all)
+    if not stacks:
+        where = f" with trunk {trunk_filter}" if trunk_filter else ""
+        sys.stderr.write(
+            f"no gh stack found{where}. Stacks are discovered through `git worktree list`; a stack "
+            "needs at least one of its layers checked out in a worktree (never `git checkout` in the main repo).\n"
+        )
+        return 2
     fetched = not args.no_fetch
     if fetched:
         run(["git", "fetch", "--quiet", "origin"], check=False)
-    numbers = [b["pr"]["number"] for b in stack["branches"] if b.get("pr")]
+    numbers = sorted({b["pr"]["number"] for st in stacks for b in st["branches"] if b.get("pr")})
     prs = {} if args.no_pr else pr_details(numbers)
-    rows, problems, notes = build_rows(stack, prs, fetched=fetched)
-    trunk_origin = origin_sha(stack["trunk"]) if fetched else None
+
+    report: list[dict] = []
+    blocks: list[str] = []
+    any_problem = False
+    for st in stacks:
+        rows, problems, notes = build_rows(st, prs, fetched=fetched)
+        trunk_origin = origin_sha(st["trunk"]) if fetched else None
+        any_problem |= bool(problems)
+        report.append({"trunk": st["trunk"], "trunk_origin": trunk_origin, "worktree": st["worktree"],
+                       "rows": rows, "problems": problems, "notes": notes, "coherent": not problems})
+        blocks.append(render_table(st, rows, problems, notes, trunk_origin=trunk_origin))
     if args.json:
-        print(json.dumps({"trunk": stack["trunk"], "trunk_origin": trunk_origin, "current": stack["currentBranch"],
-                          "rows": rows, "problems": problems, "notes": notes, "coherent": not problems}, indent=2))
+        print(json.dumps({"stacks": report, "coherent": not any_problem}, indent=2))
     else:
-        print(render_table(stack, rows, problems, notes, trunk_origin=trunk_origin))
-    return 1 if problems else 0
+        print("\n\n".join(blocks))
+        print()
+        print(legend())
+    return 1 if any_problem else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- New repo skill `.claude/skills/gh-stack-view/` (SKILL.md + `scripts/gh_stack_view.py`).
- One read-only call replaces the per-branch `gh pr view` habit: `gh stack view --json` (head/base SHAs, needsRebase, PR) + one `git fetch` + one batched GraphQL query (mergeable, mergeStateStatus, isDraft, statusCheckRollup).
- Coherence checks: each layer's base == parent's pushed head (bottom == trunk), local head == origin == PR head; problems listed with the owner action; bottom-layer-behind-trunk is a note only.
- Pure-python icon table (sprint-report icon vocabulary); the agent pastes the output verbatim and makes no rendering decisions. Exit 0 coherent / 1 problems / 2 not in a stack.

## Motivation (Rand)
Agents are oblivious to base coherence and needs-rebase on stacks and fall back to one tool call per branch, which returns neither metric. This skill forces the optimal command and shows both.

## Verification
Run from `fix/aw-pool-read-migration` (Stack A) against the live stale-tracking state: flagged L1/L2 local != origin, L2 base != parent head, L1 behind trunk as a note. `--no-fetch`, `--json`, and the detached-HEAD/develop error path exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK