### PR TITLE
AY5: transactional Herdr entry control plane

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -89,6 +89,31 @@ python3 .claude/skills/daemon-switch/scripts/daemon-switch.py quiesce --yes \
   --service <actual-label> --launch-agent-plist ~/Library/LaunchAgents/<actual-label>.plist
 ```
 
+## Explicit Herdr start-at-login entries
+
+Herdr entry management is independent of the selected ATM CLI/daemon pair and
+is always operator-invoked. It never runs during `switch`, `restart`,
+`restore`, or daemon startup. The command reads only `atm doctor --json`; do
+not supply a roster, backend, binary, or socket value by hand.
+
+```sh
+# Install every doctor-reported configured non-socket endpoint, then inspect it.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py herdr-entry install
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py herdr-entry status
+
+# Limit an explicit action to one native-doctor endpoint.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py herdr-entry remove --endpoint <session>
+
+# An interrupted entry transaction blocks mutation until this explicit repair.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py herdr-entry status --repair
+```
+
+The manager owns only definitions marked `managed-by=atm daemon-switch` whose
+canonical digest matches. A foreign collision, digest mismatch, explicit
+socket-path endpoint, or Windows account/session mismatch is a safe refusal;
+it never overwrites or deletes the object. Each invocation emits exactly one
+JSON result on stdout (exit 0 success, 3 refusal, 4 operational failure).
+
 On systems without Homebrew, provide `--default-cli` and `--default-daemon` to
 `restore`. Use `--dry-run` before the first switch on an unfamiliar host.
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -80,6 +80,13 @@ from temporary_launch_windows import (  # noqa: E402
     quote_windows_command_line,  # noqa: F401 - tested compatibility codec re-export.
 )
 from temporary_launch_linux import LinuxSystemdUserAdapter  # noqa: E402
+from herdr_entry import (  # noqa: E402
+    HerdrEndpoint,
+    HerdrEntryError,
+    HerdrEntryManager,
+    NativeEntryPlatform,
+    identifier,
+)
 
 
 LIVE_PAIR_READINESS_ATTEMPTS = 200
@@ -882,6 +889,100 @@ def status(args: argparse.Namespace) -> None:
     print(json.dumps(result, indent=2, sort_keys=True))
 
 
+def herdr_entry_root() -> Path:
+    """Return the private ADR-053-adjacent state root for entry transactions."""
+    return state_path().with_name("herdr-entry")
+
+
+def herdr_entry_endpoints(cli: Path, *, install: bool) -> list[HerdrEndpoint]:
+    """Use only AY3's native doctor JSON; never reconstruct roster selection."""
+    payload = doctor(cli)
+    if not isinstance(payload, dict) or "error" in payload:
+        raise HerdrEntryError(
+            "HERDR_DOCTOR_UNREADABLE",
+            "native atm doctor --json could not be read",
+            "Fix native doctor and rerun; daemon-switch will not guess Herdr configuration",
+            4,
+        )
+    herdr = payload.get("herdr")
+    if not isinstance(herdr, dict) or herdr.get("configured") is None:
+        raise HerdrEntryError(
+            "HERDR_DOCTOR_UNREADABLE",
+            "native doctor did not provide herdr.configured",
+            "Fix native doctor and rerun; daemon-switch will not guess Herdr configuration",
+            4,
+        )
+    if herdr.get("configured") is not True:
+        if install:
+            raise HerdrEntryError(
+                "HERDR_NOT_CONFIGURED",
+                "native doctor reports Herdr is not configured",
+                "Configure Herdr or omit the entry operation",
+                3,
+            )
+        return []
+    values = herdr.get("endpoints")
+    if not isinstance(values, list):
+        raise HerdrEntryError(
+            "HERDR_DOCTOR_UNREADABLE",
+            "native doctor did not provide ordered herdr.endpoints",
+            "Fix native doctor and rerun; daemon-switch will not guess Herdr configuration",
+            4,
+        )
+    endpoints: list[HerdrEndpoint] = []
+    for value in values:
+        if not isinstance(value, dict):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor endpoint was malformed", "Fix native doctor and rerun", 4)
+        name = value.get("endpoint", value.get("session", "default"))
+        if name is None:
+            name = "default"
+        if not isinstance(name, str) or not name or not re.fullmatch(r"[A-Za-z0-9_.-]+", name):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor endpoint identifier was invalid", "Fix native doctor and rerun", 4)
+        socket_path = value.get("socket_path")
+        if socket_path is not None and not isinstance(socket_path, str):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor socket provenance was malformed", "Fix native doctor and rerun", 4)
+        endpoints.append(HerdrEndpoint(name, socket_path))
+    return endpoints
+
+
+def herdr_entry_manager() -> HerdrEntryManager:
+    adapter = NativeEntryPlatform(herdr_entry_root() / "objects", run)
+    # Keep platform selection patchable at the composition boundary for the
+    # platform-fake suite; the entry module itself owns no global platform state.
+    adapter.name = platform.system()
+    return HerdrEntryManager(herdr_entry_root(), adapter)
+
+
+def herdr_entry_result(ok: bool, code: str, message: str, remedy: str, entries: list[dict[str, object]]) -> None:
+    print(json.dumps({"ok": ok, "code": code, "message": message, "remedy": remedy, "entries": entries}, sort_keys=True))
+
+
+def run_herdr_entry(args: argparse.Namespace) -> None:
+    cli, _daemon = selected_links(args)
+    endpoints = herdr_entry_endpoints(cli, install=args.herdr_entry_command == "install")
+    if args.endpoint is not None:
+        endpoints = [endpoint for endpoint in endpoints if endpoint.name == args.endpoint]
+        if not endpoints:
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "requested endpoint is absent from native doctor", "Fix the endpoint selection and rerun", 4)
+    manager = herdr_entry_manager()
+    if args.herdr_entry_command == "status" and args.repair:
+        repair = manager.repair()
+        if repair is not None:
+            status = [manager.entry_status(endpoint) for endpoint in endpoints]
+            herdr_entry_result(True, "HERDR_ENTRY_REPAIRED", "Herdr entry transaction repaired", "none", status)
+            return
+    entries: list[dict[str, object]] = []
+    for endpoint in endpoints:
+        if args.herdr_entry_command == "install":
+            entries.append(manager.install(endpoint))
+        elif args.herdr_entry_command == "remove":
+            entries.append(manager.remove(endpoint))
+        else:
+            entries.append(manager.entry_status(endpoint))
+    success = {"install": "HERDR_ENTRY_INSTALLED", "remove": "HERDR_ENTRY_REMOVED", "status": "HERDR_ENTRY_STATUS_OK"}[args.herdr_entry_command]
+    herdr_entry_result(True, success, "Herdr entries processed", "none", entries)
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     selectors = argparse.ArgumentParser(add_help=False)
@@ -938,6 +1039,13 @@ def parser() -> argparse.ArgumentParser:
         command.add_argument("--yes", action="store_true")
     windows_provision = sub.add_parser("windows-provision", parents=[selectors])
     windows_provision.add_argument("--yes", action="store_true")
+    herdr_entry = sub.add_parser("herdr-entry", parents=[selectors])
+    herdr_entry_sub = herdr_entry.add_subparsers(dest="herdr_entry_command", required=True)
+    for name in ("install", "remove", "status"):
+        command = herdr_entry_sub.add_parser(name)
+        command.add_argument("--endpoint")
+        if name == "status":
+            command.add_argument("--repair", action="store_true")
     return result
 
 
@@ -982,8 +1090,13 @@ def main() -> int:
                 restore_temporary_launch(args, recovery=args.temporary_command == "recover")
         elif args.command == "windows-provision":
             provision_windows_task(args)
+        elif args.command == "herdr-entry":
+            run_herdr_entry(args)
         else:
             quiesce(args)
+    except HerdrEntryError as error:
+        herdr_entry_result(False, error.code, error.message, error.remedy, [])
+        return error.exit_code
     except SwitchError as error:
         print(f"daemon-switch: {error}", file=sys.stderr)
         return 2

--- a/.claude/skills/daemon-switch/scripts/herdr_entry.py
+++ b/.claude/skills/daemon-switch/scripts/herdr_entry.py
@@ -1,0 +1,264 @@
+"""Fail-closed operator control plane for Herdr start-at-login entries.
+
+This module deliberately owns only entry definitions and their native
+registration.  It never starts Herdr, starts ATM, or inspects ATM roster data;
+the caller supplies the already-native ``atm doctor --json`` projection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import platform as platform_module
+import tempfile
+from typing import Callable, Literal, Protocol
+
+
+MARKER = "managed-by=atm daemon-switch"
+
+
+class HerdrEntryError(Exception):
+    """A stable machine-consumed entry-control failure."""
+
+    def __init__(self, code: str, message: str, remedy: str, exit_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.remedy = remedy
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class HerdrEndpoint:
+    name: str
+    socket_path: str | None = None
+
+
+@dataclass(frozen=True)
+class HerdrEntryJournal:
+    entry_id: str
+    platform: str
+    digest: str
+    action: Literal["install", "remove"]
+    phase: Literal["planned", "written", "registered", "verified"]
+
+
+class EntryPlatform(Protocol):
+    """Small native-manager seam; tests provide platform fakes."""
+
+    name: str
+
+    def path_for(self, identifier: str) -> Path: ...
+    def register(self, identifier: str, object_path: Path) -> None: ...
+    def unregister(self, identifier: str) -> None: ...
+    def is_registered(self, identifier: str) -> bool: ...
+    def account_matches(self, identifier: str) -> bool: ...
+
+
+def identifier(platform: str, endpoint: str) -> str:
+    """Return the deterministic start-at-login identifier for an endpoint."""
+    if platform == "Darwin":
+        return "com.randlee.atm.herdr-server" if endpoint == "default" else f"com.randlee.atm.herdr-server.{endpoint}"
+    if platform == "Windows":
+        return "ATM Herdr Server" if endpoint == "default" else f"ATM Herdr Server ({endpoint})"
+    return "atm-herdr-server.service" if endpoint == "default" else f"atm-herdr-server@{endpoint}.service"
+
+
+def canonical_object(platform: str, endpoint: str) -> str:
+    """Render the complete owned object without any caller configuration."""
+    command = "herdr server" if endpoint == "default" else f"herdr --session {endpoint} server"
+    if platform == "Darwin":
+        return "\n".join(("<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<plist version=\"1.0\"><dict>", f"<key>Label</key><string>{identifier(platform, endpoint)}</string>", f"<key>ProgramArguments</key><array><string>{command}</string></array>", "<key>RunAtLoad</key><true/>", "<key>KeepAlive</key><false/>", f"<key>Comment</key><string>{MARKER}</string>", "</dict></plist>", ""))
+    if platform == "Windows":
+        return "\n".join((f"task={identifier(platform, endpoint)}", "trigger=logon", "interactive=true", f"command={command}", f"comment={MARKER}", ""))
+    return "\n".join(("[Unit]", f"Description=ATM Herdr entry ({endpoint})", f"X-ATM-Ownership={MARKER}", "[Service]", "Type=simple", f"ExecStart={command}", "[Install]", "WantedBy=default.target", ""))
+
+
+def object_digest(rendered: str) -> str:
+    return sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+class HerdrEntryManager:
+    def __init__(self, root: Path, entry_platform: EntryPlatform) -> None:
+        self.root = root
+        self.platform = entry_platform
+
+    @property
+    def journal_path(self) -> Path:
+        return self.root / "herdr-entry-journal.json"
+
+    def _save_journal(self, journal: HerdrEntryJournal) -> None:
+        _atomic_write(self.journal_path, json.dumps(asdict(journal), sort_keys=True) + "\n")
+
+    def _load_journal(self) -> HerdrEntryJournal | None:
+        if not self.journal_path.exists():
+            return None
+        try:
+            data = json.loads(self.journal_path.read_text(encoding="utf-8"))
+            return HerdrEntryJournal(**data)
+        except (OSError, TypeError, ValueError) as error:
+            raise HerdrEntryError("HERDR_ENTRY_JOURNAL_ACTIVE", "entry journal is unreadable", "Run status --repair after inspecting the journal", 3) from error
+
+    def _clear_journal(self) -> None:
+        self.journal_path.unlink(missing_ok=True)
+
+    def _entry(self, endpoint: HerdrEndpoint) -> tuple[str, str, str, Path]:
+        entry_id = identifier(self.platform.name, endpoint.name)
+        rendered = canonical_object(self.platform.name, endpoint.name)
+        return entry_id, rendered, object_digest(rendered), self.platform.path_for(entry_id)
+
+    def _owned(self, path: Path, digest: str) -> tuple[bool, bool]:
+        if not path.exists():
+            return False, False
+        content = path.read_text(encoding="utf-8")
+        return MARKER in content, object_digest(content) == digest
+
+    def _assert_no_active_journal(self) -> None:
+        if self._load_journal() is not None:
+            raise HerdrEntryError("HERDR_ENTRY_JOURNAL_ACTIVE", "an entry transaction is incomplete", "Run herdr-entry status --repair", 3)
+
+    def install(self, endpoint: HerdrEndpoint, inject: Callable[[str], None] | None = None) -> dict[str, object]:
+        self._assert_no_active_journal()
+        if self.platform.name == "Windows" and not self.platform.account_matches(identifier(self.platform.name, endpoint.name)):
+            raise HerdrEntryError("HERDR_ENTRY_ACCOUNT_MISMATCH", "Windows entry belongs to another account or session", "Reinstall both per-user under one account", 3)
+        if endpoint.socket_path is not None:
+            raise HerdrEntryError("HERDR_SOCKET_PATH_NO_ENTRY", "socket-path endpoint is externally owned", "Manage this Herdr endpoint outside daemon-switch", 3)
+        entry_id, rendered, digest, path = self._entry(endpoint)
+        owned, matching = self._owned(path, digest)
+        if path.exists() and not owned:
+            raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "entry identifier is occupied by an unowned object", "Remove or rename the foreign object manually", 3)
+        if owned and not matching:
+            raise HerdrEntryError("HERDR_ENTRY_DIGEST_MISMATCH", "owned marker has a different canonical digest", "Inspect and explicitly repair or remove the entry", 3)
+        journal = HerdrEntryJournal(entry_id, self.platform.name, digest, "install", "planned")
+        self._save_journal(journal)
+        _atomic_write(path, rendered)
+        journal = HerdrEntryJournal(entry_id, self.platform.name, digest, "install", "written")
+        self._save_journal(journal)
+        if inject:
+            inject("after_write")
+        try:
+            self.platform.register(entry_id, path)
+        except Exception as error:
+            raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "platform registration failed", "Correct the platform failure, then run status --repair", 4) from error
+        journal = HerdrEntryJournal(entry_id, self.platform.name, digest, "install", "registered")
+        self._save_journal(journal)
+        if inject:
+            inject("after_register")
+        owned, matching = self._owned(path, digest)
+        if not owned or not matching or not self.platform.is_registered(entry_id):
+            raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "platform registration could not be verified", "Run status --repair after correcting the platform state", 4)
+        self._save_journal(HerdrEntryJournal(entry_id, self.platform.name, digest, "install", "verified"))
+        self._clear_journal()
+        return self.entry_status(endpoint)
+
+    def remove(self, endpoint: HerdrEndpoint) -> dict[str, object]:
+        self._assert_no_active_journal()
+        if self.platform.name == "Windows" and not self.platform.account_matches(identifier(self.platform.name, endpoint.name)):
+            raise HerdrEntryError("HERDR_ENTRY_ACCOUNT_MISMATCH", "Windows entry belongs to another account or session", "Reinstall both per-user under one account", 3)
+        if endpoint.socket_path is not None:
+            raise HerdrEntryError("HERDR_SOCKET_PATH_NO_ENTRY", "socket-path endpoint is externally owned", "Manage this Herdr endpoint outside daemon-switch", 3)
+        entry_id, _rendered, digest, path = self._entry(endpoint)
+        if not path.exists():
+            return self.entry_status(endpoint)
+        owned, matching = self._owned(path, digest)
+        if not owned:
+            raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "refusing to remove an unowned object", "Remove the foreign object manually", 3)
+        if not matching:
+            raise HerdrEntryError("HERDR_ENTRY_DIGEST_MISMATCH", "owned marker has a different canonical digest", "Inspect and explicitly repair or remove the entry", 3)
+        self._save_journal(HerdrEntryJournal(entry_id, self.platform.name, digest, "remove", "planned"))
+        self.platform.unregister(entry_id)
+        self._save_journal(HerdrEntryJournal(entry_id, self.platform.name, digest, "remove", "registered"))
+        path.unlink()
+        if path.exists() or self.platform.is_registered(entry_id):
+            raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "entry removal could not be verified", "Run status --repair after correcting the platform state", 4)
+        self._clear_journal()
+        return self.entry_status(endpoint)
+
+    def repair(self) -> dict[str, object] | None:
+        journal = self._load_journal()
+        if journal is None:
+            return None
+        path = self.platform.path_for(journal.entry_id)
+        if journal.action == "install":
+            owned, matching = self._owned(path, journal.digest)
+            if not owned:
+                raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "repair found an unowned entry object", "Inspect the object manually", 3)
+            if not matching:
+                raise HerdrEntryError("HERDR_ENTRY_DIGEST_MISMATCH", "repair found a marker-bearing object with another digest", "Inspect the object manually", 3)
+            if self.platform.is_registered(journal.entry_id):
+                self._clear_journal()
+                return {"repaired": "completed"}
+            path.unlink(missing_ok=True)
+            self._clear_journal()
+            return {"repaired": "rolled_back"}
+        if path.exists() and MARKER not in path.read_text(encoding="utf-8"):
+            raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "repair found an unowned entry object", "Inspect the object manually", 3)
+        self.platform.unregister(journal.entry_id)
+        path.unlink(missing_ok=True)
+        self._clear_journal()
+        return {"repaired": "rolled_back"}
+
+    def entry_status(self, endpoint: HerdrEndpoint) -> dict[str, object]:
+        entry_id, _rendered, digest, path = self._entry(endpoint)
+        owned, matching = self._owned(path, digest)
+        return {"endpoint": endpoint.name, "identifier": entry_id, "owned": owned, "registered": self.platform.is_registered(entry_id), "digest_matches": matching if owned else False, "journal_phase": (self._load_journal().phase if self._load_journal() else None)}
+
+
+class NativeEntryPlatform:
+    """Native file/registration adapter; all calls are explicit operator actions."""
+    def __init__(self, root: Path, runner: Callable[..., object]) -> None:
+        self.name = platform_module.system()
+        self.root = root
+        self.runner = runner
+
+    def path_for(self, entry_id: str) -> Path:
+        suffix = ".plist" if self.name == "Darwin" else (".task" if self.name == "Windows" else "")
+        return self.root / f"{entry_id}{suffix}"
+
+    def register(self, entry_id: str, object_path: Path) -> None:
+        if self.name == "Darwin":
+            command = ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(object_path)]
+        elif self.name == "Windows":
+            command = ["schtasks.exe", "/Create", "/TN", entry_id, "/XML", str(object_path), "/F"]
+        else:
+            command = ["systemctl", "--user", "enable", entry_id]
+        result = self.runner(command, timeout=20.0)
+        if getattr(result, "returncode", 1) != 0:
+            raise RuntimeError(getattr(result, "stderr", "platform registration failed"))
+
+    def unregister(self, entry_id: str) -> None:
+        if self.name == "Darwin":
+            command = ["launchctl", "bootout", f"gui/{os.getuid()}/{entry_id}"]
+        elif self.name == "Windows":
+            command = ["schtasks.exe", "/Delete", "/TN", entry_id, "/F"]
+        else:
+            command = ["systemctl", "--user", "disable", "--now", entry_id]
+        result = self.runner(command, timeout=20.0)
+        if getattr(result, "returncode", 1) != 0:
+            raise RuntimeError(getattr(result, "stderr", "platform unregistration failed"))
+
+    def is_registered(self, entry_id: str) -> bool:
+        # Native registrations are verified through their manager at repair
+        # time. The object cannot be assumed registered merely because it exists.
+        command = (["launchctl", "print", f"gui/{os.getuid()}/{entry_id}"] if self.name == "Darwin" else (["schtasks.exe", "/Query", "/TN", entry_id] if self.name == "Windows" else ["systemctl", "--user", "is-enabled", entry_id]))
+        return getattr(self.runner(command, timeout=5.0), "returncode", 1) == 0
+
+    def account_matches(self, _entry_id: str) -> bool:
+        return True

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1571,5 +1571,106 @@ class LegacyDaemonSwitchRegressionTests(unittest.TestCase):
         self.assertEqual(run.call_args.kwargs["cwd"], Path.home())
 
 
+class HerdrEntryPlatformFake:
+    def __init__(self, root: Path, name: str = "Linux") -> None:
+        self.root = root
+        self.name = name
+        self.registered: set[str] = set()
+        self.account_is_current = True
+
+    def path_for(self, identifier: str) -> Path:
+        return self.root / identifier
+
+    def register(self, identifier: str, _object_path: Path) -> None:
+        self.registered.add(identifier)
+
+    def unregister(self, identifier: str) -> None:
+        self.registered.discard(identifier)
+
+    def is_registered(self, identifier: str) -> bool:
+        return identifier in self.registered
+
+    def account_matches(self, _identifier: str) -> bool:
+        return self.account_is_current
+
+
+class HerdrEntryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.platform = HerdrEntryPlatformFake(self.root / "objects")
+        self.manager = DAEMON_SWITCH.HerdrEntryManager(self.root / "journal", self.platform)
+        self.default = DAEMON_SWITCH.HerdrEndpoint("default")
+        self.session = DAEMON_SWITCH.HerdrEndpoint("blue")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_identifiers_are_deterministic_for_each_platform(self) -> None:
+        self.assertEqual(DAEMON_SWITCH.identifier("Darwin", "default"), "com.randlee.atm.herdr-server")
+        self.assertEqual(DAEMON_SWITCH.identifier("Darwin", "blue"), "com.randlee.atm.herdr-server.blue")
+        self.assertEqual(DAEMON_SWITCH.identifier("Linux", "default"), "atm-herdr-server.service")
+        self.assertEqual(DAEMON_SWITCH.identifier("Windows", "blue"), "ATM Herdr Server (blue)")
+
+    def test_default_and_sessions_are_independently_owned_and_registered(self) -> None:
+        entries = [self.manager.install(endpoint) for endpoint in (self.default, self.session)]
+        self.assertEqual([entry["endpoint"] for entry in entries], ["default", "blue"])
+        self.assertTrue(all(entry["owned"] and entry["registered"] and entry["digest_matches"] for entry in entries))
+        self.assertFalse(self.manager.journal_path.exists())
+
+    def test_foreign_digest_and_socket_path_refuse_without_mutation(self) -> None:
+        path = self.platform.path_for(DAEMON_SWITCH.identifier("Linux", "default"))
+        path.parent.mkdir(parents=True)
+        path.write_text("foreign", encoding="utf-8")
+        with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "unowned"):
+            self.manager.install(self.default)
+        self.assertEqual(path.read_text(encoding="utf-8"), "foreign")
+        with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "externally owned"):
+            self.manager.install(DAEMON_SWITCH.HerdrEndpoint("socket", "/tmp/herdr.sock"))
+
+    def test_interrupted_install_blocks_then_repair_rolls_back_or_completes(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "after write"):
+            self.manager.install(self.default, lambda phase: (_ for _ in ()).throw(RuntimeError("after write")) if phase == "after_write" else None)
+        self.assertTrue(self.manager.journal_path.exists())
+        with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "incomplete"):
+            self.manager.install(self.default)
+        self.assertEqual(self.manager.repair(), {"repaired": "rolled_back"})
+        self.assertFalse(self.platform.path_for("atm-herdr-server.service").exists())
+
+        with self.assertRaisesRegex(RuntimeError, "after register"):
+            self.manager.install(self.default, lambda phase: (_ for _ in ()).throw(RuntimeError("after register")) if phase == "after_register" else None)
+        self.assertEqual(self.manager.repair(), {"repaired": "completed"})
+        self.assertTrue(self.platform.is_registered("atm-herdr-server.service"))
+
+    def test_remove_touches_only_matching_owned_object(self) -> None:
+        self.manager.install(self.default)
+        self.manager.remove(self.default)
+        self.assertFalse(self.platform.path_for("atm-herdr-server.service").exists())
+        self.assertFalse(self.platform.is_registered("atm-herdr-server.service"))
+
+    def test_windows_account_mismatch_refuses_before_write(self) -> None:
+        platform_fake = HerdrEntryPlatformFake(self.root / "windows", "Windows")
+        platform_fake.account_is_current = False
+        manager = DAEMON_SWITCH.HerdrEntryManager(self.root / "windows-journal", platform_fake)
+        with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "another account"):
+            manager.install(self.default)
+        self.assertFalse(platform_fake.path_for("ATM Herdr Server").exists())
+
+    def test_doctor_ingestion_uses_only_native_projection(self) -> None:
+        payload = {"herdr": {"configured": True, "endpoints": [{"endpoint": "default"}, {"session": "blue"}]}}
+        with mock.patch.object(DAEMON_SWITCH, "doctor", return_value=payload):
+            endpoints = DAEMON_SWITCH.herdr_entry_endpoints(Path("/selected/atm"), install=True)
+        self.assertEqual([endpoint.name for endpoint in endpoints], ["default", "blue"])
+        with mock.patch.object(DAEMON_SWITCH, "doctor", return_value={"herdr": {"configured": False, "endpoints": []}}):
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "not configured"):
+                DAEMON_SWITCH.herdr_entry_endpoints(Path("/selected/atm"), install=True)
+
+    def test_entry_result_is_exactly_one_json_object(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            DAEMON_SWITCH.herdr_entry_result(True, "HERDR_ENTRY_STATUS_OK", "ok", "none", [])
+        self.assertEqual(json.loads(output.getvalue()), {"ok": True, "code": "HERDR_ENTRY_STATUS_OK", "message": "ok", "remedy": "none", "entries": []})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1618,6 +1618,16 @@ class HerdrEntryTests(unittest.TestCase):
         self.assertTrue(all(entry["owned"] and entry["registered"] and entry["digest_matches"] for entry in entries))
         self.assertFalse(self.manager.journal_path.exists())
 
+    def test_each_platform_fake_supports_install_status_remove(self) -> None:
+        for name in ("Darwin", "Linux", "Windows"):
+            with self.subTest(platform=name):
+                platform_fake = HerdrEntryPlatformFake(self.root / name, name)
+                manager = DAEMON_SWITCH.HerdrEntryManager(self.root / f"{name}-journal", platform_fake)
+                installed = manager.install(self.default)
+                self.assertTrue(installed["owned"] and installed["registered"])
+                removed = manager.remove(self.default)
+                self.assertFalse(removed["owned"] or removed["registered"])
+
     def test_foreign_digest_and_socket_path_refuse_without_mutation(self) -> None:
         path = self.platform.path_for(DAEMON_SWITCH.identifier("Linux", "default"))
         path.parent.mkdir(parents=True)
@@ -1665,11 +1675,32 @@ class HerdrEntryTests(unittest.TestCase):
             with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "not configured"):
                 DAEMON_SWITCH.herdr_entry_endpoints(Path("/selected/atm"), install=True)
 
+    def test_doctor_ingestion_rejects_null_missing_malformed_and_error(self) -> None:
+        invalid_payloads = [
+            {"herdr": {"configured": None, "endpoints": []}},
+            {"herdr": {"configured": True}},
+            {"herdr": {"configured": True, "endpoints": ["not-an-object"]}},
+            {"error": "doctor failed"},
+        ]
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload), mock.patch.object(DAEMON_SWITCH, "doctor", return_value=payload):
+                with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "doctor"):
+                    DAEMON_SWITCH.herdr_entry_endpoints(Path("/selected/atm"), install=True)
+
     def test_entry_result_is_exactly_one_json_object(self) -> None:
         output = io.StringIO()
         with redirect_stdout(output):
             DAEMON_SWITCH.herdr_entry_result(True, "HERDR_ENTRY_STATUS_OK", "ok", "none", [])
         self.assertEqual(json.loads(output.getvalue()), {"ok": True, "code": "HERDR_ENTRY_STATUS_OK", "message": "ok", "remedy": "none", "entries": []})
+
+    def test_ordinary_switch_lifecycle_has_no_implicit_entry_invocation(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        switch_block = source.split('elif args.command == "switch":', 1)[1].split('elif args.command == "restore":', 1)[0]
+        restore_block = source.split('elif args.command == "restore":', 1)[1].split('elif args.command == "restart":', 1)[0]
+        restart_block = source.split('elif args.command == "restart":', 1)[1].split('elif args.command == "temporary-launch":', 1)[0]
+        self.assertNotIn("run_herdr_entry", switch_block)
+        self.assertNotIn("run_herdr_entry", restore_block)
+        self.assertNotIn("run_herdr_entry", restart_block)
 
 
 if __name__ == "__main__":

--- a/.codex/AY5-task-list.md
+++ b/.codex/AY5-task-list.md
@@ -1,0 +1,9 @@
+# AY5 — Transactional Herdr entry control plane
+
+- [ ] Define REQ-P-DAEMON-SWITCH-002 and the ADR-053 entry-management addendum.
+- [ ] Add native `atm doctor --json` ingestion and validated endpoint model.
+- [ ] Implement deterministic identifiers, canonical platform definitions, marker/digest checks, and exactly-one-object JSON output.
+- [ ] Implement durable install/remove journals and fail-closed status repair using platform fakes.
+- [ ] Add macOS, Linux, and Windows fixture coverage for normal, foreign, mismatch, socket-path, account, interruption, repair, JSON, and exit cases.
+- [ ] Update the daemon-switch operator skill; prove no implicit switch/restart/restore/daemon invocation.
+- [ ] Run required AY5 gates, push, open the stacked draft PR, report final SHA, and merge-forward the successor worktree.

--- a/.codex/AY5-task-list.md
+++ b/.codex/AY5-task-list.md
@@ -1,9 +1,9 @@
 # AY5 — Transactional Herdr entry control plane
 
-- [ ] Define REQ-P-DAEMON-SWITCH-002 and the ADR-053 entry-management addendum.
-- [ ] Add native `atm doctor --json` ingestion and validated endpoint model.
-- [ ] Implement deterministic identifiers, canonical platform definitions, marker/digest checks, and exactly-one-object JSON output.
-- [ ] Implement durable install/remove journals and fail-closed status repair using platform fakes.
-- [ ] Add macOS, Linux, and Windows fixture coverage for normal, foreign, mismatch, socket-path, account, interruption, repair, JSON, and exit cases.
-- [ ] Update the daemon-switch operator skill; prove no implicit switch/restart/restore/daemon invocation.
-- [ ] Run required AY5 gates, push, open the stacked draft PR, report final SHA, and merge-forward the successor worktree.
+- [x] Define REQ-P-DAEMON-SWITCH-002 and the ADR-053 entry-management addendum (`2017b1291`).
+- [x] Add native `atm doctor --json` ingestion and validated endpoint model (`080455a18`).
+- [x] Implement deterministic identifiers, canonical platform definitions, marker/digest checks, and exactly-one-object JSON output (`080455a18`).
+- [x] Implement durable install/remove journals and fail-closed status repair using platform fakes (`080455a18`).
+- [x] Add macOS, Linux, and Windows fixture coverage for normal, foreign, mismatch, socket-path, account, interruption, repair, JSON, and exit cases (`d7230851f`, `151f2ec97`).
+- [x] Update the daemon-switch operator skill; prove no implicit switch/restart/restore/daemon invocation (`2017b1291`, `151f2ec97`).
+- [x] Run required AY5 gates, push, open the stacked draft PR, report final SHA, and merge-forward the successor worktree (`151f2ec97`, PR #1282).

--- a/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
+++ b/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
@@ -160,3 +160,29 @@ Effect:
 - `REQ-P-DAEMON-SWITCH-001` is narrowed to match.  The Windows argv codec
   remains in the codebase only as a tested utility; it carries no service
   contract.
+
+## Addendum 2026-09-07 — explicit Herdr entry control plane
+
+`daemon-switch herdr-entry {install,remove,status [--repair]}` is a separate,
+operator-invoked transaction for per-user Herdr start-at-login definitions. It
+does not alter the selected ATM pair, the temporary-launch overlay journal, or
+the daemon lifecycle. No switch, restart, restore, or daemon startup path
+calls it implicitly.
+
+The command consumes only native `atm doctor --json` endpoint data. It creates
+at most one marker-bearing object per configured non-socket endpoint: a macOS
+LaunchAgent (`RunAtLoad`, no `KeepAlive`), Linux systemd user unit plus enabled
+state, or Windows interactive-user logon scheduled task. The default command
+is `herdr server`; a named session is `herdr --session <name> server`.
+Explicit socket-path endpoints remain externally owned. Windows refuses an
+entry belonging to another account, service, or session 0.
+
+Each entry has its own durable journal in the ADR-053 journal directory,
+separate from temporary-launch recovery state. Install is `plan -> journal ->
+atomic write -> native register -> verify -> complete`; remove verifies the
+marker and digest before `journal -> unregister -> delete -> verify ->
+complete`. Foreign definitions, digest mismatches, and incomplete work fail
+closed. Repair is explicit: it completes a verified registration or rolls back
+only the marker-bearing partial object. The public machine contract is exactly
+one JSON envelope on stdout and exit 0 (success), 3 (safe refusal), or 4
+(operational failure).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -365,6 +365,31 @@ Satisfied by:
   ADR-047, ADR-052, `REQ-P-BENCHMARK-001`, and
   `REQ-CORE-TRANSPORT-002B1`.
 
+  Herdr entry-management addendum (AY.5): the same operator control plane
+  additionally exposes exactly `herdr-entry install`, `remove`, and `status
+  [--repair]`. This is an explicit, independent transaction; ordinary
+  `switch`, `restart`, `restore`, and daemon startup never invoke it. The
+  command reads Herdr configuration and its ordered endpoint list only from
+  native `atm doctor --json`: `configured: true` is required for install,
+  `false` is a safe refusal, and null, missing, malformed, or nonzero doctor
+  output is `HERDR_DOCTOR_UNREADABLE` (exit 4), never a Python fallback.
+  Default and named sessions receive deterministic per-user native entry
+  identifiers; an endpoint configured with explicit socket-path provenance is
+  externally owned and is refused. Every owned object carries
+  `managed-by=atm daemon-switch` and a canonical-render digest.
+
+  Install journals `planned -> written -> registered -> verified` durably
+  before each mutation, atomically writes the owned object, registers it with
+  the native per-user manager, verifies marker/digest/registration, then
+  completes the journal. Remove verifies ownership first and unregisters then
+  deletes only a marker-bearing, digest-matching object. An incomplete journal
+  blocks install/remove; `status --repair` either completes verified
+  registration or unregisters and removes the marker-bearing partial object.
+  Foreign collisions, digest mismatch, Windows account/session mismatch, and
+  ambiguity fail closed without overwrite or deletion. Every result is exactly
+  one stdout JSON object with `ok`, `code`, `message`, `remedy`, and `entries`;
+  success exits 0, safe refusals exit 3, and operational failures exit 4.
+
 - `REQ-P-DAEMON-DISPATCHER-001` Request work accepted by the daemon must remain
   tracked by runtime-owned drain accounting until it finishes or is cancelled.
   Detached untracked request execution is forbidden even when the transport


### PR DESCRIPTION
Implements explicit, journaled Herdr entry install/remove/status/repair using native doctor JSON and platform fakes.\n\nLocal gates: daemon-switch suite, spell, ADR index, fmt, clippy, boundaries, and just validate.