### PR TITLE
fix(ax): close recheck2 cleanup findings

### DIFF
--- a/crates/atm-http-runtime/src/herdr_escalation.rs
+++ b/crates/atm-http-runtime/src/herdr_escalation.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 #[cfg(test)]
@@ -23,6 +23,11 @@ use crate::herdr_queue_wake::run_blocking;
 pub(crate) const HERDR_NOTIFY_DEADLINE: Duration = Duration::from_secs(5);
 pub(crate) const ESCALATION_RECIPIENT_CAP: usize = MAX_ESCALATION_RECIPIENTS;
 pub(crate) const MAX_BLOCKED_ESCALATIONS_PER_TICK: usize = 8;
+
+/// Typed daemon identity for escalation mail; the constant is a valid agent
+/// name, so it is constructed once instead of reparsed for every write.
+static DAEMON_ACTOR: LazyLock<AgentName> =
+    LazyLock::new(|| AgentName::from_validated(atm_core::boundary::DAEMON_ACTOR_NAME));
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum EscalationKind {
@@ -395,11 +400,7 @@ async fn write_escalation_mail(
         let request = WriteRequest::new(
             daemon_home.clone(),
             daemon_home,
-            atm_core::boundary::DAEMON_ACTOR_NAME
-                .parse()
-                .map_err(|error| {
-                    AtmError::validation(format!("invalid daemon actor name: {error}"))
-                })?,
+            DAEMON_ACTOR.clone(),
             &recipient,
             team,
             SendMessageSource::Inline(body),

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -193,7 +193,7 @@ approach.
 
 ADR numbering (AYS-R2-001): `docs/adr/ADR-061-governed-interface-schema-versioning.md`
 is on develop (PR #1218). Phase AX's AX.3 created
-`docs/adr/ADR-061-task-state-machine.md` on `integrate/phase-ax`, not yet
+`docs/adr/ADR-062-task-state-machine.md` on `integrate/phase-ax`, not yet
 on develop, so the two collide when phase AX lands. Resolution, owned by
 fenix inside phase AX (not AY): the AX.3 ADR is renumbered to the next
 free number on `integrate/phase-ax`, with its references in

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1639,7 +1639,7 @@ Phase AX sprint status:
 | `AX.2` | A | after AX.1; parallel with AX.3/AX.4 | `complete` | `feature/ax2-herdr-template-rendering` | `docs/plans/phase-ax/sprint-AX.2-herdr-template-rendering.md`, ADR-058 amendment, `boundaries/atm-herdr/herdr-process-adapter.toml`, `docs/atm-herdr/requirements.md` |
 | `AX.3` | B | parallel with AX.1/AX.2 | `complete` | `feature/ax3-task-state-machine` | `docs/plans/phase-ax/sprint-AX.3-task-state-machine.md`, `docs/adr/ADR-062-task-state-machine.md`, ADR-054 amendment, `boundaries/atm-storage/task-store.toml`, `boundaries/atm-storage-rusqlite/task-store-sqlite.toml` |
 | `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `complete` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |
-| `AX.5` | C | after A and B merge | `complete` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-061 reminder-cycle section |
+| `AX.5` | C | after A and B merge | `complete` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-062 reminder-cycle section |
 | `AX.6` | C | after AX.5 | `complete` | `feature/ax6-lead-notification-doctor` | `docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md` |
 | `AX.7` | D | superseded 2026-09-05 (live proof moved to release readiness) | `superseded` | none | `docs/plans/phase-ax/sprint-AX.7-herdr-dogfood-evidence.md` |
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1635,12 +1635,12 @@ Phase AX sprint status:
 
 | Sprint | Track | Execute | Status | Branch | Artifacts |
 | --- | --- | --- | --- | --- | --- |
-| `AX.1` | A | parallel with AX.3/AX.4 | `planned` | `feature/ax1-queue-template-class` | `docs/plans/phase-ax/sprint-AX.1-queue-template-class.md`, ADR-019 amendment |
-| `AX.2` | A | after AX.1; parallel with AX.3/AX.4 | `planned` | `feature/ax2-herdr-template-rendering` | `docs/plans/phase-ax/sprint-AX.2-herdr-template-rendering.md`, ADR-058 amendment, `boundaries/atm-herdr/herdr-process-adapter.toml`, `docs/atm-herdr/requirements.md` |
-| `AX.3` | B | parallel with AX.1/AX.2 | `planned` | `feature/ax3-task-state-machine` | `docs/plans/phase-ax/sprint-AX.3-task-state-machine.md`, `docs/adr/ADR-061-task-state-machine.md`, ADR-054 amendment, `boundaries/atm-storage/task-store.toml`, `boundaries/atm-storage-rusqlite/task-store-sqlite.toml` |
-| `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `planned` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |
-| `AX.5` | C | after A and B merge | `planned` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-061 reminder-cycle section |
-| `AX.6` | C | after AX.5 | `planned` | `feature/ax6-lead-notification-doctor` | `docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md` |
+| `AX.1` | A | parallel with AX.3/AX.4 | `complete` | `feature/ax1-queue-template-class` | `docs/plans/phase-ax/sprint-AX.1-queue-template-class.md`, ADR-019 amendment |
+| `AX.2` | A | after AX.1; parallel with AX.3/AX.4 | `complete` | `feature/ax2-herdr-template-rendering` | `docs/plans/phase-ax/sprint-AX.2-herdr-template-rendering.md`, ADR-058 amendment, `boundaries/atm-herdr/herdr-process-adapter.toml`, `docs/atm-herdr/requirements.md` |
+| `AX.3` | B | parallel with AX.1/AX.2 | `complete` | `feature/ax3-task-state-machine` | `docs/plans/phase-ax/sprint-AX.3-task-state-machine.md`, `docs/adr/ADR-062-task-state-machine.md`, ADR-054 amendment, `boundaries/atm-storage/task-store.toml`, `boundaries/atm-storage-rusqlite/task-store-sqlite.toml` |
+| `AX.4` | B | after AX.3; parallel with AX.1/AX.2 | `complete` | `feature/ax4-task-cli-and-docs` | `docs/plans/phase-ax/sprint-AX.4-task-cli-and-docs.md`, `docs/user-documents/tasks.md` |
+| `AX.5` | C | after A and B merge | `complete` | `feature/ax5-task-reminder-cycle` | `docs/plans/phase-ax/sprint-AX.5-task-reminder-cycle.md`, ADR-061 reminder-cycle section |
+| `AX.6` | C | after AX.5 | `complete` | `feature/ax6-lead-notification-doctor` | `docs/plans/phase-ax/sprint-AX.6-lead-notification-doctor.md` |
 | `AX.7` | D | superseded 2026-09-05 (live proof moved to release readiness) | `superseded` | none | `docs/plans/phase-ax/sprint-AX.7-herdr-dogfood-evidence.md` |
 
 ## 56. Phase AY — Native-IPC Transport Cutover For Herdr [PLANNING — DRAFT, NOT APPROVED]


### PR DESCRIPTION
## Summary
- mark completed AX.1–AX.6 rows as complete in the Phase AX project-plan table
- correct the two AX task-state ADR references to ADR-062
- construct the fixed daemon actor identity once as a typed value, rather than parsing and flattening errors per escalation write

## Findings
- `urn:atm:triage:finding/AXPE-QA-122`: fixed
- `urn:atm:triage:finding/AXPE-QA-123`: fixed
- `urn:atm:triage:finding/AXPE-RBP-005`: fixed

## Validation
- `cargo fmt --all --check`
- `cargo test -p atm-http-runtime`
- `cargo clippy -p atm-http-runtime --all-targets -- -D warnings`
- `python3 .just/check_line_counts.py`
- `just test` (1,089 Python tests; 21 skipped; full workspace Rust suite)
- `git diff --check`