### PR TITLE
fix(gh-stack-view): tolerate missing head/base and merged bottom layers in gh stack JSON

### DIFF
--- a/.claude/skills/gh-stack-view/SKILL.md
+++ b/.claude/skills/gh-stack-view/SKILL.md
@@ -88,9 +88,9 @@ VERDICT: ✅ COHERENT - every base == parent head, every head pushed and on its 
 | CI | same query, `statusCheckRollup.state` of the head commit | ✅ green · 🌀 running · ⛔ failed, do not enter · — none |
 
 `VERDICT` names the branch and the owner action for every problem (SHAs
-appear there, not in the table). A bottom layer merely behind trunk is a note,
-not a problem: do not rebase a layer whose CI could go green just to catch up
-with trunk. The legend is printed once at the end. `--json` emits
+appear there, not in the table). The lowest OPEN layer (layer 1, or the first
+layer above already-merged ones) merely behind trunk is a note, not a problem:
+do not rebase a layer whose CI could go green just to catch up with trunk. The legend is printed once at the end. `--json` emits
 `stacks[].rows[]`, `problems[]`, `notes[]`, `coherent` for agents that need to
 branch on the result.
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -194,6 +194,11 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
     problems: list[str] = []
     notes: list[str] = []
     expected_base = trunk_origin
+    # Name of the branch the next open layer must be based on.  Starts at the
+    # trunk and only advances past OPEN layers: a merged layer's content now
+    # lives in the trunk (GitHub retargets its child onto the trunk), so the
+    # layer above a merged one is judged against the trunk, not the merged head.
+    parent = trunk
     for idx, br in enumerate(stack["branches"], start=1):
         name = br["name"]
         pr = prs.get((br.get("pr") or {}).get("number") or -1, {})
@@ -203,7 +208,9 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
                          "draft": False, "mergeable": None, "merge_state": "MERGED", "ci": pr.get("ci"),
                          "base_ok": None, "origin_ok": None, "needs_rebase": False, "origin": None,
                          "pr_head": pr.get("headRefOid"), "expected_base": expected_base, "pr_base": pr.get("baseRefName")})
-            expected_base = br.get("head") or expected_base
+            # Merged: its head is (an ancestor of) the trunk head now.  The next
+            # open layer must sit on the trunk; ``parent`` stays at the trunk.
+            expected_base = trunk_origin or br.get("head") or expected_base
             continue
         # gh stack omits ``head``/``base`` for a layer that has no local branch
         # (e.g. viewed from a sibling worktree before the branch was fetched).
@@ -243,12 +250,15 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
             "ci": pr.get("ci"),
             "pr_base": pr.get("baseRefName"),
         }
-        parent = trunk if idx == 1 else stack["branches"][idx - 2]["name"]
+        parent_is_trunk = parent == trunk
         if pr and pr.get("baseRefName") not in (None, parent):
             problems.append(f"L{idx} {name}: PR #{row['pr']} base is {pr['baseRefName']}, expected {parent}")
         if base_ok is False:
-            if idx == 1 and is_ancestor(base or "", expected_base):
-                notes.append(f"L1 {name}: behind trunk ({short(base)} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
+            # The lowest OPEN layer (idx 1, or any layer whose lower layers are
+            # all merged) may sit on an older trunk commit: that is a note, not
+            # a rebase order.  Against an open parent it is a real mismatch.
+            if parent_is_trunk and is_ancestor(base or "", expected_base):
+                notes.append(f"L{idx} {name}: behind trunk ({short(base)} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
             else:
                 problems.append(f"L{idx} {name}: base {short(base)} != parent head {short(expected_base)} -> needs rebase")
         if origin_ok is False:
@@ -265,6 +275,7 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
         rows.append(row)
         # The next layer must be based on THIS layer's pushed head (fall back to local, then PR).
         expected_base = origin or head or pr.get("headRefOid") or expected_base
+        parent = name
     return rows, problems, notes
 
 

--- a/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/gh_stack_view.py
@@ -205,19 +205,32 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
                          "pr_head": pr.get("headRefOid"), "expected_base": expected_base, "pr_base": pr.get("baseRefName")})
             expected_base = br.get("head") or expected_base
             continue
+        # gh stack omits ``head``/``base`` for a layer that has no local branch
+        # (e.g. viewed from a sibling worktree before the branch was fetched).
+        # Never subscript them directly: a missing key must degrade to ❓, not crash.
+        head = br.get("head")
+        base = br.get("base")
         origin = origin_sha(name) if fetched else None
-        base_ok = (br.get("base") == expected_base) if (expected_base and br.get("base")) else None
+        base_ok = (base == expected_base) if (expected_base and base) else None
         origin_ok = None
         if origin:
-            origin_ok = br.get("head") == origin and (not pr or pr.get("headRefOid") == origin)
+            if head:
+                origin_ok = head == origin and (not pr or pr.get("headRefOid") == origin)
+            elif pr:
+                # No local head to compare; the remote side (origin vs PR) can still be checked.
+                origin_ok = pr.get("headRefOid") == origin
+        if head is None:
+            notes.append(f"L{idx} {name}: gh stack reported no local head (branch not present locally); local tracking not verified")
+        if base is None:
+            notes.append(f"L{idx} {name}: gh stack reported no base SHA; base coherence not verified")
         row = {
             "layer": idx,
             "branch": name,
             "pr": (br.get("pr") or {}).get("number"),
-            "head": br.get("head"),
+            "head": head,
             "origin": origin,
             "pr_head": pr.get("headRefOid"),
-            "base": br.get("base"),
+            "base": base,
             "expected_base": expected_base,
             "base_ok": base_ok,
             "origin_ok": origin_ok,
@@ -234,13 +247,13 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
         if pr and pr.get("baseRefName") not in (None, parent):
             problems.append(f"L{idx} {name}: PR #{row['pr']} base is {pr['baseRefName']}, expected {parent}")
         if base_ok is False:
-            if idx == 1 and is_ancestor(br.get("base", ""), expected_base):
-                notes.append(f"L1 {name}: behind trunk ({short(br['base'])} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
+            if idx == 1 and is_ancestor(base or "", expected_base):
+                notes.append(f"L1 {name}: behind trunk ({short(base)} < {short(expected_base)}); fine unless CONFLICTING, do not restart CI just to catch up")
             else:
-                problems.append(f"L{idx} {name}: base {short(br['base'])} != parent head {short(expected_base)} -> needs rebase")
+                problems.append(f"L{idx} {name}: base {short(base)} != parent head {short(expected_base)} -> needs rebase")
         if origin_ok is False:
             problems.append(
-                f"L{idx} {name}: local {short(br['head'])} / origin {short(origin)} / PR {short(pr.get('headRefOid'))} differ"
+                f"L{idx} {name}: local {short(head)} / origin {short(origin)} / PR {short(pr.get('headRefOid'))} differ"
                 " -> local tracking stale or unpushed; owner must fetch+reset or push"
             )
         if br.get("needsRebase"):
@@ -250,8 +263,8 @@ def build_rows(stack: dict, prs: dict[int, dict], *, fetched: bool) -> tuple[lis
         if pr.get("isDraft"):
             problems.append(f"L{idx} {name}: PR #{row['pr']} is DRAFT (blocks stack merge)")
         rows.append(row)
-        # The next layer must be based on THIS layer's pushed head (fall back to local).
-        expected_base = origin or br.get("head")
+        # The next layer must be based on THIS layer's pushed head (fall back to local, then PR).
+        expected_base = origin or head or pr.get("headRefOid") or expected_base
     return rows, problems, notes
 
 

--- a/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
@@ -1,0 +1,130 @@
+"""Regression tests for gh_stack_view.build_rows against gh-stack JSON shapes.
+
+gh-stack v0.1.0 omits ``head``/``base`` for a layer whose branch is not present
+locally (viewed from a sibling worktree before fetch).  The report must degrade
+to ❓/notes for that layer, never raise.  Runs under the repo pytests lint task
+(.just/run_pytests.py) and standalone with ``python3 -m unittest``.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("gh_stack_view.py")
+spec = importlib.util.spec_from_file_location("gh_stack_view_under_test", SCRIPT)
+assert spec is not None and spec.loader is not None
+gsv = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = gsv
+spec.loader.exec_module(gsv)
+
+TRUNK = "integrate/phase-ax"
+T0 = "0" * 40
+A1 = "a" * 40
+B2 = "b" * 40
+C3 = "c" * 40
+OLD = "d" * 40
+
+
+def layer(name: str, pr: int, *, head: str | None, base: str | None, needs_rebase: bool = False) -> dict:
+    entry = {"name": name, "isCurrent": False, "isMerged": False, "isQueued": False,
+             "needsRebase": needs_rebase, "pr": {"number": pr, "state": "OPEN"}}
+    if head is not None:
+        entry["head"] = head
+    if base is not None:
+        entry["base"] = base
+    return entry
+
+
+def pr(head: str, base: str, *, mergeable: str = "MERGEABLE", state: str = "CLEAN") -> dict:
+    return {"headRefOid": head, "baseRefName": base, "mergeable": mergeable,
+            "mergeStateStatus": state, "isDraft": False, "ci": "SUCCESS"}
+
+
+class BuildRowsShapeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.origins = {TRUNK: T0, "fix/bottom": A1, "fix/middle": B2, "docs/top": C3}
+        patches = [
+            mock.patch.object(gsv, "origin_sha", side_effect=lambda ref: self.origins.get(ref)),
+            mock.patch.object(gsv, "is_ancestor", return_value=False),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def coherent_stack(self) -> tuple[dict, dict]:
+        stack = {"trunk": TRUNK, "currentBranch": "fix/bottom", "branches": [
+            layer("fix/bottom", 1, head=A1, base=T0),
+            layer("fix/middle", 2, head=B2, base=A1),
+            layer("docs/top", 3, head=C3, base=B2),
+        ]}
+        prs = {1: pr(A1, TRUNK), 2: pr(B2, "fix/bottom"), 3: pr(C3, "fix/middle")}
+        return stack, prs
+
+    def test_full_shape_is_coherent(self) -> None:
+        stack, prs = self.coherent_stack()
+        rows, problems, notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(problems, [])
+        self.assertEqual(notes, [])
+        self.assertEqual([gsv.sync_icon(r) for r in rows], [gsv.ICON_SYNC["ok"]] * 3)
+
+    def test_missing_head_and_base_keys_do_not_crash(self) -> None:
+        # Regression: gh stack view --json returned layers without head/base;
+        # build_rows raised KeyError('head') while formatting the origin problem.
+        stack, prs = self.coherent_stack()
+        stack["branches"][1] = layer("fix/middle", 2, head=None, base=None)
+        stack["branches"][2] = layer("docs/top", 3, head=None, base=None)
+        rows, problems, notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(problems, [], "remote side (origin == PR head) is coherent, so no problems")
+        self.assertTrue(any("no local head" in n and "fix/middle" in n for n in notes))
+        self.assertTrue(any("no base SHA" in n and "docs/top" in n for n in notes))
+        self.assertIsNone(rows[1]["head"])
+        self.assertIsNone(rows[1]["base"])
+        self.assertIsNone(rows[1]["base_ok"])
+        self.assertEqual(gsv.sync_icon(rows[1]), gsv.ICON_SYNC["unknown"])
+
+    def test_missing_head_with_stale_pr_is_reported_not_raised(self) -> None:
+        stack, prs = self.coherent_stack()
+        stack["branches"][2] = layer("docs/top", 3, head=None, base=B2)
+        prs[3] = pr(OLD, "fix/middle")  # PR head differs from origin -> stale push
+        rows, problems, _ = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("docs/top", problems[0])
+        self.assertIn("local - / origin ccccccccc / PR ddddddddd differ", problems[0])
+        self.assertEqual(gsv.sync_icon(rows[2]), gsv.ICON_SYNC["stale"])
+
+    def test_missing_head_falls_back_to_pr_head_for_next_layer_base(self) -> None:
+        stack, prs = self.coherent_stack()
+        stack["branches"][0] = layer("fix/bottom", 1, head=None, base=T0)
+        self.origins["fix/bottom"] = None  # not fetched either
+        rows, problems, _ = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(problems, [])
+        self.assertEqual(rows[1]["expected_base"], A1)
+
+    def test_no_fetch_marks_unknown_without_raising(self) -> None:
+        stack, prs = self.coherent_stack()
+        stack["branches"][2] = layer("docs/top", 3, head=None, base=None)
+        rows, problems, _ = gsv.build_rows(stack, prs, fetched=False)
+        self.assertEqual(problems, [])
+        self.assertEqual(gsv.sync_icon(rows[2]), gsv.ICON_SYNC["unknown"])
+
+    def test_render_table_handles_missing_head(self) -> None:
+        stack, prs = self.coherent_stack()
+        stack["branches"][2] = layer("docs/top", 3, head=None, base=None)
+        rows, problems, notes = gsv.build_rows(stack, prs, fetched=True)
+        text = gsv.render_table(stack, rows, problems, notes, trunk_origin=T0)
+        self.assertIn("VERDICT: ✅ COHERENT", text)
+        self.assertIn("note: L3 docs/top: gh stack reported no local head", text)
+
+    def test_needs_rebase_and_base_mismatch_still_flagged(self) -> None:
+        stack, prs = self.coherent_stack()
+        stack["branches"][1] = layer("fix/middle", 2, head=B2, base=OLD, needs_rebase=True)
+        _, problems, _ = gsv.build_rows(stack, prs, fetched=True)
+        self.assertTrue(any("base ddddddddd != parent head aaaaaaaaa" in p for p in problems))
+        self.assertTrue(any("gh stack reports needsRebase" in p for p in problems))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
@@ -128,3 +128,74 @@ class BuildRowsShapeTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+T1 = "1" * 40  # trunk head after the bottom layer merged
+
+
+class MergedBottomLayerTests(unittest.TestCase):
+    """Regression: after ``gh stack merge``/merge-async lands the bottom layer,
+    GitHub retargets the next layer onto the trunk.  The report used to demand
+    that layer be based on the MERGED branch (PR base and base SHA), producing
+    two false problems on a stack gh-stack itself reported as needsRebase=false.
+    Seen twice on the Phase AX evidence stack (#1266 merged under #1262)."""
+
+    def setUp(self) -> None:
+        # Trunk moved from T0 to T1 (the merge commit of the bottom layer).
+        self.origins = {TRUNK: T1, "fix/bottom": A1, "fix/middle": B2, "docs/top": C3}
+        self.ancestors = {(T0, T1), (A1, T1)}
+        patches = [
+            mock.patch.object(gsv, "origin_sha", side_effect=lambda ref: self.origins.get(ref)),
+            mock.patch.object(gsv, "is_ancestor", side_effect=lambda a, b: (a, b) in self.ancestors),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def merged_bottom_stack(self, *, middle_base: str, middle_pr_base: str = TRUNK) -> tuple[dict, dict]:
+        bottom = layer("fix/bottom", 1, head=A1, base=T0)
+        bottom["isMerged"] = True
+        bottom["pr"]["state"] = "MERGED"
+        stack = {"trunk": TRUNK, "currentBranch": "docs/top", "branches": [
+            bottom,
+            layer("fix/middle", 2, head=B2, base=middle_base),
+            layer("docs/top", 3, head=C3, base=B2),
+        ]}
+        prs = {1: pr(A1, TRUNK, state="MERGED"), 2: pr(B2, middle_pr_base), 3: pr(C3, "fix/middle")}
+        return stack, prs
+
+    def test_layer_above_merged_bottom_is_judged_against_trunk(self) -> None:
+        # gh stack reports the retargeted layer's base as the pre-merge trunk
+        # commit (T0), an ancestor of the new trunk head: behind trunk, not a rebase.
+        stack, prs = self.merged_bottom_stack(middle_base=T0)
+        rows, problems, notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(problems, [], problems)
+        self.assertEqual(len(notes), 1)
+        self.assertIn("L2 fix/middle: behind trunk", notes[0])
+        self.assertEqual(gsv.sync_icon(rows[0]), gsv.ICON_MERGE["MERGED"])
+        self.assertEqual(gsv.sync_icon(rows[1]), gsv.ICON_SYNC["rebase"], "behind trunk still shows the rebase icon")
+        self.assertEqual(gsv.sync_icon(rows[2]), gsv.ICON_SYNC["ok"])
+        self.assertEqual(rows[1]["expected_base"], T1, "expected base is the trunk head, not the merged layer's head")
+
+    def test_layer_above_merged_bottom_on_trunk_head_is_clean(self) -> None:
+        stack, prs = self.merged_bottom_stack(middle_base=T1)
+        rows, problems, notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(problems, [])
+        self.assertEqual(notes, [])
+        self.assertEqual([gsv.sync_icon(r) for r in rows[1:]], [gsv.ICON_SYNC["ok"]] * 2)
+
+    def test_layer_above_merged_bottom_still_targeting_merged_branch_is_flagged(self) -> None:
+        # GitHub has not retargeted the PR yet: that IS a problem the owner must fix.
+        stack, prs = self.merged_bottom_stack(middle_base=T1, middle_pr_base="fix/bottom")
+        _rows, problems, _notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("PR #2 base is fix/bottom, expected integrate/phase-ax", problems[0])
+
+    def test_open_parent_mismatch_is_still_a_problem(self) -> None:
+        # Above an OPEN layer the ancestor leniency must not apply.
+        stack, prs = self.merged_bottom_stack(middle_base=T1)
+        stack["branches"][2]["base"] = OLD
+        self.ancestors.add((OLD, B2))
+        _rows, problems, _notes = gsv.build_rows(stack, prs, fetched=True)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("L3 docs/top: base ddddddddd != parent head bbbbbbbbb -> needs rebase", problems[0])

--- a/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
+++ b/.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py
@@ -126,9 +126,6 @@ class BuildRowsShapeTests(unittest.TestCase):
         self.assertTrue(any("gh stack reports needsRebase" in p for p in problems))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 T1 = "1" * 40  # trunk head after the bottom layer merged
 
@@ -199,3 +196,6 @@ class MergedBottomLayerTests(unittest.TestCase):
         _rows, problems, _notes = gsv.build_rows(stack, prs, fetched=True)
         self.assertEqual(len(problems), 1)
         self.assertIn("L3 docs/top: base ddddddddd != parent head bbbbbbbbb -> needs rebase", problems[0])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/run_pytests.py
+++ b/.just/run_pytests.py
@@ -50,6 +50,7 @@ def build_suite(repo_root: Path) -> unittest.TestSuite:
     test_paths.extend(sorted((repo_root / "scripts/smoke").glob("test_*.py")))
     test_paths.extend(sorted((repo_root / "scripts/phase-aq").glob("test_*.py")))
     test_paths.extend(sorted((repo_root / ".claude/skills/daemon-switch/tests").glob("test_*.py")))
+    test_paths.extend(sorted((repo_root / ".claude/skills/gh-stack-view/scripts").glob("test_*.py")))
     for test_path in test_paths:
         relative = test_path.relative_to(repo_root)
         module_name = (


### PR DESCRIPTION
## Summary
`python3 .claude/skills/gh-stack-view/scripts/gh_stack_view.py --phase ax` crashed with `KeyError: 'head'` on 2026-09-06 while the phase-ax stack was mid-sync: gh-stack v0.1.0 omits `head`/`base` for a layer whose branch is not present locally, and `build_rows()` subscripted those keys while formatting a problem line.

## Changes
- `build_rows()` reads `head`/`base` once via `.get()`; a missing value degrades to the ❓ sync icon plus an explicit note (`gh stack reported no local head` / `no base SHA`) instead of raising.
- With no local head, origin is still compared against the PR head so a stale push is reported; the next layer's expected base falls back to the PR head.
- New regression suite `.claude/skills/gh-stack-view/scripts/test_gh_stack_view.py` (7 cases) registered in `.just/run_pytests.py`, so `just lint pytests` runs it in CI.

## Verification
- `.just/run_pytests.py` from the worktree: 1089 tests, OK (21 skipped), new fixture `BuildRowsShapeTests: 7`.
- Live run against the real phase-ax stack (#1266/#1262/#1264) renders `VERDICT: ✅ COHERENT` where the unpatched script crashed.

Requested by Rand: "fix this on a /sc-git-worktree off develop" and "make sure there are tests so this does not happen again".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second defect (same skill, same day)

After the bottom layer of a stack merges, GitHub retargets the next layer onto the trunk. `build_rows` kept judging that layer against the MERGED branch (PR base and base SHA), so a stack that `gh stack view --json` reported as `needsRebase: false` everywhere rendered **NOT COHERENT** with two false problems. Hit twice on the Phase AX evidence stack after #1266 merged under #1262.

Fix: `parent` advances only past OPEN layers; a merged layer resets the expected base to the trunk head; the lowest open layer gets the same behind-trunk leniency as layer 1. Four regression tests (`MergedBottomLayerTests`). Live run against the AX stack: VERDICT COHERENT with a behind-trunk note. Repo pytests: 1093 OK.