### PR TITLE
plan(phase-ay): isolate AY.8 transport swap, recut AY.4-AY.9 into parallel stacks

### DIFF
--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -860,11 +860,11 @@ contracts, artifacts, and ownership.
 | AY.1 | Audit, version ledger, requirements, ADR, architecture/history correction | S | Docs | P-A, P-B | AY.2 | any |
 | AY.2 | Private CLI transport foundation plus portable fake/replay fixtures | M | Core stack | P-A, P-B | AY.1 | macOS/Linux + Windows CI |
 | AY.3 | Endpoint doctor/config boundary and end-to-end activation | M | Core stack | AY.2, P-E(a) | none | macOS/Linux + Windows CI |
-| AY.4 | Breaker escalation and real-composition failure/recovery lifecycle | M | Core stack | AY.3 | AY.8 | macOS/Linux + Windows CI |
-| AY.5 | Transactional Herdr entry install/remove/status/repair | M | Core stack | AY.4 | AY.8 | macOS/Linux + platform fakes |
-| AY.6 | Coordinated Herdr restart/live-handoff and ATM-restart preflight | M | Core stack | AY.5 | AY.8 | macOS/Linux + platform fakes |
-| AY.7 | Windows process correctness and installer Windows branch | S | Core/Windows stack | AY.6 | AY.8 | Windows CI lane |
-| AY.8 | Direct socket/pipe transport, fake server, compatibility/equivalence | L | Socket | AY.1, AY.2, AY.3, P-E(b) | AY.4, AY.5, AY.6, AY.7 | macOS/Linux + Windows CI |
+| AY.4 | Breaker escalation and real-composition failure/recovery lifecycle | M | Core stack | AY.3 | AY.5, AY.6, AY.7, AY.8 | macOS/Linux + Windows CI |
+| AY.5 | Transactional Herdr entry install/remove/status/repair | M | Control-plane stack | AY.3 | AY.4, AY.8 | macOS/Linux + platform fakes |
+| AY.6 | Coordinated Herdr restart/live-handoff and ATM-restart preflight | M | Control-plane stack | AY.5 | AY.4, AY.8 | macOS/Linux + platform fakes |
+| AY.7 | Windows process correctness and installer Windows branch | S | Control-plane/Windows stack | AY.6 | AY.4, AY.8 | Windows CI lane |
+| AY.8 | Direct socket/pipe transport, fake server, compatibility/equivalence | L | Transport | AY.1, AY.2, P-E(b) | AY.3, AY.4, AY.5, AY.6, AY.7 | macOS/Linux + Windows CI |
 | AY.9 | Socket-default cutover, CLI fallback, doctor projection, lifecycle/CI | M | Join | AY.7, AY.8 | none | all CI lanes |
 
 Execution waves are explicit:
@@ -873,15 +873,16 @@ Execution waves are explicit:
 | --- | --- | --- |
 | 1 | AY.1 and AY.2 | Both start after P-A/P-B; AY.1 is standalone and AY.2 is the stack bottom. |
 | 2 | AY.1 completion, AY.2 review, AY.3 development | AY.3 starts after AY.2 development/contracts are pushed and P-E(a) is approved; AY.2 merges before AY.3. |
-| 3 | AY.3 review and AY.4 development | AY.4 is stacked after AY.3 development is pushed; AY.3 merges before AY.4. |
-| 4 | AY.4 and AY.8 | AY.8 starts independently only after AY.1, AY.2, and AY.3 merge and P-E(b) is approved. |
-| 5 | AY.5 and AY.8 | AY.5 stays in the linear stack; AY.8 remains an independent sibling. |
-| 6 | AY.6 and AY.8 | Same independent concurrency; neither branch merges the unmerged sibling. |
-| 7 | AY.7 and AY.8 | Neither has a physical-host gate; AY.7's gate is the Windows CI lane (ruling 5). |
-| 8 | AY.9 | Starts from `integrate/phase-ay` only after AY.7 and AY.8 merge; the last sprint. |
+| 3 | AY.3 review, AY.4 development, AY.8 development | AY.4 is stacked after AY.3 development is pushed; AY.3 merges before AY.4. AY.8 starts from `integrate/phase-ay` the moment AY.1 and AY.2 have merged and P-E(b) is approved (both true 2026-09-06); it never waits on AY.3. |
+| 4 | AY.4, AY.5, AY.8 | AY.5 starts from `integrate/phase-ay` when AY.3 merges and develops in parallel with AY.4 (disjoint files); AY.4 merges before AY.5. |
+| 5 | AY.6, AY.7, AY.8 | Contracts first: AY.6 is stacked on AY.5 as soon as AY.5's contracts are pushed, AY.7 on AY.6 likewise; AY.8 completes independently. Neither stack merges the unmerged sibling; AY.7's gate is the Windows CI lane (ruling 5). |
+| 6 | AY.9 | Starts from `integrate/phase-ay` only after AY.7 and AY.8 merge; the last sprint. |
 
-The sole linear stack is AY.2 -> AY.3 -> AY.4 -> AY.5 -> AY.6 ->
-AY.7. Use the `/gh-stack` skill for every operation on that stack.
+There are two linear stacks (rework 2026-09-06): the core stack AY.2 ->
+AY.3 -> AY.4 and the control-plane stack AY.5 -> AY.6 -> AY.7, each
+based on `integrate/phase-ay`. AY.8 is a standalone transport branch and
+AY.9 the final join. Use the `/gh-stack` skill for every operation on
+either stack.
 Branches are created with `sc-git-worktree` from the immediate parent so
 each child carries the parent's unmerged work. Because this is an external
 worktree/PR workflow, use `gh stack link` to create or update remote stack
@@ -891,7 +892,8 @@ state, then verify actual PR bases directly:
 gh stack link --base integrate/phase-ay \
   feature/ay2-herdr-transport-seam \
   feature/ay3-herdr-endpoint-doctor-config \
-  feature/ay4-herdr-breaker-lifecycle \
+  feature/ay4-herdr-breaker-lifecycle
+gh stack link --base integrate/phase-ay \
   feature/ay5-herdr-entry-control-plane \
   feature/ay6-herdr-restart-coordination \
   feature/ay7-windows-herdr-process-installer
@@ -996,8 +998,10 @@ Common preconditions:
   public-contract inventory update to the atm-herdr boundary record,
   reviewed after AY.2's transport foundation and recordings are pushed and before AY.3
   development starts; AY.2 still merges before AY.3. The approved file is
-  AY.3's first commit. (b) AY.8: the revision below, reviewed after AY.3
-  merges and before AY.8 dispatch; the approved diff is AY.8's first commit.
+  AY.3's first commit. (b) AY.8: the revision below, reviewed before AY.8 dispatch; the approved
+  diff is AY.8's first commit. Ruled 2026-09-06 by boundary-guard: approved
+  as written; the endpoint resolver and its types stay crate-private, no
+  architecture-test exemption exists, and AY.8 does not wait on AY.3.
   Proposed diff to `boundaries/atm-herdr/herdr-process-adapter.toml`:
 
   ```toml
@@ -1055,8 +1059,7 @@ readiness on the develop build (Rand, 2026-09-05; closes AYP-R13-002).
   public types, pins and exports; the Tokio `net` feature; the `transport`
   and `socket_path` configuration keys and their validation; the socket
   values of the doctor `transport`/`endpoint` fields and their snapshots;
-  the `herdr_local_socket_client` ownership key, the AI.11 exemption line
-  and the NDJSON columns; operator documentation of the socket default.
+  the `herdr_local_socket_client` ownership key and the NDJSON columns; operator documentation of the socket default.
   The AY.8 and AY.9 sprint docs are marked superseded. Gate checks for
   Cancel are mechanical on the integrate head: `test ! -e
   crates/atm-herdr/src/transport_socket.rs`; `grep -rn
@@ -1587,3 +1590,47 @@ version, and lifecycle-label shapes.
   a bounded kill-then-reap grace period, per-call binary re-resolution, and
   CRLF-tolerant decoding) alongside its documentation and Windows-CI coverage;
   no live-hardware sprint gate was introduced.
+
+## Rework record (2026-09-06, PR from `plan/phase-ay-rework` to develop)
+
+Trigger: AY.3 ran for three hours in one dev session and the remaining
+six sprints were serialized behind it. Rand's rulings, applied verbatim:
+
+1. Sprints are designed to complete in one context window. AY.3's shape
+   (twenty commits, five crates) is the reference for "too large"; no
+   remaining sprint may exceed it, and any sprint that grows past one
+   window is split at the next contract boundary rather than continued.
+2. An eight-item serial plan is a design smell: work written against code
+   rather than traits. All Herdr implementation lives in the independent
+   `atm-herdr` crate behind `HerdrProcessAdapter`.
+3. Swapping CLI calls for UDS/named-pipe is completely hidden from the
+   rest of the application, changes no functionality, and is developed
+   independently of every feature sprint. AY.8 therefore depends only on
+   AY.1, AY.2 and P-E(b), is parallel-safe with AY.3 through AY.7, and is
+   dispatched now (cipher, fast model). AY.9 remains the composition flip.
+4. The AI.11 retired-transport guard kept named pipes out of daemon HTTP on
+   Windows; it has nothing to do with Herdr, which requires a named pipe
+   there. It is obsolete and was deleted on AY.3 (PR #1273, 45701a81e).
+   There are no named pipes in the repo other than the ones Herdr requires,
+   and AY.8 needs no exemption (D2 removed; endpoint types crate-private;
+   public-item pin unchanged).
+5. The AY.4 -> AY.5 edge was a design principle, not a file dependency.
+   AY.5 now depends on AY.3 only, branches from `integrate/phase-ay`, and
+   heads the control-plane stack AY.5 -> AY.6 -> AY.7. AY.6 and AY.7 start
+   contracts-first on their parent's pushed contracts, as AY.3 did on AY.2.
+
+Resulting concurrency after AY.3 merges: AY.4 (arch-ctm), AY.5 (arch-ctm
+or cipher), AY.8 (cipher) run at once; AY.6/AY.7 follow AY.5's contracts;
+AY.9 joins. Orchestration state in `.sprints/AY/structure.ttl` on
+`integrate/phase-ay` is updated to this order after this PR merges.
+
+Files changed by the rework: this plan (sprint map, waves, stack
+description, P-E(b), Cancel gate, this record), sprint-AY.1 (superseded
+exemption note), sprint-AY.4/AY.5/AY.6 (edges and rationales), sprint-AY.8
+(D2 removed, D4/D9/C1/C3, required work 1, acceptance 1 and 7, dispatch
+section, recommended agent).
+
+### Hardening rounds
+
+Recorded inline as each reviewer returns; the PR does not merge before every
+round below is PASS or every finding has an accepted disposition.

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1005,6 +1005,13 @@ Common preconditions:
   diff is AY.8's first commit. Ruled 2026-09-06 by boundary-guard: approved
   as written; the endpoint resolver and its types stay crate-private, no
   architecture-test exemption exists, and AY.8 does not wait on AY.3.
+  Composed-file rule: AY.3 (P-E(a)) and AY.8 (P-E(b)) both edit
+  `boundaries/atm-herdr/herdr-process-adapter.toml` and
+  `crates/atm-herdr/src/lib.rs`. Whichever merges into `integrate/phase-ay`
+  second merges the integration head forward, resolves the TOML by keeping
+  every P-E(a) inventory line and adding only the P-E(b) `io_owns` key, then
+  reruns `just lint boundaries` and `cargo test -p atm-architecture`, and
+  fenix (boundary-guard) confirms the composed file before that PR merges.
   Proposed diff to `boundaries/atm-herdr/herdr-process-adapter.toml`:
 
   ```toml
@@ -1636,12 +1643,49 @@ AY.9 joins. Orchestration state in `.sprints/AY/structure.ttl` on
 `integrate/phase-ay` is updated to this order after this PR merges.
 
 Files changed by the rework: this plan (sprint map, waves, stack
-description, P-E(b), Cancel gate, this record), sprint-AY.1 (superseded
-exemption note), sprint-AY.4/AY.5/AY.6 (edges and rationales), sprint-AY.8
-(D2 removed, D4/D9/C1/C3, required work 1, acceptance 1 and 7, dispatch
-section, recommended agent).
+description, P-E(b) and its composed-file rule, the Cancel disposition
+under "Phase AY exit gate", this record), sprint-AY.1 (superseded
+exemption note), sprint-AY.3 (AY.8 edge and dispatch prose),
+sprint-AY.4/AY.5/AY.6/AY.7 (edges, rationales, stack topology,
+preconditions, V5), sprint-AY.8 (D2 removed, D4/D9/D10/C1/C3, required
+work 1, acceptance 1 and 7, dispatch section, size/split, recommended
+agent), sprint-AY.9 (permanent CLI fallback, D10 pin name).
+
+Scaling note (Rand, 2026-09-06, 30–50 agents): today's queue-wake tick
+(5 s) spawns one `herdr list` per session every tick whether or not any
+member is pending, plus one `herdr get` per member with an open task and
+one `herdr prompt` per eligible member. The socket removes the per-call
+process cost; it does not remove the per-member call count. AY.4 (breaker
+lifecycle) and AY.6 (restart coordination) must not add per-member calls,
+and the tick should skip `list` when nothing is pending and no task is
+open, and reuse the `list` snapshot instead of a per-member `get` where the
+snapshot already carries the state. Recorded as a design constraint, not a
+new sprint.
 
 ### Hardening rounds
 
 Recorded inline as each reviewer returns; the PR does not merge before every
 round below is PASS or every finding has an accepted disposition.
+
+- boundary-guard r1 on f72b8be1b (document-level; no shell in that session,
+  so `cargo test -p atm-architecture` and the AY.3-head TOML diff were run
+  by fenix instead: architecture suite green on 45701a81e, TOML on the AY.3
+  head differs from develop only by AY.3's own contract inventory). P-E(b)
+  landed verbatim; no relaxation of any boundary field. Findings: AY.5
+  Preconditions still branched from AY.4 (fixed: branch from integrate
+  after AY.3 merges); AY.6 topology diagram and gh stack link chained all
+  six branches as one stack (fixed: control-plane stack only); AY.7 D3
+  cited boundary_enforcement.rs as being in AY.8's allowlist (fixed).
+- plan-scope-reviewer r1 (FAIL, 2 blocking / 2 important / 1 minor):
+  PLAN-SCOPE-001 AY.5 Preconditions and V5 still on AY.4 (fixed);
+  PLAN-SCOPE-002 AY.6/AY.7 narrate the old six-branch stack (fixed);
+  PLAN-SCOPE-003 D10 allowlist had no named file (fixed: named pin test
+  added to C3, AY.9 cites it); PLAN-SCOPE-004 AY.8 split risk (fixed:
+  pre-declared AY.8a/AY.8b split); M1 "Cancel gate" wording (fixed).
+- critical-plan-reviewer r1 (FAIL, 2 blocking / 2 important):
+  PLAN-CRIT-001 sprint-AY.3 still declared AY.8 must_follow (fixed);
+  PLAN-CRIT-002 AY.5 preconditions/V5 (same as above, fixed);
+  PLAN-CRIT-003 no composed-TOML rule for AY.3+AY.8 (fixed in P-E(b));
+  PLAN-CRIT-004 D10 pin unnamed (fixed). Both reviewers noted the
+  handoff-JSON input contract was not supplied; these rounds were run as
+  direct plan reviews, and the r2 dispatch names the reviewed commit.

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1024,14 +1024,17 @@ Common preconditions:
   Composed-file rule: AY.3 (P-E(a)), AY.8 (P-E(b)) and AY.10 (D7, added
   2026-09-06) all edit `boundaries/atm-herdr/herdr-process-adapter.toml`
   and `crates/atm-herdr/src/lib.rs`; AY.9 and AY.10 both edit
-  `crates/atm-herdr/src/transport.rs` and `lib.rs`. Whichever of any such
-  pair merges into `integrate/phase-ay` later merges the integration head
-  forward, resolves the TOML by keeping every earlier inventory line and
-  adding only its own key (P-E(b) `io_owns`; AY.10 the `status_stream.rs`
-  path under that same key), resolves `lib.rs`/`transport.rs` by keeping
-  both sides' items, then reruns `just lint boundaries` and `cargo test -p
-  atm-architecture -p atm-herdr`, and fenix (boundary-guard) confirms the
-  composed files before that PR merges. AY.10 is stacked on AY.8, so its
+  `crates/atm-herdr/src/transport.rs`, `lib.rs`, and
+  `crates/atm-architecture/tests/boundary_enforcement.rs` (AY.9: forbidden-
+  edge grep and factory pin; AY.10: the C1 public items in the pin list).
+  Whichever of any such pair merges into `integrate/phase-ay` later merges
+  the integration head forward, resolves the TOML by keeping every earlier
+  inventory line and adding only its own key (P-E(b) `io_owns`; AY.10 the
+  `status_stream.rs` path under that same key), resolves `lib.rs`,
+  `transport.rs`, and `boundary_enforcement.rs` by keeping both sides'
+  items and pinned entries, then reruns `just lint boundaries` and `cargo
+  test -p atm-architecture -p atm-herdr`, and fenix (boundary-guard)
+  confirms the composed files before that PR merges. AY.10 is stacked on AY.8, so its
   TOML diff is reviewed by boundary-guard against AY.8's head before AY.10
   dispatch (P-E(c)); the approved diff is AY.10's first commit.
   Proposed diff to `boundaries/atm-herdr/herdr-process-adapter.toml`:
@@ -1138,7 +1141,7 @@ transport derives the endpoint from that same configured session.
 | HR-CORE-005 | list | `herdr agent list` |
 | HR-CORE-010 (AX.6) | notify | `herdr notification show <title> --body <body> --sound request`; mail body forbidden (HR-SAFE-003); sound fixed |
 | doctor (AY.3) | server_status | `herdr status server --json` (JSON `version`, `protocol`; verified present at v0.8.0 346411fa, v0.8.2 9eb52145 and master `src/cli/status.rs`); socket: `ping`. Doctor only, never on the nudge path |
-| HR-CORE-011 (AY.10, added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited`, and five status-filtered `PaneAgentStatusChanged` per discovered pane; Herdr's probe-on-subscribe delivers each pane's current status as the first event on the same connection, which is the baseline (no replay, 20a500a7; `agent.list` used only to discover pane ids). Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter`; CLI composition provides `None` |
+| HR-CORE-011 (AY.10, added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited` (re-list triggers only; they replay retained hub history), and one unfiltered `pane.agent_status_changed { pane_id }` per discovered pane; baseline from `agent.list` taken after `SubscriptionStarted`, stream value wins when newer, changes deduped by held value. Herdr-side cost: one in-process `pane_get` per subscribed pane per 100 ms while the hub is quiet (AY.10 "Herdr facts"), accepted by Rand under rework item 7 before dispatch. Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter`; CLI composition provides `None` |
 
 Responses: HR-CORE-007 AgentSnapshot from `result.agent`; HR-CORE-008
 closed HerdrError enum keyed by Herdr error codes (unchanged by AY,
@@ -1713,10 +1716,21 @@ item 7 below, not optimized.
    agent state changes". Finding (fenix, from Herdr v0.8.2 `src/api`):
    Herdr already ships this as `events.subscribe`, one held NDJSON
    connection per session streaming every subscribed pane's agent-status
-   changes plus pane create/close; it is socket-only, has no CLI form, and
-   has no replay. Herdr probes each pane at subscribe time and delivers
-   its current status on the stream, so the baseline arrives on the same
-   connection with no snapshot-to-stream window (AY.10 C2).
+   changes plus pane create/close; it is socket-only and has no CLI form.
+   Correction (fenix, 2026-09-07, critical review r4 CRIT-401/402, verified
+   in v0.8.2 `src/api/subscriptions.rs` and `server.rs`): Herdr's stream
+   is not push-based. Each per-pane agent-status subscription is polled by
+   Herdr every 100 ms and, when the event hub is quiet, runs one
+   in-process `pane_get`; hub-only pane subscriptions replay retained
+   history on every subscribe. AY.10 C2 therefore uses one unfiltered
+   subscription per pane (N `pane_get` per 100 ms inside Herdr, 500/s at
+   50 panes, no new sockets) with the baseline from `agent.list` after
+   `SubscriptionStarted`. The only zero-poll form is a Herdr change (a
+   hub-only agent-status subscription without a pane id), which is out of
+   AY.10's scope and would need a HERDR_MINIMUM_VERSION bump. AY.10 is
+   dispatched only after this line is filled in:
+
+   Decision (Rand, YYYY-MM-DD): accept N-per-100ms | herdr change first | stop AY.10
    The earlier planning statement that notification needed one
    subscription per agent was wrong; one connection carries them all.
    Rand: "yes, I think we need to add the subscription socket."; "are you
@@ -1788,11 +1802,12 @@ round below is PASS or every finding has an accepted disposition.
   against "No new variant" and HR-CORE-008 (fixed: composition returns
   `Option<Arc<dyn HerdrStatusStream>>`, `None` on CLI, enum unchanged);
   CRIT-303 C2 took the `agent.list` baseline on a separate connection
-  before subscribing, losing transitions in the window (fixed: five
-  status-filtered per-pane subscriptions use Herdr's probe-on-subscribe as
-  the baseline on the stream itself; replacement connection started
-  before the old one closes; acceptance 2 injects a transition in the
-  window); CRIT-304 stream reconnects coupled to the host-wide nudge
+  before subscribing, losing transitions in the window (fixed in r3 as
+  scoped by five status-filtered per-pane subscriptions; that design was
+  itself withdrawn in r4, CRIT-401/402, and replaced by one unfiltered
+  subscription per pane with the snapshot taken after
+  `SubscriptionStarted`; replacement connection started before the old
+  one closes; acceptance 2 injects transitions in every window); CRIT-304 stream reconnects coupled to the host-wide nudge
   breaker (fixed: own bounded budget, no breaker access; acceptance 4);
   CRIT-305 no requirement id or ADR-058 amendment for the stream (fixed:
   D8 HR-CORE-011 plus ADR-058 paragraph); CRIT-306 exit gate was AY.9-only
@@ -1801,4 +1816,29 @@ round below is PASS or every finding has an accepted disposition.
   composed-file rule covered two editors only (fixed: three-editor rule,
   transport.rs/lib.rs pairs, P-E(c) for AY.10).
   M1 (minor): text not retained across the context compaction that
-  followed r3; r4 re-checks it rather than recording a guess.
+  followed r3; r4 found no candidate defect to attribute to it. Retired
+  as unrecoverable (CRIT-4M1); not carried forward.
+- plan-scope-reviewer r4 (FAIL, 0 blocking / 1 important; reviewed
+  7d8a03d75): SCOPE-301..305 and M1 confirmed fixed; SCOPE-401 AY.9 C1a
+  and AY.10 C3 both edit
+  `crates/atm-architecture/tests/boundary_enforcement.rs` with no
+  composition procedure (fixed: P-E composed-file rule and both sprints'
+  rationales name it as a composed file, keep-both-sides resolution).
+- critical-plan-reviewer r4 (FAIL, 2 blocking / 2 important / 1 minor;
+  reviewed 7d8a03d75; CRIT-301..307 confirmed fixed): CRIT-401 Herdr's
+  stream is server-polled and the five-filter design drove 5N `pane_get`
+  per 100 ms inside Herdr (fixed: verified in v0.8.2 source, design
+  replaced by one unfiltered subscription per pane, bound stated in AY.10
+  "Herdr facts" and HR-CORE-011, accepted-cost decision line under rework
+  item 7 gates dispatch, AY.11 evidence records Herdr CPU with and
+  without the stream); CRIT-402 per-filter sequential probes made the
+  baseline undecidable on the wire (fixed: baseline from `agent.list`
+  after `SubscriptionStarted`, stream value wins when newer, dedupe by
+  held value, D4 fake server models sequential probes, replay, and
+  duplicates, acceptance 2 covers each window); CRIT-403 no handshake
+  latency budget (fixed: C2 budget `min(deadline, 2 s + 20 ms x N)`,
+  acceptance 3a with scripted probe latency at 50 panes); CRIT-404
+  CRIT-303 recorded as unqualified fixed and AY.11 exit condition did not
+  name transient windows (fixed: ledger entry qualified above; AY.11 D2
+  logs a rebuilt-since-last-tick flag and the exit condition excludes
+  those ticks); CRIT-4M1 lost r3 M1 (retired above).

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -954,6 +954,9 @@ umbrella:
 - [`sprint-AY.7-windows-herdr-process-installer.md`](./sprint-AY.7-windows-herdr-process-installer.md)
 - [`sprint-AY.8-herdr-socket-transport.md`](./sprint-AY.8-herdr-socket-transport.md)
 - [`sprint-AY.9-herdr-socket-cutover.md`](./sprint-AY.9-herdr-socket-cutover.md)
+- [`sprint-AY.10-herdr-status-stream.md`](./sprint-AY.10-herdr-status-stream.md)
+- [`sprint-AY.11-herdr-stream-shadow-parity.md`](./sprint-AY.11-herdr-stream-shadow-parity.md)
+- [`sprint-AY.12-herdr-drop-poll.md`](./sprint-AY.12-herdr-drop-poll.md)
 
 Not a sprint: [`release-readiness-herdr-live-proof.md`](./release-readiness-herdr-live-proof.md)
 is the live macOS/Windows checklist run under release readiness after the
@@ -1872,3 +1875,7 @@ round below is PASS or every finding has an accepted disposition.
   rationale, AY.12 allowlist conditional removed, `crates/atm-herdr`
   excluded, Size section added); PLAN-CRIT-M1 HR-CORE-011 row read as
   already accepted (fixed: reworded as gated on the item-7 line).
+- plan-scope-reviewer r6 (FAIL, 0 blocking / 1 important; reviewed
+  651f6c5b0; PLAN-SCOPE-501/502/M2 confirmed fixed): PLAN-SCOPE-601 the
+  authoritative sprint-file list stopped at AY.9 (fixed: AY.10, AY.11,
+  AY.12 links added).

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1125,7 +1125,7 @@ Decision (Rand, YYYY-MM-DD): Ship|Defer <phase>|Cancel
 quality-mgr's phase-ending gate must refuse the integrate/phase-ay to
 develop PR while `grep -E '^Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): (Ship|Defer [A-Z]+|Cancel)$'`
 finds no line in this file, or while
-`grep -E '^   Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): (drop poll|keep both|stop)$'`
+`grep -E '^   Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): (drop poll|keep both|stop subscription work)$'`
 finds no line under rework item 7. This is the forcing function that
 AQ2.6 and ADR-058 lacked (see AW-READY-W1).
 
@@ -1757,7 +1757,7 @@ item 7 below, not optimized.
    poll). AY.12 dispatches only after this line is filled in from AY.11's
    dogfood evidence:
 
-   Decision (Rand, YYYY-MM-DD): drop poll | keep both | stop
+   Decision (Rand, YYYY-MM-DD): drop poll | keep both | stop subscription work
 
 ### Hardening rounds
 
@@ -1879,3 +1879,14 @@ round below is PASS or every finding has an accepted disposition.
   651f6c5b0; PLAN-SCOPE-501/502/M2 confirmed fixed): PLAN-SCOPE-601 the
   authoritative sprint-file list stopped at AY.9 (fixed: AY.10, AY.11,
   AY.12 links added).
+- critical-plan-reviewer r6 (FAIL, 1 blocking / 2 important / 2 minor;
+  reviewed 651f6c5b0; PLAN-CRIT-501/502/M1 confirmed fixed, three
+  decision-line greps verified disjoint): PLAN-CRIT-601 the AY.10a/b
+  split gave acceptance 1 to AY.10a, which cannot satisfy it (fixed:
+  AY.10a-scoped form of 1, full 1 moved to AY.10b); PLAN-CRIT-602
+  acceptance 7 and 8 unassigned in the split (fixed: 7 with D8 on AY.10a,
+  8 on each half); PLAN-CRIT-603 AY.10 out-of-scope still said the breaker
+  question is decided in AY.12 (fixed); PLAN-CRIT-M2 split section did not
+  restate the AY.8b parent override (fixed); PLAN-CRIT-M3 AY.12 option
+  `stop` easy to confuse with `stop AY.10` (fixed: renamed `stop
+  subscription work`, grep updated).

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1126,6 +1126,16 @@ finds no line in this file, or while
 finds no line under rework item 7. This is the forcing function that
 AQ2.6 and ADR-058 lacked (see AW-READY-W1).
 
+AY.10's dispatch gate uses the same mechanism one step earlier: fenix
+refuses to render AY.10's dev-task, and quality-mgr refuses the AY.10 PR,
+while
+`grep -E '^   Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): accept N-per-100ms$'`
+finds no line under rework item 7. The three item-7 answers are distinct
+strings (`accept N-per-100ms`, `herdr change first`, `stop AY.10`) so no
+pattern here matches another line's answer; `herdr change first` re-plans
+AY.10 by plan amendment and `stop AY.10` retires AY.10 to AY.12 and the
+socket stream with it.
+
 ## Request set the transport must carry (from phase AX contract)
 
 Source of truth: feature/ax6-lead-notification-doctor (PR #1204, head
@@ -1141,7 +1151,7 @@ transport derives the endpoint from that same configured session.
 | HR-CORE-005 | list | `herdr agent list` |
 | HR-CORE-010 (AX.6) | notify | `herdr notification show <title> --body <body> --sound request`; mail body forbidden (HR-SAFE-003); sound fixed |
 | doctor (AY.3) | server_status | `herdr status server --json` (JSON `version`, `protocol`; verified present at v0.8.0 346411fa, v0.8.2 9eb52145 and master `src/cli/status.rs`); socket: `ping`. Doctor only, never on the nudge path |
-| HR-CORE-011 (AY.10, added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited` (re-list triggers only; they replay retained hub history), and one unfiltered `pane.agent_status_changed { pane_id }` per discovered pane; baseline from `agent.list` taken after `SubscriptionStarted`, stream value wins when newer, changes deduped by held value. Herdr-side cost: one in-process `pane_get` per subscribed pane per 100 ms while the hub is quiet (AY.10 "Herdr facts"), accepted by Rand under rework item 7 before dispatch. Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter`; CLI composition provides `None` |
+| HR-CORE-011 (AY.10, added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited` (re-list triggers only; they replay retained hub history), and one unfiltered `pane.agent_status_changed { pane_id }` per discovered pane; baseline from `agent.list` taken after `SubscriptionStarted`, stream value wins when newer, changes deduped by held value. Herdr-side cost: one in-process `pane_get` per subscribed pane per 100 ms while the hub is quiet (AY.10 "Herdr facts"), acceptance is gated on the decision line under rework item 7, recorded before AY.10 is dispatched (see AY.10 frontmatter `status`). Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter`; CLI composition provides `None` |
 
 Responses: HR-CORE-007 AgentSnapshot from `result.agent`; HR-CORE-008
 closed HerdrError enum keyed by Herdr error codes (unchanged by AY,
@@ -1842,3 +1852,23 @@ round below is PASS or every finding has an accepted disposition.
   name transient windows (fixed: ledger entry qualified above; AY.11 D2
   logs a rebuilt-since-last-tick flag and the exit condition excludes
   those ticks); CRIT-4M1 lost r3 M1 (retired above).
+- plan-scope-reviewer r5 (FAIL, 0 blocking / 2 important / 1 minor;
+  reviewed cb073fdfd; SCOPE-401 confirmed fixed): PLAN-SCOPE-501 AY.10
+  had no pre-declared split despite eight deliverables (fixed: AY.10a
+  trait/factory/pin/docs and AY.10b protocol/fake streaming/tests, branch
+  and stack fields, C3 split, AY.11 retarget, same amendment rule as
+  AY.8); PLAN-SCOPE-502 AY.10 did not state the P-E(c) precondition
+  (fixed: "Dispatch and PR topology" names the boundary-guard review
+  against AY.8's head, D7 and Required work 1 bind the approved diff to
+  the first commit); PLAN-SCOPE-M2 ADR-058 path unnamed (fixed: exact
+  file in C3).
+- critical-plan-reviewer r5 (FAIL, 0 blocking / 2 important / 1 minor;
+  reviewed cb073fdfd; CRIT-401..404 confirmed fixed, CRIT-4M1 retired):
+  PLAN-CRIT-501 AY.10's item-7 decision had no forcing function (fixed:
+  AY.10 frontmatter `status: gated`, mechanical grep in the exit-gate
+  section, both fenix dispatch and quality-mgr PR refusal); PLAN-CRIT-502
+  AY.12 carried an unforced breaker-coupling decision and no Size section
+  (fixed: decision resolved in AY.10 C2 as no coupling for the phase with
+  rationale, AY.12 allowlist conditional removed, `crates/atm-herdr`
+  excluded, Size section added); PLAN-CRIT-M1 HR-CORE-011 row read as
+  already accepted (fixed: reworded as gated on the item-7 line).

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -374,7 +374,7 @@ grounded in the tag rather than assumed.
 | `herdr server` | Entry unchanged (`src/main.rs:542`); `run_server` moved to `src/server/headless/bootstrap.rs` (207be3c7) with identical duplicate detection and restore | No change |
 | Endpoint resolution: `ipc.rs`, `session.rs`, `api/client.rs`, `socket_paths.rs` | Byte-identical across the range | No change |
 | NDJSON envelope, `agent.*` shapes, limits, `notification show`, CLI argv and exit codes | No change; additive methods and fields only (`ping.capabilities.endpoint_protocol_generation`, `workspace.close.close_group`, `worktree.*.trust_repository`, new `pane.*`, `command.invoke`, `integration.list`) | Parsers must tolerate unknown fields; AY.1 asserts it |
-| `events.subscribe` | Starts at the live sequence, no replay (20a500a7) | Irrelevant unless AY.8 subscribes; documented |
+| `events.subscribe` | Starts at the live sequence, no replay (20a500a7); present since fbd20ad6 (v0.8.2), absent at v0.8.0 | AY.10 subscribes; no replay is why every (re)subscribe takes an `agent.list` baseline |
 | Autostart | Still none at HEAD (grep for login item / LaunchAgent / RunAtLoad / autostart / schtasks / Register-ScheduledTask / systemd / SMAppService: only SSH keepalive hits) | Confirms the installer-owned start-at-login entry design |
 | API pipe ACL | Unchanged: `restrict_socket_permissions` is a no-op on Windows (`src/ipc.rs:342-345`); the SDDL DACL at `ipc.rs:141-167` serves only the remote-attach bridge | AY.8 boundary revision records the API pipe as default-DACL |
 
@@ -851,7 +851,8 @@ User-experience contract (AY.3 through AY.6 acceptance, verified by req-qa):
 
 ## Sprint map, parallel tracks and stacking
 
-Nine sprints, numbered sequentially. Each row maps to exactly one
+Twelve sprints, numbered sequentially (AY.10–AY.12 added 2026-09-06 for the
+subscription socket; see rework item 7). Each row maps to exactly one
 authoritative sprint file. Relations follow
 `.claude/skills/plan-hardening/sprint-planning-guidelines.md`:
 `must_follow` names a development/merge dependency, while
@@ -868,7 +869,10 @@ contracts, artifacts, and ownership.
 | AY.6 | Coordinated Herdr restart/live-handoff and ATM-restart preflight | M | Control-plane stack | AY.5 | AY.4, AY.8 | macOS/Linux + platform fakes |
 | AY.7 | Windows process correctness and installer Windows branch | S | Control-plane/Windows stack | AY.6 | AY.4, AY.8 | Windows CI lane |
 | AY.8 | Direct socket/pipe transport, fake server, compatibility/equivalence | L | Transport | AY.1, AY.2, P-E(b) | AY.3, AY.4, AY.5, AY.6, AY.7 | macOS/Linux + Windows CI |
-| AY.9 | Socket-default cutover, CLI fallback, doctor projection, lifecycle/CI | M | Join | AY.7, AY.8 | none | all CI lanes |
+| AY.9 | Socket-default cutover, CLI fallback, doctor projection, lifecycle/CI | M | Join | AY.7, AY.8 | AY.10 | all CI lanes |
+| AY.10 | Held `events.subscribe` stream in atm-herdr behind `HerdrStatusStream` | M | Transport (stacked on AY.8) | AY.8 | AY.4, AY.5, AY.6, AY.7, AY.9 | macOS/Linux + Windows CI |
+| AY.11 | Daemon shadow consumption of the stream; poll stays authoritative; parity counters | M | Join | AY.9, AY.10 | none | all CI lanes |
+| AY.12 | Stream becomes the state source; poll removed on the socket path | S | Join (gated on Rand's decision on AY.11 evidence) | AY.11 | none | all CI lanes |
 
 Execution waves are explicit:
 
@@ -878,13 +882,16 @@ Execution waves are explicit:
 | 2 | AY.1 completion, AY.2 review, AY.3 development | AY.3 starts after AY.2 development/contracts are pushed and P-E(a) is approved; AY.2 merges before AY.3. |
 | 3 | AY.3 review, AY.4 development, AY.8 development | AY.4 is stacked after AY.3 development is pushed; AY.3 merges before AY.4. AY.8 starts from `integrate/phase-ay` the moment AY.1 and AY.2 have merged and P-E(b) is approved (both true 2026-09-06); it never waits on AY.3. |
 | 4 | AY.4, AY.5, AY.8 | AY.5 starts from `integrate/phase-ay` when AY.3 merges and develops in parallel with AY.4 (disjoint files); AY.4 merges before AY.5. |
-| 5 | AY.6, AY.7, AY.8 | Contracts first: AY.6 is stacked on AY.5 as soon as AY.5's contracts are pushed, AY.7 on AY.6 likewise; AY.8 completes independently. Neither stack merges the unmerged sibling; AY.7's gate is the Windows CI lane (ruling 5). |
-| 6 | AY.9 | Starts from `integrate/phase-ay` only after AY.7 and AY.8 merge; the last sprint. |
+| 5 | AY.6, AY.7, AY.8, AY.10 | Contracts first: AY.6 is stacked on AY.5 as soon as AY.5's contracts are pushed, AY.7 on AY.6 likewise; AY.10 on AY.8 as soon as AY.8's `SocketIo` and fake server are pushed. Neither stack merges the unmerged sibling; AY.7's gate is the Windows CI lane (ruling 5). |
+| 6 | AY.9, AY.10 | AY.9 starts from `integrate/phase-ay` only after AY.7 and AY.8 merge; AY.10 completes on its stack and merges after AY.8. |
+| 7 | AY.11 | Starts from `integrate/phase-ay` after AY.9 and AY.10 merge. |
+| 8 | AY.12 | Dispatched only after a dated "Decision (Rand, ...): drop poll" is recorded under rework item 7; the last sprint. |
 
 There are two linear stacks (rework 2026-09-06): the core stack AY.2 ->
 AY.3 -> AY.4 and the control-plane stack AY.5 -> AY.6 -> AY.7, each
-based on `integrate/phase-ay`. AY.8 is a standalone transport branch and
-AY.9 the final join. Use the `/gh-stack` skill for every operation on
+based on `integrate/phase-ay`. AY.8 is a standalone transport branch with
+AY.10 stacked on it (AY.8 -> AY.10); AY.9 and AY.11 are joins and AY.12
+the gated last sprint. Use the `/gh-stack` skill for every operation on
 either stack.
 Branches are created with `sc-git-worktree` from the immediate parent so
 each child carries the parent's unmerged work. Because this is an external
@@ -1104,6 +1111,7 @@ transport derives the endpoint from that same configured session.
 | HR-CORE-005 | list | `herdr agent list` |
 | HR-CORE-010 (AX.6) | notify | `herdr notification show <title> --body <body> --sound request`; mail body forbidden (HR-SAFE-003); sound fixed |
 | doctor (AY.3) | server_status | `herdr status server --json` (JSON `version`, `protocol`; verified present at v0.8.0 346411fa, v0.8.2 9eb52145 and master `src/cli/status.rs`); socket: `ping`. Doctor only, never on the nudge path |
+| AY.10 (added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited`, and `PaneAgentStatusChanged` per baseline pane; one `agent.list` per (re)subscribe as the baseline (no replay, 20a500a7). Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter` |
 
 Responses: HR-CORE-007 AgentSnapshot from `result.agent`; HR-CORE-008
 closed HerdrError enum keyed by Herdr error codes (unchanged by AY);
@@ -1653,28 +1661,44 @@ exemption note), sprint-AY.3 (AY.8 edge and dispatch prose),
 sprint-AY.4/AY.5/AY.6/AY.7 (edges, rationales, stack topology,
 preconditions, V5), sprint-AY.8 (D2 removed, D4/D9/D10/C1/C3, required
 work 1, acceptance 1 and 7, dispatch section, size/split, recommended
-agent), sprint-AY.9 (permanent CLI fallback, D10 pin name).
+agent), sprint-AY.9 (permanent CLI fallback, D10 pin name). Subscription
+socket (2026-09-06): sprint-AY.10, AY.11, AY.12 added; this plan (sprint
+map, waves, stack description, request-set table, drift row, scaling
+note, item 7); sprint-AY.8 (AY.10 edge, out of scope); sprint-AY.9 (out
+of scope).
 
 Scaling note (Rand, 2026-09-06, 30–50 agents): today's queue-wake tick
 (5 s) spawns one `herdr list` per session every tick whether or not any
 member is pending, plus one `herdr get` per member with an open task and
 one `herdr prompt` per eligible member. The socket removes the per-call
-process cost; it does not remove the per-member call count. AY.4 (breaker
-lifecycle) and AY.6 (restart coordination) must not add per-member calls,
-and the tick should skip `list` when nothing is pending and no task is
-open, and reuse the `list` snapshot instead of a per-member `get` where the
-snapshot already carries the state. The negative constraint (no new
-per-member calls in AY.4/AY.6) is in force now. The tick optimization itself
-is not owned by any AY sprint: Rand (2026-09-06) has since asked for a push
-model (the daemon must know every agent state change, sourced from either
-Herdr or schook HTTP POSTs from hook triggers), which supersedes optimizing
-the poll. It is tracked as rework item 7 below, open pending Rand's ruling.
+process cost; it does not remove the per-member call count. Rand: "we
+shouldn't be creating 50 sockets every 5 seconds"; "I would expect all
+agent queries would be done on a single socket." AY.4 (breaker lifecycle)
+and AY.6 (restart coordination) must not add per-member calls; that
+negative constraint is in force now. The tick itself is replaced through
+item 7 below, not optimized.
 
-7. (open) Agent state changes. Rand, 2026-09-06: "I really want herdr to
-   simply tell us when an agent state changes"; "we need to 'know' every time
-   an agent state changes"; "it's either herdr or schooks and track it as http
-   posts from hook triggers." Not designed in this plan and not a Phase AY
-   sprint; keep whatever eventually does this simple.
+7. Agent state changes. Rand, 2026-09-06: "I really want herdr to simply
+   tell us when an agent state changes"; "we need to 'know' every time an
+   agent state changes". Finding (fenix, from Herdr v0.8.2 `src/api`):
+   Herdr already ships this as `events.subscribe`, one held NDJSON
+   connection per session streaming every subscribed pane's agent-status
+   changes plus pane create/close; it is socket-only, has no CLI form, and
+   has no replay, so each (re)subscribe takes one `agent.list` baseline.
+   The earlier planning statement that notification needed one
+   subscription per agent was wrong; one connection carries them all.
+   Rand: "yes, I think we need to add the subscription socket."; "are you
+   proposing we do both and verify they match. once they match we can drop
+   the polling?"; "this is a prudent solution."; "and probably lowest
+   risk". Done as three sprints, each one context window: AY.10 (stream in
+   atm-herdr behind `HerdrStatusStream`, stacked on AY.8), AY.11 (daemon
+   holds the stream in shadow mode, poll stays the authority, parity
+   counters logged and projected by doctor), AY.12 (stream becomes the
+   state source, poll removed on the socket path; CLI path keeps the
+   poll). AY.12 dispatches only after this line is filled in from AY.11's
+   dogfood evidence:
+
+   Decision (Rand, YYYY-MM-DD): drop poll | keep both | stop
 
 ### Hardening rounds
 

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -626,7 +626,10 @@ installed, doctor prints one line "herdr: not configured".
   `server_not_running` code), `ServerUnavailable` (binary not found;
   cause names what was searched), `ProtocolMismatch`, `Timeout`. **No new
   variant is introduced**; the previous revision's
-  `HerdrError::NotRunning` is `ServerNotRunning`.
+  `HerdrError::NotRunning` is `ServerNotRunning`. AY.10 keeps this true:
+  the CLI transport has no status stream, so the composition returns
+  `None` for it instead of an error (AY.10 D3), and stream reconnects use
+  the stream's own budget, never the nudge breaker below (AY.10 C2).
 - Direct socket calls share a 16-permit per-invoker cap. Permit acquisition,
   connect, Windows `ERROR_PIPE_BUSY` retry, write, flush, and read all consume
   the caller's one absolute deadline; busy-pipe attempts wait 10 ms (clipped to
@@ -907,6 +910,9 @@ gh stack link --base integrate/phase-ay \
   feature/ay5-herdr-entry-control-plane \
   feature/ay6-herdr-restart-coordination \
   feature/ay7-windows-herdr-process-installer
+gh stack link --base integrate/phase-ay \
+  feature/ay8-herdr-socket-transport \
+  feature/ay10-herdr-status-stream
 
 gh pr view feature/ay2-herdr-transport-seam --json headRefName,baseRefName,state
 gh pr view feature/ay3-herdr-endpoint-doctor-config --json headRefName,baseRefName,state
@@ -914,6 +920,8 @@ gh pr view feature/ay4-herdr-breaker-lifecycle --json headRefName,baseRefName,st
 gh pr view feature/ay5-herdr-entry-control-plane --json headRefName,baseRefName,state
 gh pr view feature/ay6-herdr-restart-coordination --json headRefName,baseRefName,state
 gh pr view feature/ay7-windows-herdr-process-installer --json headRefName,baseRefName,state
+gh pr view feature/ay8-herdr-socket-transport --json headRefName,baseRefName,state
+gh pr view feature/ay10-herdr-status-stream --json headRefName,baseRefName,state
 ```
 
 All commands are noninteractive. The parent-development-pushed event,
@@ -923,10 +931,11 @@ policy narrows the general `/gh-stack` workflow: never run `gh stack
 rebase`, `gh stack sync`, or `gh stack merge`; do not force-push; merge
 each PR in dependency order with `gh pr merge --merge`.
 
-AY.1 is standalone. AY.8 is a standalone three-parent join created from
-the merged integration head; AY.9 is a standalone two-parent join and the
-phase's last sprint. None is passed to `gh stack link`, and no unmerged
-sibling is ever merged into one of those branches.
+AY.1 is standalone. AY.8 is a standalone transport branch (with AY.10
+stacked on it); AY.9 is a standalone two-parent join; AY.11 is a
+standalone join after AY.9 and AY.10; AY.12 is gated. AY.1, AY.9, AY.11
+and AY.12 are never passed to `gh stack link`, and no unmerged sibling is
+ever merged into one of those branches.
 
 The sprint files below are authoritative. Each has the template's literal
 mandatory YAML keys `id`, `title`, `status`, `branch`, and `target`, plus exact
@@ -1012,13 +1021,19 @@ Common preconditions:
   diff is AY.8's first commit. Ruled 2026-09-06 by boundary-guard: approved
   as written; the endpoint resolver and its types stay crate-private, no
   architecture-test exemption exists, and AY.8 does not wait on AY.3.
-  Composed-file rule: AY.3 (P-E(a)) and AY.8 (P-E(b)) both edit
-  `boundaries/atm-herdr/herdr-process-adapter.toml` and
-  `crates/atm-herdr/src/lib.rs`. Whichever merges into `integrate/phase-ay`
-  second merges the integration head forward, resolves the TOML by keeping
-  every P-E(a) inventory line and adding only the P-E(b) `io_owns` key, then
-  reruns `just lint boundaries` and `cargo test -p atm-architecture`, and
-  fenix (boundary-guard) confirms the composed file before that PR merges.
+  Composed-file rule: AY.3 (P-E(a)), AY.8 (P-E(b)) and AY.10 (D7, added
+  2026-09-06) all edit `boundaries/atm-herdr/herdr-process-adapter.toml`
+  and `crates/atm-herdr/src/lib.rs`; AY.9 and AY.10 both edit
+  `crates/atm-herdr/src/transport.rs` and `lib.rs`. Whichever of any such
+  pair merges into `integrate/phase-ay` later merges the integration head
+  forward, resolves the TOML by keeping every earlier inventory line and
+  adding only its own key (P-E(b) `io_owns`; AY.10 the `status_stream.rs`
+  path under that same key), resolves `lib.rs`/`transport.rs` by keeping
+  both sides' items, then reruns `just lint boundaries` and `cargo test -p
+  atm-architecture -p atm-herdr`, and fenix (boundary-guard) confirms the
+  composed files before that PR merges. AY.10 is stacked on AY.8, so its
+  TOML diff is reviewed by boundary-guard against AY.8's head before AY.10
+  dispatch (P-E(c)); the approved diff is AY.10's first commit.
   Proposed diff to `boundaries/atm-herdr/herdr-process-adapter.toml`:
 
   ```toml
@@ -1045,12 +1060,22 @@ Common acceptance for every sprint: merge gate 0 blocking / 0 important /
 time (never a dispatch gate), no flaky-test tolerance, frozen files
 untouched without a written ruling, no tokio in atm-core.
 
-## Phase AY exit gate (AY.9 disposition)
+## Phase AY exit gate (AY.9 disposition, then AY.11 and item 7)
 
-Phase AY is not complete until a dated decision, after the AY.9 cutover
+Phase completion (2026-09-06, with AY.10–AY.12 added): the
+integrate/phase-ay to develop PR opens only after (1) the AY.9 cutover
+decision below is recorded, (2) AY.11 has merged and its parity evidence
+from the rand-m4 dogfood run is recorded under rework item 7, and (3)
+item 7's own decision line is filled in. If that decision is "drop poll",
+AY.12 merges into integrate/phase-ay before the develop PR opens; "keep
+both" and "stop" close the phase without AY.12. There is no interim
+develop merge between AY.9 and AY.11. quality-mgr's phase-ending gate
+refuses the develop PR while either decision line below is missing.
+
+The AY.9 cutover decision is a dated decision, after the AY.9 cutover
 has merged with all three CI lanes green, the socket-default and
 explicit-CLI lifecycle suites passing, and the AY.8 equivalence suite
-unchanged, is recorded here and in `docs/project-plan.md`, chosen by Rand
+unchanged, recorded here and in `docs/project-plan.md`, chosen by Rand
 from exactly these. No live run is an input to this decision (ruling 5);
 the phase-ending critical review on the integrate head is. The official
 benchmark is not part of this gate either: it runs once at release
@@ -1093,8 +1118,10 @@ Decision (Rand, YYYY-MM-DD): Ship|Defer <phase>|Cancel
 
 quality-mgr's phase-ending gate must refuse the integrate/phase-ay to
 develop PR while `grep -E '^Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): (Ship|Defer [A-Z]+|Cancel)$'`
-finds no line in this file. This is the forcing function that AQ2.6 and
-ADR-058 lacked (see AW-READY-W1).
+finds no line in this file, or while
+`grep -E '^   Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): (drop poll|keep both|stop)$'`
+finds no line under rework item 7. This is the forcing function that
+AQ2.6 and ADR-058 lacked (see AW-READY-W1).
 
 ## Request set the transport must carry (from phase AX contract)
 
@@ -1111,10 +1138,11 @@ transport derives the endpoint from that same configured session.
 | HR-CORE-005 | list | `herdr agent list` |
 | HR-CORE-010 (AX.6) | notify | `herdr notification show <title> --body <body> --sound request`; mail body forbidden (HR-SAFE-003); sound fixed |
 | doctor (AY.3) | server_status | `herdr status server --json` (JSON `version`, `protocol`; verified present at v0.8.0 346411fa, v0.8.2 9eb52145 and master `src/cli/status.rs`); socket: `ping`. Doctor only, never on the nudge path |
-| AY.10 (added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited`, and `PaneAgentStatusChanged` per baseline pane; one `agent.list` per (re)subscribe as the baseline (no replay, 20a500a7). Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter` |
+| HR-CORE-011 (AY.10, added 2026-09-06) | status stream | No CLI equivalent. Socket only: `events.subscribe` held connection, one per session, subscriptions `pane.created`, `pane.closed`, `pane.agent_detected`, `pane.exited`, and five status-filtered `PaneAgentStatusChanged` per discovered pane; Herdr's probe-on-subscribe delivers each pane's current status as the first event on the same connection, which is the baseline (no replay, 20a500a7; `agent.list` used only to discover pane ids). Exposed by `HerdrStatusStream`, separate from `HerdrProcessAdapter`; CLI composition provides `None` |
 
 Responses: HR-CORE-007 AgentSnapshot from `result.agent`; HR-CORE-008
-closed HerdrError enum keyed by Herdr error codes (unchanged by AY);
+closed HerdrError enum keyed by Herdr error codes (unchanged by AY,
+including AY.10);
 HR-CORE-009 and HR-SAFE-005..007 breaker on infrastructure-class failures
 (connect/IO class on a socket). HR-SAFE-001 no send-keys fallback;
 HR-SAFE-002 every call bounded; HR-SAFE-004 no durable Herdr state in
@@ -1664,8 +1692,10 @@ work 1, acceptance 1 and 7, dispatch section, size/split, recommended
 agent), sprint-AY.9 (permanent CLI fallback, D10 pin name). Subscription
 socket (2026-09-06): sprint-AY.10, AY.11, AY.12 added; this plan (sprint
 map, waves, stack description, request-set table, drift row, scaling
-note, item 7); sprint-AY.8 (AY.10 edge, out of scope); sprint-AY.9 (out
-of scope).
+note, item 7); sprint-AY.8 (AY.10 edge, out of scope, split clause);
+sprint-AY.9 (out of scope, AY.10/AY.11 edges, C1a allowlist, AC 9a,
+intro); this plan again after round 3 (Failure behaviour, P-E composed
+rule and P-E(c), gh stack example, exit gate, request-set row).
 
 Scaling note (Rand, 2026-09-06, 30–50 agents): today's queue-wake tick
 (5 s) spawns one `herdr list` per session every tick whether or not any
@@ -1684,7 +1714,9 @@ item 7 below, not optimized.
    Herdr already ships this as `events.subscribe`, one held NDJSON
    connection per session streaming every subscribed pane's agent-status
    changes plus pane create/close; it is socket-only, has no CLI form, and
-   has no replay, so each (re)subscribe takes one `agent.list` baseline.
+   has no replay. Herdr probes each pane at subscribe time and delivers
+   its current status on the stream, so the baseline arrives on the same
+   connection with no snapshot-to-stream window (AY.10 C2).
    The earlier planning statement that notification needed one
    subscription per agent was wrong; one connection carries them all.
    Rand: "yes, I think we need to add the subscription socket."; "are you
@@ -1740,3 +1772,33 @@ round below is PASS or every finding has an accepted disposition.
   amendment scope); PLAN-CRIT-007 scaling-note tick optimization unowned
   (disposition: superseded by Rand's push-model direction, tracked as
   rework item 7, open).
+- plan-scope-reviewer r3 (FAIL, 1 blocking / 3 important / 1 minor;
+  reviewed 01b4d4e10): SCOPE-301 AY.9 frontmatter had no AY.10 relation
+  and `parallel_with: []` (fixed); SCOPE-302 AY.10 C3 named an unverified
+  pin file (fixed: `crates/atm-architecture/tests/boundary_enforcement.rs`);
+  SCOPE-303 AY.9 had no changed-file allowlist and the factory file was
+  unnamed (fixed: C1a names `crates/atm-herdr/src/transport.rs`, AC 9a);
+  SCOPE-304 AY.8 split clause did not retarget AY.10 (fixed); SCOPE-305
+  AY.11/AY.12 cited a nonexistent `docs/atm-herdr/operations.md` (fixed:
+  `docs/atm-herdr/architecture.md` operator section); M1 AY.9 "last
+  sprint" sentence (fixed).
+- critical-plan-reviewer r3 (FAIL, 4 blocking / 3 important; reviewed
+  01b4d4e10): CRIT-301 AY.9 "last sprint"/disposition prose contradicted
+  AY.11/AY.12 (fixed); CRIT-302 AY.10 D3 added `HerdrError::Unsupported`
+  against "No new variant" and HR-CORE-008 (fixed: composition returns
+  `Option<Arc<dyn HerdrStatusStream>>`, `None` on CLI, enum unchanged);
+  CRIT-303 C2 took the `agent.list` baseline on a separate connection
+  before subscribing, losing transitions in the window (fixed: five
+  status-filtered per-pane subscriptions use Herdr's probe-on-subscribe as
+  the baseline on the stream itself; replacement connection started
+  before the old one closes; acceptance 2 injects a transition in the
+  window); CRIT-304 stream reconnects coupled to the host-wide nudge
+  breaker (fixed: own bounded budget, no breaker access; acceptance 4);
+  CRIT-305 no requirement id or ADR-058 amendment for the stream (fixed:
+  D8 HR-CORE-011 plus ADR-058 paragraph); CRIT-306 exit gate was AY.9-only
+  with no phase-completion definition after AY.11/AY.12 (fixed: exit gate
+  rewritten, second mechanical decision-line check); CRIT-307 P-E
+  composed-file rule covered two editors only (fixed: three-editor rule,
+  transport.rs/lib.rs pairs, P-E(c) for AY.10).
+  M1 (minor): text not retained across the context compaction that
+  followed r3; r4 re-checks it rather than recording a guess.

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -62,10 +62,10 @@ owning or supervising Herdr, excluded by ruling 1. Compatibility
 ownership: AY.8's equivalence suite proves the socket client emits the
 same request set and error mapping as the CLI transport for every Herdr
 release at or above `HERDR_MINIMUM_VERSION`; AY.9 keeps the CLI transport
-as a permanent, explicitly selected fallback (Rand, 2026-09-06: the CLI
-implementation has worked from the start; if UDS or named pipes misbehave
-we fall back to CLI calls) so a socket defect or Herdr drift is absorbed by
-configuration, never by a hotfix. AY.8 and AY.9 are therefore the design answer to
+as a permanent alternative selected once at daemon start (Rand,
+2026-09-06: the CLI implementation has worked from the start; pick CLI or
+UDS/named pipe in config, never switch at runtime) so a socket defect or
+Herdr drift is absorbed by a config edit plus restart, never by a hotfix. AY.8 and AY.9 are therefore the design answer to
 the phase's transport and failure-model drivers, not a separate modernization.
 
 Post-mortem entry: filed as AW-READY-W1 (blocking) with a

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1897,3 +1897,7 @@ round below is PASS or every finding has an accepted disposition.
   17244c653; PLAN-CRIT-601/602/603/M2 and PLAN-SCOPE-601 confirmed fixed):
   PLAN-CRIT-701 (M3 reopened) exit-gate prose still said bare "stop"
   (fixed: "stop subscription work"; no bare "stop" reference remains).
+- critical-plan-reviewer r8 (PASS, 0 findings; reviewed f555ca75f;
+  PLAN-CRIT-701 confirmed fixed). Both reviewers PASS: plan-scope r7 on
+  17244c653, critical r8 on f555ca75f. Amendment hardening closed pending
+  Rand's approval of PR #1277 and the item-7 AY.10 decision line.

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1670,16 +1670,11 @@ model (the daemon must know every agent state change, sourced from either
 Herdr or schook HTTP POSTs from hook triggers), which supersedes optimizing
 the poll. It is tracked as rework item 7 below, open pending Rand's ruling.
 
-7. (open) Agent-state push model. Rand, 2026-09-06: "we need to 'know' every
-   time an agent state changes"; "it's either herdr or schooks and track it
-   as http posts from hook triggers." Herdr 0.8.2 offers `herdr agent wait`
-   (one held wait per agent, no session-wide subscription); hooks give
-   agent-originated transitions over HTTP for any harness, including
-   non-tmux hermes agents. Ruling (Rand, 2026-09-06): the push model is an
-   entirely separate repo/project, not a Phase AY sprint and not something
-   that lands in hours; Phase AY neither designs nor owns it. Constraint in
-   force for AY: no sprint adds poll-side machinery (tick tuning, per-agent
-   pollers, session-wide subscriptions) that the push model would replace.
+7. (open) Agent state changes. Rand, 2026-09-06: "I really want herdr to
+   simply tell us when an agent state changes"; "we need to 'know' every time
+   an agent state changes"; "it's either herdr or schooks and track it as http
+   posts from hook triggers." Not designed in this plan and not a Phase AY
+   sprint; keep whatever eventually does this simple.
 
 ### Hardening rounds
 

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1630,10 +1630,14 @@ six sprints were serialized behind it. Rand's rulings, applied verbatim:
    heads the control-plane stack AY.5 -> AY.6 -> AY.7. AY.6 and AY.7 start
    contracts-first on their parent's pushed contracts, as AY.3 did on AY.2.
 6. The CLI transport is not deprecated or scheduled for removal. It has
-   worked from the start and stays as the permanent fallback: selected only
-   by `herdr.transport = "cli"`, reported by doctor, never chosen at runtime
-   when a socket connect fails (a connect failure is a Herdr-unavailable
-   breaker event, exactly like a spawn failure today). Both transports run
+   worked from the start and stays as the permanent alternative. The
+   transport is chosen exactly once, at daemon start, from
+   `herdr.transport` (`socket` default, `cli` explicit) in the AY.9
+   composition factory; it is reported by doctor and never changes while
+   the daemon runs. There is no per-call or runtime fallback: a socket
+   connect failure is a Herdr-unavailable breaker event, exactly like a
+   spawn failure today, and switching transports means editing config and
+   restarting the daemon. Both transports run
    the AY.8 equivalence suite on every CI lane for as long as both exist.
    The atm 1.6.0 removal clauses are withdrawn from the plan, AY.8 and AY.9.
 

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -62,8 +62,10 @@ owning or supervising Herdr, excluded by ruling 1. Compatibility
 ownership: AY.8's equivalence suite proves the socket client emits the
 same request set and error mapping as the CLI transport for every Herdr
 release at or above `HERDR_MINIMUM_VERSION`; AY.9 keeps the CLI transport
-as an explicit fallback for one minor release so a Herdr drift can be
-absorbed without a hotfix. AY.8 and AY.9 are therefore the design answer to
+as a permanent, explicitly selected fallback (Rand, 2026-09-06: the CLI
+implementation has worked from the start; if UDS or named pipes misbehave
+we fall back to CLI calls) so a socket defect or Herdr drift is absorbed by
+configuration, never by a hotfix. AY.8 and AY.9 are therefore the design answer to
 the phase's transport and failure-model drivers, not a separate modernization.
 
 Post-mortem entry: filed as AW-READY-W1 (blocking) with a
@@ -608,7 +610,8 @@ installed, doctor prints one line "herdr: not configured".
   nothing is configured the child inherits the daemon's ambient
   environment unmodified. HR-CORE-006 is **retained unchanged**; the
   previous revision's deletion of it is withdrawn. The CLI fallback is
-  retained through atm 1.5.x and removed in atm 1.6.0. atm never reads
+  retained permanently as an explicit operator selection (no removal
+  release; superseded 2026-09-06). atm never reads
   `HERDR_SESSION` or `HERDR_SOCKET_PATH` from its own environment to
   synthesize a choice (requirements.md:153-160). Tests: AY.2 (env
   mapping and exclusivity, relative-path rejection), AY.3 (doctor
@@ -1007,7 +1010,7 @@ Common preconditions:
   ```toml
   [ownership]
   io_owns = [
-    "tokio_process_spawn",          # CLI transport (retained until the AY.9 fallback window closes)
+    "tokio_process_spawn",          # CLI transport (permanent explicit fallback)
     "herdr_argv_construction",      # CLI transport (same)
     "herdr_local_socket_client",    # new: UDS / named-pipe NDJSON client, transport_socket.rs only
     "herdr_json_error_parsing",
@@ -1015,8 +1018,8 @@ Common preconditions:
   ]
   ```
 
-  `io_forbidden` is unchanged. The two CLI keys are dropped in the sprint
-  that removes the CLI fallback (atm 1.6.0, after AY.9), not in AY.8.
+  `io_forbidden` is unchanged. The two CLI keys are permanent: the CLI
+  transport is the retained explicit fallback (ruled 2026-09-06).
 
 AYP-R2-011 (approval blocker on P-C/P-D placeholders) is closed by
 ruling 5 (r23): no sprint depends on P-C or P-D, so plan approval (P-B)
@@ -1106,7 +1109,8 @@ Boundary: `boundaries/atm-herdr/herdr-process-adapter.toml` io_owns
 `tokio_process_spawn` and `herdr_argv_construction`. AY.2 changes neither
 (pure motion inside the crate). AY.8 adds `herdr_local_socket_client`
 under the P-E revision and keeps both CLI keys while the CLI path exists
-(additive, AYP-R2-002); the CLI keys go when the CLI code goes. forbidden_edges stay (no
+(additive, AYP-R2-002); the CLI keys are permanent because the CLI
+transport is the retained explicit fallback (2026-09-06). forbidden_edges stay (no
 atm-core/atm-storage/rusqlite into atm-herdr; no atm-herdr into
 daemon/runtime crates).
 
@@ -1618,6 +1622,13 @@ six sprints were serialized behind it. Rand's rulings, applied verbatim:
    AY.5 now depends on AY.3 only, branches from `integrate/phase-ay`, and
    heads the control-plane stack AY.5 -> AY.6 -> AY.7. AY.6 and AY.7 start
    contracts-first on their parent's pushed contracts, as AY.3 did on AY.2.
+6. The CLI transport is not deprecated or scheduled for removal. It has
+   worked from the start and stays as the permanent fallback: selected only
+   by `herdr.transport = "cli"`, reported by doctor, never chosen at runtime
+   when a socket connect fails (a connect failure is a Herdr-unavailable
+   breaker event, exactly like a spawn failure today). Both transports run
+   the AY.8 equivalence suite on every CI lane for as long as both exist.
+   The atm 1.6.0 removal clauses are withdrawn from the plan, AY.8 and AY.9.
 
 Resulting concurrency after AY.3 merges: AY.4 (arch-ctm), AY.5 (arch-ctm
 or cipher), AY.8 (cipher) run at once; AY.6/AY.7 follow AY.5's contracts;

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1675,8 +1675,11 @@ the poll. It is tracked as rework item 7 below, open pending Rand's ruling.
    as http posts from hook triggers." Herdr 0.8.2 offers `herdr agent wait`
    (one held wait per agent, no session-wide subscription); hooks give
    agent-originated transitions over HTTP for any harness, including
-   non-tmux hermes agents. Ruling and owning sprint to be recorded here; no
-   AY sprint may add poll-side machinery in the meantime.
+   non-tmux hermes agents. Ruling (Rand, 2026-09-06): the push model is an
+   entirely separate repo/project, not a Phase AY sprint and not something
+   that lands in hours; Phase AY neither designs nor owns it. Constraint in
+   force for AY: no sprint adds poll-side machinery (tick tuning, per-agent
+   pollers, session-wide subscriptions) that the push model would replace.
 
 ### Hardening rounds
 

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1074,7 +1074,7 @@ decision below is recorded, (2) AY.11 has merged and its parity evidence
 from the rand-m4 dogfood run is recorded under rework item 7, and (3)
 item 7's own decision line is filled in. If that decision is "drop poll",
 AY.12 merges into integrate/phase-ay before the develop PR opens; "keep
-both" and "stop" close the phase without AY.12. There is no interim
+both" and "stop subscription work" close the phase without AY.12. There is no interim
 develop merge between AY.9 and AY.11. quality-mgr's phase-ending gate
 refuses the develop PR while either decision line below is missing.
 
@@ -1890,3 +1890,10 @@ round below is PASS or every finding has an accepted disposition.
   restate the AY.8b parent override (fixed); PLAN-CRIT-M3 AY.12 option
   `stop` easy to confuse with `stop AY.10` (fixed: renamed `stop
   subscription work`, grep updated).
+- plan-scope-reviewer r7 (PASS, 0 findings; reviewed 17244c653;
+  PLAN-SCOPE-601 confirmed fixed; AY.10 split acceptance mapping, AY.10
+  out-of-scope wording, and the AY.12 option rename verified consistent).
+- critical-plan-reviewer r7 (FAIL, 0 blocking / 1 important; reviewed
+  17244c653; PLAN-CRIT-601/602/603/M2 and PLAN-SCOPE-601 confirmed fixed):
+  PLAN-CRIT-701 (M3 reopened) exit-gate prose still said bare "stop"
+  (fixed: "stop subscription work"; no bare "stop" reference remains).

--- a/docs/plans/phase-ay/phase-ay-plan.md
+++ b/docs/plans/phase-ay/phase-ay-plan.md
@@ -1663,8 +1663,20 @@ process cost; it does not remove the per-member call count. AY.4 (breaker
 lifecycle) and AY.6 (restart coordination) must not add per-member calls,
 and the tick should skip `list` when nothing is pending and no task is
 open, and reuse the `list` snapshot instead of a per-member `get` where the
-snapshot already carries the state. Recorded as a design constraint, not a
-new sprint.
+snapshot already carries the state. The negative constraint (no new
+per-member calls in AY.4/AY.6) is in force now. The tick optimization itself
+is not owned by any AY sprint: Rand (2026-09-06) has since asked for a push
+model (the daemon must know every agent state change, sourced from either
+Herdr or schook HTTP POSTs from hook triggers), which supersedes optimizing
+the poll. It is tracked as rework item 7 below, open pending Rand's ruling.
+
+7. (open) Agent-state push model. Rand, 2026-09-06: "we need to 'know' every
+   time an agent state changes"; "it's either herdr or schooks and track it
+   as http posts from hook triggers." Herdr 0.8.2 offers `herdr agent wait`
+   (one held wait per agent, no session-wide subscription); hooks give
+   agent-originated transitions over HTTP for any harness, including
+   non-tmux hermes agents. Ruling and owning sprint to be recorded here; no
+   AY sprint may add poll-side machinery in the meantime.
 
 ### Hardening rounds
 
@@ -1693,3 +1705,16 @@ round below is PASS or every finding has an accepted disposition.
   PLAN-CRIT-004 D10 pin unnamed (fixed). Both reviewers noted the
   handoff-JSON input contract was not supplied; these rounds were run as
   direct plan reviews, and the r2 dispatch names the reviewed commit.
+- plan-scope-reviewer r2 (FAIL, 1 blocking; reviewed 66f34c462): all r1
+  ids confirmed fixed; PLAN-SCOPE-005 AY.9 AC5 and out-of-scope still
+  required an "exact removal release" (fixed in 57ebeb7ce: AC5 and the
+  out-of-scope bullet now state no removal release exists; plan line ~67
+  and AY.9 intro/L-suite wording aligned to daemon-start selection).
+- critical-plan-reviewer r2 (FAIL, 1 blocking / 2 important; reviewed
+  66f34c462): all r1 ids confirmed fixed; PLAN-CRIT-005 same as
+  PLAN-SCOPE-005 (fixed); PLAN-CRIT-006 AY.8a/AY.8b split had no branch,
+  stack, TOML or AY.9-retarget rule (fixed: split contingency now names
+  branches, stack fields, C3 per half, AY.9 must_follow retarget, and the
+  amendment scope); PLAN-CRIT-007 scaling-note tick optimization unowned
+  (disposition: superseded by Rand's push-model direction, tracked as
+  rework item 7, open).

--- a/docs/plans/phase-ay/sprint-AY.1-herdr-audit-docs.md
+++ b/docs/plans/phase-ay/sprint-AY.1-herdr-audit-docs.md
@@ -143,6 +143,9 @@ The amendment states all of the following without changing their meaning:
 - the AI.11 retired-listener ban governs ATM's own IPC listener. AY.8 may exempt
   only `crates/atm-herdr/src/transport_socket.rs` for the Herdr client, while
   `named_pipe` / `NamedPipe` remain banned everywhere else under `crates/`.
+  (Superseded 2026-09-06, after AY.1 merged: Rand ruled the guard obsolete,
+  it was deleted on AY.3, and AY.8 needs no exemption; ADR-058 carries no
+  exemption wording. See phase-ay-plan.md "Rework record".)
 
 ### C3 — drift ledger procedure
 

--- a/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
+++ b/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
@@ -1,0 +1,243 @@
+---
+id: AY.10
+phase: AY
+sprint: AY.10
+title: Herdr agent-status subscription stream in atm-herdr, behind a trait
+branch: feature/ay10-herdr-status-stream
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay10-herdr-status-stream
+integration_branch: integrate/phase-ay
+stack_parent: AY.8
+pr_target: feature/ay8-herdr-socket-transport
+target: integrate/phase-ay
+status: draft
+recommended_agent: cipher
+recommended_model: fast
+added: 2026-09-06 (subscription socket; see phase-ay-plan.md "Rework record" item 7)
+execution_track: socket
+parallel_with: [AY.4, AY.5, AY.6, AY.7, AY.9]
+dependency_relations:
+  - prerequisite: AY.8
+    dependent: AY.10
+    relation: must_follow
+    rationale: the held subscription connection reuses AY.8's endpoint resolution, NDJSON framing, line cap, and fake socket server.
+  - prerequisite: AY.9
+    dependent: AY.10
+    relation: parallel_safe
+    rationale: AY.9 owns the daemon-bootstrap composition and doctor files; AY.10 touches only atm-herdr and its fixtures and is consumed by nothing until AY.11.
+  - prerequisite: AY.10
+    dependent: AY.11
+    relation: must_follow
+    rationale: AY.11 consumes the stream trait this sprint lands.
+---
+
+# AY.10 — Herdr agent-status subscription stream in atm-herdr, behind a trait
+
+Add one held Herdr `events.subscribe` connection per configured session that
+delivers agent-status changes to atm as they happen, exposed through a new
+trait in `atm-herdr`. Nothing consumes it in this sprint. The daemon's
+polling behaviour is unchanged.
+
+## Why (Rand, 2026-09-06)
+
+"we shouldn't be creating 50 sockets every 5 seconds"; "I would expect all
+agent queries would be done on a single socket."; "yes, I think we need to
+add the subscription socket."; "are you proposing we do both and verify
+they match. once they match we can drop the polling?"; "this is a prudent
+solution."; "and probably lowest risk". This sprint is the "add the
+subscription socket" half. AY.11 is the "do both and verify they match"
+half. Dropping the poll is AY.12, gated on AY.11's evidence and Rand's
+decision.
+
+## Herdr facts this sprint rests on (v0.8.2 9eb52145, `src/api`)
+
+- `events.subscribe` (`schema.rs:231`, `schema/events.rs:12`) takes
+  `{"subscriptions":[...]}`, replies `SubscriptionStarted`, then streams one
+  JSON line per matching event until the client closes
+  (`server.rs` `stream_subscriptions`). It is the only long-lived request
+  shape atm uses; every other request stays one-request-per-connection
+  (AY.8 C2).
+- Subscriptions are per pane: `PaneAgentStatusChanged { pane_id,
+  agent_status: Option<..> }` (`schema/events.rs:76`). `pane.created`,
+  `pane.closed`, `pane.agent_detected`, `pane.exited` are subscribable
+  without a pane id. Adding a pane to the set requires a new
+  `events.subscribe` request, which is a new connection.
+- The stream starts at the live sequence with no replay (drift table,
+  20a500a7). Events missed while disconnected are gone; the only way to
+  recover state is one `agent.list`.
+- No CLI equivalent exists (`herdr agent wait` is one-shot, one agent).
+  The stream is socket-only; the CLI transport reports it unsupported.
+
+## Dispatch and PR topology
+
+Stack child of AY.8: create the branch from
+`feature/ay8-herdr-socket-transport` with `sc-git-worktree` once AY.8's
+`SocketIo` and fake server are pushed (contracts first, same rule as the
+core stack); do not wait for AY.8 to merge. PR target is AY.8's branch;
+link with `gh stack link --base integrate/phase-ay
+feature/ay8-herdr-socket-transport feature/ay10-herdr-status-stream`. If
+the AY.8a/AY.8b split is exercised, the parent is AY.8b. Never merge an
+unmerged parallel sibling into this branch.
+
+## Deliverables
+
+- [ ] D1 — `pub trait HerdrStatusStream` in `crates/atm-herdr/src/lib.rs`
+  (C1). `HerdrProcessAdapter` is byte-identical to its AY.2 pin. The
+  public-item pin gains exactly the C1 items; that is an additive minor
+  change under ADR-061 and is recorded in the pin test in the same commit.
+- [ ] D2 — `crates/atm-herdr/src/status_stream.rs`: socket implementation
+  of C1 over AY.8's endpoint resolver and NDJSON framing. One held
+  connection per `subscribe` call, outside AY.8's 16 request permits and
+  counted by its own permit of exactly 1 per session per invoker. C2 is
+  the connection contract.
+- [ ] D3 — CLI transport: `subscribe` returns
+  `HerdrError::Unsupported { feature: "events.subscribe" }` immediately;
+  no process is spawned. `HerdrError` gains that one variant (HR-CORE-008
+  stays closed; variant added in the same commit as the pin update).
+- [ ] D4 — fake socket server (`tests/support/fake_herdr_socket/**`, AY.8
+  D7) gains a streaming mode: accepts `events.subscribe`, replies
+  `SubscriptionStarted`, then emits scripted event lines, delays, EOF, and
+  over-cap lines from a fixture script. Recordings live under
+  `tests/fixtures/herdr-versions/0.8.2/events/`.
+- [ ] D5 — tests in `crates/atm-herdr/tests/status_stream.rs` (C3 list)
+  with paused Tokio time and no wall-clock sleeps.
+- [ ] D6 — `docs/atm-herdr/herdr-versions.md`: `events.subscribe` column
+  (absent 0.8.0; present 0.8.2 fbd20ad6; no replay 20a500a7).
+- [ ] D7 — `boundaries/atm-herdr/herdr-process-adapter.toml`: the AY.8
+  `herdr_local_socket_client` key also owns `status_stream.rs`; no other
+  boundary field changes. Composed-file rule P-E(b) applies.
+
+### Paths to delete
+
+None.
+
+## Code contracts
+
+### C1 — trait
+
+```rust
+pub trait HerdrStatusStream: Send + Sync {
+    /// Opens one held subscription for `session`. Returns after the server
+    /// acknowledges the subscription and the baseline `agent.list` has been
+    /// taken; never returns a stream that has not emitted `Baseline`.
+    fn subscribe<'a>(
+        &'a self,
+        session: Option<&'a HerdrSession>,
+        deadline: RequestDeadline,
+    ) -> Pin<Box<dyn Future<Output = Result<HerdrStatusEvents, HerdrError>> + Send + 'a>>;
+}
+
+/// Ordered, bounded receiver. Dropping it closes the connection and joins
+/// the reader task; nothing outlives the receiver.
+pub struct HerdrStatusEvents { /* crate-private fields */ }
+
+impl HerdrStatusEvents {
+    pub async fn next(&mut self) -> Option<HerdrStatusEvent>;
+}
+
+pub enum HerdrStatusEvent {
+    /// Emitted once after every successful (re)subscribe: the full
+    /// `agent.list` snapshot taken on that connection.
+    Baseline(Vec<AgentSnapshot>),
+    Changed { agent: AgentName, status: HerdrAgentStatus, observed_at: Instant },
+    Gone { agent: AgentName, observed_at: Instant },
+    /// Connection lost; the implementation is reconnecting. The next event
+    /// is `Baseline` or `Closed`.
+    Disconnected { reason: HerdrError },
+    /// Reconnect budget exhausted or deadline passed; receiver is finished.
+    Closed { reason: HerdrError },
+}
+```
+
+`AgentSnapshot`, `AgentName`, `HerdrAgentStatus`, `RequestDeadline`,
+`HerdrSession`, and `HerdrError` are the existing AY.2 types. No message
+bodies, pane titles, or command lines are carried; the event maps pane
+events to agent names using the same pane-to-agent projection `agent.list`
+already uses.
+
+### C2 — connection contract
+
+```text
+acquire the single stream permit for (invoker, session)
+connect (AY.8 endpoint resolution, deadline, pipe-busy retry)
+send one agent.list on a separate one-request connection; emit Baseline
+send events.subscribe with: pane.created, pane.closed, pane.agent_detected,
+  pane.exited, and PaneAgentStatusChanged for every pane in the baseline
+read SubscriptionStarted; then read lines until EOF or error
+on pane.created or pane.agent_detected for an unknown pane:
+  close, reconnect, resubscribe (which re-takes the baseline)
+on EOF/error: emit Disconnected, back off (100 ms, 200, 400, capped 5 s,
+  max 10 attempts), reconnect, resubscribe
+line cap 1 MiB; a longer line is a protocol error -> Disconnected
+```
+
+The receiver owns the reader task; `Drop` cancels it and releases the
+permit. No detached task. Runtime drain rules are AY.8 C2's. Reconnect
+attempts are infrastructure-class failures under the existing breaker
+policy (HR-SAFE-005..007); the breaker opening ends the stream with
+`Closed`.
+
+### C3 — changed-file allowlist
+
+- `crates/atm-herdr/src/lib.rs` (trait, event types, one error variant, pin)
+- `crates/atm-herdr/src/status_stream.rs` (new)
+- `crates/atm-herdr/src/transport_socket.rs` (expose framing helpers crate-private)
+- `crates/atm-herdr/src/transport_cli.rs` (D3 only)
+- `crates/atm-herdr/tests/status_stream.rs` (new)
+- `crates/atm-herdr/tests/support/fake_herdr_socket/**`
+- `crates/atm-herdr/tests/fixtures/herdr-versions/0.8.2/events/**` (new)
+- `crates/atm-herdr/tests/public_item_pin.rs` (or the AY.2 pin's actual file)
+- `boundaries/atm-herdr/herdr-process-adapter.toml`
+- `docs/atm-herdr/herdr-versions.md`
+
+No file under `crates/atm-daemon-bootstrap`, `crates/atm-http-runtime`,
+or `crates/atm-daemon` changes.
+
+### Size
+
+One crate, one new module, one fixture mode, one test file: expected to
+fit one context window. No split is pre-declared; if it does not fit, that
+is a plan amendment, not a dispatch-time decision.
+
+## Required work
+
+1. Land D1/D3/D7 (trait, error variant, pin, boundary) as the first commit.
+2. Implement C2 against the fake server's streaming mode; close every
+   reconnect, resubscribe, cap, deadline, and cancellation case.
+3. Prove nothing else changed: `HerdrProcessAdapter` pin unchanged, no
+   daemon crate in the diff, C3 subset check.
+
+## Acceptance criteria
+
+1. `subscribe` on the socket transport emits `Baseline` before returning
+   the receiver; on the CLI transport returns `Unsupported` without
+   spawning.
+2. Scripted fixtures pass for: status change delivery order; pane.created
+   triggers resubscribe and a fresh `Baseline`; EOF triggers
+   `Disconnected` then `Baseline` within the backoff schedule under paused
+   time; 11th failure yields `Closed`; over-cap line yields
+   `Disconnected`; dropping the receiver joins the task and releases the
+   permit (no detached task, asserted with the AY.8 cancellation harness).
+3. Exactly one held connection per session is observable at the fake
+   server while the receiver lives, regardless of agent count (fixture
+   with 50 panes).
+4. `git diff <parent>..HEAD -- crates/atm-daemon-bootstrap
+   crates/atm-http-runtime crates/atm-daemon` is empty; the PR file set is
+   a subset of C3.
+5. `HerdrProcessAdapter` byte-identical to the AY.2 pin; the public-item
+   pin diff is exactly the C1 items and the one error variant.
+6. Common phase merge gate (zero blocking/important/in-scope minor,
+   quality-mgr PASS, three CI lanes green at merge).
+
+## Required validation
+
+- `just validate` on all three CI lanes.
+- `cargo test -p atm-herdr`.
+- `python3 .just/check_line_counts.py`.
+- Compare the PR file list mechanically against C3.
+
+## Out of scope
+
+- Consuming the stream anywhere (AY.11).
+- Changing the queue-wake tick or poll interval (AY.11, AY.12).
+- Any Herdr change; any CLI subscribe emulation.
+- The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
+++ b/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
@@ -335,12 +335,17 @@ edits: expected to fit one context window. If it does not, the split point
 is fixed in advance, the same way as AY.8's: sprint AY.10a lands D1, D3,
 D7 and D8 with C1 (trait and event types, factory return that is `None`
 for both transports until AY.10b flips the socket branch to `Some`, pin,
-boundary key, HR-CORE-011, ADR-058 paragraph) and acceptance 1, 5 and 6,
-and AY.10b lands D2, D4, D5 and D6 with C2 (`status_stream.rs`, fake
-server streaming mode, the protocol test file, herdr-versions column) and
-acceptance 2, 3, 3a and 4, stacked on AY.10a. If the split is exercised:
-AY.10a keeps this sprint's branch (`feature/ay10-herdr-status-stream`,
-`pr_target` AY.8's branch, `stack_parent` AY.8) and AY.10b is
+boundary key, HR-CORE-011, ADR-058 paragraph) with acceptance 5, 6 and
+7 plus an AY.10a-scoped form of 1 (the factory returns `None` for both
+transports and spawns nothing; `subscribe` is not yet reachable), and
+AY.10b lands D2, D4, D5 and D6 with C2 (`status_stream.rs`, fake server
+streaming mode, the protocol test file, herdr-versions column) with the
+full acceptance 1, 2, 3, 3a and 4, stacked on AY.10a. Acceptance 8 (the
+common merge gate) applies to each half independently. If the split is
+exercised: AY.10a keeps this sprint's branch
+(`feature/ay10-herdr-status-stream`, `pr_target` AY.8's branch,
+`stack_parent` AY.8, or AY.8b if that split is also exercised, per
+"Dispatch and PR topology") and AY.10b is
 `feature/ay10b-herdr-status-stream-protocol` (`stack_parent` AY.10a,
 `pr_target` AY.10a's branch, linked with `gh stack link --base
 integrate/phase-ay feature/ay8-herdr-socket-transport
@@ -430,7 +435,8 @@ other split is permitted without a plan amendment.
 
 - Consuming the stream anywhere (AY.11).
 - Changing the queue-wake tick or poll interval (AY.11, AY.12).
-- Coupling stream failures to the nudge breaker (decided in AY.12).
+- Coupling stream failures to the nudge breaker: closed as no coupling in
+  this sprint's C2, for the whole phase including AY.12.
 - Any Herdr change, including a hub-only agent-status subscription that
   would remove the per-pane `pane_get` cost; if Rand chooses that route
   under rework item 7, this sprint is re-planned, not stretched. Any CLI

--- a/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
+++ b/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
@@ -23,7 +23,7 @@ dependency_relations:
   - prerequisite: AY.9
     dependent: AY.10
     relation: parallel_safe
-    rationale: AY.9 owns the daemon-bootstrap composition and doctor files; AY.10 touches only atm-herdr, its fixtures, the architecture pin, and the Herdr requirement docs, and is consumed by nothing until AY.11.
+    rationale: AY.9 owns the daemon-bootstrap composition and doctor files; AY.10 touches only atm-herdr, its fixtures, the architecture pin, and the Herdr requirement docs, and is consumed by nothing until AY.11. The shared `lib.rs`, `transport.rs`, and `crates/atm-architecture/tests/boundary_enforcement.rs` edits are composed under the P-E rule in phase-ay-plan.md (keep both sides' items and pinned entries).
   - prerequisite: AY.10
     dependent: AY.11
     relation: must_follow
@@ -33,9 +33,11 @@ dependency_relations:
 # AY.10 — Herdr agent-status subscription stream in atm-herdr, behind a trait
 
 Add one held Herdr `events.subscribe` connection per configured session that
-delivers agent-status changes to atm as they happen, exposed through a new
-trait in `atm-herdr`. Nothing consumes it in this sprint. The daemon's
-polling behaviour is unchanged.
+delivers agent-status changes to atm as Herdr observes them, exposed through
+a new trait in `atm-herdr`. Nothing consumes it in this sprint. The daemon's
+polling behaviour is unchanged. What the held connection costs inside Herdr
+is stated in "Herdr facts" and is Rand's accepted-cost decision under
+phase-ay-plan.md rework item 7, recorded before this sprint is dispatched.
 
 ## Why (Rand, 2026-09-06)
 
@@ -48,43 +50,68 @@ subscription socket" half. AY.11 is the "do both and verify they match"
 half. Dropping the poll is AY.12, gated on AY.11's evidence and Rand's
 decision.
 
-## Herdr facts this sprint rests on (v0.8.2 9eb52145, `src/api`)
+## Herdr facts this sprint rests on (v0.8.2 9eb52145, `src/api`, `src/app`)
 
 - `events.subscribe` (`schema.rs:231`, `schema/events.rs:12`) takes
   `{"subscriptions":[...]}`, replies `SubscriptionStarted`, then streams one
   JSON line per matching event until the client closes
-  (`server.rs` `stream_subscriptions`). It is the only long-lived request
-  shape atm uses; every other request stays one-request-per-connection
-  (AY.8 C2).
+  (`server.rs` `stream_subscriptions`, ~735-751). It is the only long-lived
+  request shape atm uses; every other request stays
+  one-request-per-connection (AY.8 C2).
+- Herdr's stream is server-side polled, not pushed. `stream_subscriptions`
+  polls every subscription on the connection every 100 ms
+  (`CONNECTION_POLL_INTERVAL`, `server.rs:28`) and returns at most one event
+  per subscription per tick.
 - `Subscription::PaneAgentStatusChanged { pane_id, agent_status:
-  Option<AgentStatus> }` (`schema/events.rs:76`) is per pane and per
-  status. At subscribe time Herdr probes the pane (`pane_get`,
-  `subscriptions.rs` ~205-240) and, when the pane's current status equals
-  the subscription's `agent_status`, emits that status as the first event
-  on the stream; later it emits only changes matching the filter, deduped
-  against the probe (`subscriptions.rs` ~340-410). `AgentStatus` has five
-  values: `Idle`, `Working`, `Blocked`, `Done`, `Unknown`
-  (`schema/common.rs:154`). Five status-filtered subscriptions per pane
-  therefore deliver the pane's current status as the first event on the
-  same connection that carries subsequent changes. That is the baseline
-  mechanism this sprint uses; no separate `agent.list` snapshot is taken
-  for status, so there is no window between a snapshot and the start of
-  the stream in which a transition can be lost.
-- `pane.created`, `pane.closed`, `pane.updated` (carries full `PaneInfo`
-  including `agent_status`, `schema/panes.rs:549`), `pane.exited`, and
-  `pane.agent_detected` are subscribable without a pane id.
+  Option<AgentStatus> }` (`schema/events.rs:76`; `agent_status` omitted =
+  every change) is per pane. At subscribe Herdr records the event-hub
+  sequence, then runs one `pane_get` probe for the pane (`subscriptions.rs`
+  ~255-285). On each tick (`poll_result`, ~389-470) it drains hub
+  `PaneAgentStatusChanged` events for the pane; when the hub has had no new
+  event at all since the previous tick it runs one more `pane_get` and emits
+  a change if the pane's status or presentation differs from its last
+  snapshot. Consequences this sprint is designed around:
+  1. Cost: every `PaneAgentStatusChanged` subscription costs Herdr one
+     in-process `pane_get` (a channel round trip to Herdr's app thread, not
+     a socket) per 100 ms while the hub is quiet. With one subscription per
+     pane that is 10N `pane_get`/s inside Herdr for N subscribed panes
+     (500/s at the plan's 50-agent target). A status filter does not reduce
+     it, so one unfiltered subscription per pane is the minimum for this
+     subscription kind; the round-3 design of five filtered subscriptions
+     per pane (5N, 2,500/s at 50 panes) is withdrawn.
+  2. No zero-poll form exists at 0.8.2. `PaneAgentStatusChanged` is emitted
+     to the hub on every status or presentation change (`src/app/api.rs`
+     ~640-660) but is subscribable only per pane through the probing
+     subscription above. `pane.updated` is hub-only but is emitted on
+     agent-name, title, and runtime changes (`api.rs:618`,
+     `runtime.rs:338,444`, `terminal_titles.rs:73`, `agents.rs:60,136`), not
+     on status changes, so it cannot carry status.
+  3. Duplicates are normal: a change after the sequence capture is on the
+     hub and is delivered even when the subscribe probe already reflected
+     it. The client dedupes by value (C2).
+- Hub-only subscriptions (`pane.created`, `pane.closed`, `pane.exited`,
+  `pane.agent_detected`; no pane id) drain the event hub only, with no
+  `pane_get`, and are created with `last_sequence: 0` (`subscriptions.rs`
+  ~180-215), so every (re)subscribe replays whatever the hub still retains
+  (512-entry ring, `event_hub.rs`; only structural events are pushed to the
+  hub, pane output is not). C2 therefore treats these events as re-list
+  triggers, never as facts, and their one-event-per-tick drain rate is
+  irrelevant because the trigger is coalesced.
 - The wire `EventEnvelope { event, data }` (`schema/events.rs:362`)
-  carries no sequence number. The stream starts at the live sequence with
-  no replay (drift table, 20a500a7). A pane created while no subscription
-  covering `pane.created` is open is invisible until the next
-  `agent.list`; C2 closes that gap by never being without such a
-  subscription.
-- `agent.list` returns `pane_id` per agent; it is used here only to map
-  agent names to pane ids when the pane set is discovered, never as a
-  status source.
+  carries no sequence number and no probe-versus-live marker. The baseline
+  is therefore taken from `agent.list` after `SubscriptionStarted` (C2),
+  not from the stream's first events.
+- `agent.list` returns `pane_id` and `agent_status` per agent; it is used
+  here to discover the pane set and as the baseline snapshot.
 - No CLI equivalent exists (`herdr agent wait` is one-shot, one agent).
   The stream is socket-only. The CLI composition provides no stream
   (C1); no error variant is needed and none is added.
+- Bound this sprint adds inside Herdr while a stream is held: one
+  `pane_get` per subscribed pane per 100 ms while the hub is quiet, plus N
+  sequential `pane_get` probes per (re)subscribe handshake. Zero new
+  sockets; the poll path's one `agent.list` per 5 s is unchanged until
+  AY.12. AY.11's dogfood evidence records Herdr's process CPU with and
+  without the stream open so the cost is measured, not only derived.
 
 ## Dispatch and PR topology
 
@@ -117,26 +144,34 @@ unmerged parallel sibling into this branch.
   CLI transport has no `subscribe`; nothing is spawned; no CLI code
   changes.
 - [ ] D4 — fake socket server (`tests/support/fake_herdr_socket/**`, AY.8
-  D7) gains a streaming mode: accepts `events.subscribe`, records the
-  subscription set, replies `SubscriptionStarted`, emits the per-pane
-  probe event for each status-filtered subscription matching the scripted
-  pane state, then emits scripted event lines, delays, EOF, and over-cap
-  lines from a fixture script; it also serves scripted `agent.list`
-  responses on one-request connections and counts open connections.
-  Recordings live under `tests/fixtures/herdr-versions/0.8.2/events/`.
+  D7) gains a streaming mode that models the Herdr facts above, not an
+  idealised push server: accepts `events.subscribe`, records the
+  subscription set, runs one scripted-latency probe per
+  `PaneAgentStatusChanged` subscription in order and replies
+  `SubscriptionStarted` only after the last probe, replays scripted
+  retained hub history (e.g. old `pane.created` lines) on every subscribe,
+  then emits scripted event lines (including lines whose status equals the
+  pane's current value), delays, EOF, and over-cap lines from a fixture
+  script; serves scripted `agent.list` responses with scripted reply
+  latency on one-request connections; counts open connections and the
+  subscription entries per connection. Recordings live under
+  `tests/fixtures/herdr-versions/0.8.2/events/`.
 - [ ] D5 — tests in `crates/atm-herdr/tests/status_stream.rs` (C3 list)
   with paused Tokio time and no wall-clock sleeps.
 - [ ] D6 — `docs/atm-herdr/herdr-versions.md`: `events.subscribe` column
-  (absent 0.8.0; present 0.8.2 fbd20ad6; no replay 20a500a7; per-pane
-  probe-on-subscribe semantics).
+  (absent 0.8.0; present 0.8.2 fbd20ad6; agent-status subscriptions start
+  at the live sequence, 20a500a7, and fall back to one `pane_get` per pane
+  per 100 ms tick; hub-only subscriptions replay retained history).
 - [ ] D7 — `boundaries/atm-herdr/herdr-process-adapter.toml`: the AY.8
   `herdr_local_socket_client` key also owns `status_stream.rs`; no other
   boundary field changes. Composed-file rule P-E(b) applies (this sprint
   is the third editor; see phase-ay-plan.md P-E).
 - [ ] D8 — `docs/atm-herdr/requirements.md` gains one requirement id,
   HR-CORE-011 (status stream: socket-only, one held connection per
-  session, per-pane probe baseline, own reconnect budget, no nudge-breaker
-  coupling), and ADR-058 gains an amendment paragraph recording that the
+  session, one unfiltered `PaneAgentStatusChanged` subscription per pane,
+  `agent.list` baseline after `SubscriptionStarted`, value-deduped
+  changes, own reconnect budget, no nudge-breaker coupling, Herdr-side
+  cost bound as stated in this sprint), and ADR-058 gains an amendment paragraph recording that the
   subscription socket is added alongside the poll and that dropping the
   poll is a separate decision (item 7 of the rework record). No other
   requirement changes.
@@ -153,8 +188,9 @@ None.
 pub trait HerdrStatusStream: Send + Sync {
     /// Opens the held subscription for `session`. Returns after the server
     /// has acknowledged the subscription (`SubscriptionStarted`) and the
-    /// per-pane probe events have been read for every discovered pane;
-    /// the first event the receiver yields is `Baseline`.
+    /// `agent.list` baseline snapshot has been taken; the first event the
+    /// receiver yields is `Baseline`. The handshake runs under the C2
+    /// handshake budget, never longer than `deadline`.
     fn subscribe<'a>(
         &'a self,
         session: Option<&'a HerdrSession>,
@@ -171,9 +207,10 @@ impl HerdrStatusEvents {
 }
 
 pub enum HerdrStatusEvent {
-    /// Emitted once after every successful (re)subscribe: one entry per
-    /// discovered pane, built from the per-pane probe events delivered on
-    /// this connection.
+    /// Emitted once after every successful (re)subscribe or replacement:
+    /// one entry per listed agent, from the `agent.list` snapshot taken
+    /// after `SubscriptionStarted`, overridden per agent by any status
+    /// event read from the stream before the snapshot reply.
     Baseline(Vec<AgentSnapshot>),
     Changed { agent: AgentName, status: HerdrAgentStatus, observed_at: Instant },
     Gone { agent: AgentName, observed_at: Instant },
@@ -197,23 +234,35 @@ already uses.
 ```text
 acquire the single stream permit for (invoker, session); every request
   below runs under that permit, never under AY.8's 16 request permits
-discover: one agent.list on a one-request connection -> {agent -> pane_id}
-connect (AY.8 endpoint resolution, deadline, pipe-busy retry)
+discover: one agent.list on a one-request connection -> pane set
+  {agent -> pane_id}
+connect (AY.8 endpoint resolution, pipe-busy retry)
 send events.subscribe with:
   pane.created, pane.closed, pane.exited, pane.agent_detected (no pane id)
-  PaneAgentStatusChanged { pane_id, agent_status: Some(s) } for every
-    discovered pane and every s in {Idle, Working, Blocked, Done, Unknown}
-read SubscriptionStarted; read the probe events (one per discovered pane
-  whose status matched a filter); emit Baseline built from them
-then read lines until EOF or error; map PaneAgentStatusChanged -> Changed,
-  pane.closed / pane.exited -> Gone
-on pane.created or pane.agent_detected for a pane not in the set:
-  coalesce for 1 s, then open a replacement connection, subscribe it
-  (discovery + the same subscription set + the new panes), wait for its
-  SubscriptionStarted and probe events, emit Baseline from the
-  replacement, and only then close the previous connection. The previous
-  connection stays open until the replacement has started so no
-  pane.created can fall between the two.
+  pane.agent_status_changed { pane_id } (no agent_status filter) for every
+    pane in the pane set
+read SubscriptionStarted
+snapshot: one agent.list on a one-request connection; emit Baseline from
+  it, except that for any agent whose pane.agent_status_changed was read
+  from the stream between SubscriptionStarted and the snapshot reply the
+  stream value wins (it is newer); record every agent's held value
+then read lines until EOF or error:
+  pane.agent_status_changed whose status differs from the held value for
+    that agent -> Changed, update the held value; equal -> dropped (Herdr
+    delivers duplicates, see Herdr facts); unknown pane -> re-list trigger
+  pane.created / pane.agent_detected / pane.closed / pane.exited -> re-list
+    trigger only (hub-only subscriptions replay retained history on every
+    subscribe, so these lines are never treated as facts)
+re-list trigger: coalesce for 1 s, then one agent.list on a one-request
+  connection; pane set unchanged -> nothing; agents no longer listed ->
+  Gone; new panes -> replacement connection: run this procedure again with
+  the new pane set, wait for the replacement's Baseline to be emitted, and
+  only then close the previous connection (nothing falls between the two)
+handshake budget: connect + subscribe + snapshot must complete within
+  min(deadline, 2 s + 20 ms x panes in the set) (atm's choice: Herdr runs
+  one sequential pane_get probe per subscribed pane before
+  SubscriptionStarted; 3 s at 50 panes); a handshake past its budget is a
+  failed attempt below
 on EOF/error (including a line over the 1 MiB cap): emit Disconnected,
   back off (100 ms, 200, 400, doubling, capped at 5 s, at most 10
   consecutive failed attempts; atm's own choice, not a Herdr value),
@@ -223,8 +272,16 @@ after the 10th consecutive failure or when the deadline passes: emit
   Closed and release the permit
 ```
 
+Why this loses nothing: Herdr records the hub sequence before probing each
+pane, so every status change after subscribe reaches the stream; the
+snapshot is taken after `SubscriptionStarted`, so a change before the
+snapshot is in the snapshot, a change after it is on the stream, and a
+change seen by both is the same value twice and is dropped by the held
+value comparison. The stream never needs a probe-versus-live marker.
+
 Two connections exist for a session only during a replacement handover;
-otherwise exactly one. Dropping the receiver cancels the reader task,
+otherwise exactly one. The subscription set on a connection is exactly
+4 + N entries for N panes. Dropping the receiver cancels the reader task,
 closes any connection, and releases the permit. No detached task. Runtime
 drain rules are AY.8 C2's.
 
@@ -262,8 +319,10 @@ does not fit, that is a plan amendment, not a dispatch-time decision.
 
 1. Land D1/D3/D7/D8 (trait, factory return, pin, boundary, requirement
    id, ADR amendment) as the first commit.
-2. Implement C2 against the fake server's streaming mode; close every
-   handover, reconnect, resubscribe, cap, deadline, and cancellation case.
+2. Implement C2 against the fake server's streaming mode (sequential
+   scripted-latency probes, replayed history, duplicate-valued events);
+   close every handover, reconnect, resubscribe, cap, handshake-budget,
+   deadline, and cancellation case.
 3. Prove nothing else changed: `HerdrProcessAdapter` pin unchanged,
    `HerdrError` unchanged, no daemon crate in the diff, C3 subset check.
 
@@ -273,23 +332,36 @@ does not fit, that is a plan amendment, not a dispatch-time decision.
    event and the factory returns `Some` for socket and `None` for CLI; no
    process is spawned on the CLI path.
 2. Scripted fixtures pass for: status change delivery order; a status
-   transition scripted to occur between the fake server's `agent.list`
-   reply and `SubscriptionStarted` is delivered as the probe value in
-   `Baseline` (nothing lost, nothing duplicated); pane.created triggers a
-   replacement connection whose `Baseline` includes the new pane, with a
-   pane.created scripted during the handover window still delivered; the
-   old connection closes only after the replacement's
-   `SubscriptionStarted`; EOF triggers `Disconnected` then `Baseline`
-   within the backoff schedule under paused time; the 10th consecutive
-   failure yields `Closed`; an over-cap line yields `Disconnected`;
-   dropping the receiver joins the task and releases the permit (no
-   detached task, asserted with the AY.8 cancellation harness).
+   transition scripted between two panes' subscribe probes is delivered
+   exactly once (in `Baseline` or as one `Changed`, never both); a
+   transition scripted between `SubscriptionStarted` and the `agent.list`
+   reply appears in `Baseline` with the stream value and yields no
+   `Changed`; a stream line whose status equals the held value yields
+   nothing; replayed `pane.created` history on subscribe with an unchanged
+   pane set yields one `agent.list` and no replacement (connection count
+   stays 1); `pane.created` for a new pane yields a replacement whose
+   `Baseline` includes it, with a `pane.created` scripted during the
+   handover still acted on; the old connection closes only after the
+   replacement's `Baseline`; a listed agent that disappears yields `Gone`;
+   EOF yields `Disconnected` then `Baseline` within the backoff schedule
+   under paused time; the 10th consecutive failure yields `Closed`; an
+   over-cap line yields `Disconnected`; dropping the receiver joins the
+   task and releases the permit (no detached task, asserted with the AY.8
+   cancellation harness).
 3. Exactly one held connection per session is observable at the fake
    server while the receiver lives (two only during a handover),
-   regardless of agent count (fixture with 50 panes); a churn storm of 20
-   pane.created events within 1 s yields one replacement connection, and
-   AY.8's 16 request permits are never acquired by the stream (fake
-   invoker asserts the permit count stays at 16 throughout).
+   regardless of agent count (fixture with 50 panes); the fake server
+   asserts the subscription set is exactly 4 + N entries with no
+   `agent_status` filter; a churn storm of 20 pane.created events within
+   1 s yields one `agent.list` and one replacement connection; AY.8's 16
+   request permits are never acquired by the stream (fake invoker asserts
+   the permit count stays at 16 throughout).
+3a. Handshake budget: with 50 panes and 10 ms scripted latency per probe
+   plus 50 ms `agent.list` latency, `subscribe` completes inside the 3 s
+   budget under paused time; with 100 ms per probe the handshake is
+   reported as a failed attempt (`Disconnected`, then backoff) and the
+   budget is `min(deadline, 2 s + 20 ms x N)` by assertion at N = 1 and
+   N = 50.
 4. Stream failures leave the nudge breaker state unchanged (breaker
    observed closed before and after 10 scripted stream failures).
 5. `git diff <parent>..HEAD -- crates/atm-daemon-bootstrap
@@ -314,5 +386,8 @@ does not fit, that is a plan amendment, not a dispatch-time decision.
 - Consuming the stream anywhere (AY.11).
 - Changing the queue-wake tick or poll interval (AY.11, AY.12).
 - Coupling stream failures to the nudge breaker (decided in AY.12).
-- Any Herdr change; any CLI subscribe emulation; any `HerdrError` change.
+- Any Herdr change, including a hub-only agent-status subscription that
+  would remove the per-pane `pane_get` cost; if Rand chooses that route
+  under rework item 7, this sprint is re-planned, not stretched. Any CLI
+  subscribe emulation; any `HerdrError` change.
 - The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
+++ b/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: AY.8
 pr_target: feature/ay8-herdr-socket-transport
 target: integrate/phase-ay
-status: draft
+status: gated (dispatch only after "Decision (Rand, YYYY-MM-DD): accept N-per-100ms" is recorded in phase-ay-plan.md item 7; "herdr change first" re-plans this sprint, "stop AY.10" retires it)
 recommended_agent: cipher
 recommended_model: fast
 added: 2026-09-06 (subscription socket; see phase-ay-plan.md "Rework record" item 7)
@@ -124,6 +124,18 @@ feature/ay8-herdr-socket-transport feature/ay10-herdr-status-stream`. If
 the AY.8a/AY.8b split is exercised, the parent is AY.8b. Never merge an
 unmerged parallel sibling into this branch.
 
+Two preconditions gate dispatch. First, the decision line under rework
+item 7 of phase-ay-plan.md reads `accept N-per-100ms` (frontmatter
+`status`); fenix refuses to render the dev-task while
+`grep -E '^   Decision \(Rand, [0-9]{4}-[0-9]{2}-[0-9]{2}\): accept N-per-100ms$'`
+finds no line in that file, and quality-mgr refuses the AY.10 PR on the
+same check. Second, P-E(c): the
+`boundaries/atm-herdr/herdr-process-adapter.toml` diff this sprint makes
+(D7) is reviewed by boundary-guard against AY.8's head before dispatch,
+exactly as AY.8 D1 was reviewed against `integrate/phase-ay`; the approved
+diff is this sprint's first commit (Required work 1). If AY.8's TOML
+changes after that review, the review is redone before the first commit.
+
 ## Deliverables
 
 - [ ] D1 — `pub trait HerdrStatusStream` and the C1 event types in
@@ -165,7 +177,9 @@ unmerged parallel sibling into this branch.
 - [ ] D7 — `boundaries/atm-herdr/herdr-process-adapter.toml`: the AY.8
   `herdr_local_socket_client` key also owns `status_stream.rs`; no other
   boundary field changes. Composed-file rule P-E(b) applies (this sprint
-  is the third editor; see phase-ay-plan.md P-E).
+  is the third editor; see phase-ay-plan.md P-E), and the diff is
+  approved by boundary-guard against AY.8's head before dispatch (P-E(c),
+  "Dispatch and PR topology").
 - [ ] D8 — `docs/atm-herdr/requirements.md` gains one requirement id,
   HR-CORE-011 (status stream: socket-only, one held connection per
   session, one unfiltered `PaneAgentStatusChanged` subscription per pane,
@@ -288,8 +302,13 @@ drain rules are AY.8 C2's.
 The reconnect budget is the stream's own. Stream failures never call into
 the ADR-058 D10.1 nudge breaker (HR-SAFE-005..007), never open it, and
 never read its state; the poll path's breaker is untouched by this sprint.
-Whether stream failures should feed a breaker is decided in AY.12, when
-the stream becomes a state source, not here.
+This holds for the whole phase, including AY.12 when the stream becomes
+the state source: the breaker guards request-path infrastructure failures
+(HR-CORE-009), while a stream that exhausts its budget already surfaces as
+`Closed` and the consumer falls back to its last `Baseline` (AY.11 D2,
+AY.12 D4). Coupling the two would open the nudge breaker, and block
+prompts that the request socket could still deliver, on a stream-only
+fault. HR-CORE-011 records "no nudge-breaker coupling" as final.
 
 ### C3 — changed-file allowlist
 
@@ -304,21 +323,47 @@ the stream becomes a state source, not here.
 - `boundaries/atm-herdr/herdr-process-adapter.toml`
 - `docs/atm-herdr/herdr-versions.md`
 - `docs/atm-herdr/requirements.md` (HR-CORE-011)
-- `docs/adr/` ADR-058 file (amendment paragraph)
+- `docs/adr/ADR-058-herdr-local-steer-backend-contract.md` (amendment paragraph)
 
 No file under `crates/atm-daemon-bootstrap`, `crates/atm-http-runtime`,
 or `crates/atm-daemon` changes. `transport_cli.rs` does not change.
 
-### Size
+### Size and pre-declared split
 
 One crate, one new module, one fixture mode, one test file, two doc
-edits: expected to fit one context window. No split is pre-declared; if it
-does not fit, that is a plan amendment, not a dispatch-time decision.
+edits: expected to fit one context window. If it does not, the split point
+is fixed in advance, the same way as AY.8's: sprint AY.10a lands D1, D3,
+D7 and D8 with C1 (trait and event types, factory return that is `None`
+for both transports until AY.10b flips the socket branch to `Some`, pin,
+boundary key, HR-CORE-011, ADR-058 paragraph) and acceptance 1, 5 and 6,
+and AY.10b lands D2, D4, D5 and D6 with C2 (`status_stream.rs`, fake
+server streaming mode, the protocol test file, herdr-versions column) and
+acceptance 2, 3, 3a and 4, stacked on AY.10a. If the split is exercised:
+AY.10a keeps this sprint's branch (`feature/ay10-herdr-status-stream`,
+`pr_target` AY.8's branch, `stack_parent` AY.8) and AY.10b is
+`feature/ay10b-herdr-status-stream-protocol` (`stack_parent` AY.10a,
+`pr_target` AY.10a's branch, linked with `gh stack link --base
+integrate/phase-ay feature/ay8-herdr-socket-transport
+feature/ay10-herdr-status-stream
+feature/ay10b-herdr-status-stream-protocol`); both dispatch gates above
+apply at AY.10a only (AY.10b edits no boundary TOML and needs no new
+decision); C3 splits by deliverable (AY.10a: lib.rs, transport.rs,
+boundary_enforcement.rs, the boundary TOML, requirements.md, the ADR-058
+file; AY.10b: status_stream.rs, transport_socket.rs,
+tests/status_stream.rs, tests/support/fake_herdr_socket/**,
+tests/fixtures/herdr-versions/0.8.2/events/**, herdr-versions.md);
+AY.11's `must_follow` retargets to AY.10b (AY.11 consumes the working
+stream, not the trait alone), and the stack becomes AY.8 -> AY.10a ->
+AY.10b. Exercising the split is a plan amendment PR that updates this
+section's status, AY.11's dependency_relations and frontmatter, and the
+sprint map and wave tables in phase-ay-plan.md in the same commit. No
+other split is permitted without a plan amendment.
 
 ## Required work
 
 1. Land D1/D3/D7/D8 (trait, factory return, pin, boundary, requirement
-   id, ADR amendment) as the first commit.
+   id, ADR amendment) as the first commit; the D7 TOML hunk is the
+   boundary-guard-approved P-E(c) diff, byte for byte.
 2. Implement C2 against the fake server's streaming mode (sequential
    scripted-latency probes, replayed history, duplicate-valued events);
    close every handover, reconnect, resubscribe, cap, handshake-budget,

--- a/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
+++ b/docs/plans/phase-ay/sprint-AY.10-herdr-status-stream.md
@@ -23,7 +23,7 @@ dependency_relations:
   - prerequisite: AY.9
     dependent: AY.10
     relation: parallel_safe
-    rationale: AY.9 owns the daemon-bootstrap composition and doctor files; AY.10 touches only atm-herdr and its fixtures and is consumed by nothing until AY.11.
+    rationale: AY.9 owns the daemon-bootstrap composition and doctor files; AY.10 touches only atm-herdr, its fixtures, the architecture pin, and the Herdr requirement docs, and is consumed by nothing until AY.11.
   - prerequisite: AY.10
     dependent: AY.11
     relation: must_follow
@@ -56,16 +56,35 @@ decision.
   (`server.rs` `stream_subscriptions`). It is the only long-lived request
   shape atm uses; every other request stays one-request-per-connection
   (AY.8 C2).
-- Subscriptions are per pane: `PaneAgentStatusChanged { pane_id,
-  agent_status: Option<..> }` (`schema/events.rs:76`). `pane.created`,
-  `pane.closed`, `pane.agent_detected`, `pane.exited` are subscribable
-  without a pane id. Adding a pane to the set requires a new
-  `events.subscribe` request, which is a new connection.
-- The stream starts at the live sequence with no replay (drift table,
-  20a500a7). Events missed while disconnected are gone; the only way to
-  recover state is one `agent.list`.
+- `Subscription::PaneAgentStatusChanged { pane_id, agent_status:
+  Option<AgentStatus> }` (`schema/events.rs:76`) is per pane and per
+  status. At subscribe time Herdr probes the pane (`pane_get`,
+  `subscriptions.rs` ~205-240) and, when the pane's current status equals
+  the subscription's `agent_status`, emits that status as the first event
+  on the stream; later it emits only changes matching the filter, deduped
+  against the probe (`subscriptions.rs` ~340-410). `AgentStatus` has five
+  values: `Idle`, `Working`, `Blocked`, `Done`, `Unknown`
+  (`schema/common.rs:154`). Five status-filtered subscriptions per pane
+  therefore deliver the pane's current status as the first event on the
+  same connection that carries subsequent changes. That is the baseline
+  mechanism this sprint uses; no separate `agent.list` snapshot is taken
+  for status, so there is no window between a snapshot and the start of
+  the stream in which a transition can be lost.
+- `pane.created`, `pane.closed`, `pane.updated` (carries full `PaneInfo`
+  including `agent_status`, `schema/panes.rs:549`), `pane.exited`, and
+  `pane.agent_detected` are subscribable without a pane id.
+- The wire `EventEnvelope { event, data }` (`schema/events.rs:362`)
+  carries no sequence number. The stream starts at the live sequence with
+  no replay (drift table, 20a500a7). A pane created while no subscription
+  covering `pane.created` is open is invisible until the next
+  `agent.list`; C2 closes that gap by never being without such a
+  subscription.
+- `agent.list` returns `pane_id` per agent; it is used here only to map
+  agent names to pane ids when the pane set is discovered, never as a
+  status source.
 - No CLI equivalent exists (`herdr agent wait` is one-shot, one agent).
-  The stream is socket-only; the CLI transport reports it unsupported.
+  The stream is socket-only. The CLI composition provides no stream
+  (C1); no error variant is needed and none is added.
 
 ## Dispatch and PR topology
 
@@ -80,31 +99,47 @@ unmerged parallel sibling into this branch.
 
 ## Deliverables
 
-- [ ] D1 — `pub trait HerdrStatusStream` in `crates/atm-herdr/src/lib.rs`
-  (C1). `HerdrProcessAdapter` is byte-identical to its AY.2 pin. The
-  public-item pin gains exactly the C1 items; that is an additive minor
-  change under ADR-061 and is recorded in the pin test in the same commit.
+- [ ] D1 — `pub trait HerdrStatusStream` and the C1 event types in
+  `crates/atm-herdr/src/lib.rs`. `HerdrProcessAdapter` is byte-identical
+  to its AY.2 pin. `HerdrError` is unchanged. The public-item pin in
+  `crates/atm-architecture/tests/boundary_enforcement.rs` gains exactly the
+  C1 items; that is an additive minor change under ADR-061 and is recorded
+  in the same commit.
 - [ ] D2 — `crates/atm-herdr/src/status_stream.rs`: socket implementation
   of C1 over AY.8's endpoint resolver and NDJSON framing. One held
-  connection per `subscribe` call, outside AY.8's 16 request permits and
-  counted by its own permit of exactly 1 per session per invoker. C2 is
-  the connection contract.
-- [ ] D3 — CLI transport: `subscribe` returns
-  `HerdrError::Unsupported { feature: "events.subscribe" }` immediately;
-  no process is spawned. `HerdrError` gains that one variant (HR-CORE-008
-  stays closed; variant added in the same commit as the pin update).
+  connection per session, outside AY.8's 16 request permits and counted by
+  its own permit of exactly 1 per session per invoker. C2 is the
+  connection contract.
+- [ ] D3 — composition: the transport factory in
+  `crates/atm-herdr/src/transport.rs` returns, next to the
+  `HerdrProcessInvoker`, an `Option<Arc<dyn HerdrStatusStream>>` that is
+  `Some` for the socket transport and `None` for the CLI transport. The
+  CLI transport has no `subscribe`; nothing is spawned; no CLI code
+  changes.
 - [ ] D4 — fake socket server (`tests/support/fake_herdr_socket/**`, AY.8
-  D7) gains a streaming mode: accepts `events.subscribe`, replies
-  `SubscriptionStarted`, then emits scripted event lines, delays, EOF, and
-  over-cap lines from a fixture script. Recordings live under
-  `tests/fixtures/herdr-versions/0.8.2/events/`.
+  D7) gains a streaming mode: accepts `events.subscribe`, records the
+  subscription set, replies `SubscriptionStarted`, emits the per-pane
+  probe event for each status-filtered subscription matching the scripted
+  pane state, then emits scripted event lines, delays, EOF, and over-cap
+  lines from a fixture script; it also serves scripted `agent.list`
+  responses on one-request connections and counts open connections.
+  Recordings live under `tests/fixtures/herdr-versions/0.8.2/events/`.
 - [ ] D5 — tests in `crates/atm-herdr/tests/status_stream.rs` (C3 list)
   with paused Tokio time and no wall-clock sleeps.
 - [ ] D6 — `docs/atm-herdr/herdr-versions.md`: `events.subscribe` column
-  (absent 0.8.0; present 0.8.2 fbd20ad6; no replay 20a500a7).
+  (absent 0.8.0; present 0.8.2 fbd20ad6; no replay 20a500a7; per-pane
+  probe-on-subscribe semantics).
 - [ ] D7 — `boundaries/atm-herdr/herdr-process-adapter.toml`: the AY.8
   `herdr_local_socket_client` key also owns `status_stream.rs`; no other
-  boundary field changes. Composed-file rule P-E(b) applies.
+  boundary field changes. Composed-file rule P-E(b) applies (this sprint
+  is the third editor; see phase-ay-plan.md P-E).
+- [ ] D8 — `docs/atm-herdr/requirements.md` gains one requirement id,
+  HR-CORE-011 (status stream: socket-only, one held connection per
+  session, per-pane probe baseline, own reconnect budget, no nudge-breaker
+  coupling), and ADR-058 gains an amendment paragraph recording that the
+  subscription socket is added alongside the poll and that dropping the
+  poll is a separate decision (item 7 of the rework record). No other
+  requirement changes.
 
 ### Paths to delete
 
@@ -116,9 +151,10 @@ None.
 
 ```rust
 pub trait HerdrStatusStream: Send + Sync {
-    /// Opens one held subscription for `session`. Returns after the server
-    /// acknowledges the subscription and the baseline `agent.list` has been
-    /// taken; never returns a stream that has not emitted `Baseline`.
+    /// Opens the held subscription for `session`. Returns after the server
+    /// has acknowledged the subscription (`SubscriptionStarted`) and the
+    /// per-pane probe events have been read for every discovered pane;
+    /// the first event the receiver yields is `Baseline`.
     fn subscribe<'a>(
         &'a self,
         session: Option<&'a HerdrSession>,
@@ -135,8 +171,9 @@ impl HerdrStatusEvents {
 }
 
 pub enum HerdrStatusEvent {
-    /// Emitted once after every successful (re)subscribe: the full
-    /// `agent.list` snapshot taken on that connection.
+    /// Emitted once after every successful (re)subscribe: one entry per
+    /// discovered pane, built from the per-pane probe events delivered on
+    /// this connection.
     Baseline(Vec<AgentSnapshot>),
     Changed { agent: AgentName, status: HerdrAgentStatus, observed_at: Instant },
     Gone { agent: AgentName, observed_at: Instant },
@@ -149,7 +186,8 @@ pub enum HerdrStatusEvent {
 ```
 
 `AgentSnapshot`, `AgentName`, `HerdrAgentStatus`, `RequestDeadline`,
-`HerdrSession`, and `HerdrError` are the existing AY.2 types. No message
+`HerdrSession`, and `HerdrError` are the existing AY.2 types; the enum
+`HerdrError` does not change (HR-CORE-008 stays closed). No message
 bodies, pane titles, or command lines are carried; the event maps pane
 events to agent names using the same pane-to-agent projection `agent.list`
 already uses.
@@ -157,81 +195,117 @@ already uses.
 ### C2 — connection contract
 
 ```text
-acquire the single stream permit for (invoker, session)
+acquire the single stream permit for (invoker, session); every request
+  below runs under that permit, never under AY.8's 16 request permits
+discover: one agent.list on a one-request connection -> {agent -> pane_id}
 connect (AY.8 endpoint resolution, deadline, pipe-busy retry)
-send one agent.list on a separate one-request connection; emit Baseline
-send events.subscribe with: pane.created, pane.closed, pane.agent_detected,
-  pane.exited, and PaneAgentStatusChanged for every pane in the baseline
-read SubscriptionStarted; then read lines until EOF or error
-on pane.created or pane.agent_detected for an unknown pane:
-  close, reconnect, resubscribe (which re-takes the baseline)
-on EOF/error: emit Disconnected, back off (100 ms, 200, 400, capped 5 s,
-  max 10 attempts), reconnect, resubscribe
-line cap 1 MiB; a longer line is a protocol error -> Disconnected
+send events.subscribe with:
+  pane.created, pane.closed, pane.exited, pane.agent_detected (no pane id)
+  PaneAgentStatusChanged { pane_id, agent_status: Some(s) } for every
+    discovered pane and every s in {Idle, Working, Blocked, Done, Unknown}
+read SubscriptionStarted; read the probe events (one per discovered pane
+  whose status matched a filter); emit Baseline built from them
+then read lines until EOF or error; map PaneAgentStatusChanged -> Changed,
+  pane.closed / pane.exited -> Gone
+on pane.created or pane.agent_detected for a pane not in the set:
+  coalesce for 1 s, then open a replacement connection, subscribe it
+  (discovery + the same subscription set + the new panes), wait for its
+  SubscriptionStarted and probe events, emit Baseline from the
+  replacement, and only then close the previous connection. The previous
+  connection stays open until the replacement has started so no
+  pane.created can fall between the two.
+on EOF/error (including a line over the 1 MiB cap): emit Disconnected,
+  back off (100 ms, 200, 400, doubling, capped at 5 s, at most 10
+  consecutive failed attempts; atm's own choice, not a Herdr value),
+  reconnect, resubscribe, emit Baseline; a successful resubscribe resets
+  the attempt count
+after the 10th consecutive failure or when the deadline passes: emit
+  Closed and release the permit
 ```
 
-The receiver owns the reader task; `Drop` cancels it and releases the
-permit. No detached task. Runtime drain rules are AY.8 C2's. Reconnect
-attempts are infrastructure-class failures under the existing breaker
-policy (HR-SAFE-005..007); the breaker opening ends the stream with
-`Closed`.
+Two connections exist for a session only during a replacement handover;
+otherwise exactly one. Dropping the receiver cancels the reader task,
+closes any connection, and releases the permit. No detached task. Runtime
+drain rules are AY.8 C2's.
+
+The reconnect budget is the stream's own. Stream failures never call into
+the ADR-058 D10.1 nudge breaker (HR-SAFE-005..007), never open it, and
+never read its state; the poll path's breaker is untouched by this sprint.
+Whether stream failures should feed a breaker is decided in AY.12, when
+the stream becomes a state source, not here.
 
 ### C3 — changed-file allowlist
 
-- `crates/atm-herdr/src/lib.rs` (trait, event types, one error variant, pin)
+- `crates/atm-herdr/src/lib.rs` (trait, event types)
 - `crates/atm-herdr/src/status_stream.rs` (new)
+- `crates/atm-herdr/src/transport.rs` (D3 factory return only)
 - `crates/atm-herdr/src/transport_socket.rs` (expose framing helpers crate-private)
-- `crates/atm-herdr/src/transport_cli.rs` (D3 only)
 - `crates/atm-herdr/tests/status_stream.rs` (new)
 - `crates/atm-herdr/tests/support/fake_herdr_socket/**`
 - `crates/atm-herdr/tests/fixtures/herdr-versions/0.8.2/events/**` (new)
-- `crates/atm-herdr/tests/public_item_pin.rs` (or the AY.2 pin's actual file)
+- `crates/atm-architecture/tests/boundary_enforcement.rs` (public-item pin: C1 items)
 - `boundaries/atm-herdr/herdr-process-adapter.toml`
 - `docs/atm-herdr/herdr-versions.md`
+- `docs/atm-herdr/requirements.md` (HR-CORE-011)
+- `docs/adr/` ADR-058 file (amendment paragraph)
 
 No file under `crates/atm-daemon-bootstrap`, `crates/atm-http-runtime`,
-or `crates/atm-daemon` changes.
+or `crates/atm-daemon` changes. `transport_cli.rs` does not change.
 
 ### Size
 
-One crate, one new module, one fixture mode, one test file: expected to
-fit one context window. No split is pre-declared; if it does not fit, that
-is a plan amendment, not a dispatch-time decision.
+One crate, one new module, one fixture mode, one test file, two doc
+edits: expected to fit one context window. No split is pre-declared; if it
+does not fit, that is a plan amendment, not a dispatch-time decision.
 
 ## Required work
 
-1. Land D1/D3/D7 (trait, error variant, pin, boundary) as the first commit.
+1. Land D1/D3/D7/D8 (trait, factory return, pin, boundary, requirement
+   id, ADR amendment) as the first commit.
 2. Implement C2 against the fake server's streaming mode; close every
-   reconnect, resubscribe, cap, deadline, and cancellation case.
-3. Prove nothing else changed: `HerdrProcessAdapter` pin unchanged, no
-   daemon crate in the diff, C3 subset check.
+   handover, reconnect, resubscribe, cap, deadline, and cancellation case.
+3. Prove nothing else changed: `HerdrProcessAdapter` pin unchanged,
+   `HerdrError` unchanged, no daemon crate in the diff, C3 subset check.
 
 ## Acceptance criteria
 
-1. `subscribe` on the socket transport emits `Baseline` before returning
-   the receiver; on the CLI transport returns `Unsupported` without
-   spawning.
-2. Scripted fixtures pass for: status change delivery order; pane.created
-   triggers resubscribe and a fresh `Baseline`; EOF triggers
-   `Disconnected` then `Baseline` within the backoff schedule under paused
-   time; 11th failure yields `Closed`; over-cap line yields
-   `Disconnected`; dropping the receiver joins the task and releases the
-   permit (no detached task, asserted with the AY.8 cancellation harness).
+1. `subscribe` on the socket transport yields `Baseline` as the first
+   event and the factory returns `Some` for socket and `None` for CLI; no
+   process is spawned on the CLI path.
+2. Scripted fixtures pass for: status change delivery order; a status
+   transition scripted to occur between the fake server's `agent.list`
+   reply and `SubscriptionStarted` is delivered as the probe value in
+   `Baseline` (nothing lost, nothing duplicated); pane.created triggers a
+   replacement connection whose `Baseline` includes the new pane, with a
+   pane.created scripted during the handover window still delivered; the
+   old connection closes only after the replacement's
+   `SubscriptionStarted`; EOF triggers `Disconnected` then `Baseline`
+   within the backoff schedule under paused time; the 10th consecutive
+   failure yields `Closed`; an over-cap line yields `Disconnected`;
+   dropping the receiver joins the task and releases the permit (no
+   detached task, asserted with the AY.8 cancellation harness).
 3. Exactly one held connection per session is observable at the fake
-   server while the receiver lives, regardless of agent count (fixture
-   with 50 panes).
-4. `git diff <parent>..HEAD -- crates/atm-daemon-bootstrap
-   crates/atm-http-runtime crates/atm-daemon` is empty; the PR file set is
-   a subset of C3.
-5. `HerdrProcessAdapter` byte-identical to the AY.2 pin; the public-item
-   pin diff is exactly the C1 items and the one error variant.
-6. Common phase merge gate (zero blocking/important/in-scope minor,
+   server while the receiver lives (two only during a handover),
+   regardless of agent count (fixture with 50 panes); a churn storm of 20
+   pane.created events within 1 s yields one replacement connection, and
+   AY.8's 16 request permits are never acquired by the stream (fake
+   invoker asserts the permit count stays at 16 throughout).
+4. Stream failures leave the nudge breaker state unchanged (breaker
+   observed closed before and after 10 scripted stream failures).
+5. `git diff <parent>..HEAD -- crates/atm-daemon-bootstrap
+   crates/atm-http-runtime crates/atm-daemon crates/atm-herdr/src/transport_cli.rs`
+   is empty; the PR file set is a subset of C3.
+6. `HerdrProcessAdapter` byte-identical to the AY.2 pin; `HerdrError`
+   byte-identical; the public-item pin diff is exactly the C1 items.
+7. HR-CORE-011 present in `docs/atm-herdr/requirements.md` and the
+   ADR-058 amendment paragraph present.
+8. Common phase merge gate (zero blocking/important/in-scope minor,
    quality-mgr PASS, three CI lanes green at merge).
 
 ## Required validation
 
 - `just validate` on all three CI lanes.
-- `cargo test -p atm-herdr`.
+- `cargo test -p atm-herdr -p atm-architecture`.
 - `python3 .just/check_line_counts.py`.
 - Compare the PR file list mechanically against C3.
 
@@ -239,5 +313,6 @@ is a plan amendment, not a dispatch-time decision.
 
 - Consuming the stream anywhere (AY.11).
 - Changing the queue-wake tick or poll interval (AY.11, AY.12).
-- Any Herdr change; any CLI subscribe emulation.
+- Coupling stream failures to the nudge breaker (decided in AY.12).
+- Any Herdr change; any CLI subscribe emulation; any `HerdrError` change.
 - The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
+++ b/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
@@ -53,8 +53,10 @@ Ordinary PR, target `integrate/phase-ay`, no `gh stack link`.
   runtime-owned task per configured session that calls
   `HerdrStatusStream::subscribe`, applies `Baseline`/`Changed`/`Gone` to a
   RAM map `{AgentName -> (HerdrAgentStatus, observed_at)}`, and on `Closed`
-  waits the queue-wake interval and subscribes again. Started only when the
-  selected transport is socket (AY.9 D1); on CLI the task is not spawned.
+  waits the queue-wake interval and subscribes again. Spawned only when the
+  AY.10 D3 factory returned `Some(stream)` (socket transport); on CLI the
+  factory returns `None` and no task exists. Stream failures never touch
+  the nudge breaker (AY.10 C2).
   Follows the RAM write-through rule already in force for the roster.
 - [ ] D2 — parity check inside `tick_once` in
   `crates/atm-http-runtime/src/herdr_queue_wake.rs`: after the tick's
@@ -72,8 +74,7 @@ Ordinary PR, target `integrate/phase-ay`, no `gh stack link`.
   process: every counter, the CLI-selected no-spawn case, resubscribe after
   `Closed`, and drain (the shadow task stops within the runtime shutdown
   deadline, no detached task).
-- [ ] D5 — `docs/atm-herdr/operations.md` (or the AY.9 doc that owns the
-  Herdr operator section): what the parity counters mean and the exit
+- [ ] D5 — `docs/atm-herdr/architecture.md` operator section (the file AY.9 D5 updates; `docs/atm-herdr/operations.md` does not exist and is not created): what the parity counters mean and the exit
   condition for AY.12 below.
 
 ### Paths to delete
@@ -96,7 +97,7 @@ only the parity block is added to `tick_once`).
 - `crates/atm-daemon-bootstrap/src/replacement_handler.rs` (pass the
   stream handle next to the invoker; one site)
 - doctor projection file owned by AY.9 D4 (five counters)
-- `docs/atm-herdr/operations.md`
+- `docs/atm-herdr/architecture.md` (operator section)
 
 ### Size
 

--- a/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
+++ b/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
@@ -1,0 +1,137 @@
+---
+id: AY.11
+phase: AY
+sprint: AY.11
+title: Daemon consumes the status stream in shadow mode and records parity with the poll
+branch: feature/ay11-herdr-stream-shadow-parity
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay11-herdr-stream-shadow-parity
+integration_branch: integrate/phase-ay
+stack_parent: none
+pr_target: integrate/phase-ay
+target: integrate/phase-ay
+status: draft
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+added: 2026-09-06 (subscription socket; see phase-ay-plan.md "Rework record" item 7)
+execution_track: join
+parallel_with: []
+dependency_relations:
+  - prerequisite: AY.9
+    dependent: AY.11
+    relation: must_follow
+    rationale: the socket transport must be the selected production composition before the daemon can hold a stream.
+  - prerequisite: AY.10
+    dependent: AY.11
+    relation: must_follow
+    rationale: consumes the HerdrStatusStream trait.
+  - prerequisite: AY.11
+    dependent: AY.12
+    relation: must_follow
+    rationale: AY.12 removes the poll only on AY.11's recorded parity evidence and Rand's decision.
+---
+
+# AY.11 — Daemon consumes the status stream in shadow mode and records parity with the poll
+
+Run both. The existing 5 s queue-wake poll stays the authority for every
+decision the daemon makes. Alongside it, one held stream per configured
+session (AY.10) maintains a second, stream-derived agent-state map. Every
+tick compares the two and counts disagreements. Nothing the daemon does
+changes on the basis of the stream in this sprint.
+
+Rand, 2026-09-06: "are you proposing we do both and verify they match.
+once they match we can drop the polling?"; "this is a prudent solution.";
+"and probably lowest risk".
+
+## Dispatch and PR topology
+
+Standalone from `integrate/phase-ay` after AY.9 and AY.10 have merged.
+Ordinary PR, target `integrate/phase-ay`, no `gh stack link`.
+
+## Deliverables
+
+- [ ] D1 — `crates/atm-http-runtime/src/herdr_status_shadow.rs` (new): a
+  runtime-owned task per configured session that calls
+  `HerdrStatusStream::subscribe`, applies `Baseline`/`Changed`/`Gone` to a
+  RAM map `{AgentName -> (HerdrAgentStatus, observed_at)}`, and on `Closed`
+  waits the queue-wake interval and subscribes again. Started only when the
+  selected transport is socket (AY.9 D1); on CLI the task is not spawned.
+  Follows the RAM write-through rule already in force for the roster.
+- [ ] D2 — parity check inside `tick_once` in
+  `crates/atm-http-runtime/src/herdr_queue_wake.rs`: after the tick's
+  `list`, compare each agent's polled status with the shadow map. Count
+  `match`, `stream_stale` (stream older than one interval), `mismatch`,
+  `stream_missing` (agent absent from stream map), `stream_extra`. Emit one
+  structured log line per tick with the five counters and, for each
+  mismatch, agent name plus both statuses. Never a message body, never a
+  pane title.
+- [ ] D3 — `HerdrQueueWakeStats` gains the five counters; the existing
+  stats sink and the doctor's Herdr section (AY.3/AY.9) project them as
+  `herdr.stream_parity.*`.
+- [ ] D4 — tests in `crates/atm-http-runtime/tests/herdr_stream_parity.rs`
+  against the AY.10 fake server streaming mode and the existing fake
+  process: every counter, the CLI-selected no-spawn case, resubscribe after
+  `Closed`, and drain (the shadow task stops within the runtime shutdown
+  deadline, no detached task).
+- [ ] D5 — `docs/atm-herdr/operations.md` (or the AY.9 doc that owns the
+  Herdr operator section): what the parity counters mean and the exit
+  condition for AY.12 below.
+
+### Paths to delete
+
+None.
+
+## Contracts
+
+No public API change. No config key: shadow mode is on whenever the socket
+transport is selected. `HERDR_POLL_INTERVAL_MS` and every prompt/reminder
+decision are untouched (`git diff` on the decision functions is empty;
+only the parity block is added to `tick_once`).
+
+### Changed-file allowlist
+
+- `crates/atm-http-runtime/src/herdr_status_shadow.rs` (new)
+- `crates/atm-http-runtime/src/herdr_queue_wake.rs` (parity block, stats)
+- `crates/atm-http-runtime/src/lib.rs` (module and spawn at composition)
+- `crates/atm-http-runtime/tests/herdr_stream_parity.rs` (new)
+- `crates/atm-daemon-bootstrap/src/replacement_handler.rs` (pass the
+  stream handle next to the invoker; one site)
+- doctor projection file owned by AY.9 D4 (five counters)
+- `docs/atm-herdr/operations.md`
+
+### Size
+
+One new module, one parity block, one test file: one context window.
+
+## Acceptance criteria
+
+1. With socket selected, exactly one stream per session is held for the
+   daemon's lifetime (fake server asserts connection count with 50 agents
+   scripted).
+2. Every decision path in `tick_once` is byte-identical to its AY.9 state
+   except the parity block; a test proves prompts and reminders are
+   unaffected by any shadow-map content, including a fully wrong map.
+3. All five counters are exercised by tests and projected by doctor.
+4. CLI selected: no shadow task, counters absent from doctor.
+5. Drain: shadow task and stream receiver stop within the runtime shutdown
+   deadline; no detached task.
+6. Common phase merge gate.
+
+## Exit condition this sprint records (input to AY.12)
+
+Parity evidence is the daemon's own log over a dogfood run on rand-m4
+with the normal team active: consecutive ticks with `mismatch == 0` and
+`stream_missing == 0` (`stream_stale` is expected around a change and is
+not a failure). The number of ticks and the run length are Rand's call
+when he reads the evidence; this sprint does not fix a threshold.
+
+## Required validation
+
+- `just validate` on all three CI lanes.
+- `cargo test -p atm-http-runtime`.
+- `python3 .just/check_line_counts.py`.
+
+## Out of scope
+
+- Using the stream for any decision; removing or slowing the poll (AY.12).
+- Any `atm-herdr` change (AY.10 owns the crate).
+- The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
+++ b/docs/plans/phase-ay/sprint-AY.11-herdr-stream-shadow-parity.md
@@ -63,9 +63,11 @@ Ordinary PR, target `integrate/phase-ay`, no `gh stack link`.
   `list`, compare each agent's polled status with the shadow map. Count
   `match`, `stream_stale` (stream older than one interval), `mismatch`,
   `stream_missing` (agent absent from stream map), `stream_extra`. Emit one
-  structured log line per tick with the five counters and, for each
-  mismatch, agent name plus both statuses. Never a message body, never a
-  pane title.
+  structured log line per tick with the five counters, a
+  `rebuilt_since_last_tick` flag (true when the shadow map received a
+  `Baseline` or `Disconnected` since the previous tick: reconnect or
+  replacement handover), and, for each mismatch, agent name plus both
+  statuses. Never a message body, never a pane title.
 - [ ] D3 — `HerdrQueueWakeStats` gains the five counters; the existing
   stats sink and the doctor's Herdr section (AY.3/AY.9) project them as
   `herdr.stream_parity.*`.
@@ -122,8 +124,15 @@ One new module, one parity block, one test file: one context window.
 Parity evidence is the daemon's own log over a dogfood run on rand-m4
 with the normal team active: consecutive ticks with `mismatch == 0` and
 `stream_missing == 0` (`stream_stale` is expected around a change and is
-not a failure). The number of ticks and the run length are Rand's call
-when he reads the evidence; this sprint does not fix a threshold.
+not a failure). Ticks with `rebuilt_since_last_tick == true` (reconnect or
+replacement handover, AY.10 C2) are expected transient noise: they are
+excluded from the consecutive count, do not reset it, and are reported
+separately with their count; a mismatch on any other tick is a genuine
+parity failure. The evidence also records Herdr's process CPU over the
+run with the stream open and, for the same length, with the daemon on
+the CLI transport (stream absent), so the AY.10 Herdr-side cost is
+measured. The number of ticks and the run length are Rand's call when he
+reads the evidence; this sprint does not fix a threshold.
 
 ## Required validation
 

--- a/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
+++ b/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
@@ -54,10 +54,19 @@ sending due prompts and reminders from queued mail. On the CLI transport
 - `crates/atm-http-runtime/tests/**` for the two files above
 - doctor projection file (counter removal)
 - `docs/atm-herdr/architecture.md` (operator section)
-- `crates/atm-herdr/src/status_stream.rs` only if this sprint decides that
-  stream failures feed the nudge breaker (AY.10 C2 defers that decision
-  here); `docs/atm-herdr/requirements.md` HR-CORE-011 is amended in the
-  same commit if so
+
+No file under `crates/atm-herdr` changes. Stream failures do not feed the
+nudge breaker; AY.10 C2 and HR-CORE-011 settle that for the phase (a
+stream fault surfaces as `Closed` and the map falls back to its last
+`Baseline`, which D4 exercises). This sprint carries no open design
+decision beyond the drop-poll line that gates it.
+
+### Size
+
+Two production files in one crate, their tests, one doctor projection
+edit, one doc section: expected to fit one context window. No split is
+pre-declared; if it does not fit, that is a plan amendment, not a
+dispatch-time decision.
 
 ## Acceptance criteria
 
@@ -70,6 +79,5 @@ sending due prompts and reminders from queued mail. On the CLI transport
 ## Out of scope
 
 - Any change to prompt/reminder policy.
-- Any `atm-herdr` change other than the breaker-coupling decision named
-  in the allowlist.
+- Any `atm-herdr` change; the breaker question is closed in AY.10 C2.
 - The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
+++ b/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
@@ -1,0 +1,70 @@
+---
+id: AY.12
+phase: AY
+sprint: AY.12
+title: Stream becomes the state source; poll removed
+branch: feature/ay12-herdr-drop-poll
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay12-herdr-drop-poll
+integration_branch: integrate/phase-ay
+stack_parent: none
+pr_target: integrate/phase-ay
+target: integrate/phase-ay
+status: gated (dispatch only after "Decision (Rand, YYYY-MM-DD): drop poll" is recorded in phase-ay-plan.md item 7)
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+added: 2026-09-06 (subscription socket; see phase-ay-plan.md "Rework record" item 7)
+execution_track: join
+parallel_with: []
+dependency_relations:
+  - prerequisite: AY.11
+    dependent: AY.12
+    relation: must_follow
+    rationale: parity evidence from AY.11 and Rand's decision on it gate this sprint.
+---
+
+# AY.12 — Stream becomes the state source; poll removed
+
+Once AY.11's parity evidence is accepted, the shadow map becomes the map.
+The queue-wake tick no longer calls `list` or per-member `get`; agent state
+comes from the stream, and the tick keeps only its existing duty of
+sending due prompts and reminders from queued mail. On the CLI transport
+(no stream) the poll remains exactly as today.
+
+## Deliverables
+
+- [ ] D1 — `tick_once` reads agent state from the AY.11 map when the
+  socket transport is selected; the `list`/`get` calls run only when the
+  CLI transport is selected. `HERDR_POLL_INTERVAL_MS` remains as the
+  prompt/reminder cadence.
+- [ ] D2 — one `agent.list` per session on every (re)subscribe is already
+  the `Baseline` event (AY.10); D1 must not add another.
+- [ ] D3 — the parity block and counters are deleted with the poll on the
+  socket path; the CLI path never had them.
+- [ ] D4 — lifecycle tests (AY.4 matrix rerun under stream-sourced state):
+  Herdr restart, stream `Closed`, and breaker open all leave prompt
+  decisions correct on the next `Baseline`.
+- [ ] D5 — docs: the operator section drops the parity counters and states
+  the two state sources by transport.
+
+### Changed-file allowlist
+
+- `crates/atm-http-runtime/src/herdr_queue_wake.rs`
+- `crates/atm-http-runtime/src/herdr_status_shadow.rs` (rename to
+  `herdr_status.rs` allowed)
+- `crates/atm-http-runtime/tests/**` for the two files above
+- doctor projection file (counter removal)
+- `docs/atm-herdr/operations.md`
+
+## Acceptance criteria
+
+1. Fake server with 50 agents: after connect, zero `agent.list`/`agent.get`
+   requests over ten ticks on the socket path; the CLI path issues the same
+   requests it does today.
+2. AY.4 lifecycle matrix green under stream-sourced state.
+3. Common phase merge gate.
+
+## Out of scope
+
+- Any change to prompt/reminder policy.
+- Any `atm-herdr` change.
+- The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
+++ b/docs/plans/phase-ay/sprint-AY.12-herdr-drop-poll.md
@@ -53,7 +53,11 @@ sending due prompts and reminders from queued mail. On the CLI transport
   `herdr_status.rs` allowed)
 - `crates/atm-http-runtime/tests/**` for the two files above
 - doctor projection file (counter removal)
-- `docs/atm-herdr/operations.md`
+- `docs/atm-herdr/architecture.md` (operator section)
+- `crates/atm-herdr/src/status_stream.rs` only if this sprint decides that
+  stream failures feed the nudge breaker (AY.10 C2 defers that decision
+  here); `docs/atm-herdr/requirements.md` HR-CORE-011 is amended in the
+  same commit if so
 
 ## Acceptance criteria
 
@@ -66,5 +70,6 @@ sending due prompts and reminders from queued mail. On the CLI transport
 ## Out of scope
 
 - Any change to prompt/reminder policy.
-- Any `atm-herdr` change.
+- Any `atm-herdr` change other than the breaker-coupling decision named
+  in the allowlist.
 - The legacy synchronous daemon.

--- a/docs/plans/phase-ay/sprint-AY.3-herdr-endpoint-doctor-config.md
+++ b/docs/plans/phase-ay/sprint-AY.3-herdr-endpoint-doctor-config.md
@@ -25,8 +25,8 @@ dependency_relations:
     rationale: AY.4 consumes the complete typed endpoint observations, doctor projection, configuration wiring, and presence correlation delivered here.
   - prerequisite: AY.3
     dependent: AY.8
-    relation: must_follow
-    rationale: AY.8 extends the endpoint/transport contracts and edits the architecture gate established here, so its independent multi-parent branch is created only after AY.1, AY.2, and AY.3 merge.
+    relation: parallel_safe
+    rationale: (rework 2026-09-06) AY.8 changes no behavior and stays inside atm-herdr behind HerdrProcessAdapter; the architecture gate this sprint retires needs no exemption. AY.8 starts once AY.1 and AY.2 merge and never waits on AY.3. Both sprints edit the atm-herdr boundary TOML and lib.rs; whichever merges second resolves at merge-forward and re-runs the composed-TOML check named in the plan's P-E section.
 ---
 
 # AY.3 — Herdr endpoint doctor and daemon configuration
@@ -66,9 +66,9 @@ pushed, not QA completion, triggers a merge commit from AY.2 into AY.3 before
 every development or fix round. Parent PRs merge into `integrate/phase-ay`
 first.
 
-AY.8 socket work is not in this stack. It becomes eligible only after AY.1,
-AY.2, and AY.3 have merged and then runs independently in parallel with
-AY.4–AY.7.
+AY.8 socket work is not in this stack. It is dispatched once AY.1 and AY.2
+have merged and P-E(b) is approved, never waits on AY.3, and runs
+independently in parallel with AY.3–AY.7 (rework 2026-09-06).
 
 ## Preconditions
 

--- a/docs/plans/phase-ay/sprint-AY.4-herdr-breaker-lifecycle.md
+++ b/docs/plans/phase-ay/sprint-AY.4-herdr-breaker-lifecycle.md
@@ -21,12 +21,12 @@ dependency_relations:
     rationale: lifecycle assertions consume AY.3's fully composed client configuration, typed endpoint doctor, presence correlation, and deterministic doctor projection; AY.4 is stacked directly on AY.3.
   - prerequisite: AY.4
     dependent: AY.5
-    relation: must_follow
-    rationale: operator entry ownership starts only after the optional-startup and Herdr-failure model is proven end to end, preventing the installer control plane from becoming an implicit runtime repair mechanism.
+    relation: parallel_safe
+    rationale: AY.4 owns Tokio/Axum breaker escalation, bootstrap escalation config and real-composition lifecycle tests; AY.5 owns daemon-switch entry scripts/tests, requirements, ADR-053 and skill docs. The files are disjoint, so development runs in parallel. The design rule that the installer control plane never becomes an implicit runtime repair mechanism is enforced by AY.5's own acceptance (no daemon lifecycle code path calls entry repair) and by AY.5 merging after AY.4 (rework 2026-09-06).
   - prerequisite: AY.4
     dependent: AY.8
     relation: parallel_safe
-    rationale: AY.4 owns Tokio/Axum breaker escalation, bootstrap escalation config, CLI-reference text, and real-composition lifecycle tests after AY.3; AY.8 owns atm-herdr socket transport, socket fixtures, version-ledger text, boundary revisions, and its architecture exemption, so their exact paths and artifacts do not intersect.
+    rationale: AY.4 owns Tokio/Axum breaker escalation, bootstrap escalation config, CLI-reference text, and real-composition lifecycle tests after AY.3; AY.8 owns atm-herdr socket transport, socket fixtures, version-ledger text, and one boundary-ownership key, so their exact paths and artifacts do not intersect.
 ---
 
 # AY.4 — Herdr breaker escalation and failure lifecycle

--- a/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
+++ b/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
@@ -79,10 +79,9 @@ AY.5. Neither branch merges an unmerged sibling.
 ## Preconditions
 
 - P-A and P-B from the Phase AY plan are satisfied.
-- AY.4 development is pushed, and AY.5 is created from
-  `feature/ay4-herdr-breaker-lifecycle`.
-- AY.3's `atm doctor --json` schema and AY.4's optional/failure lifecycle are
-  green on the parent stack.
+- AY.3 has merged into `integrate/phase-ay`, and AY.5 is created from that
+  integration head (never from AY.4; the two develop in parallel).
+- AY.3's `atm doctor --json` schema is green on `integrate/phase-ay`.
 - The implementer has read the current `.claude/skills/daemon-switch/SKILL.md`,
   `scripts/daemon-switch.py`, its tests, REQ-P-DAEMON-SWITCH-001, and ADR-053.
 
@@ -273,8 +272,8 @@ This is the authoritative validation list.
 - [ ] V3 — `just lint spell` and `just lint adr-index` exit zero.
 - [ ] V4 — `just validate` exits zero.
 - [ ] V5 — `gh pr view feature/ay5-herdr-entry-control-plane --json
-  headRefName,baseRefName,state` reports base
-  `feature/ay4-herdr-breaker-lifecycle`; AY.8 is not in this stack.
+  headRefName,baseRefName,state` reports base `integrate/phase-ay`; neither
+  AY.4 nor AY.8 is in this stack.
 
 ## Non-closure and out of scope
 

--- a/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
+++ b/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
@@ -11,14 +11,19 @@ recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core
 parallel_with: [AY.8]
-stack_parent: feature/ay4-herdr-breaker-lifecycle
-pr_target: feature/ay4-herdr-breaker-lifecycle
-target: feature/ay4-herdr-breaker-lifecycle
+stack_parent: none
+pr_target: integrate/phase-ay
+target: integrate/phase-ay
+rework: 2026-09-06 (AY.5 is the bottom of the control-plane stack; see phase-ay-plan.md "Rework record")
 dependency_relations:
-  - prerequisite: AY.4
+  - prerequisite: AY.3
     dependent: AY.5
     relation: must_follow
-    rationale: the operator control plane is introduced only after AY.4 proves that Herdr absence/failure remains a bounded Tokio/Axum runtime condition and is never repaired implicitly by daemon lifecycle code.
+    rationale: every entry operation consumes the native Herdr doctor state and composed client configuration that AY.3 lands; AY.5 branches from `integrate/phase-ay` once AY.3 has merged.
+  - prerequisite: AY.4
+    dependent: AY.5
+    relation: parallel_safe
+    rationale: disjoint files (AY.4: atm-http-runtime/bootstrap breaker escalation; AY.5: daemon-switch entry scripts/tests, requirements, ADR-053, skill docs). AY.5 develops in parallel with AY.4 from `integrate/phase-ay` and merges after AY.4. Acceptance here must prove no daemon lifecycle code path invokes entry repair, which is the invariant the old serial ordering protected (rework 2026-09-06).
   - prerequisite: AY.5
     dependent: AY.6
     relation: must_follow
@@ -26,7 +31,7 @@ dependency_relations:
   - prerequisite: AY.5
     dependent: AY.8
     relation: parallel_safe
-    rationale: AY.5 edits daemon-switch scripts/tests, requirements, ADR-053, and skill documentation; AY.8 edits atm-herdr socket transport, fixtures, boundary revision, and architecture exemption after their shared AY.3 contracts merge.
+    rationale: AY.5 edits daemon-switch scripts/tests, requirements, ADR-053, and skill documentation; AY.8 edits atm-herdr socket transport, fixtures, and one boundary-ownership key; no file is shared.
 ---
 
 # AY.5 — Transactional Herdr entry control plane
@@ -39,10 +44,14 @@ restart, restore, or daemon startup.
 
 ## Delivery topology and `/gh-stack`
 
-AY.5 is stacked between breaker lifecycle and coordinated restart:
+AY.5 is the bottom of the control-plane stack (rework 2026-09-06). It
+branches from `integrate/phase-ay` after AY.3 merges and develops in
+parallel with AY.4, which lives in the separate core stack:
 
 ```text
-integrate/phase-ay <- AY.2 <- AY.3 <- AY.4 <- AY.5 <- AY.6 <- AY.7
+integrate/phase-ay <- AY.2 <- AY.3 <- AY.4          (core stack)
+integrate/phase-ay <- AY.5 <- AY.6 <- AY.7          (control-plane stack)
+integrate/phase-ay <- AY.8                          (transport track)
 ```
 
 Use the `/gh-stack` skill only through noninteractive forms:
@@ -51,9 +60,6 @@ Use the `/gh-stack` skill only through noninteractive forms:
 git config rerere.enabled true
 git config remote.pushDefault origin
 gh stack link --base integrate/phase-ay \
-  feature/ay2-herdr-transport-seam \
-  feature/ay3-herdr-endpoint-doctor-config \
-  feature/ay4-herdr-breaker-lifecycle \
   feature/ay5-herdr-entry-control-plane
 gh pr view feature/ay5-herdr-entry-control-plane \
   --json headRefName,baseRefName,state
@@ -63,8 +69,9 @@ Append AY.6 and AY.7 with `gh stack link <stack-number> <branch>`. Phase AY
 uses `link` for its external-worktree stack and verifies bases with
 `gh pr view --json`.
 It forbids `gh stack rebase`, `gh stack sync`, and `gh stack merge`; use merge
-commits, no force-push, and parent-first PR completion. AY.4 development pushed
-triggers merge-forward into AY.5 before every development/fix round.
+commits, no force-push, and parent-first PR completion. AY.4 and AY.5 share
+no files; AY.5 merges after AY.4, and any AY.4 merge into
+`integrate/phase-ay` is merged forward into AY.5 before its next round.
 
 AY.8 is a separate branch from `integrate/phase-ay` and is parallel-safe with
 AY.5. Neither branch merges an unmerged sibling.

--- a/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
+++ b/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
@@ -43,7 +43,8 @@ is still protocol-mismatched.
 AY.6 is stacked directly above AY.5 and below Windows completion AY.7:
 
 ```text
-integrate/phase-ay <- AY.2 <- AY.3 <- AY.4 <- AY.5 <- AY.6 <- AY.7
+integrate/phase-ay <- AY.5 <- AY.6 <- AY.7          (control-plane stack)
+integrate/phase-ay <- AY.2 <- AY.3 <- AY.4          (core stack, separate)
 ```
 
 Use the `/gh-stack` skill noninteractively:
@@ -52,9 +53,6 @@ Use the `/gh-stack` skill noninteractively:
 git config rerere.enabled true
 git config remote.pushDefault origin
 gh stack link --base integrate/phase-ay \
-  feature/ay2-herdr-transport-seam \
-  feature/ay3-herdr-endpoint-doctor-config \
-  feature/ay4-herdr-breaker-lifecycle \
   feature/ay5-herdr-entry-control-plane \
   feature/ay6-herdr-restart-coordination
 gh pr view feature/ay6-herdr-restart-coordination \

--- a/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
+++ b/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
@@ -26,7 +26,7 @@ dependency_relations:
   - prerequisite: AY.6
     dependent: AY.8
     relation: parallel_safe
-    rationale: AY.6 edits daemon-switch restart logic/tests and operator governance/docs; AY.8 edits atm-herdr socket transport, protocol fixtures, boundary revision, and architecture exemption after shared AY.3 contracts merge.
+    rationale: AY.6 edits daemon-switch restart logic/tests and operator governance/docs; AY.8 edits atm-herdr socket transport, protocol fixtures, and one boundary-ownership key; no file is shared.
 ---
 
 # AY.6 — Coordinated Herdr endpoint restart

--- a/docs/plans/phase-ay/sprint-AY.7-windows-herdr-process-installer.md
+++ b/docs/plans/phase-ay/sprint-AY.7-windows-herdr-process-installer.md
@@ -43,8 +43,8 @@ AY.7 dispatches when AY.6 development is pushed; it has no physical-machine
 precondition. Its branch is created from
 `feature/ay6-herdr-restart-coordination`, not from the integration branch.
 
-Use the `/gh-stack` skill for the phase's linear implementation stack. After
-the `AY.2 -> AY.3 -> AY.4 -> AY.5 -> AY.6 -> AY.7` branches and PRs exist,
+Use the `/gh-stack` skill for the control-plane stack. After the
+`AY.5 -> AY.6 -> AY.7` branches and PRs exist,
 append AY.7 to the already-linked remote stack with explicit non-interactive
 arguments, then verify the PR base with ordinary GitHub JSON:
 
@@ -97,7 +97,7 @@ completion fails the sprint.
   `CREATE_NO_WINDOW`, `herdr.exe`, `cfg(windows)` process handling) appears
   outside `crates/atm-herdr/src/transport_cli.rs`.
   `crates/atm-architecture/tests/boundary_enforcement.rs` is not touched by
-  AY.7 (it is in AY.8's C3 allowlist; this keeps AY.7/AY.8 `parallel_safe`).
+  AY.7 or AY.8 (the AI.11 gate it once carried was retired on AY.3).
   The public `HerdrProcessAdapter` signatures and the `HerdrError` enum
   remain unchanged.
 - [ ] D4 — verify the Windows branches of AY.5 entry management and AY.6

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -278,9 +278,12 @@ deliverable (AY.8a: Cargo.toml, boundary TOML, transport_socket.rs,
 transport.rs, lib.rs, tests/socket_construction_pin.rs, herdr-versions.md;
 AY.8b: tests/support/fake_herdr_socket/** and the equivalence tests); and
 AY.9's `must_follow` retargets to AY.8b, because AY.9 needs the equivalence
-suite. Exercising the split is a plan amendment PR that updates this
-section's status, AY.9's dependency_relations, and the sprint map and wave
-tables in phase-ay-plan.md in the same commit. No other split is permitted
+suite; AY.10's `stack_parent`/`pr_target` retarget to AY.8b (AY.10 needs the
+fake socket server, which rides AY.8b), and the stack becomes AY.8a ->
+AY.8b -> AY.10. Exercising the split is a plan amendment PR that updates
+this section's status, AY.9's and AY.10's dependency_relations and
+frontmatter, and the sprint map and wave tables in phase-ay-plan.md in the
+same commit. No other split is permitted
 without a plan amendment.
 
 ## Required work

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -137,10 +137,13 @@ completion fails the sprint.
   only public item of `atm-herdr` remains `HerdrProcessAdapter` and its
   existing contract types.
 - [ ] D10 — preserve the no-cutover guard: no change under
-  `crates/atm-daemon-bootstrap`, and an architecture allowlist permits
-  `HerdrIo::Socket(` construction only in `transport_socket.rs` test modules
-  and `crates/atm-herdr/tests/`. AY.9 removes that temporary allowlist when it
-  owns transport selection.
+  `crates/atm-daemon-bootstrap`, and the construction-site pin
+  `socket_variant_constructed_only_in_tests` in
+  `crates/atm-herdr/tests/socket_construction_pin.rs` scans
+  `crates/atm-herdr/src/**/*.rs` and permits `HerdrIo::Socket(` only inside
+  `#[cfg(test)]` modules of `transport_socket.rs` and under
+  `crates/atm-herdr/tests/`. AY.9 rewrites that same test to permit the one
+  production factory when it owns transport selection.
 
 ### Paths to delete
 
@@ -243,6 +246,7 @@ AY.8 may add or edit only:
 
 - `crates/atm-herdr/src/transport_socket.rs`
 - `crates/atm-herdr/tests/support/fake_herdr_socket/**`
+- `crates/atm-herdr/tests/socket_construction_pin.rs` (D10 pin)
 - `crates/atm-herdr/src/transport.rs`
 - `crates/atm-herdr/src/lib.rs` (one module declaration; no new public exports)
 - `crates/atm-herdr/Cargo.toml` (Tokio `net` feature only if needed)
@@ -251,6 +255,16 @@ AY.8 may add or edit only:
 
 Any additional production path is a scope change requiring the sprint plan to
 be amended and re-reviewed before implementation continues.
+
+### Size and pre-declared split
+
+AY.8 is one crate, one new module, one fixture server and one test file, so
+it is expected to fit one context window despite ten deliverables. If it does
+not, the split point is fixed in advance: sprint AY.8a lands D1–D6 and C1–C2
+(TOML, `SocketIo`, endpoint resolver, NDJSON framing, cancellation and
+permits, macOS/Linux UDS lane) and AY.8b lands D7–D8 (fake socket server,
+Windows named-pipe lane, equivalence suite) stacked on AY.8a. D9 and D10
+ride AY.8a. No other split is permitted without a plan amendment.
 
 ## Required work
 

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -48,6 +48,10 @@ dependency_relations:
     dependent: AY.9
     relation: must_follow
     rationale: AY.9 alone selects and defaults to the production socket transport after this implementation merges.
+  - prerequisite: AY.8
+    dependent: AY.10
+    relation: must_follow
+    rationale: AY.10 stacks on this branch and reuses SocketIo, endpoint resolution, framing, and the fake socket server for the held events.subscribe stream.
 ---
 
 # AY.8 — Direct Herdr socket and named-pipe transport without cutover
@@ -329,5 +333,7 @@ without a plan amendment.
 - Doctor projection changes (AY.9) or live platform evidence (release
   readiness, ruling 5).
 - Removing the CLI transport or its ownership keys.
+- Streaming methods (`events.subscribe`): AY.10, stacked on this branch.
+  AY.8's fake server needs no streaming mode; AY.10 adds it.
 - Any patch, hardening, or remodeling of the legacy synchronous daemon. The
   eventual selection point remains the Tokio/Axum `atm-http-runtime` path.

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -264,7 +264,20 @@ not, the split point is fixed in advance: sprint AY.8a lands D1–D6 and C1–C2
 (TOML, `SocketIo`, endpoint resolver, NDJSON framing, cancellation and
 permits, macOS/Linux UDS lane) and AY.8b lands D7–D8 (fake socket server,
 Windows named-pipe lane, equivalence suite) stacked on AY.8a. D9 and D10
-ride AY.8a. No other split is permitted without a plan amendment.
+ride AY.8a. If the split is exercised: AY.8a keeps this sprint's branch
+(`feature/ay8-herdr-socket-transport`, target `integrate/phase-ay`, stack
+parent none) and AY.8b is `feature/ay8b-herdr-socket-equivalence`
+(`stack_parent` AY.8a, `pr_target` AY.8a's branch, linked with `gh stack
+link --base integrate/phase-ay`); the P-E(b) composed-TOML rule applies at
+AY.8a only (D1 rides there; AY.8b edits no boundary TOML); C3 splits by
+deliverable (AY.8a: Cargo.toml, boundary TOML, transport_socket.rs,
+transport.rs, lib.rs, tests/socket_construction_pin.rs, herdr-versions.md;
+AY.8b: tests/support/fake_herdr_socket/** and the equivalence tests); and
+AY.9's `must_follow` retargets to AY.8b, because AY.9 needs the equivalence
+suite. Exercising the split is a plan amendment PR that updates this
+section's status, AY.9's dependency_relations, and the sprint map and wave
+tables in phase-ay-plan.md in the same commit. No other split is permitted
+without a plan amendment.
 
 ## Required work
 

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -10,8 +10,9 @@ stack_parent: none
 pr_target: integrate/phase-ay
 target: integrate/phase-ay
 status: draft
-recommended_agent: arch-ctm
-recommended_model: deep-reasoning
+recommended_agent: cipher
+recommended_model: fast
+rework: 2026-09-06 (transport isolation ruling; see phase-ay-plan.md "Rework record")
 execution_track: socket
 parallel_with: [AY.4, AY.5, AY.6, AY.7]
 dependency_relations:
@@ -25,8 +26,8 @@ dependency_relations:
     rationale: HerdrIo, HerdrClientConfig, replay recordings, and the portable fake-Herdr process must exist before the socket variant is added.
   - prerequisite: AY.3
     dependent: AY.8
-    relation: must_follow
-    rationale: both sprints edit boundary_enforcement.rs, so AY.3's long-lived-child guard must land before AY.8 adds the one AI.11 exemption.
+    relation: parallel_safe
+    rationale: AY.8 changes no behavior and touches only atm-herdr internals behind `HerdrProcessAdapter`; the AI.11 gate it once had to exempt was retired on AY.3. P-E(b) was ruled on 2026-09-06 (boundary-guard, TOML diff approved unchanged). AY.8's D1 TOML edit layers onto whatever contract inventory AY.3 lands; resolve at merge-forward, never by waiting.
   - prerequisite: AY.4
     dependent: AY.8
     relation: parallel_safe
@@ -58,11 +59,14 @@ this sprint.
 
 ## Dispatch, parallelism, and PR topology
 
-AY.8 is a multi-parent join. Dispatch it only after AY.1, AY.2, and AY.3 have
-merged into `integrate/phase-ay` and the P-E boundary revision has been
-approved. Create the branch from that integration head. It is not a child of
-AY.3 and is not part of the implementation stack: `/gh-stack` stacks are linear and
-cannot encode three prerequisites or a branch shared across stacks.
+AY.8 is the independent transport track. Dispatch it as soon as AY.1 and AY.2
+have merged into `integrate/phase-ay` and P-E(b) is approved (both true as of
+2026-09-06). Create the branch from that integration head. It is not a child
+of AY.3 and is not part of the implementation stack. Governing rule (Rand,
+2026-09-06): the CLI to UDS/named-pipe swap changes no functionality and is
+completely hidden behind `HerdrProcessAdapter`; every other phase feature is
+developed independently of it, and AY.8 must not wait on, or be waited on by,
+any feature sprint.
 
 AY.8 runs in parallel with AY.4, AY.5, AY.6, and AY.7 because the exact changed-file
 allowlist below does not intersect their owned files or public artifacts. Use
@@ -84,18 +88,19 @@ completion fails the sprint.
   `boundaries/atm-herdr/herdr-process-adapter.toml` is the first commit. It adds
   only `herdr_local_socket_client` to `io_owns`; `io_forbidden` is unchanged and
   the CLI ownership keys remain while the fallback exists.
-- [ ] D2 — `ai11_guarded_workspace_sources` in
-  `crates/atm-architecture/tests/boundary_enforcement.rs` excludes exactly
-  `crates/atm-herdr/src/transport_socket.rs`, with a rationale citing ADR-058 D3
-  and AY.8. A pin test asserts that this is the only exemption. This is the
-  second commit, after D1.
+- [x] D2 — removed 2026-09-06. The AI.11 retired-Windows-transport gate was
+  deleted on AY.3 (PR #1273): the repo has no named pipes other than the ones
+  Herdr requires, so there is nothing to exempt. AY.8 does not edit
+  `boundary_enforcement.rs`.
 - [ ] D3 — add `crates/atm-herdr/src/transport_socket.rs` with crate-private
   `SocketIo` and `HerdrIo::Socket(SocketIo)`. Use
   `tokio::net::UnixStream` on Unix and
   `tokio::net::windows::named_pipe::ClientOptions` on Windows; add only Tokio's
   `net` feature if it is not already enabled. No process is spawned and no
   dependency on `interprocess` is added.
-- [ ] D4 — add the pure endpoint resolver and public endpoint types in C1.
+- [ ] D4 — add the pure endpoint resolver and crate-private endpoint types in
+  C1. Byte fixtures for every C1 case live in a `#[cfg(test)]` module inside
+  `transport_socket.rs`, so no item needs to be public for testing.
   Precedence is explicit `socket_path`, then the per-call session-derived path,
   then default. Environment values are captured once at composition and
   injected; transport code never reads ambient `XDG_CONFIG_HOME`, `APPDATA`, or
@@ -127,9 +132,10 @@ completion fails the sprint.
   `docs/atm-herdr/herdr-versions.md` gains ping/request/response/error-code
   NDJSON columns for every release from 0.8.0, keyed on `ping.version` and
   capabilities rather than `PROTOCOL_VERSION`.
-- [ ] D9 — amend the AY.2 public-item pin by adding exactly
-  `herdr_api_endpoint`, `HerdrHostEnv`, and `HerdrEndpoint`; `SocketIo` remains
-  `pub(crate)`.
+- [ ] D9 — no net additions to the AY.2 public-item pin: `herdr_api_endpoint`,
+  `HerdrHostEnv`, `HerdrEndpoint`, and `SocketIo` are all `pub(crate)`. The
+  only public item of `atm-herdr` remains `HerdrProcessAdapter` and its
+  existing contract types.
 - [ ] D10 — preserve the no-cutover guard: no change under
   `crates/atm-daemon-bootstrap`, and an architecture allowlist permits
   `HerdrIo::Socket(` construction only in `transport_socket.rs` test modules
@@ -146,20 +152,20 @@ None.
 
 ```rust
 /// Pure; performs no probe or I/O.
-pub fn herdr_api_endpoint(
+pub(crate) fn herdr_api_endpoint(
     cfg: &HerdrClientConfig,
     session: Option<&HerdrSession>,
     env: &HerdrHostEnv,
 ) -> HerdrEndpoint;
 
-pub struct HerdrHostEnv {
-    pub xdg_config_home: Option<PathBuf>,
-    pub appdata: Option<PathBuf>,
-    pub home: Option<PathBuf>,
-    pub platform: Platform,
+pub(crate) struct HerdrHostEnv {
+    pub(crate) xdg_config_home: Option<PathBuf>,
+    pub(crate) appdata: Option<PathBuf>,
+    pub(crate) home: Option<PathBuf>,
+    pub(crate) platform: Platform,
 }
 
-pub enum HerdrEndpoint {
+pub(crate) enum HerdrEndpoint {
     UnixSocket(PathBuf),
     NamedPipe(String), // full \\.\pipe\... name
 }
@@ -238,10 +244,8 @@ AY.8 may add or edit only:
 - `crates/atm-herdr/src/transport_socket.rs`
 - `crates/atm-herdr/tests/support/fake_herdr_socket/**`
 - `crates/atm-herdr/src/transport.rs`
-- `crates/atm-herdr/src/lib.rs` (one module declaration and exports for C1)
+- `crates/atm-herdr/src/lib.rs` (one module declaration; no new public exports)
 - `crates/atm-herdr/Cargo.toml` (Tokio `net` feature only if needed)
-- `crates/atm-architecture/tests/boundary_enforcement.rs`
-- the AY.2 public-item pin test under `crates/atm-architecture/tests/`
 - `boundaries/atm-herdr/herdr-process-adapter.toml`
 - `docs/atm-herdr/herdr-versions.md`
 
@@ -250,8 +254,8 @@ be amended and re-reviewed before implementation continues.
 
 ## Required work
 
-1. Land the approved boundary record first and the pinned AI.11 exemption
-   second; do not begin socket code until both diffs match P-E(b).
+1. Land the approved boundary record first; do not begin socket code until
+   the diff matches P-E(b).
 2. Implement endpoint resolution and the bounded one-request protocol as one
    transport boundary, then close every Unix-socket and named-pipe failure with
    the fake server on its owning CI lane.
@@ -261,8 +265,7 @@ be amended and re-reviewed before implementation continues.
 
 ## Acceptance criteria
 
-1. D1 is the first commit and exactly matches the P-E ruling; D2 is the second
-   commit and pins one exemption.
+1. D1 is the first commit and exactly matches the P-E ruling.
 2. Endpoint-resolution byte fixtures pass for every C1 case, including the
    full Windows pipe string.
 3. Both transports pass the same adapter equivalence suite on macOS, Linux,
@@ -276,7 +279,8 @@ be amended and re-reviewed before implementation continues.
    of C3.
 6. `herdr-versions.md` contains complete NDJSON columns for every listed
    release from 0.8.0.
-7. The public-item pin contains exactly the three D9 additions.
+7. The AY.2 public-item pin is unchanged by this sprint; `cargo doc` or the pin
+   test shows no new public items in `atm-herdr`.
 8. `gh pr view feature/ay8-herdr-socket-transport --json
    headRefName,baseRefName,state` reports base `integrate/phase-ay`; AY.8 is not
    linked into the implementation stack.

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -13,8 +13,16 @@ status: draft
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: join
-parallel_with: []
+parallel_with: [AY.10]
 dependency_relations:
+  - prerequisite: AY.9
+    dependent: AY.10
+    relation: parallel_safe
+    rationale: AY.10 changes only atm-herdr, its fixtures, the architecture pin, and Herdr docs; AY.9 owns the composition, config reader, and doctor files. Neither reads the other's diff; the shared `crates/atm-herdr/src/lib.rs` and `transport.rs` edits are composed under the P-E rule in phase-ay-plan.md.
+  - prerequisite: AY.9
+    dependent: AY.11
+    relation: must_follow
+    rationale: AY.11 spawns the shadow task only on the socket composition AY.9 selects.
   - prerequisite: AY.7
     dependent: AY.9
     relation: must_follow
@@ -31,9 +39,12 @@ Select the AY.8 socket transport in the Tokio/Axum production composition,
 make it the default with the CLI transport as the permanent explicit
 alternative, and close its
 configuration, doctor, and automated lifecycle contracts on all three CI
-lanes. AY.9 is the phase's last sprint; live macOS/Windows operator proof
-is release readiness after the phase lands on develop (ruling 5), and the
-phase disposition is taken on AY.9's automated gates.
+lanes. AY.9 is the socket-cutover join; AY.10 runs beside it and AY.11
+(and AY.12 if Rand decides to drop the poll) follow it before the phase
+lands on develop. Live macOS/Windows operator proof is release readiness
+after the phase lands on develop (ruling 5); the Ship/Defer/Cancel
+disposition of the cutover is taken on AY.9's automated gates, and phase
+completion is defined under "Phase AY exit gate" in phase-ay-plan.md.
 
 ## Dispatch and PR topology
 
@@ -171,6 +182,30 @@ fixture matrix adds omitted, `socket`, `cli`, unknown string, and unknown key.
 The unknown string and unknown key both fail with `ConfigParseFailed`, with the
 file and offending key/value named according to AY.3's error contract.
 
+### C1a — changed-file allowlist
+
+- `crates/atm-herdr/src/transport.rs` (the one production factory; the
+  AY.9 pin names this file)
+- `crates/atm-herdr/src/lib.rs` (factory export only)
+- `crates/atm-herdr/tests/socket_construction_pin.rs` (AY.8 D10 allowlist
+  replaced by the production-factory pin)
+- `crates/atm-daemon-bootstrap/src/herdr_config.rs` (closed transport enum,
+  `socket_path`, validation matrix)
+- `crates/atm-daemon-bootstrap/src/replacement_handler.rs` (composition
+  selects the factory)
+- `crates/atm-daemon-bootstrap/src/herdr_lifecycle_tests.rs` (L1–L12 under
+  socket default and explicit CLI)
+- `crates/atm-core/src/doctor/**` files that AY.3 D4 created for the Herdr
+  section (transport/endpoint fields and snapshots)
+- `crates/atm-architecture/tests/boundary_enforcement.rs` (forbidden-edge
+  grep for `HerdrEndpoint`, factory pin)
+- `docs/atm-herdr/architecture.md`, `docs/atm-herdr/requirements.md`,
+  `docs/project-plan.md`, user configuration reference
+- `.sprints/AY/events.ttl`
+
+No file under `crates/atm-daemon` changes; `transport_socket.rs`,
+`transport_cli.rs`, and `status_stream.rs` do not change.
+
 ### C2 — doctor projection
 
 The existing endpoint schema is extended by populated values, not new keys:
@@ -260,6 +295,10 @@ serialized JSON, human output, snapshots, or transport logs.
    parent PRs merged; AY.9 is not linked into the implementation stack.
 9. No path under `docs/plans/phase-ay/evidence/` is added or changed by AY.9;
    no sprint carries live evidence.
+9a. The PR file set is a subset of C1a (`git diff --name-only <base>..HEAD`
+    compared mechanically), and `git diff <base>..HEAD -- crates/atm-daemon
+    crates/atm-herdr/src/transport_socket.rs crates/atm-herdr/src/transport_cli.rs
+    crates/atm-herdr/src/status_stream.rs` is empty.
 10. The sprint meets the common phase merge gate: zero blocking, important, or
     in-scope minor findings; quality-mgr posts PASS; all three CI lanes are
     green at merge time; no flaky-test allowance applies.

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -66,9 +66,11 @@ completion fails the sprint.
   production factory inside `atm-herdr`. No second composition site is
   introduced.
 - [ ] D2 — retain CLI as a permanent, explicit, documented fallback (rework
-  2026-09-06). It is selected only by `herdr.transport = "cli"`; doctor
-  reports the active transport; runtime failure never silently falls back
-  from socket to CLI (a socket connect failure is a Herdr-unavailable breaker
+  2026-09-06). The transport is chosen exactly once at daemon start by the
+  D1 factory from `herdr.transport`; `cli` is selected only by explicit
+  config; doctor reports the active transport; the choice never changes
+  while the daemon runs and runtime failure never falls back from socket
+  to CLI (a socket connect failure is a Herdr-unavailable breaker
   event with the same mapping as a CLI spawn failure). No removal release is
   scheduled and no ownership-key cleanup is recorded.
 - [ ] D3 — rerun AY.4's authoritative lifecycle matrix L1–L12 against the

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -18,7 +18,7 @@ dependency_relations:
   - prerequisite: AY.9
     dependent: AY.10
     relation: parallel_safe
-    rationale: AY.10 changes only atm-herdr, its fixtures, the architecture pin, and Herdr docs; AY.9 owns the composition, config reader, and doctor files. Neither reads the other's diff; the shared `crates/atm-herdr/src/lib.rs` and `transport.rs` edits are composed under the P-E rule in phase-ay-plan.md.
+    rationale: AY.10 changes only atm-herdr, its fixtures, the architecture pin, and Herdr docs; AY.9 owns the composition, config reader, and doctor files. Neither reads the other's diff; the shared `crates/atm-herdr/src/lib.rs`, `transport.rs`, and `crates/atm-architecture/tests/boundary_enforcement.rs` edits are composed under the P-E rule in phase-ay-plan.md.
   - prerequisite: AY.9
     dependent: AY.11
     relation: must_follow

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -61,7 +61,8 @@ completion fails the sprint.
   `atm-herdr`, the invoker factory builds `HerdrIo::Socket` or `HerdrIo::Cli`;
   the crate-private enum never crosses the crate boundary. Default to `socket`;
   reject every other string with `AtmErrorCode::ConfigParseFailed`. Replace
-  AY.8's test-only construction-site allowlist with a pin that permits the one
+  AY.8's `socket_variant_constructed_only_in_tests` pin
+  (`crates/atm-herdr/tests/socket_construction_pin.rs`) with a pin that permits the one
   production factory inside `atm-herdr`. No second composition site is
   introduced.
 - [ ] D2 — retain CLI as a permanent, explicit, documented fallback (rework

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -272,6 +272,8 @@ serialized JSON, human output, snapshots, or transport logs.
 ## Out of scope
 
 - New Herdr capabilities or a change to Herdr's protocol.
+- Consuming the AY.10 status stream or changing the queue-wake poll
+  (AY.11, AY.12). AY.9 selects the transport; it does not hold a stream.
 - Removing or deprecating the CLI transport (no removal release exists).
 - Live macOS/Windows proof (release readiness) and the phase disposition
   (Rand, on AY.9's automated gates and the phase-ending review).

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -28,7 +28,8 @@ dependency_relations:
 # AY.9 — Herdr socket cutover, doctor projection, and lifecycle validation
 
 Select the AY.8 socket transport in the Tokio/Axum production composition,
-make it the default with an explicit one-minor CLI fallback, and close its
+make it the default with the CLI transport as the permanent explicit
+fallback, and close its
 configuration, doctor, and automated lifecycle contracts on all three CI
 lanes. AY.9 is the phase's last sprint; live macOS/Windows operator proof
 is release readiness after the phase lands on develop (ruling 5), and the
@@ -63,11 +64,12 @@ completion fails the sprint.
   AY.8's test-only construction-site allowlist with a pin that permits the one
   production factory inside `atm-herdr`. No second composition site is
   introduced.
-- [ ] D2 — retain CLI as an explicit, documented fallback through atm 1.5.x
-  and remove it in atm 1.6.0. It is selected only by
-  `herdr.transport = "cli"`; runtime failure never silently falls back from
-  socket to CLI. Add the 1.6.0 removal and ownership-key cleanup to
-  `docs/project-plan.md`.
+- [ ] D2 — retain CLI as a permanent, explicit, documented fallback (rework
+  2026-09-06). It is selected only by `herdr.transport = "cli"`; doctor
+  reports the active transport; runtime failure never silently falls back
+  from socket to CLI (a socket connect failure is a Herdr-unavailable breaker
+  event with the same mapping as a CLI spawn failure). No removal release is
+  scheduled and no ownership-key cleanup is recorded.
 - [ ] D3 — rerun AY.4's authoritative lifecycle matrix L1–L12 against the
   socket default on all three CI lanes. Adapt only: no binary becomes endpoint
   not configured or
@@ -99,8 +101,8 @@ completion fails the sprint.
   `HerdrIo::Socket(` construction. Replace it with the production-factory pin
   in D1; do not delete the underlying architecture assertion.
 
-No other path is deleted in the Ship case. CLI transport removal is the
-atm 1.6.0 follow-up recorded by D2, not part of AY.9.
+No other path is deleted in the Ship case. The CLI transport is never
+removed (D2).
 
 ## Code and configuration contracts
 
@@ -221,7 +223,7 @@ serialized JSON, human output, snapshots, or transport logs.
    production-factory pin, then run socket-default and explicit-CLI lifecycle
    suites on every CI platform.
 3. Align doctor snapshots and operator docs with the canonical tagged schema,
-   record the atm 1.6.0 fallback-removal obligation, and keep all live evidence
+   document the permanent explicit CLI fallback, and keep all live evidence
    out of this sprint (ruling 5).
 
 ## Acceptance criteria
@@ -246,8 +248,8 @@ serialized JSON, human output, snapshots, or transport logs.
    crate boundary.
 7. The AY.3 config-reader matrix includes omitted, `socket`, `cli`, unknown
    string, and unknown key; only the two supported values parse through
-   `HerdrClientConfig::try_new`, its fields remain private, and 1.6.0 is the
-   pinned CLI-removal release.
+   `HerdrClientConfig::try_new`, its fields remain private, and no removal
+   release for the CLI transport is recorded anywhere in the plan.
 8. `gh pr view feature/ay9-herdr-socket-cutover --json
    headRefName,baseRefName,state` reports base `integrate/phase-ay` after both
    parent PRs merged; AY.9 is not linked into the implementation stack.

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -29,7 +29,7 @@ dependency_relations:
 
 Select the AY.8 socket transport in the Tokio/Axum production composition,
 make it the default with the CLI transport as the permanent explicit
-fallback, and close its
+alternative, and close its
 configuration, doctor, and automated lifecycle contracts on all three CI
 lanes. AY.9 is the phase's last sprint; live macOS/Windows operator proof
 is release readiness after the phase lands on develop (ruling 5), and the
@@ -79,7 +79,7 @@ completion fails the sprint.
   unreachable; `server_not_running` becomes refused/absent endpoint; the old
   protocol-mismatch case becomes a server-recording/version switch between
   calls with no daemon restart. Keep the distinct below-minimum case and keep
-  CLI variants green while fallback exists. L5 shutdown/drain and resource
+  CLI variants green permanently (both transports are supported). L5 shutdown/drain and resource
   release, L10 restart dedup, L11 flapping suppression, and L12 stalled-
   notification deadline are explicitly included after the transport swap.
 - [ ] D4 — extend doctor without crossing crate boundaries: each endpoint
@@ -244,8 +244,10 @@ serialized JSON, human output, snapshots, or transport logs.
    forbidden-edge grep proves `HerdrEndpoint` does not enter atm-core or
    atm-daemon-bootstrap.
 4. The AY.2 zero-regression oracle passes through the socket default.
-5. The CLI fallback, cutover release, exact removal release, and later deletion
-   of CLI ownership keys are recorded in user docs and `docs/project-plan.md`.
+5. User docs and `docs/project-plan.md` record the CLI transport as a
+   permanent, explicitly selected alternative (`herdr.transport = "cli"`),
+   the cutover release, and that no removal release and no CLI ownership-key
+   cleanup are scheduled.
 6. The temporary AY.8 test-only allowlist is replaced and the one production
    Socket factory inside `atm-herdr` is pinned; `HerdrIo` does not cross its
    crate boundary.
@@ -270,7 +272,7 @@ serialized JSON, human output, snapshots, or transport logs.
 ## Out of scope
 
 - New Herdr capabilities or a change to Herdr's protocol.
-- Removing the CLI fallback in the same release as cutover.
+- Removing or deprecating the CLI transport (no removal release exists).
 - Live macOS/Windows proof (release readiness) and the phase disposition
   (Rand, on AY.9's automated gates and the phase-ending review).
 - Any patch, hardening, or remodeling of the legacy synchronous daemon. D1 is


### PR DESCRIPTION
Plan rework on a worktree off develop per Rand (2026-09-06): "plan reworks should be done on /sc-git-worktree off develop, not made on the fly".

Rulings applied (recorded inline under "Rework record" in docs/plans/phase-ay/phase-ay-plan.md):
- sprints are designed to complete in one context window
- all Herdr implementation lives in atm-herdr behind HerdrProcessAdapter
- the CLI to UDS/named-pipe swap is hidden and developed independently of every feature sprint: AY.8 now depends only on AY.1, AY.2 and P-E(b) and is parallel-safe with AY.3 through AY.7
- the AI.11 named-pipe guard was daemon-HTTP-only and obsolete; deleted on AY.3 (#1273). AY.8 D2 (exemption) removed, endpoint resolver/types crate-private, public-item pin unchanged (boundary-guard P-E(b) ruling)
- AY.4 to AY.5 edge was a principle, not a file dependency: AY.5 now heads a second stack AY.5 -> AY.6 -> AY.7 from integrate/phase-ay, parallel with AY.4
- subscription socket (rework item 7): AY.10 (held `events.subscribe` stream in atm-herdr behind `HerdrStatusStream`, stacked on AY.8), AY.11 (daemon shadow consumption, parity counters, poll stays authoritative), AY.12 (poll dropped on the socket path; gated on Rand's drop-poll decision). Herdr v0.8.2 source verified: agent-status subscriptions are server-polled (one in-process `pane_get` per subscribed pane per 100 ms while the hub is quiet); AY.10 uses one unfiltered subscription per pane and is gated on Rand's accepted-cost line under item 7 (`accept N-per-100ms | herdr change first | stop AY.10`). Stream failures never couple to the nudge breaker, for the whole phase.

Docs-only. Hardening: plan-scope-reviewer PASS (r7, 17244c653), critical-plan-reviewer PASS (r8, f555ca75f); all rounds recorded inline under "Hardening rounds". Merge to develop needs Rand's approval.

Two lines for Rand to fill under rework item 7 before the gated sprints dispatch: the AY.10 cost decision (before AY.10) and the drop-poll decision (before AY.12, from AY.11 evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
