### PR TITLE
fix(ax): phase-end recheck findings (AXPE-QA-117, RSH-003, RBP-003, RBP-004)

### DIFF
--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -13,7 +13,7 @@ pub use atm_storage::contract::{AckTransition, Message, MessageKey};
 pub use atm_storage::{
     AsyncTaskLedgerReader, BuiltInNudgeTemplateKind, DAEMON_ACTOR_NAME, EscalationScope,
     MAX_ESCALATION_RECIPIENTS, NudgeTemplateOverrideStore, ReadDeadline, ReminderOutcome,
-    TASK_STALLED_REMINDER_THRESHOLD, TaskEventRow, TaskRow, TaskStore,
+    TASK_STALLED_REMINDER_THRESHOLD, TaskEventKind, TaskEventRow, TaskRow, TaskStore,
     TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
 };
 

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -442,7 +442,7 @@ impl AsyncMessageReceivedHookEmitter for HerdrReceivedHook {
                 }
                 Err(error) => {
                     let outcome = error.emission_outcome();
-                    tracing::warn!(backend = "herdr", member = %dispatch.event.recipient, error = ?error, outcome, "Herdr wake-up was not accepted");
+                    tracing::warn!(subsystem = "received_hook_selector", action = "herdr_prompt", backend = "herdr", member = %dispatch.event.recipient, error = ?error, outcome, "Herdr wake-up was not accepted");
                     return Err(error.into());
                 }
             }

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -442,7 +442,7 @@ impl AsyncMessageReceivedHookEmitter for HerdrReceivedHook {
                 }
                 Err(error) => {
                     let outcome = error.emission_outcome();
-                    tracing::warn!(subsystem = "received_hook_selector", action = "herdr_prompt", backend = "herdr", member = %dispatch.event.recipient, error = ?error, outcome, "Herdr wake-up was not accepted");
+                    tracing::warn!(subsystem = "herdr_queue_wake", action = "herdr_prompt", backend = "herdr", member = %dispatch.event.recipient, error = ?error, outcome, "Herdr wake-up was not accepted");
                     return Err(error.into());
                 }
             }

--- a/crates/atm-http-runtime/src/herdr_escalation.rs
+++ b/crates/atm-http-runtime/src/herdr_escalation.rs
@@ -23,6 +23,21 @@ use crate::herdr_queue_wake::run_blocking;
 pub(crate) const HERDR_NOTIFY_DEADLINE: Duration = Duration::from_secs(5);
 pub(crate) const ESCALATION_RECIPIENT_CAP: usize = MAX_ESCALATION_RECIPIENTS;
 pub(crate) const MAX_BLOCKED_ESCALATIONS_PER_TICK: usize = 8;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum EscalationKind {
+    LeadNotified,
+    BlockedEscalated,
+}
+
+impl EscalationKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::LeadNotified => "lead_notified",
+            Self::BlockedEscalated => "blocked_escalated",
+        }
+    }
+}
 pub(crate) const BLOCKED_NOTIFY_MS: u64 = 60_000;
 pub(crate) const BLOCKED_RENOTIFY_MS: u64 = 600_000;
 
@@ -144,7 +159,7 @@ pub(crate) async fn escalate(
     team: &TeamName,
     mail_body: &str,
     notification: &EscalationNotification,
-    kind: &str,
+    kind: EscalationKind,
 ) -> EscalationOutcome {
     let targets = match load_escalation_targets(runtime, task_store, team).await {
         Ok(targets) => targets,
@@ -168,7 +183,7 @@ pub(crate) async fn escalate(
         event = "herdr_queue_poll_outcome",
         subsystem = "herdr_queue_wake",
         action = "escalation",
-        outcome = kind,
+        outcome = kind.as_str(),
         team = %team,
         lead_present = outcome.lead.is_some(),
         recipients_written = outcome.recipients_written,
@@ -310,14 +325,14 @@ async fn notify_only(
     herdr_process: &dyn HerdrProcessAdapter,
     team: &TeamName,
     notification: &EscalationNotification,
-    kind: &str,
+    kind: EscalationKind,
 ) -> EscalationOutcome {
     let notify_ok = notify(herdr_process, notification).await;
     tracing::info!(
         event = "herdr_queue_poll_outcome",
         subsystem = "herdr_queue_wake",
         action = "escalation",
-        outcome = kind,
+        outcome = kind.as_str(),
         team = %team,
         lead_present = false,
         recipients_written = 0,

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -2033,7 +2033,7 @@ mod tests {
             &team,
             "mail body is separate",
             &notification,
-            "lead_notified",
+            crate::herdr_escalation::EscalationKind::LeadNotified,
         )
         .await;
         assert_eq!(outcome.recipients_written, 1);

--- a/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake_escalation.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use atm_core::boundary::{
-    AsyncTaskLedgerReader, MemberKey, ReadDeadline, ReminderOutcome, TaskEventRow, TaskRow,
-    TaskState,
+    AsyncTaskLedgerReader, MemberKey, ReadDeadline, ReminderOutcome, TaskEventKind, TaskEventRow,
+    TaskRow, TaskState,
 };
 use atm_core::types::IsoTimestamp;
 
 use crate::herdr_escalation::{
-    BLOCKED_NOTIFY_MS, EscalationNotification, MAX_BLOCKED_ESCALATIONS_PER_TICK, escalate,
+    BLOCKED_NOTIFY_MS, EscalationKind, EscalationNotification, MAX_BLOCKED_ESCALATIONS_PER_TICK,
+    escalate,
 };
 use crate::herdr_queue_wake::{HerdrQueueWakePump, HerdrQueueWakeStats, run_blocking};
 
@@ -64,7 +65,7 @@ pub(crate) async fn maybe_escalate_task(
         &row.team,
         &body,
         &notification,
-        "lead_notified",
+        EscalationKind::LeadNotified,
     )
     .await;
     record_escalation_stats(stats, &outcome);
@@ -93,13 +94,13 @@ async fn reminder_events(
 fn task_escalation_body(row: &TaskRow, now: IsoTimestamp, events: &[TaskEventRow]) -> String {
     let first = events
         .iter()
-        .find(|event| event.event.as_str() == "reminded")
+        .find(|event| event.event == TaskEventKind::Reminded)
         .map(|event| event.at)
         .unwrap_or(row.assigned_at);
     let outcome = events
         .iter()
         .rev()
-        .find(|event| event.event.as_str() == "reminded")
+        .find(|event| event.event == TaskEventKind::Reminded)
         .and_then(|event| event.outcome)
         .map(ReminderOutcome::as_str)
         .unwrap_or("unknown");
@@ -222,7 +223,7 @@ async fn escalate_one_blocked(
         member.team(),
         &body,
         &notification,
-        "blocked_escalated",
+        EscalationKind::BlockedEscalated,
     )
     .await;
     record_escalation_stats(stats, &outcome);

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -164,6 +164,16 @@ Error codes should describe the failure class, not a specific prose message.
 - `ATM_WAIT_TIMEOUT`
 - `ATM_ACK_INVALID_STATE`
 - `ATM_CLEAR_INVALID_STATE`
+- `ATM_ROSTER_NO_LEAD` — assign one lead: `atm teams update-member <team>
+  <member> --agent-type lead`
+- `ATM_ROSTER_MULTIPLE_LEADS` — keep one lead: `atm teams update-member <team>
+  <member> --agent-type <other type>`
+- `ATM_ROSTER_RESERVED_NAME` — rename the member: `atm-daemon is reserved for
+  daemon-originated messages`
+- `ATM_TASK_STALLED` — check the assignee or close the task: `atm send <assignee>
+  --task-complete <task_id> --stdin`
+- `ATM_MEMBER_BLOCKED` — `<member> is waiting for interactive input; attach to
+  its Herdr agent and answer the prompt`
 
 ### 5.6 Observability
 


### PR DESCRIPTION
## Summary

- Register the five AX.6 doctor warning codes and remediation guidance.
- Add the established received-hook observability fields to Herdr rejection warnings.
- Replace stringly-typed escalation kinds with a closed enum and use `TaskEventKind::Reminded` for event matching.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p atm-http-runtime --lib` (227 passed)
- `cargo test -p atm-daemon-bootstrap --lib` (59 passed)
- `python3 .just/check_line_counts.py`
- `just test` and `just lint spell` could not start because `.bootstrap-venv/bin/python` is absent in this worktree.

Findings addressed: AXPE-QA-117, AXPE-RSH-003, AXPE-RBP-003, AXPE-RBP-004.