### PR TITLE
tooling: enforce fmt + clippy locally with a tracked pre-push hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Git hooks are POSIX shell scripts executed by Git's bundled sh on every
+# platform, including Git for Windows. A CRLF checkout (core.autocrlf=true)
+# breaks the shebang line, so pin LF regardless of the client's autocrlf.
+.githooks/* text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,14 +40,11 @@ if ! cargo fmt --all --check; then
     exit 1
 fi
 
-echo "pre-push: running clippy -D warnings (same invocation as CI)" >&2
-# `just _lint-clippy` pins PYO3_PYTHON to the bootstrap venv; fall back to plain
-# cargo clippy in a worktree that has not run `just bootstrap` yet.
-if command -v just >/dev/null 2>&1 && [ -x .bootstrap-venv/bin/python ]; then
-    just _lint-clippy
-else
-    cargo clippy --workspace --all-targets -- -D warnings
-fi
+echo "pre-push: running cargo clippy --workspace --all-targets -- -D warnings" >&2
+# This is byte-for-byte the gating clippy job in .github/workflows/ci.yml
+# (job "clippy"): bare cargo, no PYO3_PYTHON, no venv, no `just`. Keeping it
+# identical to CI is the whole point; do not route it through the Justfile.
+cargo clippy --workspace --all-targets -- -D warnings
 status=$?
 if [ "$status" -ne 0 ]; then
     echo "pre-push: REFUSED. Clippy reported warnings; fix them before pushing." >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Pre-push gate: CI must never fail on formatting or clippy. Every push of
+# Rust changes runs the same two checks CI runs, locally, before the push
+# leaves this machine. Installed by `just bootstrap` (or `just hooks`) via
+# `git config core.hooksPath .githooks`; the setting is repo-wide, so one
+# install covers every worktree.
+#
+# Explicit opt-out only: ATM_SKIP_PUSH_GATE=1 skips the gate and says so.
+# There is no implicit bypass.
+set -u
+
+if [ "${ATM_SKIP_PUSH_GATE:-}" = "1" ]; then
+    echo "pre-push: ATM_SKIP_PUSH_GATE=1 set; skipping fmt/clippy gate" >&2
+    exit 0
+fi
+
+zero=0000000000000000000000000000000000000000
+needs_gate=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    [ "$local_sha" = "$zero" ] && continue   # branch delete: nothing to check
+    if [ "$remote_sha" = "$zero" ]; then
+        range="$local_sha"
+    else
+        range="$remote_sha..$local_sha"
+    fi
+    if git rev-list "$range" 2>/dev/null | head -n 1 | grep -q .; then
+        if git diff --name-only "$range" 2>/dev/null | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
+            needs_gate=1
+        fi
+    fi
+done
+
+if [ "$needs_gate" -eq 0 ]; then
+    exit 0
+fi
+
+echo "pre-push: running cargo fmt --all --check" >&2
+if ! cargo fmt --all --check; then
+    echo "pre-push: REFUSED. Formatting differs from rustfmt; run 'just fmt write' and amend." >&2
+    exit 1
+fi
+
+echo "pre-push: running clippy -D warnings (same invocation as CI)" >&2
+# `just _lint-clippy` pins PYO3_PYTHON to the bootstrap venv; fall back to plain
+# cargo clippy in a worktree that has not run `just bootstrap` yet.
+if command -v just >/dev/null 2>&1 && [ -x .bootstrap-venv/bin/python ]; then
+    just _lint-clippy
+else
+    cargo clippy --workspace --all-targets -- -D warnings
+fi
+status=$?
+if [ "$status" -ne 0 ]; then
+    echo "pre-push: REFUSED. Clippy reported warnings; fix them before pushing." >&2
+    exit "$status"
+fi
+exit 0

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -290,6 +290,42 @@ class BootstrapTests(unittest.TestCase):
         justfile = (SCRIPT.parents[1] / "Justfile").read_text(encoding="utf-8")
         self.assertIn('if os_family() == "windows" { "py -3.14" }', justfile)
 
+class GitHookTests(unittest.TestCase):
+    HOOK = Path(__file__).resolve().parents[2] / ".githooks" / "pre-push"
+
+    def test_pre_push_hook_is_tracked_and_executable(self) -> None:
+        self.assertTrue(self.HOOK.is_file())
+        self.assertTrue(self.HOOK.stat().st_mode & 0o111, "hook must be executable")
+        text = self.HOOK.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("#!/bin/sh"))
+        self.assertIn("cargo fmt --all --check", text)
+        self.assertIn("-D warnings", text)
+        self.assertIn("ATM_SKIP_PUSH_GATE", text)
+
+    def test_install_git_hooks_sets_repo_hooks_path(self) -> None:
+        with mock.patch.object(bootstrap, "run") as run:
+            bootstrap.install_git_hooks(dry_run=True)
+        run.assert_called_once_with(["git", "config", "core.hooksPath", ".githooks"], dry_run=True)
+
+    def test_install_git_hooks_skips_outside_a_checkout(self) -> None:
+        with (
+            mock.patch.object(bootstrap, "inside_git_checkout", return_value=False),
+            mock.patch.object(bootstrap, "run") as run,
+        ):
+            bootstrap.install_git_hooks(dry_run=False)
+        run.assert_not_called()
+
+    def test_install_git_hooks_refuses_when_hook_file_is_missing(self) -> None:
+        with (
+            mock.patch.object(bootstrap, "inside_git_checkout", return_value=True),
+            mock.patch.object(bootstrap, "ROOT", Path("/nonexistent-atm-root")),
+            mock.patch.object(bootstrap, "run") as run,
+        ):
+            with self.assertRaises(bootstrap.BootstrapError):
+                bootstrap.install_git_hooks(dry_run=False)
+        run.assert_not_called()
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_bootstrap.py
+++ b/.just/tests/test_bootstrap.py
@@ -327,5 +327,24 @@ class GitHookTests(unittest.TestCase):
 
 
 
+    def test_hooks_only_installs_hooks_without_bootstrapping_tools(self) -> None:
+        with (
+            mock.patch.object(bootstrap, "install_git_hooks") as install,
+            mock.patch.object(bootstrap, "bootstrap") as full,
+        ):
+            self.assertEqual(bootstrap.main(["bootstrap.py", "--hooks-only"]), 0)
+        install.assert_called_once_with(dry_run=False)
+        full.assert_not_called()
+
+    def test_hooks_only_surfaces_bootstrap_errors(self) -> None:
+        with mock.patch.object(bootstrap, "install_git_hooks", side_effect=bootstrap.BootstrapError("boom")):
+            self.assertEqual(bootstrap.main(["bootstrap.py", "--hooks-only"]), 1)
+
+    def test_hook_is_pinned_to_lf_line_endings(self) -> None:
+        attributes = self.HOOK.parents[1] / ".gitattributes"
+        self.assertIn(".githooks/* text eol=lf", attributes.read_text(encoding="utf-8"))
+        self.assertNotIn(b"\r\n", self.HOOK.read_bytes(), "hook must be LF-only in the tree")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Justfile
+++ b/Justfile
@@ -26,6 +26,11 @@ help:
 bootstrap *args:
     {{seed_python_cmd}} tools/bootstrap.py {{args}}
 
+# Install the tracked git hooks (pre-push fmt + clippy gate). `just bootstrap`
+# does this too; use this recipe to (re)install without a full bootstrap.
+hooks:
+    git config core.hooksPath .githooks
+
 [private]
 _fmt-write:
     cargo fmt --all

--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ bootstrap *args:
 # Install the tracked git hooks (pre-push fmt + clippy gate). `just bootstrap`
 # does this too; use this recipe to (re)install without a full bootstrap.
 hooks:
-    git config core.hooksPath .githooks
+    {{seed_python_cmd}} tools/bootstrap.py --hooks-only
 
 [private]
 _fmt-write:

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -277,11 +277,22 @@ CI runs Rust 1.94.1 clippy with `-D warnings`. Local toolchains may be older and
 
 - **Deprecated APIs**: Use `assert_cmd::cargo::cargo_bin_cmd!("atm")` instead of the deprecated `Command::cargo_bin("atm")`.
 
-### Pre-Commit Check
+### Pre-Push Gate
+
+CI must never fail on formatting or clippy. The tracked hook
+`.githooks/pre-push` runs `cargo fmt --all --check` and the CI clippy
+invocation (`just _lint-clippy`, `-D warnings`) before any push that touches
+Rust sources or Cargo manifests, and refuses the push on failure. `just
+bootstrap` installs it via `git config core.hooksPath .githooks`; `just hooks`
+reinstalls it on its own. The setting is repository-wide, so it covers every
+worktree.
+
+The only bypass is explicit: `ATM_SKIP_PUSH_GATE=1 git push`. It prints that
+it skipped. Do not use it to push code that has not passed the gate.
 
 Always run before declaring implementation complete:
 ```bash
-cargo clippy -- -D warnings
+just fmt check && just _lint-clippy
 ```
 
 ## Temporary Files and Directories

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -280,19 +280,21 @@ CI runs Rust 1.94.1 clippy with `-D warnings`. Local toolchains may be older and
 ### Pre-Push Gate
 
 CI must never fail on formatting or clippy. The tracked hook
-`.githooks/pre-push` runs `cargo fmt --all --check` and the CI clippy
-invocation (`just _lint-clippy`, `-D warnings`) before any push that touches
-Rust sources or Cargo manifests, and refuses the push on failure. `just
-bootstrap` installs it via `git config core.hooksPath .githooks`; `just hooks`
-reinstalls it on its own. The setting is repository-wide, so it covers every
-worktree.
+`.githooks/pre-push` runs `cargo fmt --all --check` and the exact CI clippy
+command (`cargo clippy --workspace --all-targets -- -D warnings`, bare cargo,
+no venv) before any push that touches Rust sources or Cargo manifests, and
+refuses the push on failure. `just bootstrap` installs it via `git config
+core.hooksPath .githooks`; `just hooks` reinstalls it on its own through the
+same guards. The setting is repository-wide, so it covers every worktree.
+`.gitattributes` pins the hook to LF so a Windows checkout with
+`core.autocrlf=true` cannot corrupt the shebang line.
 
 The only bypass is explicit: `ATM_SKIP_PUSH_GATE=1 git push`. It prints that
 it skipped. Do not use it to push code that has not passed the gate.
 
 Always run before declaring implementation complete:
 ```bash
-just fmt check && just _lint-clippy
+just fmt check && cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 ## Temporary Files and Directories

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -703,8 +703,17 @@ def main(argv: Sequence[str]) -> int:
     """Run a real bootstrap or a reviewable command-only dry run."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="Print exact install commands without changing state.")
+    parser.add_argument(
+        "--hooks-only",
+        action="store_true",
+        help="Only (re)install the tracked git hooks; skip the tool bootstrap.",
+    )
     args = parser.parse_args(argv[1:])
     try:
+        if args.hooks_only:
+            install_git_hooks(dry_run=args.dry_run)
+            print("bootstrap: git hooks installed (core.hooksPath=.githooks).")
+            return 0
         bootstrap(load_manifest(), dry_run=args.dry_run)
     except (BootstrapError, KeyError, OSError, tomllib.TOMLDecodeError) as error:
         print(f"bootstrap refused: {error}", file=sys.stderr)

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -639,6 +639,29 @@ def verify_installed_tools(manifest: BootstrapManifest, python: Path) -> None:
             raise BootstrapError(f"Python package {package} must be exactly {version}; found {actual}.")
 
 
+HOOKS_DIR = ".githooks"
+
+
+def inside_git_checkout() -> bool:
+    """True when ROOT is a git worktree (a `.git` directory or worktree file)."""
+    return (ROOT / ".git").exists()
+
+
+def install_git_hooks(*, dry_run: bool) -> None:
+    """Point core.hooksPath at the tracked hooks so pushes run the fmt/clippy gate.
+
+    The setting lives in the repository config, so one install covers every
+    worktree. Outside a git checkout (an exported tarball) there is nothing
+    to configure and the step is skipped rather than failed.
+    """
+    if not inside_git_checkout():
+        print("bootstrap: not a git checkout; skipping git hook install")
+        return
+    if not (ROOT / HOOKS_DIR / "pre-push").is_file():
+        raise BootstrapError(f"{HOOKS_DIR}/pre-push is missing; the tracked pre-push gate must exist")
+    run(["git", "config", "core.hooksPath", HOOKS_DIR], dry_run=dry_run)
+
+
 def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
     """Install the complete contract, then verify it rather than trusting installs."""
     synchronize_macos_seed_tools(manifest, dry_run=dry_run)
@@ -673,6 +696,7 @@ def bootstrap(manifest: BootstrapManifest, *, dry_run: bool) -> None:
     run(pip_install_command(python), dry_run=dry_run)
     if not dry_run:
         verify_installed_tools(manifest, python)
+    install_git_hooks(dry_run=dry_run)
 
 
 def main(argv: Sequence[str]) -> int:


### PR DESCRIPTION
## Why

PR #1254 failed the Format check in CI on an intermediate push. Per Rand: "we should never fail fmt/clippy in ci". This PR moves that gate in front of `git push`.

## What

- **`.githooks/pre-push`** (tracked, executable, LF-pinned): for any pushed range that touches `*.rs` or a `Cargo.toml`/`Cargo.lock`, runs `cargo fmt --all --check` and then `cargo clippy --workspace --all-targets -- -D warnings`, byte-identical to the gating clippy job in `ci.yml`. Docs-only pushes and branch deletions are not gated. Bypass is explicit opt-out only: `ATM_SKIP_PUSH_GATE=1 git push`.
- **`.gitattributes`**: `.githooks/* text eol=lf` so a Windows checkout with `core.autocrlf=true` cannot corrupt the shebang.
- **`tools/bootstrap.py`**: `just bootstrap` sets `core.hooksPath=.githooks` (repo-level config, covers every worktree) and refuses to continue if the tracked hook is missing. New `--hooks-only` flag runs just that step through the same guards.
- **`Justfile`**: `just hooks` runs `tools/bootstrap.py --hooks-only`.
- **`.just/tests/test_bootstrap.py`**: 7 new tests (hook tracked and executable; LF-only and pinned; install sets hooksPath; skipped outside a checkout; refuses on missing hook; `--hooks-only` installs without full bootstrap; `--hooks-only` surfaces errors).
- **`docs/cross-platform-guidelines.md`**: "Pre-Commit Check" section replaced by "Pre-Push Gate".

## QA round 1 (FAIL 4/6 at 3f680a451) → fixed at a2cf111fc

| Finding | Fix |
|---|---|
| ATM-QA-001 blocking, no LF pin | `.gitattributes`; verified `git -c core.autocrlf=true clone` yields `#!/bin/sh\n` |
| ATM-QA-002 important, Unix-only venv probe | probe removed; hook no longer uses `just` or the venv at all |
| RBQA-F201 important, "same as CI" was false | hook runs the bare ci.yml command, no `PYO3_PYTHON` |
| Minor, `just hooks` bypassed guards | routed through `bootstrap.py --hooks-only` |
| Minor, pytest count | corrected below |

## Verification (at a2cf111fc)

| Check | Result |
|---|---|
| `.just/tests/test_bootstrap.py` | 34 passed |
| `just lint pytests` (at 3f680a451) | 1089 ran, 1068 passed, 21 skipped, 0 failed |
| `just lint spell` / `lines` / `function-length` | pass |
| Hook, docs-only range | exit 0, no cargo run |
| Hook, `ATM_SKIP_PUSH_GATE=1` | exit 0, skipped with message |
| Hook, Rust-touching range (4c838157a..HEAD) | fmt + clippy both run, exit 0 |
| `just hooks` | prints `git config core.hooksPath .githooks`, hooksPath set |
| `git -c core.autocrlf=true ls-files --eol .githooks/pre-push` | `i/lf w/lf attr/text eol=lf` |

Not touched: any daemon runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
