### PR TITLE
docs: record AY1 Herdr compatibility contract

### DIFF
--- a/docs/adr/ADR-058-herdr-local-steer-backend-contract.md
+++ b/docs/adr/ADR-058-herdr-local-steer-backend-contract.md
@@ -573,7 +573,10 @@ the adapter, `atm-herdr`) is normatively documented in
 - `--wait`, `agent_prompt_stalled`, `agent send-keys`, `pane send-keys`,
   `pane send-input`, `events.subscribe`/`events.wait`, `herdr api snapshot`.
 - Any Herdr-side queue, per-turn tracking, or idempotency of repeated prompts.
-- Herdr on Windows (named-pipe transport exists but is out of AQ scope).
+- Live Windows evidence is not part of the Phase AQ contract; AY.7 owns
+  Windows process correctness and release readiness owns live platform proof.
+  The named-pipe transport remains part of the supported cross-platform
+  Herdr implementation.
 - Text of `error.message`, `AgentInfo` fields other than `agent_status`,
   and the ordering of JSON keys.
 
@@ -692,3 +695,32 @@ never emits `send-keys`, `send_input`, tmux, or a pane id for this path. The
 adapter applies the caller's bounded deadline and reports a non-zero Herdr
 exit as a typed failure. Lead and configured-recipient mail remain independent
 delivery attempts, so a notification failure does not erase their outcomes.
+
+## Amendment — Phase AY compatibility and Windows scope (2026-09-06)
+
+This amendment supersedes the earlier pin and scope wording while preserving
+the original decision history above.
+
+1. **Cross-platform contract.** D3 specifies Unix-domain sockets on macOS and
+   Linux and Herdr's named pipe on Windows. The transport is an implementation
+   detail: ATM exposes the same command set, typed errors, and breaker
+   semantics on all three platforms. Windows-specific process correctness and
+   CI evidence belong to AY.7; live platform proof belongs to release
+   readiness. The former Windows scope-out is deleted.
+2. **Minimum version.** The former `d79fd746` / protocol-21 pin is replaced by
+   `HERDR_MINIMUM_VERSION` under ADR-061. The current minimum is 0.8.0, and
+   one ATM build supports every Herdr release at or above that floor. v0.8.2
+   is the current design/recording target. Herdr `PROTOCOL_VERSION` remains a
+   secondary bincode-client fact, not the NDJSON compatibility floor; the
+   per-release facts and recordings live in
+   [`docs/atm-herdr/herdr-versions.md`](../atm-herdr/herdr-versions.md).
+3. **Drift and parsing.** New capabilities are additive or runtime-detected;
+   parsers key on stable error codes and tolerate unknown fields, never
+   message text. The v0.8.0 blocked-prompt behaviour and the newer
+   `agent_prompt --wait` outcome are replayed as version deltas without a
+   speculative version adapter.
+4. **AI.11 clarification.** The retired-listener ban governs ATM's own IPC
+   listener. AY.8 may exempt only
+   `crates/atm-herdr/src/transport_socket.rs` for the Herdr client. The
+   `named_pipe` / `NamedPipe` symbols remain banned everywhere else under
+   `crates/`; this amendment does not authorize legacy daemon remodeling.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,17 @@ Phase-S portability note:
   contract
 - Phase S planning is tracked in [`docs/plans/phase-S/plan-phase-S.md`](./plan-phase-S.md)
 
+### 1.4 Herdr local steer backend
+
+The Herdr local-steer client is documented in
+[`docs/atm-herdr/architecture.md`](./atm-herdr/architecture.md), especially
+section 12's Phase AY compatibility and platform contract. Its normative
+requirements, including the cross-platform command/error/lifecycle contract,
+are in [`docs/atm-herdr/requirements.md`](./atm-herdr/requirements.md).
+The Phase AQ2-6 Windows deferral is superseded: AY.7 owns Windows process
+correctness and release-readiness owns live Windows proof, while the supported
+Herdr contract remains shared across macOS, Linux, and Windows.
+
 Phase-AA simplification note:
 - the current daemon composition root and daemon-routed doctor model are not
   the intended steady-state architecture

--- a/docs/atm-herdr/architecture.md
+++ b/docs/atm-herdr/architecture.md
@@ -283,6 +283,7 @@ pub mod testing {
         Wait { agent: String, session: Option<atm_core::HerdrSession>, until: Vec<super::HerdrAgentStatus>, timeout: std::time::Duration },
         Get { agent: String, session: Option<atm_core::HerdrSession>, breaker_policy: super::BreakerPolicy },
         List { session: Option<atm_core::HerdrSession> },
+        Notify { title: String, body: String },
     }
 
     /// Records every call for assertion; configurable per-call outcome.
@@ -297,6 +298,7 @@ pub mod testing {
         pub fn queue_wait_result(&self, result: Result<super::HerdrWaitOutcome, super::HerdrError>) { /* .. */ }
         pub fn queue_get_result(&self, result: Result<super::HerdrGetOutcome, super::HerdrError>) { /* .. */ }
         pub fn queue_list_result(&self, result: Result<super::HerdrListOutcome, super::HerdrError>) { /* .. */ }
+        pub fn queue_notify_result(&self, result: Result<(), super::HerdrError>) { /* .. */ }
     }
 
     impl super::HerdrProcessAdapter for FakeHerdrProcessAdapter { /* .. */ }

--- a/docs/atm-herdr/architecture.md
+++ b/docs/atm-herdr/architecture.md
@@ -566,3 +566,61 @@ following are not true:
 - exactly one `HerdrSpawnBreaker::new(` and one `HerdrProcessInvoker::new(`
   call site exist in the workspace, both inside
   `atm-daemon-bootstrap::build_replacement_handler` (finding 101, §9)
+
+## 12. Phase AY compatibility and platform contract
+
+Phase AY carries the Herdr client from the CLI process boundary toward native
+IPC: Unix-domain sockets on macOS/Linux and a named pipe on Windows. The
+transport difference is internal. The ATM-visible command set, typed errors,
+breaker semantics, bounded per-call failure model, and optional-dependency
+behaviour remain the same on all three platforms.
+
+The daemon does not own Herdr. Herdr owns its server, endpoint, session, and
+restart lifecycle; the ATM daemon neither launches Herdr nor waits for it at
+startup. A missing, late, unreachable, or crashed Herdr produces a bounded
+failure on the Herdr harness only. ATM messaging, tmux, Hermes, and doctor
+remain available. This rule applies to both the legacy CLI adapter during the
+AY transition and the native socket adapter; it does not authorize changes to
+the frozen synchronous daemon.
+
+### 12.1 Version-agnostic compatibility
+
+`HERDR_MINIMUM_VERSION` is the release floor and is owned by
+`crates/atm-herdr`; it is currently 0.8.0 under ADR-061. One ATM build
+supports every Herdr release at or above that floor. v0.8.2 is the design and
+recording target, while Herdr's integer `PROTOCOL_VERSION` is only a
+secondary bincode-client fact and is not the NDJSON compatibility floor.
+
+The single client implementation is deliberately version-agnostic:
+
+- new capabilities are additive or detected from `ping.version` and
+  `ping.capabilities`;
+- parsers key on stable error codes, tolerate unknown JSON fields, and never
+  match mutable error-message text;
+- the compatibility ledger at
+  [`herdr-versions.md`](herdr-versions.md) records the six operations,
+  per-release protocol facts, source drift, and the AY.2 recording-manifest
+  path (`crates/atm-herdr/tests/fixtures/herdr-versions/manifest.json`);
+- a release adds a recording set only when drift changes an ATM operation;
+  an unabsorbable change is escalated to Rand for a minimum-version decision
+  or an approved second implementation.
+
+### 12.2 Platform ownership and evidence
+
+The Herdr client contract does not claim live Windows evidence. AY.7 owns
+Windows-specific process correctness: console suppression, per-spawn binary
+resolution, CRLF-tolerant decoding, named-pipe handling, and kill-then-reap
+behaviour. Release readiness owns live Windows proof and the official
+benchmark. AY.1 records the audit and compatibility contract; it does not
+invent a Windows pass result.
+
+The former Phase AQ statement that Windows was outside scope is superseded.
+The supported-platform rule is instead recorded by HR-PLAT-001 and
+HR-LIFE-001 in `docs/atm-herdr/requirements.md` and by the Phase AY amendment
+to ADR-058. The three ATM-owned layers remain separate:
+
+```text
+Herdr lifecycle and endpoint ownership  ->  Herdr
+ATM transport/client + bounded failures ->  atm-herdr
+ATM startup, messaging, doctor policy   ->  atm-http-runtime / composition root
+```

--- a/docs/atm-herdr/architecture.md
+++ b/docs/atm-herdr/architecture.md
@@ -219,6 +219,14 @@ pub trait HerdrProcessAdapter: Send + Sync {
         session: Option<&'a atm_core::HerdrSession>,
         deadline: atm_core::RequestDeadline,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<HerdrListOutcome, HerdrError>> + Send + 'a>>;
+
+    /// Shows a desktop notification without targeting a Herdr pane.
+    fn notify<'a>(
+        &'a self,
+        title: &'a str,
+        body: &'a str,
+        deadline: atm_core::RequestDeadline,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), HerdrError>> + Send + 'a>>;
 }
 
 // -- breaker ------------------------------------------------------------------

--- a/docs/atm-herdr/herdr-versions.md
+++ b/docs/atm-herdr/herdr-versions.md
@@ -1,0 +1,145 @@
+# Herdr Compatibility Ledger
+
+Status: AY.1 baseline, 2026-09-06
+
+This ledger is the compatibility authority for the Herdr client contract. ATM
+supports every Herdr release at or above `HERDR_MINIMUM_VERSION`; it does not
+select the newest release and does not require a daemon restart when Herdr is
+upgraded. The current minimum is **0.8.0**, set by Rand under ADR-061. The
+design and recording target is v0.8.2. There is no v0.8.1 release.
+
+`PROTOCOL_VERSION` is recorded as a secondary fact. It versions Herdr's
+bincode client socket, not the NDJSON API used by the ATM CLI transport, and
+must not be used as the compatibility floor. For the direct socket transport,
+ATM keys compatibility on the Herdr release reported by `ping.version` and
+feature/capability data.
+
+## Supported release matrix
+
+| Herdr reference | Release/provenance | `PROTOCOL_VERSION` | Windows artifact | ATM support status | Conformance recording |
+| --- | --- | ---: | --- | --- | --- |
+| v0.8.0 | tag commit `857196de`, 2026-08-03 | 19 | No official Windows artifact; Windows was beta packaging without a release job | Minimum supported release; Unix lanes | v0.8.2 design recording plus the v0.8.0 blocked-prompt delta mode |
+| v0.8.1 | No tag/release | — | — | No release to support or record | None; do not invent a compatibility row |
+| v0.8.2 | tag commit `34ba52cc`, 2026-08-19; design target | 20 | Official Windows x86_64 artifact | Supported on all released platforms | `docs/plans/phase-aq/fixtures/herdr-cli-contract-fixture.md` F1–F6 |
+| `3a822e81` | master reference, 2026-09-05; untagged snapshot | 22 | Installer/release changes are recorded as drift; not a released floor | Reference-only drift target; additive changes must remain compatible | Compare against v0.8.2; add a recording only if an ATM operation changes |
+
+The v0.8.0-to-v0.8.2 review found identical argv, flags, JSON shapes, and exit
+codes for all six ATM operations. Its only ATM-path error-behaviour delta is
+the v0.8.2 pre-write `agent_blocked` rejection. The v0.8.2-to-master review
+found the same six-operation surface and error-code set, with one material
+`agent prompt --wait` activity-gate outcome change: `timeout` may replace
+`agent_prompt_stalled`. ATM maps both by stable code and does not inspect
+message text.
+
+## Six-operation contract manifest
+
+The following manifest is repeated for each supported release. The v0.8.2
+recording is the canonical shape; v0.8.0 uses it plus the documented
+blocked-prompt delta; master uses it plus the documented wait-gate delta.
+
+| Operation | Direct argv | Success JSON shape / consumed fields | Failure shape and exit | ATM use |
+| --- | --- | --- | --- | --- |
+| `agent prompt` | `herdr agent prompt <AgentName> <rendered nudge template>` | `{"id":"cli:agent:prompt","result":{"type":"agent_prompted","agent":{...}}}`; no agent fields are consumed by the immediate path | `{"id":"...","error":{"code":"...","message":"..."}}`, exit 1; exit 2 is an impossible argv-construction bug | Immediate steer; no `--wait`; rendered built-in template only |
+| `agent wait` | `herdr agent wait <AgentName> --until idle --until done --until blocked --timeout <ms>` | `{"id":"cli:agent:wait","result":{"type":"agent_info","agent":{"agent_status":"...",...}}}`; `agent_status` is the contracted field | `agent_not_found`, `agent_not_running`, `timeout`, and transport codes as structured exit-1 errors; malformed status/timeout is exit 2 | Retained adapter contract; not invoked by Phase AQ |
+| `agent get` | `herdr agent get <AgentName>` | `{"id":"cli:agent:get","result":{"type":"agent_info","agent":{"agent_status":"...",...}}}`; doctor reads `agent_status` only | `agent_not_found` or `agent_target_ambiguous`, plus transport codes, as structured exit-1 errors; malformed arity is exit 2 | Doctor presence probe; `BreakerPolicy::Bypass` |
+| `agent list` | `herdr agent list` | `{"id":"cli:agent:list","result":{"type":"agent_list","agents":[...]}}`; ATM reads each entry's `name` and `agent_status` | A missing member is a normal exit-0 list absence; transport failures are structured exit-1 errors; extra argv is exit 2 | Queue-pump polling, once per distinct configured session |
+| `notification show` | `herdr notification show <title> --body <body> --sound request` | Exit 0; title/body are separate argv values. No response field is part of ATM's contract | Non-zero is a typed adapter failure; error code is parsed when provided | Lead escalation notification; independent of mail delivery |
+| `status server --json` | `herdr status server --json` | JSON includes `version` and `protocol`; the socket transport's equivalent is `ping` | Doctor-only transport failure; never used to gate daemon startup or messaging | Doctor server-status probe, not a nudge |
+
+Source and fixture anchors for the manifest are ADR-058 D2–D10, the Phase AY
+plan's request-set table, and
+[`herdr-cli-contract-fixture.md`](../plans/phase-aq/fixtures/herdr-cli-contract-fixture.md)
+F1–F6. The fixture is derived from source, not a live transcript; it uses
+placeholder names and omits mutable message text from the compatibility rules.
+
+## Version-specific deltas
+
+### v0.8.0
+
+- `PROTOCOL_VERSION` is 19.
+- `agent prompt`, `agent wait`, `agent get`, `agent list`, `notification
+  show`, and `status server --json` retain the manifest's argv and response
+  shapes.
+- `agent prompt` to an already blocked agent submitted and then waited. The
+  fake-Herdr replay for v0.8.0 must model this delta; ATM's outcome remains
+  compatible with the normal wait/error handling.
+- Windows has no official release artifact at this version. This is a
+  packaging fact, not a Windows feature exclusion or a raised minimum.
+
+### v0.8.2
+
+- `PROTOCOL_VERSION` is 20.
+- This is the canonical design recording and the first official Windows
+  release artifact.
+- A blocked prompt is rejected before input with `agent_blocked`.
+- The canonical recording is the existing F1–F6 fixture set.
+
+### master `3a822e81`
+
+- `PROTOCOL_VERSION` is 22; this is not a new minimum.
+- `agent prompt --wait` has the activity-gate drift recorded in the Phase AY
+  plan: `timeout` can replace `agent_prompt_stalled`, and the message text is
+  not stable. Parsers must continue to key on codes.
+- Endpoint resolution, NDJSON framing, agent JSON fields, notification argv,
+  and exit-code surfaces remain compatible. Additive fields are ignored.
+- Windows installer PATH handling prepends the versioned release directory;
+  ATM resolves the configured/binary alias per spawn and never persists the
+  resolved path.
+
+## AY.2 recording-manifest path
+
+AY.2 owns the portable fake-Herdr recordings and replay fixtures. This ledger
+records their manifest path without copying fixture bodies:
+
+```text
+crates/atm-herdr/tests/fixtures/herdr-versions/manifest.json
+```
+
+The manifest must identify the release, source revision, `PROTOCOL_VERSION`,
+and the six operation recording names. The v0.8.0 replay is a delta mode over
+the v0.8.2 recording, not a second copied body. A future release adds a new
+recording set only when the drift procedure below finds a change in one of the
+six operations.
+
+## Drift-check procedure
+
+At every AY sprint start and at phase end:
+
+1. Confirm the maintained reference checkout is
+   `/Users/randlee/Documents/github/herdr`; record its branch and `HEAD`.
+2. Compare the last recorded revision with the current reference:
+   `git diff <last-recorded>..HEAD --` over the client-facing paths below.
+3. Review changes for argv, flags, JSON fields, error codes, exit status,
+   endpoint selection, framing, and platform process behaviour. Ignore
+   message text and JSON key ordering.
+4. If none of ATM's six operations changes, append a dated no-surface-drift
+   entry. If one changes, add a recording manifest or a documented delta,
+   update the affected parser/fixture contract, and obtain the required
+   schema review before accepting the release.
+5. If a change cannot be absorbed additively, escalate to Rand for either a
+   recorded `HERDR_MINIMUM_VERSION` decision or an approved second transport
+   implementation. Never silently raise the minimum or assume the newest
+   Herdr.
+
+Client-facing paths scanned by the drift check:
+
+```text
+src/api/
+src/cli/agent.rs
+src/cli/notification.rs
+src/cli/spec.rs
+src/cli.rs
+src/cli/protocol_guard.rs
+src/ipc.rs
+src/session.rs
+src/integration/env.rs
+src/protocol/wire.rs
+distribution/
+```
+
+## Ledger entries
+
+| Date | Compared revisions | Result | Action |
+| --- | --- | --- | --- |
+| 2026-09-05 | v0.8.0 `857196de` → v0.8.2 `34ba52cc` | Six-operation argv/flags/JSON/exit surface unchanged; blocked-prompt rejection added | One v0.8.2 recording plus v0.8.0 fake delta |
+| 2026-09-05 | v0.8.2 `34ba52cc` → master `3a822e81` | Six-operation surface and error-code set unchanged; wait-gate and protocol integer drifted | Keep one recording; parse stable codes and ignore additive fields |

--- a/docs/atm-herdr/requirements.md
+++ b/docs/atm-herdr/requirements.md
@@ -19,8 +19,10 @@ emitter/selector wiring, or `atm-http-runtime` queue-pump orchestration.
 
 This crate is introduced by Phase AQ (sprints AQ2.6 and AQ2.7) and is
 governed by [ADR-058](../adr/ADR-058-herdr-local-steer-backend-contract.md),
-which pins the Herdr release and records every argv, exit-code, and
-error-code claim this crate relies on. Where any other document disagrees
+which records every argv, exit-code, and error-code claim this crate relies
+on. Release compatibility is governed by the ledger in
+[`herdr-versions.md`](herdr-versions.md) under ADR-061; ADR-058 remains
+authoritative for the operation contract. Where any other document disagrees
 with ADR-058 on Herdr's own behavior, ADR-058 is authoritative; this
 document cites it by decision id (`D1`-`D10.1`).
 
@@ -59,9 +61,10 @@ document cites it by decision id (`D1`-`D10.1`).
 - a fake `HerdrProcessAdapter` implementation behind a `test-utils` Cargo
   feature, recording every call for assertion, for use by every consumer
   crate's tests
-- the Herdr version/protocol pin: `herdr` `0.8.2`, wire protocol `20`
-  (ADR-058 "Pinned Herdr revision"), and the fixture-currency obligation
-  that keeps this crate's parsing in step with a pin bump
+- the Herdr compatibility policy: every Herdr release at or above
+  `HERDR_MINIMUM_VERSION` (`0.8.0`) is supported simultaneously by one ATM
+  build; v0.8.2 is the current design/recording target and
+  `PROTOCOL_VERSION` is recorded as a secondary fact in `herdr-versions.md`
 
 `atm-herdr` does not own:
 
@@ -184,6 +187,16 @@ The `atm-herdr` crate uses the `HR-*` namespace, grouped by category:
   always runs under `BreakerPolicy::Bypass` (`HR-SAFE-007`) and is
   therefore outside this sharing: it never opens, closes, or is blocked by
   the breaker.
+
+- `HR-PLAT-001` ATM exposes the same Herdr command set, typed errors, and
+  breaker semantics on macOS, Linux, and Windows. UDS versus named-pipe
+  transport is an implementation detail and MUST NOT create a
+  platform-specific feature set.
+- `HR-LIFE-001` The ATM daemon never depends on Herdr for startup or
+  readiness, never starts or stops Herdr, and does not restart for a Herdr
+  upgrade. Missing, late, unreachable, or crashed Herdr is reported as a
+  bounded per-call failure on the Herdr harness while ATM messaging, tmux,
+  Hermes, and doctor remain up.
 
 ### 3.2 Safety Requirements
 
@@ -320,16 +333,21 @@ The `atm-herdr` crate uses the `HR-*` namespace, grouped by category:
   failure counter (ADR-058 D10.1 "Required evidence").
 - `HR-TEST-006` No test in this crate, or in any consumer crate's test
   suite, invokes a live `herdr` binary or a live Herdr server. CI never
-  depends on Herdr being installed. Live validation is a separate,
-  manually-run transcript procedure (ADR-058 "Required evidence";
-  `herdr-cli-contract-fixture.md` §F5) outside the automated test suite.
+  depends on Herdr being installed. The portable fake-Herdr fixture replays
+  the recorded v0.8.2 operation set and the v0.8.0 and newer-version delta
+  modes for every supported release; each replay runs on every CI lane.
+  Live validation is a separate, manually-run transcript procedure (ADR-058
+  "Required evidence"; `herdr-cli-contract-fixture.md` §F5) outside the
+  automated test suite.
 
 ### 3.5 Version and Pin Policy
 
-- `HR-VER-001` `atm-herdr` targets Herdr `0.8.2`, wire protocol `20`
-  (ADR-058 "Pinned Herdr revision"). This crate's argv and parsing logic
-  are derived from the Herdr source at checkout `d79fd746`, verified
-  byte-identical to tag `v0.8.2` for every cited surface.
+- `HR-VER-001` `atm-herdr` supports every Herdr release at or above
+  `HERDR_MINIMUM_VERSION` (`0.8.0`) under ADR-061. The design and recording
+  target is Herdr `0.8.2`; its wire protocol `20` is recorded in
+  `herdr-versions.md` as a secondary fact. This crate's argv and parsing
+  logic are derived from the recorded v0.8.2 source revision and must remain
+  compatible with the v0.8.0 and master deltas in that ledger.
 - `HR-VER-002` A Herdr release that changes any row of ADR-058's
   exit-code or error-code tables is a fix-forward event for this crate —
   never a silent pin bump. AQ6's ecosystem preflight re-runs
@@ -373,9 +391,10 @@ The `atm-herdr` crate docs must remain aligned with:
 - `atm-herdr` does not run or wrap `agent start` or `agent rename`.
   These are operator/launch-convention commands (ADR-058 D6); the
   external team launcher runs them directly, not through this crate.
-- `atm-herdr` does not support Herdr on Windows in Phase AQ (ADR-058
-  "Explicitly NOT relied upon": named-pipe transport exists in Herdr but
-  is out of scope here).
+- Windows uses Herdr's named-pipe transport and has the same command,
+  error, and lifecycle contract as macOS/Linux. AY.7 owns Windows-specific
+  process correctness and CI evidence; this crate's portable contract does
+  not depend on live Windows evidence.
 - `atm-herdr` does not retry a lifecycle-shaped failure
   (`agent_blocked`, `agent_not_found`, `agent_not_ready`,
   `agent_target_ambiguous`) itself; retry/requeue/release policy for

--- a/docs/atm-herdr/requirements.md
+++ b/docs/atm-herdr/requirements.md
@@ -31,11 +31,12 @@ document cites it by decision id (`D1`-`D10.1`).
 `atm-herdr` owns:
 
 - the `HerdrProcessAdapter` trait: the async `prompt` / `wait` / `get` /
-  `list` contract consumed by the immediate steer path and the AQ2.7
-  queue-tick pump
+  `list` / `notify` contract consumed by immediate steer, the AQ2.7
+  queue-tick pump, and lead escalation notification paths
 - `HerdrProcessInvoker`, the concrete `tokio::process`-backed
   implementation: argv construction for every `herdr agent ...` shape this
-  crate emits (`prompt`, `wait`, `get`, `list`), `HERDR_SESSION` set on the
+  crate emits (`prompt`, `wait`, `get`, `list`) and the `notification show`
+  shape emitted by `notify`, `HERDR_SESSION` set on the
   **child process environment, per invocation**, only when the calling
   member's roster row (or, for `list`, the caller-supplied session)
   carries a `Some` session (ADR-058 D1's per-member model; the daemon's
@@ -108,10 +109,10 @@ The `atm-herdr` crate uses the `HR-*` namespace, grouped by category:
 ### 3.1 Functional Requirements
 
 - `HR-CORE-001` `atm-herdr` owns the `HerdrProcessAdapter` trait with
-  `prompt`, `wait`, `get`, and `list` methods, each returning a typed
-  outcome or `HerdrError` over an injected external deadline. This is the
-  only cross-crate contract point; no consumer constructs `herdr` argv
-  itself.
+  `prompt`, `wait`, `get`, `list`, and `notify` methods. The agent methods
+  return typed outcomes and `notify` returns `()` or `HerdrError`, all over
+  an injected external deadline. This is the only cross-crate contract
+  point; no consumer constructs `herdr` argv itself.
 - `HR-CORE-002` `HerdrProcessInvoker::prompt` emits exactly
   `herdr agent prompt <AgentName> <text>` (ADR-058 D2) with no `--wait` and
   no other flag. `<text>` is the caller-supplied rendered built-in nudge
@@ -296,17 +297,19 @@ The `atm-herdr` crate uses the `HR-*` namespace, grouped by category:
 
 - `HR-TEST-001` A fake `HerdrProcessAdapter` implementation, gated behind
   the `test-utils` Cargo feature, records every `prompt` / `wait` / `get` /
-  `list` call (agent, session, and — for `wait` — the requested `--until`
-  set and timeout) for assertion and is configurable to return any
+  `list` / `notify` call (agent/session for agent calls, title/body for
+  `notify`, and — for `wait` — the requested `--until` set and timeout) for
+  assertion and is configurable to return any
   `HerdrError` variant or outcome. It is the sole test double any
   consumer crate uses below the adapter boundary (precedent: AQ2.6/AQ2.7's
   `forbidden_test_bypasses` rule forbidding a real `HerdrProcessInvoker` in
   non-live test paths).
 - `HR-TEST-002` Argv-construction tests assert byte-for-byte equality
   against `herdr-cli-contract-fixture.md`'s F1/F2/F3 argv rows for every
-  emitted shape (`prompt`, `wait`, `get`, `list`), including the `--until`
-  ordering and the millisecond `--timeout` value, so a future refactor
-  cannot silently drift from the pinned contract.
+  emitted agent shape (`prompt`, `wait`, `get`, `list`), including the
+  `--until` ordering and the millisecond `--timeout` value; `notify` is
+  asserted against HR-CORE-010's notification argv. A future refactor
+  cannot silently drift from the contract.
 - `HR-TEST-003` Stderr-parsing tests cover every row of ADR-058 D8's
   error-code table plus F1.8/F2.8/F3.5's argv-construction-bug rows
   (asserted unreachable by construction, never merely "not tested"), each
@@ -413,14 +416,15 @@ The `atm-herdr` crate docs must remain aligned with:
 
 `req-qa` should treat these as fail-closed presence checks:
 
-- `HR-CORE-001`–`HR-CORE-005`
-  - `HerdrProcessAdapter` exists with exactly `prompt`, `wait`, `get`,
-    `list` methods; a grep for `herdr` argv literals or Herdr JSON field
+- `HR-CORE-001`–`HR-CORE-005`, `HR-CORE-010`
+  - `HerdrProcessAdapter` exists with `prompt`, `wait`, `get`, `list`, and
+    `notify` methods; a grep for `herdr` argv literals or Herdr JSON field
     names (`agent_status`, `error.code`, `agent_blocked`, …) outside
     `crates/atm-herdr` fails the source-audit gate (see
     `boundaries.md`)
-  - argv-equality tests exist for all four emitted shapes and match
-    `herdr-cli-contract-fixture.md` verbatim
+  - argv-equality tests exist for all four agent shapes and the notification
+    shape, matching `herdr-cli-contract-fixture.md` and HR-CORE-010
+    respectively
   - a grep of `atm-http-runtime`'s `HerdrQueueWakePump` confirms it calls
     `list` and `prompt`, never `wait`, in Phase AQ
 - `HR-CORE-006`

--- a/docs/atm-herdr/windows-process-audit.md
+++ b/docs/atm-herdr/windows-process-audit.md
@@ -1,0 +1,72 @@
+# Herdr Cross-Platform Process Audit
+
+Status: AY.1 documentation baseline, 2026-09-06
+
+This audit records the six Herdr operations used by ATM and the process and
+endpoint behaviours that affect them. The source citations below are the
+recorded citations from the Phase AY plan and ADR-058. The maintained Herdr
+checkout named by the plan (`/Users/randlee/Documents/github/herdr`) was not
+present in the AY.1 worktree, so this document does not claim a fresh checkout
+or live observation. The recorded revisions are v0.8.0 (`857196de`), v0.8.2
+(`34ba52cc`), and master `3a822e81`.
+
+`ATM` relies on argv shape, selected JSON fields, stable error codes, and exit
+status. It does not rely on mutable message text, JSON key order, workspace
+labels, or live Windows evidence. Every Windows observation is explicitly
+owned by AY.7 or release readiness.
+
+## Audited behaviours
+
+| Behaviour | Expected behaviour | Herdr v0.8.0 source file/line | Herdr v0.8.2 source file/line | Herdr `3a822e81` source file/line | Observation and verdict | Windows observation |
+| --- | --- | --- | --- | --- | --- | --- |
+| `agent prompt` — immediate steer | Emit `herdr agent prompt <AgentName> <rendered nudge template>` as one direct argv vector. Success is `result.type=agent_prompted`; failures are structured `error.code` with exit 1; malformed argv is exit 2. No `--wait` is emitted by ATM. | `src/cli/spec.rs:294-357` (prompt/wait flags) | `src/cli/agent.rs:778-841`; `src/app/api/agents.rs:63-130` | `src/cli/agent.rs:424-545,757-826`; prompt argv unchanged | Same argv, JSON shape, exit codes, and error-code surface. v0.8.2 adds the pre-write `agent_blocked` rejection where v0.8.0 submitted and then waited. **Verdict: no action; record the v0.8.0 behavioural delta.** | `AY.7 / release readiness: no recorded Windows Herdr observation in this repository; process correctness is verified in the Windows CI lane and live proof is release readiness.` |
+| `agent wait` — retained contract | Emit `herdr agent wait <AgentName> --until idle --until done --until blocked --timeout <ms>` when a future caller uses the retained adapter method. Success is `result.type=agent_info`; `timeout`, `agent_not_running`, and target errors are structured exit-1 outcomes. Phase AQ does not invoke it. | `src/cli/spec.rs:294-357` | `src/cli/agent.rs:506-560`; `src/api/wait.rs:141-152,470-495,616-619` | `src/api/wait.rs:177-320,516,662-664` | The argv contract is unchanged. Master changes the activity gate and can surface `timeout` where v0.8.2 surfaced `agent_prompt_stalled`. ATM keys on codes, never text. **Verdict: no action; additive compatibility handling.** | `AY.7 / release readiness: no recorded Windows Herdr observation; Windows process and cancellation coverage belongs to AY.7.` |
+| `agent get` — doctor presence probe | Emit `herdr agent get <AgentName>`. Success is `result.type=agent_info`; ATM reads only `agent_status`. Target errors are `agent_not_found` or `agent_target_ambiguous`; no PTY write occurs. | `src/cli/agent.rs:438-465` (agent dispatch/get surface) | `src/cli/agent.rs:20,450-465`; `src/app/api/agents.rs:25-32` | `src/cli/agent.rs:424-545`; `src/app/api/agents.rs:25-32` unchanged | Shape and error set are unchanged. **Verdict: no action.** | `AY.7 / release readiness: no recorded Windows Herdr observation; doctor’s Windows endpoint result is release-readiness evidence.` |
+| `agent list` — queue-pump status probe | Emit `herdr agent list` with no target or session argument. Success is `result.type=agent_list` with `agents[]`; `name` and `agent_status` are the only ATM-consumed fields. | `src/cli/agent.rs:438-448` (recorded tag surface) | `src/cli/agent.rs:19,438-448`; `src/app/api/agents.rs:16-22` | `src/cli/agent.rs:424-545`; list argv and response shape unchanged | Shape, exit codes, and error set are unchanged. An absent name is a normal empty/list result, not `agent_not_found`. **Verdict: no action.** | `AY.7 / release readiness: no recorded Windows Herdr observation; Windows command construction and transport process coverage belong to AY.7.` |
+| `notification show` — lead escalation | Emit `herdr notification show <title> --body <body> --sound request`, preserving title and body as separate argv elements. Success is exit 0; non-zero is a typed adapter failure. | `src/cli/notification.rs:28` | `src/cli/notification.rs:28` | `src/cli/notification.rs` (unchanged surface; source citation recorded in the Phase AY plan) | The argv and failure contract are unchanged. **Verdict: no action.** | `AY.7 / release readiness: no recorded Windows Herdr observation; Windows process creation and console suppression are AY.7, live proof is release readiness.` |
+| `status server --json` — doctor server status | Emit `herdr status server --json` for the CLI doctor path. Record JSON `version` and `protocol`; socket transport uses `ping` instead. This is doctor-only, never a nudge path. | `src/cli/status.rs` (verified at v0.8.0 revision `346411fa`) | `src/cli/status.rs` (verified at v0.8.2 revision `9eb52145`) | `src/cli/status.rs` (master; unchanged response fields) | `version` and `protocol` are present at all three references. **Verdict: no action; retain as a six-operation ledger row.** | `AY.7 / release readiness: no recorded Windows Herdr observation; endpoint and doctor proof are release-readiness evidence.` |
+| Session and endpoint selection | Resolve explicit session, then `HERDR_SOCKET_PATH`, then `HERDR_SESSION`, then the default `<config_dir>/herdr.sock`. A named session is a separate Herdr server, not a workspace. ATM supplies the member session only on the child environment. | `src/session.rs` (recorded endpoint model; exact tag line not retained) | `src/session.rs:96-101,161-181`; `src/ipc.rs:44-51,137,247` | `src/session.rs:96-101,161-181`; `src/ipc.rs:44-51,137,247` byte-identical | The endpoint model is unchanged from v0.8.2 to master. The AY.1 ledger records v0.8.0 as the minimum compatibility release without inventing an unrecorded line citation. **Verdict: no action.** | `AY.7 / release readiness: named-pipe naming and per-user endpoint behaviour require Windows CI/process coverage; no live Windows evidence is claimed here.` |
+| Transport, framing, and protocol | Use local sockets with one NDJSON request line and one JSON response line. Unix uses UDS; Windows uses a named pipe. `PROTOCOL_VERSION` is a secondary bincode-client fact, not the NDJSON compatibility floor. | `src/ipc.rs` and `src/protocol/wire.rs` (recorded v0.8.0 protocol 19) | `src/ipc.rs:10-11,137,247`; `src/protocol/wire.rs:20` (protocol 20) | `src/ipc.rs:10-11,137,247`; `src/protocol/wire.rs:20` → 22 | The transport and NDJSON shapes are unchanged; only the secondary protocol integer drifts 19 → 20 → 22. **Verdict: no action; govern minimum release with ADR-061.** | `AY.7 / release readiness: Windows named-pipe and kill/reap correctness are AY.7; no live pipe observation is recorded here.` |
+| Error and exit-code mapping | Exit 0 is success JSON; exit 1 is structured failure JSON on stderr; exit 2 is usage/argv failure. ATM matches stable `error.code`, tolerates unknown fields/codes, and never matches `error.message`. | `src/cli.rs` / `src/app/api/agents.rs` (recorded tag sources) | `src/cli.rs:738-797`; `src/app/api/agents.rs:82-110,290-318` | `src/cli.rs:738-797`; `src/api/wait.rs:662-664` for changed wait text | v0.8.0 → v0.8.2: `agent_blocked` becomes a pre-write rejection; start-only codes are not ATM-path codes. v0.8.2 → master: `agent_prompt_stalled`/`timeout` wait outcome changes, while codes and JSON shapes remain compatible. **Verdict: no action; fake replay must cover both outcomes.** | `AY.7 / release readiness: no recorded Windows error transcript; CRLF decoding and process failure mapping are AY.7.` |
+| Windows packaging and process lifecycle | A released Windows artifact exists from v0.8.2 onward; v0.8.0 had no official Windows release artifact. ATM must treat Windows as supported, resolve `herdr.exe` per call, suppress console creation, and kill/reap bounded children. | `distribution/` (v0.8.0 beta packaging; no release job) | `release.yml` / `windows-arm64.yml` (release artifact fact recorded by the plan) | `distribution/install.ps1:881-904`; `src/ipc.rs:342-345` | v0.8.2 is the first official Windows artifact; master changes PATH installation and retains the same API-pipe ACL limitation. **Verdict: AY.7 production fix/verification; not an AY.1 live-evidence claim.** | `AY.7 / release readiness: authoritative owner. This audit records no Windows pass, benchmark, or live machine result.` |
+
+## Version drift summary
+
+### v0.8.0 → v0.8.2
+
+The six ATM operations retain the same argv, flags, JSON shapes, and exit
+codes. The client-facing files changed, but the changes affecting ATM are
+limited to the recorded `agent_blocked` behaviour: v0.8.2 rejects a prompt to
+an already blocked agent before input, while v0.8.0 submitted and then waited.
+ATM already has a typed `AgentBlocked` outcome, so the difference is handled
+without a version branch. `agent_not_ready` and `agent_pane_busy` are
+`agent start` codes and are not part of ATM's six-operation path.
+
+The packaging difference is material but not a compatibility floor: v0.8.0
+has no official Windows artifact, while v0.8.2 has a Windows x86_64 release
+artifact. The minimum remains 0.8.0 on supported Unix platforms and the
+Windows user population begins at the first official Windows artifact.
+
+### v0.8.2 → `3a822e81`
+
+The six operations retain their argv, flags, JSON shapes, exit codes, and
+error-code set. The material behavioural drift is in `agent prompt --wait`:
+the activity gate and the resulting `timeout`/`agent_prompt_stalled` outcome
+changed. The protocol integer moved 20 → 22, but it versions Herdr's bincode
+client socket, not the NDJSON API. Endpoint resolution, notification, and
+agent response fields remain compatible. New JSON fields are additive and
+must be ignored by ATM parsers.
+
+Windows installer PATH handling changed in master, so ATM must resolve the
+configured/binary alias per spawn and never persist a resolved executable
+path. The Windows API pipe remains default-DACL; AY.7 records the boundary and
+process implications.
+
+## Verdict vocabulary
+
+- **no action** — the recorded contract is compatible with ATM's one
+  version-agnostic implementation.
+- **production fix** — implementation or test work belongs to a later AY
+  sprint, chiefly AY.7 for Windows process correctness.
+- **upstream request** — Herdr must change before ATM can support the desired
+  contract; no such request is raised by this audit.

--- a/docs/plans/phase-aq/sprint-AQ2-6-herdr-steer-backend.md
+++ b/docs/plans/phase-aq/sprint-AQ2-6-herdr-steer-backend.md
@@ -725,9 +725,9 @@ this doc cites it by decision id (`D1`–`D8`).
     the `herdr_string_containment_gate` source-audit rule,
     `docs/atm-herdr/{requirements.md,architecture.md,boundaries.md}` present
     and current, `cargo test -p atm-architecture`, and `just test` pass on
-    all three lanes. Herdr command fixtures run on macOS/ubuntu; Windows
-    verifies selection and command construction only until a supported
-    Windows Herdr deployment is explicitly added. **(deliverable 5)**
+    all three lanes. Herdr command fixtures run on macOS/ubuntu; the Windows
+    process-correctness and named-pipe work is superseded into Phase AY.7,
+    with live Windows proof retained as release readiness. **(deliverable 5)**
 16. `atm doctor --json` exposes a top-level `herdr_breaker: { state:
     "closed"|"open", retry_after_ms, consecutive_failures }` field sourced
     from `HerdrSpawnBreaker::state()`; a fixture opens the breaker and


### PR DESCRIPTION
## Summary
- add the AY.1 cross-platform process audit and Herdr version compatibility ledger
- define version-floor, Windows named-pipe, lifecycle, and replay requirements
- amend ADR-058 and supersede the Phase AQ Windows scope-out with AY.7 ownership

## Validation
- `git diff --check`
- `just lint spell`
- `just lint adr-index`
- full lint/test exercised; existing RULE-003, boundary, integration, and disk-capacity environment findings are documented in the handoff