### PR TITLE
docs(ax): codify pre-merge proof operations

### DIFF
--- a/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
+++ b/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
@@ -43,6 +43,16 @@ through normal PR review. Provisioning remains outside timed samples, and the
 runner must still validate the account-local manifest before touching state or
 starting a daemon.
 
+Benchmark completion reports are sent directly to the requestor's full
+host-qualified address (`<agent>@<team>.<host>`) exactly as supplied in the
+task assignment; a bare agent name must never be resolved by guessing the
+host. Benchmark evidence uses the fixed sequence
+`ATM_CAPACITY_HOST_LABEL=<host>-atmbench just benchmark`,
+`just benchmark-report`, and `just benchmark-publish`. The per-lane result
+JSON, `<campaign>.campaign.json`, and `<campaign>.xhtml` are committed under
+`site/reports/send-message-benchmark/`; hand-written or ad-hoc XHTML or JSON
+is not accepted.
+
 The benchmark runner must validate an account-local manifest against the
 executing process before it can touch state or start a daemon. The manifest
 binds the benchmark workflow to the account's UID, home, canonical durable

--- a/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
+++ b/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
@@ -43,7 +43,7 @@ through normal PR review. Provisioning remains outside timed samples, and the
 runner must still validate the account-local manifest before touching state or
 starting a daemon.
 
-Benchmark completion reports are sent directly to the requestor's full
+Benchmark completion reports are sent directly to the requester's full
 host-qualified address (`<agent>@<team>.<host>`) exactly as supplied in the
 task assignment; a bare agent name must never be resolved by guessing the
 host. Benchmark evidence uses the fixed sequence

--- a/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
+++ b/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
@@ -32,6 +32,12 @@ being a separate OS user; it is not an alternate scope for the interactive
 user. The account name is supplied by an operator/bootstrap workflow and is
 never a hardcoded identity or hostname.
 
+The running benchmark agent provisions its own disposable benchmark account
+as part of the workflow when needed; the workflow does not require a human to
+pre-provision that account. Provisioning remains outside timed samples, and
+the runner must still validate the account-local manifest before touching
+state or starting a daemon.
+
 The benchmark runner must validate an account-local manifest against the
 executing process before it can touch state or start a daemon. The manifest
 binds the benchmark workflow to the account's UID, home, canonical durable

--- a/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
+++ b/docs/adr/ADR-052-benchmark-account-isolation-and-snapshot-policy.md
@@ -34,9 +34,14 @@ never a hardcoded identity or hostname.
 
 The running benchmark agent provisions its own disposable benchmark account
 as part of the workflow when needed; the workflow does not require a human to
-pre-provision that account. Provisioning remains outside timed samples, and
-the runner must still validate the account-local manifest before touching
-state or starting a daemon.
+pre-provision that account. The agent reports minor blockers it fixes itself,
+may make any change needed to meet or exceed benchmark floors, and fixes
+regressions itself as part of the same run without escalating to Rand or
+starting a separate agent dispatch loop. The run is never interrupted or
+second-guessed mid-run; quality-mgr and team-lead judge the fixes afterward
+through normal PR review. Provisioning remains outside timed samples, and the
+runner must still validate the account-local manifest before touching state or
+starting a daemon.
 
 The benchmark runner must validate an account-local manifest against the
 executing process before it can touch state or start a daemon. The manifest

--- a/docs/plans/phase-ax/phase-ax-plan.md
+++ b/docs/plans/phase-ax/phase-ax-plan.md
@@ -3,6 +3,7 @@ title: "Phase AX — Nudge templates on every backend and task-state tracking"
 phase: AX
 branch: integrate/phase-ax
 status: closeout
+worktree: ../atm-core-worktrees/integrate/phase-ax
 owner: fenix (plan author); team-lead (dispatch); arch-ctm / Cipher-311d (implementation)
 base_revision: 5b1baacef (develop)
 integration_branch: integrate/phase-ax
@@ -337,6 +338,15 @@ test or evidence gate.
 - Task priority, reassignment, expiry, configurable intervals.
 
 ## 6. Execution notes
+
+### Pre-merge release proof
+
+AX implementation is complete and the phase is in `closeout`. The required
+physical benchmark and fixture-smoke procedure is
+the [pre-merge live-proof runbook](./premerge-live-proof.md).  That runbook is
+the operative source for the dedicated-account route, the benchmark matrix,
+and the separate smoke lanes.  It intentionally does not revive AX.7: AX.7
+remains superseded as recorded in the sprint table.
 
 - Development happens in worktrees created by `sc-git-worktree`; PR
   bases and bottom-to-top merging are managed by `gh stack`. `gh stack`

--- a/docs/plans/phase-ax/premerge-live-proof.md
+++ b/docs/plans/phase-ax/premerge-live-proof.md
@@ -59,10 +59,14 @@ A red result is not a terminal status report.  Preserve its generated artifact
 and use the pre-created remediation worktree to do the following before asking
 for operator help:
 
-The running benchmark agent is empowered to fix minor blockers itself and to
-make any change necessary to meet or exceed the benchmark floors.  It does not
-need to escalate to a human first; it must preserve the candidate, evidence,
-and account-isolation rules below while doing so.
+The running benchmark agent owns this full loop: it reports minor blockers it
+fixes itself, is empowered to make any change necessary to meet or exceed the
+benchmark floors, and fixes benchmark regressions itself as part of the same
+run.  It does not escalate to Rand or start a separate agent dispatch loop for
+these fixes.  The benchmark run is never interrupted or second-guessed
+mid-run; quality-mgr and team-lead judge the correctness of the fixes
+afterward through normal PR review.  The agent must preserve the candidate,
+evidence, and account-isolation rules below while doing so.
 
 1. Reproduce the failing target locally with the same candidate, account,
    target/profile, and release build; distinguish a measured floor regression

--- a/docs/plans/phase-ax/premerge-live-proof.md
+++ b/docs/plans/phase-ax/premerge-live-proof.md
@@ -123,7 +123,7 @@ version or its unavailability, all report paths, the benchmark comparison
 table, each smoke result, evidence branch SHA, and one explicit verdict:
 `NO REGRESSION`, `REGRESSION`, or `COULD NOT RUN`.  State a precise preflight
 or input blocker instead of changing execution mode to obtain a green result.
-Send the completion report directly to the requestor using the requestor's
+Send the completion report directly to the requester using the requester's
 full host-qualified address (`<agent>@<team>.<host>`) exactly as given in the
 task assignment.  A bare agent name resolves to the runner's own host and may
 silently misroute the report; task assignments must provide the full address.

--- a/docs/plans/phase-ax/premerge-live-proof.md
+++ b/docs/plans/phase-ax/premerge-live-proof.md
@@ -23,10 +23,12 @@ remodeling.
    - a separate `/sc-git-worktree` remediation branch, used only when a
      benchmark result or harness failure needs root-cause and correction.
      Never put source edits on the evidence branch.
-3. Physical performance evidence runs as the pre-provisioned dedicated account
-   over `ssh atmbench@rand-m5.local`, not from the interactive rand-m4 account.
-   Confirm `whoami` is `atmbench` and `~/.atm/benchmark-account.json` exists
-   before running a benchmark.  Do not bootstrap or reset another account.
+3. Physical performance evidence runs as the runner-provisioned dedicated
+   account over `ssh atmbench@rand-m5.local`, not from the interactive rand-m4
+   account.  The running agent may provision this disposable account when it
+   is absent; confirm `whoami` is `atmbench` and
+   `~/.atm/benchmark-account.json` exists before running a benchmark.  Do not
+   bootstrap or reset another account.
 
 ## Benchmark gate
 
@@ -56,6 +58,11 @@ cross-account interference.
 A red result is not a terminal status report.  Preserve its generated artifact
 and use the pre-created remediation worktree to do the following before asking
 for operator help:
+
+The running benchmark agent is empowered to fix minor blockers itself and to
+make any change necessary to meet or exceed the benchmark floors.  It does not
+need to escalate to a human first; it must preserve the candidate, evidence,
+and account-isolation rules below while doing so.
 
 1. Reproduce the failing target locally with the same candidate, account,
    target/profile, and release build; distinguish a measured floor regression

--- a/docs/plans/phase-ax/premerge-live-proof.md
+++ b/docs/plans/phase-ax/premerge-live-proof.md
@@ -41,6 +41,15 @@ just benchmark-report
 just benchmark-publish
 ```
 
+The evidence path is fixed and exclusive: run only
+`ATM_CAPACITY_HOST_LABEL=<host>-atmbench just benchmark`, then
+`just benchmark-report` (which renders
+`templates/benchmark-report/benchmark-run.xhtml.j2`), then
+`just benchmark-publish`.  The per-lane result JSON, the
+`<campaign>.campaign.json`, and the `<campaign>.xhtml` must all be committed
+under `site/reports/send-message-benchmark/`.  Hand-written or ad-hoc XHTML or
+JSON is never accepted as benchmark evidence.
+
 `just benchmark` is one complete release matrix, producing reviewed results
 for sqlite, UDS, TCP, and TCP-TLS.  The selected `--transport` and `--target`
 forms are diagnostic-only and do not meet this gate.  Compare each candidate
@@ -114,3 +123,7 @@ version or its unavailability, all report paths, the benchmark comparison
 table, each smoke result, evidence branch SHA, and one explicit verdict:
 `NO REGRESSION`, `REGRESSION`, or `COULD NOT RUN`.  State a precise preflight
 or input blocker instead of changing execution mode to obtain a green result.
+Send the completion report directly to the requestor using the requestor's
+full host-qualified address (`<agent>@<team>.<host>`) exactly as given in the
+task assignment.  A bare agent name resolves to the runner's own host and may
+silently misroute the report; task assignments must provide the full address.

--- a/docs/plans/phase-ax/premerge-live-proof.md
+++ b/docs/plans/phase-ax/premerge-live-proof.md
@@ -1,0 +1,105 @@
+---
+title: "Phase AX pre-merge live proof"
+phase: AX
+status: release_readiness
+branch: integrate/phase-ax
+worktree: ../atm-core-worktrees/integrate/phase-ax
+---
+
+# Phase AX pre-merge live proof
+
+This is the operational procedure for a candidate already integrated on
+`integrate/phase-ax`.  It records performance and smoke evidence; it does not
+authorize source changes, database-state substitution, trust edits, or daemon
+remodeling.
+
+## Preconditions
+
+1. Fetch the candidate and record both `HEAD` and
+   `origin/integrate/phase-ax`; they must equal the approved candidate SHA.
+2. Create two clean worktrees from that SHA before measurement:
+   - an evidence worktree/branch, which retains only runner-generated reports
+     byte-for-byte and is pushed without a pull request; and
+   - a separate `/sc-git-worktree` remediation branch, used only when a
+     benchmark result or harness failure needs root-cause and correction.
+     Never put source edits on the evidence branch.
+3. Physical performance evidence runs as the pre-provisioned dedicated account
+   over `ssh atmbench@rand-m5.local`, not from the interactive rand-m4 account.
+   Confirm `whoami` is `atmbench` and `~/.atm/benchmark-account.json` exists
+   before running a benchmark.  Do not bootstrap or reset another account.
+
+## Benchmark gate
+
+From the clean candidate worktree under `atmbench`:
+
+```bash
+git rev-parse HEAD
+ATM_CAPACITY_HOST_LABEL=m5-atmbench just benchmark
+just benchmark-report
+just benchmark-publish
+```
+
+`just benchmark` is one complete release matrix, producing reviewed results
+for sqlite, UDS, TCP, and TCP-TLS.  The selected `--transport` and `--target`
+forms are diagnostic-only and do not meet this gate.  Compare each candidate
+target to the newest same-host, same-target, matched-profile artifact and the
+recorded floor.  Report p50, p95, requests per second, artifact path, and the
+PASS/FAIL status for every target.
+
+The runner starts, stops, snapshots, and restores only its own disposable
+benchmark-account daemon.  Do not stop or restart an ambient dogfood daemon:
+the benchmark's account isolation is specifically intended to avoid that
+cross-account interference.
+
+### Failure handling: root-cause before escalation
+
+A red result is not a terminal status report.  Preserve its generated artifact
+and use the pre-created remediation worktree to do the following before asking
+for operator help:
+
+1. Reproduce the failing target locally with the same candidate, account,
+   target/profile, and release build; distinguish a measured floor regression
+   from bootstrap, signing, report, account, or environmental failure.
+2. Inspect the candidate diff and the retained raw/result evidence; identify
+   the responsible code path or prove that the failure is outside the
+   candidate.
+3. If it is a code regression, implement the smallest corrective change on
+   the remediation branch, run the relevant local tests plus formatting and
+   clippy, commit/push the fix through normal review, and advance the
+   candidate only after the fix lands.
+4. Rebuild and rerun the complete matrix on that new exact candidate.  Keep
+   every prior failing artifact; never overwrite, hand-edit, or relabel it as
+   a pass.
+
+Escalate immediately only for an external authority/input gap (for example
+missing benchmark-host access, unavailable account, absent signing identity,
+or a required peer-pair configuration).  A report that merely repeats a
+minor blocker or failing score without this due diligence is incomplete.
+
+## Smoke gate
+
+Run fixture smoke independently from the benchmark-account workflow:
+
+```bash
+just smoke normal
+```
+
+For peer-pair, an approved host-supplied role configuration and output location
+are mandatory:
+
+```bash
+just smoke peer-pair --config <approved-role-config> --evidence-dir <output-dir>
+```
+
+There is no bare or default loopback peer-pair command.  Never invent
+identities, trust entries, certificates, addresses, or a role configuration to
+make the lane execute.  If the inputs are unavailable, report the lane as not
+run and name the missing inputs.
+
+## Completion report
+
+Report the candidate SHA, execution host/account and OS/architecture, Herdr
+version or its unavailability, all report paths, the benchmark comparison
+table, each smoke result, evidence branch SHA, and one explicit verdict:
+`NO REGRESSION`, `REGRESSION`, or `COULD NOT RUN`.  State a precise preflight
+or input blocker instead of changing execution mode to obtain a green result.

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -35,10 +35,13 @@ replacement for functional smoke coverage. Each successful run writes its
 immutable JSON, its XHTML panel, and the aggregate report beneath
 `site/reports/`; the recipe rebuilds the report automatically. Use
 `just benchmark-report` only to rebuild or inspect already-published evidence.
-The running benchmark agent is empowered to fix minor blockers itself and to
-make any change necessary to meet or exceed benchmark floors without
-escalating to a human first; follow the [Phase AX pre-merge live proof
-policy](plans/phase-ax/premerge-live-proof.md) for the required safeguards.
+The running benchmark agent reports minor blockers it fixes itself, is
+empowered to make any change necessary to meet or exceed benchmark floors, and
+fixes regressions itself as part of the same run without escalating to Rand or
+starting a separate agent dispatch loop.  The run is never interrupted or
+second-guessed mid-run; quality-mgr and team-lead review the resulting fixes
+afterward through the normal PR process.  Follow the [Phase AX pre-merge live
+proof policy](plans/phase-ax/premerge-live-proof.md) for the safeguards.
 Use its public peer-wire targets, not a Cargo feature or a private harness:
 
 ```bash

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -35,6 +35,10 @@ replacement for functional smoke coverage. Each successful run writes its
 immutable JSON, its XHTML panel, and the aggregate report beneath
 `site/reports/`; the recipe rebuilds the report automatically. Use
 `just benchmark-report` only to rebuild or inspect already-published evidence.
+The running benchmark agent is empowered to fix minor blockers itself and to
+make any change necessary to meet or exceed benchmark floors without
+escalating to a human first; follow the [Phase AX pre-merge live proof
+policy](plans/phase-ax/premerge-live-proof.md) for the required safeguards.
 Use its public peer-wire targets, not a Cargo feature or a private harness:
 
 ```bash

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -42,6 +42,13 @@ starting a separate agent dispatch loop.  The run is never interrupted or
 second-guessed mid-run; quality-mgr and team-lead review the resulting fixes
 afterward through the normal PR process.  Follow the [Phase AX pre-merge live
 proof policy](plans/phase-ax/premerge-live-proof.md) for the safeguards.
+Benchmark evidence follows a fixed, exclusive path: run
+`ATM_CAPACITY_HOST_LABEL=<host>-atmbench just benchmark`, then
+`just benchmark-report`, then `just benchmark-publish`; commit the per-lane
+result JSON, `<campaign>.campaign.json`, and `<campaign>.xhtml` under
+`site/reports/send-message-benchmark/`.  The report and evidence reply must go
+directly to the requestor's full host-qualified address (`<agent>@<team>.<host>`)
+exactly as given in the task assignment; never guess from a bare agent name.
 Use its public peer-wire targets, not a Cargo feature or a private harness:
 
 ```bash

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -22,6 +22,14 @@ just smoke inbound-peer-combine --panes-dir <directory> --hosts <hosts> --output
 just smoke graft-hermes [arguments accepted by the Hermes graft smoke]
 ```
 
+`peer-pair` has no implicit loopback fixture.  It always requires both
+`--config` and `--evidence-dir`; the supplied role configuration owns its
+identities, public-client commands, and any runner-owned daemon paths.  Do not
+invoke bare `just smoke peer-pair`, do not synthesize a trust record, and do
+not substitute the `normal` fixture for this release-evidence lane.  If no
+approved role configuration is supplied, report peer-pair as not run with that
+exact input blocker.
+
 `just benchmark` is the separate, canonical performance gate; it is not a
 replacement for functional smoke coverage. Each successful run writes its
 immutable JSON, its XHTML panel, and the aggregate report beneath

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -47,7 +47,7 @@ Benchmark evidence follows a fixed, exclusive path: run
 `just benchmark-report`, then `just benchmark-publish`; commit the per-lane
 result JSON, `<campaign>.campaign.json`, and `<campaign>.xhtml` under
 `site/reports/send-message-benchmark/`.  The report and evidence reply must go
-directly to the requestor's full host-qualified address (`<agent>@<team>.<host>`)
+directly to the requester's full host-qualified address (`<agent>@<team>.<host>`)
 exactly as given in the task assignment; never guess from a bare agent name.
 Use its public peer-wire targets, not a Cargo feature or a private harness:
 

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -187,6 +187,42 @@ account that already owns ATM durable state. `just benchmark` then validates
 that manifest before release-binary lookup, daemon startup, SQLite access, or
 temporary benchmark setup. The interactive account must fail this preflight.
 
+### 4.5.2 Physical benchmark operator route
+
+The provisioned physical benchmark account is currently reached from a
+developer host as `atmbench@rand-m5.local`.  Do not infer the benchmark
+account from the interactive host or try to bootstrap the interactive account:
+the expected interactive-account failure is the safety property above.
+
+Use a clean worktree on the exact candidate revision.  Leave the account's
+primary checkout alone if it has retained report artifacts or other work in
+progress.  The account-local worktree must be clean before measurement.
+
+```bash
+ssh atmbench@rand-m5.local
+cd ~/github/atm-core-worktrees/<candidate-worktree>
+git rev-parse HEAD                 # must equal the candidate revision
+ATM_CAPACITY_HOST_LABEL=m5-atmbench just benchmark
+                                   # complete sqlite, UDS, TCP, and TCP-TLS matrix
+just benchmark-report
+just benchmark-publish             # stages only validated public report artifacts
+```
+
+`just benchmark` is the only release-quality admission benchmark command.  A
+selected `--target` or `--transport` profile is deliberately diagnostic-only:
+the runner requires `--diagnostic-only` for it and that output cannot satisfy
+the complete benchmark gate or establish a release baseline.  Never replace a
+full matrix with separate `just benchmark --transport uds` or `tcp` commands.
+The `m5-atmbench` label is required to select the reviewed same-host floors;
+do not use the implicit `local` label for this physical campaign.
+
+The benchmark runner owns only the validated account's disposable daemon,
+state, snapshot, and cleanup lifecycle.  It must not stop, restart, switch,
+or otherwise alter an ambient dogfood daemon on either the interactive host or
+the benchmark host.  A missing or invalid benchmark-account manifest is an
+exact preflight blocker; report it without attempting an `ATM_HOME` override,
+trust edit, alternate runtime root, or interactive-account bootstrap.
+
 ### 4.6 Coverage Reporting
 
 Coverage reporting is a separate reporting surface.


### PR DESCRIPTION
## Summary
- documents the Phase AX pre-merge proof operation and runbook
- aligns the Phase AX plan, smoke testing, and testing guidance

Recreated from the original docs commit on `integrate/phase-ax` rather than `develop`. The current `closeout` plan status is retained.

Base: `integrate/phase-ax`