### PR TITLE
fix(storage): await graft receiver lookups through reader pool

### DIFF
--- a/.triage/phase-aw/findings/QA-POOL-ASYNC-1.ttl
+++ b/.triage/phase-aw/findings/QA-POOL-ASYNC-1.ttl
@@ -15,12 +15,14 @@
   triage:severity "minor" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-06T20:30:00Z"^^xsd:dateTime ;
   triage:foundIn triage:phase-aw-gate-closeout ;
   triage:foundAt "2026-09-06T18:53:31Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/QA-POOL-ASYNC-1/R1> ;
+  triage:closedAt "2026-09-06T21:15:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:triageRecordVersion "1" .
 
 <urn:atm:triage:occurrence/QA-POOL-ASYNC-1/R1>
@@ -28,8 +30,8 @@
   triage:file "crates/atm-http-runtime/src/storage_and_nudge_router.rs" ;
   triage:line 785 ;
   triage:snippet "self.control_path_sync_bridge.run(deadline, move || {" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "develop" ;
   triage:headSha "dba42148d" ;
   triage:occursIn <urn:atm:triage:worktree/develop/dba42148d> .
@@ -40,3 +42,12 @@
   triage:branch "develop" ;
   triage:headSha "dba42148d" ;
   triage:orderIndex 0 .
+
+<urn:atm:triage:resolution/QA-POOL-ASYNC-1/r1>
+  a triage:Resolution ;
+  triage:findingId "QA-POOL-ASYNC-1" ;
+  triage:resolutionNote "quality-mgr closure at PR #1261 (fix/aw-pool-graft-lookup-async -> develop, head 09495c629). graft_receiver_lookup (crates/atm-http-runtime/src/storage_and_nudge_router.rs:774-796, verified by direct read) now calls store.lookup_with_deadline_async(&team, &agent, remaining).await directly through a new AsyncGraftReceiverEndpointStore companion trait (crates/atm-storage/src/contract.rs:987-1002), modeled on the existing AsyncMessageStore supertrait/default-error layering convention (contract.rs:686-731). The SQLite implementation (graft_receiver_endpoint_store.rs:339-357) routes through SharedDb::read_with_deadline_async (shared_db.rs:243-257) into ReaderPool::submit (reader_pool.rs:428-539) -- the genuine async lane with persistent worker threads, mpsc dispatch, and tokio::time::timeout on both enqueue and reply legs, distinct from the sync read_with_deadline/submit_blocking path. No spawn_blocking or control_path_sync_bridge remains on this call path (confirmed by direct read and repo-wide grep). A deadline-expiry test (async_lookup_returns_hit_miss_and_deadline_error_from_reader_pool, graft_receiver_endpoint_store.rs:469-499) exercises a real Duration::ZERO timeout producing a DeadlineExpired error, not a stub. A new function-scoped regression guard (crates/atm-architecture/tests/boundary_enforcement.rs:2017-2036) source-slices graft_receiver_lookup's body and asserts presence of lookup_with_deadline_async plus absence of spawn_blocking/control_path_sync_bridge. Ripple touches in atm-core/service_runtime.rs, atm-storage/factory.rs, atm-storage/testing.rs, atm-runtime-test-support/lib.rs, atm-graft/runtime/mod.rs are narrow trait-type substitutions required for end-to-end wiring, not unrelated changes. Verified by four independent reviewers (req-qa, arch-qa, ruthless-boundary-qa, rust-qa-agent: fmt/clippy/test all green) plus my own direct read of the call site and grep sweep; diff does not touch crates/atm-daemon (legacy sync daemon, frozen Phase-AM deletion target). ruthless-boundary-qa raised one separate Important finding (RBQA-AW-POOL-ASYNC1-F001: no boundary TOML record exists for the new AsyncGraftReceiverEndpointStore trait, unlike its AsyncMessageStore precedent) -- independently confirmed via python3 .just/lint_boundaries.py passing green despite the gap; this is a real governance-coverage gap but does not regress or bear on QA-POOL-ASYNC-1's original ask and is routed to team-lead as a new finding for separate triage, not folded into this closure." ;
+  triage:resolvedAt "2026-09-06T21:15:00Z"^^xsd:dateTime ;
+  triage:resolvedStatus "fixed" ;
+  triage:resolvedHeadSha "09495c629" ;
+  triage:resolvedBranch "fix/aw-pool-graft-lookup-async" .

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -2025,8 +2025,9 @@ fn aw_pool_graft_receiver_lookup_uses_the_deadline_bounded_reader_lane() {
         .expect("graft receiver lookup route must remain present");
 
     assert!(
-        lookup.contains("tokio::task::spawn_blocking") && lookup.contains("lookup_with_deadline"),
-        "the unpaired graft receiver lookup must run through the deadline-bounded reader lane"
+        lookup.contains("lookup_with_deadline_async")
+            && !lookup.contains("tokio::task::spawn_blocking"),
+        "the unpaired graft receiver lookup must await the deadline-bounded reader lane directly"
     );
     assert!(
         !lookup.contains("control_path_sync_bridge"),

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -134,7 +134,10 @@ pub use api::{
     MAX_HTTP_REQUEST_BODY_BYTES, RequestDeadline,
 };
 pub use atm_storage::derive_ack_requirement;
-pub use atm_storage::{GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease};
+pub use atm_storage::{
+    AsyncGraftReceiverEndpointStore, GraftEndpointStoreError, GraftReceiverEndpointStore,
+    GraftReceiverLease,
+};
 pub use atm_storage::{TemplateFrontmatter, TemplateSha};
 pub use atm_temp::{
     AtmTemp, AtmTempError, EnvSource, ProcessEnvSource, resolve_atm_temp, send_to_staging_dir,

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -10,10 +10,11 @@ use std::sync::{Arc, MutexGuard, RwLock};
 use std::time::{Duration, Instant};
 
 use atm_storage::{
-    AsyncMessageSearchStore, AsyncMessageStore as SharedAsyncMessageStore, GraftEndpointStoreError,
-    GraftReceiverEndpointStore, GraftReceiverLease, MessageStore as SharedMessageStore,
-    OwnerGeneration, PendingNudgeStore, RosterMemberEphemeralState, RosterRuntimeMirror,
-    RosterStore as SharedRosterStore, TemplateCatalogStore,
+    AsyncGraftReceiverEndpointStore, AsyncMessageSearchStore,
+    AsyncMessageStore as SharedAsyncMessageStore, GraftEndpointStoreError, GraftReceiverLease,
+    MessageStore as SharedMessageStore, OwnerGeneration, PendingNudgeStore,
+    RosterMemberEphemeralState, RosterRuntimeMirror, RosterStore as SharedRosterStore,
+    TemplateCatalogStore,
 };
 
 use crate::boundary::TemplateComposer;
@@ -310,7 +311,7 @@ pub struct LocalServiceRuntime {
     /// nudge, e.g. plain-text mailbox tests.
     pending_nudge_store: Option<std::sync::Arc<dyn PendingNudgeStore + Send + Sync>>,
     graft_receiver_endpoint_store:
-        Option<std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>>,
+        Option<std::sync::Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync>>,
     /// Optional renderer selected by the bootstrap composition root. Core send
     /// policy sees only this port; it never depends on `sc-composer` itself.
     pub(crate) template_composer: Option<std::sync::Arc<dyn TemplateComposer>>,
@@ -472,7 +473,7 @@ impl LocalServiceRuntime {
     #[must_use]
     pub fn with_graft_receiver_endpoint_store(
         mut self,
-        store: std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
+        store: std::sync::Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync>,
     ) -> Self {
         self.graft_receiver_endpoint_store = Some(store);
         self
@@ -480,7 +481,7 @@ impl LocalServiceRuntime {
 
     pub fn graft_receiver_endpoint_store(
         &self,
-    ) -> Result<std::sync::Arc<dyn GraftReceiverEndpointStore + Send + Sync>, AtmError> {
+    ) -> Result<std::sync::Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync>, AtmError> {
         self.graft_receiver_endpoint_store.clone().ok_or_else(|| {
             AtmError::daemon_unavailable(
                 "the graft receiver endpoint store was not installed in this runtime",

--- a/crates/atm-graft/src/runtime/mod.rs
+++ b/crates/atm-graft/src/runtime/mod.rs
@@ -1720,7 +1720,7 @@ mod tests {
         // `atm-http-runtime`'s own replacement-router tests use to reach a
         // real SQLite-backed store: `atm-graft` may not depend on
         // `atm-storage-rusqlite` directly (repository boundary lint).
-        let store: Arc<Mutex<Arc<dyn atm_core::GraftReceiverEndpointStore + Send + Sync>>> =
+        let store: Arc<Mutex<Arc<dyn atm_core::AsyncGraftReceiverEndpointStore + Send + Sync>>> =
             Arc::new(Mutex::new(
                 atm_runtime_test_support::open_graft_receiver_endpoint_store(&db_path)
                     .expect("open sqlite-backed graft receiver endpoint store"),
@@ -1766,15 +1766,16 @@ mod tests {
 
         let team = TeamName::from_validated(TEST_TEAM);
         let agent = AgentName::from_validated(TEST_QA);
-        let lookup =
-            |store: &Arc<Mutex<Arc<dyn atm_core::GraftReceiverEndpointStore + Send + Sync>>>| {
-                store
-                    .lock()
-                    .expect("store")
-                    .lookup(&team, &agent)
-                    .ok()
-                    .flatten()
-            };
+        let lookup = |store: &Arc<
+            Mutex<Arc<dyn atm_core::AsyncGraftReceiverEndpointStore + Send + Sync>>,
+        >| {
+            store
+                .lock()
+                .expect("store")
+                .lookup(&team, &agent)
+                .ok()
+                .flatten()
+        };
         assert!(
             wait_until(Duration::from_secs(3), || lookup(&store).is_some()),
             "the initial announce must persist a lease before any daemon restart"

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -786,19 +786,10 @@ impl StorageAndNudgeRouter {
             )
         })?;
         let store = self.service_runtime.graft_receiver_endpoint_store()?;
-        let lease = tokio::task::spawn_blocking(move || {
-            store
-                .lookup_with_deadline(&team, &agent, remaining)
-                .map_err(graft_store_error)
-        })
-        .await
-        .map_err(|source| {
-            AtmError::new(
-                atm_core::error::AtmErrorCode::InternalError,
-                "graft receiver lease reader task ended unexpectedly",
-            )
-            .with_cause(source)
-        })??;
+        let lease = store
+            .lookup_with_deadline_async(&team, &agent, remaining)
+            .await
+            .map_err(graft_store_error)?;
         Ok(ApiResponse::new(ResponseEnvelope::GraftReceiverLookup(
             lease,
         )))

--- a/crates/atm-runtime-test-support/src/lib.rs
+++ b/crates/atm-runtime-test-support/src/lib.rs
@@ -256,7 +256,7 @@ pub fn open_sqlite_boundary(path: impl AsRef<Path>) -> Result<RuntimeAssembly, A
 /// exposing a concrete SQLite handle to the HTTP runtime.
 pub fn open_graft_receiver_endpoint_store(
     path: impl AsRef<Path>,
-) -> Result<Arc<dyn atm_core::GraftReceiverEndpointStore + Send + Sync>, AtmError> {
+) -> Result<Arc<dyn atm_storage::AsyncGraftReceiverEndpointStore + Send + Sync>, AtmError> {
     let backend = atm_storage_rusqlite::SqliteStorageBackend::new(path)?;
     Ok(backend.graft_receiver_endpoint_store())
 }

--- a/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
+++ b/crates/atm-storage-rusqlite/src/graft_receiver_endpoint_store.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use atm_storage::OwnerGeneration;
 use atm_storage::contract::{
-    GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
-    GraftReceiverRegistration, sealed,
+    AsyncGraftReceiverEndpointStore, GraftEndpointStoreError, GraftReceiverEndpointStore,
+    GraftReceiverLease, GraftReceiverRegistration, sealed,
 };
 use atm_storage::types::{AgentName, LocalCapability, TeamName};
 use chrono::{DateTime, Utc};
@@ -33,6 +33,57 @@ impl sealed::Sealed for SqliteGraftReceiverEndpointStore {}
 // architectural self-loop.
 fn storage_error(error: atm_storage::AtmError) -> GraftEndpointStoreError {
     GraftEndpointStoreError::storage(&error)
+}
+
+macro_rules! lookup_lease {
+    ($connection:expr, $db:expr, $team:expr, $agent:expr) => {
+        $connection
+            .query_row(
+                "SELECT endpoint, capability, owner_generation,
+                    registered_at, last_seen_at, unreachable_at
+             FROM graft_receiver_endpoints
+             WHERE team = ?1 AND agent = ?2;",
+                params![$team.as_str(), $agent.as_str()],
+                |row| {
+                    let endpoint = row.get::<_, String>(0)?.parse().map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?;
+                    let capability = LocalCapability::parse_base64url(&row.get::<_, String>(1)?)
+                        .map_err(|error| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                1,
+                                rusqlite::types::Type::Text,
+                                Box::new(std::io::Error::other(error.to_string())),
+                            )
+                        })?;
+                    Ok(GraftReceiverLease {
+                        endpoint,
+                        capability,
+                        owner_generation: OwnerGeneration::new(row.get::<_, String>(2)?).map_err(
+                            |error| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    2,
+                                    rusqlite::types::Type::Text,
+                                    Box::new(std::io::Error::other(error.to_string())),
+                                )
+                            },
+                        )?,
+                        registered_at: parse_timestamp(row.get::<_, String>(3)?)?,
+                        last_seen_at: parse_timestamp(row.get::<_, String>(4)?)?,
+                        unreachable_since: row
+                            .get::<_, Option<String>>(5)?
+                            .map(parse_timestamp)
+                            .transpose()?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| $db.error("failed to look up graft receiver endpoint", error))
+    };
 }
 
 impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
@@ -245,52 +296,7 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
         let db = Arc::clone(&self.db);
         self.db
             .read_with_deadline(deadline, move |connection| {
-                connection
-                    .query_row(
-                        "SELECT endpoint, capability, owner_generation,
-                                registered_at, last_seen_at, unreachable_at
-                         FROM graft_receiver_endpoints
-                         WHERE team = ?1 AND agent = ?2;",
-                        params![team.as_str(), agent.as_str()],
-                        |row| {
-                            let endpoint = row.get::<_, String>(0)?.parse().map_err(|error| {
-                                rusqlite::Error::FromSqlConversionFailure(
-                                    0,
-                                    rusqlite::types::Type::Text,
-                                    Box::new(error),
-                                )
-                            })?;
-                            let capability =
-                                LocalCapability::parse_base64url(&row.get::<_, String>(1)?)
-                                    .map_err(|error| {
-                                        rusqlite::Error::FromSqlConversionFailure(
-                                            1,
-                                            rusqlite::types::Type::Text,
-                                            Box::new(std::io::Error::other(error.to_string())),
-                                        )
-                                    })?;
-                            Ok(GraftReceiverLease {
-                                endpoint,
-                                capability,
-                                owner_generation: OwnerGeneration::new(row.get::<_, String>(2)?)
-                                    .map_err(|error| {
-                                        rusqlite::Error::FromSqlConversionFailure(
-                                            2,
-                                            rusqlite::types::Type::Text,
-                                            Box::new(std::io::Error::other(error.to_string())),
-                                        )
-                                    })?,
-                                registered_at: parse_timestamp(row.get::<_, String>(3)?)?,
-                                last_seen_at: parse_timestamp(row.get::<_, String>(4)?)?,
-                                unreachable_since: row
-                                    .get::<_, Option<String>>(5)?
-                                    .map(parse_timestamp)
-                                    .transpose()?,
-                            })
-                        },
-                    )
-                    .optional()
-                    .map_err(|error| db.error("failed to look up graft receiver endpoint", error))
+                lookup_lease!(connection, db.as_ref(), &team, &agent)
             })
             .map_err(storage_error)
     }
@@ -327,6 +333,26 @@ impl GraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
             return Err(GraftEndpointStoreError::NotOwner);
         }
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncGraftReceiverEndpointStore for SqliteGraftReceiverEndpointStore {
+    async fn lookup_with_deadline_async(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+        deadline: Duration,
+    ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError> {
+        let team = team.clone();
+        let agent = agent.clone();
+        let db = Arc::clone(&self.db);
+        self.db
+            .read_with_deadline_async(deadline, move |connection| {
+                lookup_lease!(connection, db.as_ref(), &team, &agent)
+            })
+            .await
+            .map_err(storage_error)
     }
 }
 
@@ -437,6 +463,38 @@ mod tests {
             .lookup_with_deadline(&team, &agent, Duration::ZERO)
             .expect_err("an expired deadline must not use the default reader deadline");
 
+        assert!(error.to_string().contains("deadline"));
+    }
+
+    #[tokio::test]
+    async fn async_lookup_returns_hit_miss_and_deadline_error_from_reader_pool() {
+        let store = store();
+        let (team, agent) = names();
+        let registration = registration(GENERATION_ONE, "127.0.0.1:43101");
+        store
+            .register(&registration, timestamp(10))
+            .expect("register fixture lease");
+
+        let hit = store
+            .lookup_with_deadline_async(&team, &agent, Duration::from_secs(1))
+            .await
+            .expect("async reader-pool lookup")
+            .expect("registered lease");
+        assert_eq!(hit.endpoint, registration.endpoint);
+
+        let missing_agent = AgentName::from_validated("no-lease");
+        assert_eq!(
+            store
+                .lookup_with_deadline_async(&team, &missing_agent, Duration::from_secs(1))
+                .await
+                .expect("async missing lookup"),
+            None
+        );
+
+        let error = store
+            .lookup_with_deadline_async(&team, &agent, Duration::ZERO)
+            .await
+            .expect_err("expired async deadline must not enter the default reader deadline");
         assert!(error.to_string().contains("deadline"));
     }
 

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -54,9 +54,9 @@ pub use crate::observability::{
     SqliteObservability, SqliteObservabilityEvent, SqliteObservabilityOutcome,
 };
 use atm_storage::contract::{
-    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, AsyncMailboxReader,
-    AsyncMessageStore, GraftReceiverEndpointStore, MailboxBucketCounts, MailboxScope, Message,
-    MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource,
+    AsyncGraftReceiverEndpointStore, AsyncMailboxReader, AsyncMessageStore, MailboxBucketCounts,
+    MailboxScope, Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
 };
 use atm_storage::schema::MessageEnvelope;
 use atm_storage::types::{AgentName, TeamName};
@@ -866,7 +866,7 @@ impl SqliteStorageBackend {
 
     pub fn graft_receiver_endpoint_store(
         &self,
-    ) -> Arc<dyn GraftReceiverEndpointStore + Send + Sync> {
+    ) -> Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync> {
         self.graft_receiver_endpoint_store.clone()
     }
 

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -1,13 +1,13 @@
 use crate::mail_messages_schema::{mail_messages_index_ddl, mail_messages_table_ddl};
 pub(crate) use crate::shared_db_reader_lanes::SharedDb;
 use crate::writer::{WriteOp, WriteOpResult, validate_upsert_message_request};
-use atm_storage::AsyncMailboxReader;
 use atm_storage::TemplateMessageAdmission;
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message,
 };
 use atm_storage::error::AtmError;
 use atm_storage::schema::ThreadMode;
+use atm_storage::{AsyncMailboxReader, ReadLaneError};
 #[cfg(test)]
 use rusqlite::OpenFlags;
 use rusqlite::{Connection, Error as RusqliteError, TransactionBehavior};
@@ -235,6 +235,25 @@ impl SharedDb {
                 Ok(operation(connection))
             })
             .map_err(AtmError::from)?
+    }
+
+    /// Awaits one pure read on the shared reader pool with the caller's
+    /// deadline. Tokio request paths use this instead of wrapping the
+    /// synchronous compatibility surface in `spawn_blocking`.
+    pub(crate) async fn read_with_deadline_async<T>(
+        &self,
+        deadline: std::time::Duration,
+        operation: impl FnOnce(&Connection) -> Result<T, AtmError> + Send + 'static,
+    ) -> Result<T, AtmError>
+    where
+        T: Send + 'static,
+    {
+        self.read_pool
+            .submit(deadline, move |connection, _target| {
+                operation(connection).map_err(read_lane_storage_error)
+            })
+            .await
+            .map_err(AtmError::from)
     }
 
     /// Runs a pure inspection read under the shared pool's tool-class cap.
@@ -521,6 +540,14 @@ impl SharedDb {
             #[cfg(test)]
             SharedDbTarget::InMemory { .. } => None,
         }
+    }
+}
+
+fn read_lane_storage_error(error: AtmError) -> ReadLaneError {
+    ReadLaneError::Storage {
+        code: error.code(),
+        message: error.message().to_owned(),
+        cause: error.cause().map(str::to_owned),
     }
 }
 

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -978,6 +978,29 @@ pub trait GraftReceiverEndpointStore: sealed::Sealed + Send + Sync {
     ) -> Result<(), GraftEndpointStoreError>;
 }
 
+/// Tokio-safe counterpart to [`GraftReceiverEndpointStore`] lease lookups.
+///
+/// The synchronous trait remains the compatibility surface for non-Tokio
+/// callers. HTTP request paths use this companion so a SQLite backend can
+/// await its bounded reader lane directly instead of consuming a Tokio
+/// blocking worker merely to wait for that lane.
+#[async_trait::async_trait]
+pub trait AsyncGraftReceiverEndpointStore: GraftReceiverEndpointStore {
+    /// Looks up one receiver lease through the backend-owned asynchronous
+    /// reader lane.
+    async fn lookup_with_deadline_async(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+        _deadline: Duration,
+    ) -> Result<Option<GraftReceiverLease>, GraftEndpointStoreError> {
+        let error = AtmError::daemon_unavailable(
+            "graft receiver endpoint store does not implement async lease lookup",
+        );
+        Err(GraftEndpointStoreError::storage(&error))
+    }
+}
+
 /// A non-empty, opaque certificate fingerprint. It cannot be confused with a
 /// private-key reference at storage and transport boundaries.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/atm-storage/src/factory.rs
+++ b/crates/atm-storage/src/factory.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::{
-    AsyncMailboxReader, AsyncMessageSearchStore, AsyncMessageStore, AtmError,
-    DiagnosticTimelineStore, GraftReceiverEndpointStore, MessageSearchStore, MessageStore,
+    AsyncGraftReceiverEndpointStore, AsyncMailboxReader, AsyncMessageSearchStore,
+    AsyncMessageStore, AtmError, DiagnosticTimelineStore, MessageSearchStore, MessageStore,
     NudgeTemplateOverrideStore, PeerConfigStore, PendingNudgeStore, RosterRuntimeMirror,
     RosterStore, TemplateCatalogStore,
 };
@@ -114,7 +114,7 @@ pub struct StorageHandles {
     roster_runtime_mirror: Arc<dyn RosterRuntimeMirror + Send + Sync>,
     nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     pending_nudge_store: Arc<dyn PendingNudgeStore + Send + Sync>,
-    graft_receiver_endpoint_store: Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
+    graft_receiver_endpoint_store: Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync>,
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
     template_catalog_store: Arc<dyn TemplateCatalogStore + Send + Sync>,
     message_search_store: Arc<dyn MessageSearchStore + Send + Sync>,
@@ -142,7 +142,7 @@ pub struct StorageHandleParts {
     pub roster: WriteThroughRosterStore,
     pub nudge_template_override_store: Arc<dyn NudgeTemplateOverrideStore + Send + Sync>,
     pub pending_nudge_store: Arc<dyn PendingNudgeStore + Send + Sync>,
-    pub graft_receiver_endpoint_store: Arc<dyn GraftReceiverEndpointStore + Send + Sync>,
+    pub graft_receiver_endpoint_store: Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync>,
     pub peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
     pub template_catalog_store: Arc<dyn TemplateCatalogStore + Send + Sync>,
     pub message_search_store: Arc<dyn MessageSearchStore + Send + Sync>,
@@ -167,7 +167,7 @@ impl fmt::Debug for StorageHandles {
             .field("pending_nudge_store", &"dyn PendingNudgeStore")
             .field(
                 "graft_receiver_endpoint_store",
-                &"dyn GraftReceiverEndpointStore",
+                &"dyn AsyncGraftReceiverEndpointStore",
             )
             .field("peer_config_store", &"dyn PeerConfigStore")
             .field("template_catalog_store", &"dyn TemplateCatalogStore")
@@ -239,7 +239,7 @@ impl StorageHandles {
 
     pub fn graft_receiver_endpoint_store(
         &self,
-    ) -> Arc<dyn GraftReceiverEndpointStore + Send + Sync> {
+    ) -> Arc<dyn AsyncGraftReceiverEndpointStore + Send + Sync> {
         Arc::clone(&self.graft_receiver_endpoint_store)
     }
 

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -33,8 +33,8 @@ pub mod roles {
 pub use analyst_query::{AnalystQueryRow, AnalystQueryStore, AnalystQueryValue};
 pub use contract::{
     AckRequirementState, AckTransition, AcknowledgementCommit, AcknowledgementReplyBuilder,
-    AcknowledgementSource, AgentType, AsyncMailboxReader, AsyncMessageStore,
-    BuiltInNudgeTemplateKind, CertificateFingerprint, GraftEndpointStoreError,
+    AcknowledgementSource, AgentType, AsyncGraftReceiverEndpointStore, AsyncMailboxReader,
+    AsyncMessageStore, BuiltInNudgeTemplateKind, CertificateFingerprint, GraftEndpointStoreError,
     GraftReceiverEndpointStore, GraftReceiverLease, GraftReceiverRegistration, HttpsInterface,
     LocalCertificate, MAX_NUDGE_ATTEMPTS, MailMessageState, MailboxBucketCounts, MailboxScope,
     Message, MessageFingerprint, MessageKey, MessageQuery, MessageReceivedEvent, MessageStore,

--- a/crates/atm-storage/src/testing.rs
+++ b/crates/atm-storage/src/testing.rs
@@ -10,9 +10,9 @@
 use chrono::{DateTime, Utc};
 
 use crate::contract::{
-    AsyncMailboxReader, GraftEndpointStoreError, GraftReceiverEndpointStore, GraftReceiverLease,
-    GraftReceiverRegistration, MailboxScope, Message, MessageKey, MessageQuery, ReadDeadline,
-    ReadLaneError, sealed,
+    AsyncGraftReceiverEndpointStore, AsyncMailboxReader, GraftEndpointStoreError,
+    GraftReceiverEndpointStore, GraftReceiverLease, GraftReceiverRegistration, MailboxScope,
+    Message, MessageKey, MessageQuery, ReadDeadline, ReadLaneError, sealed,
 };
 use crate::types::{AgentName, IsoTimestamp, OwnerGeneration, TeamName};
 
@@ -70,6 +70,9 @@ impl GraftReceiverEndpointStore for NoopGraftReceiverEndpointStore {
         Ok(())
     }
 }
+
+#[async_trait::async_trait]
+impl AsyncGraftReceiverEndpointStore for NoopGraftReceiverEndpointStore {}
 
 /// Deterministic in-memory double for the sealed async mailbox-read contract.
 /// It is intentionally available only through the `test-utils` feature.


### PR DESCRIPTION
## Summary
- add the sealed async graft-receiver endpoint companion trait
- submit SQLite graft lookup directly to the deadline-bounded reader pool
- await the lookup in the HTTP router without `spawn_blocking`

Finding: QA-POOL-ASYNC-1

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- python3 .just/lint_boundaries.py
- python3 -m unittest discover -s .just/tests -p "test_*.py"
- python3 scripts/check-function-length.py
- git diff --check