### PR TITLE
chore(release): bump workspace version to 1.5.3

### DIFF
--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -234,6 +234,110 @@ def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
                     )
 
 
+SIMPLE_SPECIFIER_CLAUSE = re.compile(r"(>=|<=|==|!=|>|<)\s*(\d+(?:\.\d+)*)")
+
+
+def version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def specifier_admits(version: str, specifier: str) -> bool:
+    """Evaluate a simple comma-separated PEP 440-style specifier (>=, <=, ==, !=, >, <).
+
+    Deliberately minimal (no pre-releases, no ~=, no packaging dependency) --
+    this repo's own pyproject.toml dependency pins only ever use this shape.
+    """
+
+    candidate = version_tuple(version)
+    clauses = SIMPLE_SPECIFIER_CLAUSE.findall(specifier)
+    if not clauses:
+        fail(f"unsupported version specifier shape: {specifier!r}")
+    for operator, bound in clauses:
+        bound_tuple = version_tuple(bound)
+        # Compare on the shorter length so "1.5" bounds admit "1.5.3" candidates.
+        length = min(len(candidate), len(bound_tuple))
+        lhs, rhs = candidate[:length], bound_tuple[:length]
+        if operator == ">=" and not lhs >= rhs:
+            return False
+        if operator == "<=" and not lhs <= rhs:
+            return False
+        if operator == "==" and not lhs == rhs:
+            return False
+        if operator == "!=" and not lhs != rhs:
+            return False
+        if operator == ">" and not lhs > rhs:
+            return False
+        if operator == "<" and not lhs < rhs:
+            return False
+    return True
+
+
+PYTHON_DEPENDENCY_ENTRY = re.compile(r"^([A-Za-z0-9_.-]+)\s*(.*)$")
+
+
+def workspace_dynamic_python_packages(repo_root: Path, workspace_version: str) -> dict[str, str]:
+    """Map Python package name -> version for every workspace pyproject.toml whose
+    version is derived from the Cargo workspace version (``dynamic = ["version"]``),
+    e.g. the atm-graft wheel. These are the packages other in-workspace pyproject.toml
+    dependency pins must track when the workspace version bumps.
+    """
+
+    packages: dict[str, str] = {}
+    for pyproject in sorted((repo_root / "crates").glob("*/pyproject.toml")):
+        manifest = tomllib.loads(read_text(pyproject))
+        project = manifest.get("project", {})
+        if not isinstance(project, dict):
+            continue
+        name = project.get("name")
+        dynamic = project.get("dynamic", [])
+        if isinstance(name, str) and isinstance(dynamic, list) and "version" in dynamic:
+            packages[name] = workspace_version
+    return packages
+
+
+def validate_python_dependency_pins(repo_root: Path, workspace_version: str) -> bool:
+    """Fail if any in-workspace pyproject.toml pins a workspace-tracked Python
+    package (e.g. hermes-atm's ``atm-graft`` dependency) with a specifier the
+    current workspace version no longer satisfies. Prevents the class of bug
+    where a crate's own ``version`` field is bumped but a sibling's dependency
+    range on it is left stale (e.g. ``atm-graft>=1.4,<1.5`` after atm-graft
+    itself moved to 1.5.x).
+    """
+
+    dynamic_packages = workspace_dynamic_python_packages(repo_root, workspace_version)
+    if not dynamic_packages:
+        return False
+
+    checked_any = False
+    for pyproject in sorted((repo_root / "crates").glob("*/pyproject.toml")):
+        manifest = tomllib.loads(read_text(pyproject))
+        project = manifest.get("project", {})
+        if not isinstance(project, dict):
+            continue
+        dependencies = project.get("dependencies", [])
+        if not isinstance(dependencies, list):
+            continue
+        rel_manifest = pyproject.relative_to(repo_root).as_posix()
+        for entry in dependencies:
+            if not isinstance(entry, str):
+                continue
+            match = PYTHON_DEPENDENCY_ENTRY.match(entry.strip())
+            if match is None:
+                continue
+            dependency_name, specifier = match.group(1), match.group(2).strip()
+            target_version = dynamic_packages.get(dependency_name)
+            if target_version is None or not specifier:
+                continue
+            checked_any = True
+            if not specifier_admits(target_version, specifier):
+                fail(
+                    f"{rel_manifest} dependency {entry!r}: specifier does not admit "
+                    f'the current workspace-tracked "{dependency_name}" version '
+                    f'"{target_version}" -- update the pin (e.g. to track the workspace minor)'
+                )
+    return checked_any
+
+
 def validate_lockfile(repo_root: Path, workspace_version: str) -> None:
     lock = tomllib.loads(read_text(repo_root / "Cargo.lock"))
     packages = lock.get("package", [])
@@ -398,6 +502,8 @@ def main() -> int:
         executed_checks.append("winget")
     if validate_release_wiring(repo_root, config):
         executed_checks.append("release wiring")
+    if validate_python_dependency_pins(repo_root, workspace_version):
+        executed_checks.append("Python registry dependency pins")
 
     for line in workspace_crate_section_lines(repo_root):
         print(line)

--- a/.just/lint_hermes_atm_boundary.py
+++ b/.just/lint_hermes_atm_boundary.py
@@ -11,6 +11,7 @@ import sys
 import tomllib
 
 from lint_common import build_report, discover_repo_root, monotonic_now, print_report
+from check_version_sync import validate_workspace_version
 
 
 LINT_NAME = "hermes-atm-boundary"
@@ -66,8 +67,17 @@ def collect_violations(repo_root: Path) -> list[Violation]:
         violations.append(Violation(str(BOUNDARY_PATH), "forbidden references must cover rusqlite and reqwest"))
 
     dependencies = package.get("project", {}).get("dependencies", [])
-    if dependencies != ["atm-graft>=1.4,<1.5"]:
-        violations.append(Violation(str(PACKAGE_PATH), "dependencies must be exactly the public atm-graft 1.4.x contract"))
+    workspace_version = validate_workspace_version(repo_root)
+    major, minor = (int(part) for part in workspace_version.split(".")[:2])
+    expected_dependency = f"atm-graft>={major}.{minor},<{major}.{minor + 1}"
+    if dependencies != [expected_dependency]:
+        violations.append(
+            Violation(
+                str(PACKAGE_PATH),
+                f"dependencies must be exactly the public atm-graft {major}.{minor}.x contract "
+                f'("{expected_dependency}"), tracking the current workspace minor version',
+            )
+        )
     package_text = (repo_root / PACKAGE_PATH).read_text(encoding="utf-8").lower()
     for dependency in FORBIDDEN_DEPENDENCIES:
         if dependency in package_text:

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -20,6 +20,8 @@ from check_version_sync import success_message
 from check_version_sync import validate_release_version_lockstep
 from check_version_sync import KIT_RELEASE_ARTIFACTS
 from check_version_sync import replace_version_occurrences
+from check_version_sync import specifier_admits
+from check_version_sync import validate_python_dependency_pins
 from prerelease_tag import copy_tracked_files
 from prerelease_tag import sync_python_version
 
@@ -276,6 +278,63 @@ ManifestVersion: 1.3.2-beta-21-pre
             self.assertFalse((destination / "secret.txt").exists())
             self.assertTrue((destination / "link.txt").is_symlink())
             self.assertEqual(os.readlink(destination / "link.txt"), "target.txt")
+
+    def test_specifier_admits_evaluates_comma_separated_bounds(self) -> None:
+        self.assertTrue(specifier_admits("1.5.3", ">=1.5,<1.6"))
+        self.assertFalse(specifier_admits("1.5.3", ">=1.4,<1.5"))
+        self.assertTrue(specifier_admits("1.5.3", "==1.5.3"))
+        self.assertFalse(specifier_admits("1.5.3", "!=1.5.3"))
+
+    def _write_pyproject(self, path: Path, name: str, *, dynamic_version: bool, dependencies: list[str] | None = None) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = ["[project]", f'name = "{name}"']
+        if dynamic_version:
+            lines.append('dynamic = ["version"]')
+        else:
+            lines.append('version = "0.1.0"')
+        if dependencies is not None:
+            deps = ", ".join(f'"{dep}"' for dep in dependencies)
+            lines.append(f"dependencies = [{deps}]")
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_validate_python_dependency_pins_rejects_stale_specifier(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self._write_pyproject(
+                repo_root / "crates/atm-graft-python/pyproject.toml",
+                "atm-graft",
+                dynamic_version=True,
+            )
+            self._write_pyproject(
+                repo_root / "crates/hermes-atm/pyproject.toml",
+                "hermes-atm",
+                dynamic_version=False,
+                dependencies=["atm-graft>=1.4,<1.5"],
+            )
+
+            with self.assertRaises(SystemExit) as error:
+                validate_python_dependency_pins(repo_root, "1.5.3")
+
+            message = str(error.exception)
+            self.assertIn("crates/hermes-atm/pyproject.toml", message)
+            self.assertIn("does not admit", message)
+
+    def test_validate_python_dependency_pins_accepts_tracking_specifier(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self._write_pyproject(
+                repo_root / "crates/atm-graft-python/pyproject.toml",
+                "atm-graft",
+                dynamic_version=True,
+            )
+            self._write_pyproject(
+                repo_root / "crates/hermes-atm/pyproject.toml",
+                "hermes-atm",
+                dynamic_version=False,
+                dependencies=["atm-graft>=1.5,<1.6"],
+            )
+
+            self.assertTrue(validate_python_dependency_pins(repo_root, "1.5.3"))
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_lint_hermes_atm_boundary.py
+++ b/.just/tests/test_lint_hermes_atm_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import shutil
 import sys
 import tempfile
@@ -17,6 +18,7 @@ class HermesAtmBoundaryLintTests(unittest.TestCase):
     def copy_fixture(self, destination: Path) -> None:
         root = JUST_DIR.parent
         for relative in (
+            "Cargo.toml",
             "boundaries/hermes-atm/runtime-composition.toml",
             "crates/hermes-atm/pyproject.toml",
             "crates/hermes-atm/src/hermes_atm",
@@ -49,7 +51,16 @@ class HermesAtmBoundaryLintTests(unittest.TestCase):
             root = Path(temp)
             self.copy_fixture(root)
             package = root / "crates/hermes-atm/pyproject.toml"
-            package.write_text(package.read_text(encoding="utf-8").replace('dependencies = ["atm-graft>=1.4,<1.5"]', 'dependencies = ["atm-graft>=1.4,<1.5", "atm-daemon"]'), encoding="utf-8")
+            original = package.read_text(encoding="utf-8")
+            match = re.search(r'dependencies = \[("atm-graft[^"]*")\]', original)
+            assert match is not None, "fixture pyproject.toml has no single-entry atm-graft dependencies list"
+            package.write_text(
+                original.replace(
+                    match.group(0),
+                    f'dependencies = [{match.group(1)}, "atm-daemon"]',
+                ),
+                encoding="utf-8",
+            )
             findings = collect_violations(root)
             self.assertTrue(any("forbidden package edge" in item.message for item in findings))
 

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.5.1
+PackageVersion: 1.5.3
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.1/atm_1.5.1_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.3/atm_1.5.3_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.5.1
+ManifestVersion: 1.5.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-herdr",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "atm-herdr"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "serde_json",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "atm-observability"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "sc-observability",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -405,14 +405,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "peer-tls"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "atm-storage",
  "rcgen",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1964,7 +1964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sc-lint-attributes",
- "sc-lint-directives 1.5.1",
+ "sc-lint-directives 1.5.3",
  "serde",
  "serde_json",
  "syn 2.0.119",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.5.1"
+version = "1.5.3"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.3"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]
@@ -63,17 +63,17 @@ getrandom = "0.3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 semver = { version = "1", features = ["serde"] }
 async-trait = "0.1"
-atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.1" }
-atm-observability = { path = "crates/atm-observability", version = "1.5.1" }
-atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.1" }
-atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.1" }
-atm-error = { path = "crates/atm-error", version = "1.5.1" }
-atm-graft = { path = "crates/atm-graft", version = "1.5.1" }
-atm-herdr = { path = "crates/atm-herdr", version = "1.5.1" }
-atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.1" }
-atm-runtime = { path = "crates/atm-runtime", version = "1.5.1" }
+atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.3" }
+atm-observability = { path = "crates/atm-observability", version = "1.5.3" }
+atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.3" }
+atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.3" }
+atm-error = { path = "crates/atm-error", version = "1.5.3" }
+atm-graft = { path = "crates/atm-graft", version = "1.5.3" }
+atm-herdr = { path = "crates/atm-herdr", version = "1.5.3" }
+atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.3" }
+atm-runtime = { path = "crates/atm-runtime", version = "1.5.3" }
 atm-runtime-test-support = { path = "crates/atm-runtime-test-support" }
-atm-storage = { path = "crates/atm-storage", version = "1.5.1" }
-atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.1" }
-atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.1" }
-peer-tls = { path = "crates/peer-tls", version = "1.5.1" }
+atm-storage = { path = "crates/atm-storage", version = "1.5.3" }
+atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.3" }
+atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.3" }
+peer-tls = { path = "crates/peer-tls", version = "1.5.3" }

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-query"
-version = "1.5.1"
+version = "1.5.3"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.5.3"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
-dependencies = ["atm-graft>=1.4,<1.5"]
+dependencies = ["atm-graft>=1.5,<1.6"]
 authors = [{ name = "atm-core contributors" }]
 license = { text = "MIT OR Apache-2.0" }
 classifiers = [

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.5.1"
+version = "1.5.3"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
## Summary

Patch bump 1.5.1 -> 1.5.3 on `develop` (1.5.2 is already taken by `integrate/phase-ay`'s own `prerelease/v1.5.2` tag at `98e41f521`, so it's skipped to keep prerelease tag numbers unique across branches). This gives the current `develop` head (`89bd7d256` -- Phase AX merge + PR #1268) an unambiguous version number of its own, per Rand's ruling that every commit used for integration testing needs a patch bump + tag.

- Cargo.toml (workspace.package.version + internal path-dep version pins), Cargo.lock (`cargo update --workspace --offline`), `crates/atm-query-python/pyproject.toml`, `crates/hermes-atm/pyproject.toml`, `.winget/randlee.agent-team-mail.yaml` -- same file set as the 1.5.1 bump (`0a1a1f0e2`).
- Generated via the repo's own `.just/prerelease_tag.py` manifest-update/validation logic (`candidate_changes`), targeting `1.5.3` explicitly rather than its default auto-increment (which would collide with the taken `1.5.2`).
- `python3 .just/check_version_sync.py` passes: workspace_version=1.5.3, lockstep across all crates/pyproject/winget/Cargo.lock confirmed.

## Next step (after merge)

Tag `prerelease/v1.5.3` (annotated) at the merge commit, matching the existing `prerelease/v1.5.1`/`prerelease/v1.5.2` scheme. That tag push triggers `prerelease-archive.yml` to build the linux/macOS/windows archives (no GitHub Release) for the HERMES-GRAFT-COLIMA-R1 integration test.

## Test plan
- [x] `check_version_sync.py` passes locally
- [ ] CI green (this touches Cargo.lock/manifests -- full CI, not waived)