### PR TITLE
fix(graft): nudge carries the rendered template only (REQ-CORE-GRAFT-001)

### DIFF
--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.5.3
+PackageVersion: 1.5.4
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.3/atm_1.5.3_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.4/atm_1.5.4_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.5.3
+ManifestVersion: 1.5.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-herdr",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "atm-herdr"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "serde_json",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "atm-observability"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "sc-observability",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -405,14 +405,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "peer-tls"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "atm-storage",
  "rcgen",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1964,7 +1964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sc-lint-attributes",
- "sc-lint-directives 1.5.3",
+ "sc-lint-directives 1.5.4",
  "serde",
  "serde_json",
  "syn 2.0.119",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]
@@ -63,17 +63,17 @@ getrandom = "0.3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 semver = { version = "1", features = ["serde"] }
 async-trait = "0.1"
-atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.3" }
-atm-observability = { path = "crates/atm-observability", version = "1.5.3" }
-atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.3" }
-atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.3" }
-atm-error = { path = "crates/atm-error", version = "1.5.3" }
-atm-graft = { path = "crates/atm-graft", version = "1.5.3" }
-atm-herdr = { path = "crates/atm-herdr", version = "1.5.3" }
-atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.3" }
-atm-runtime = { path = "crates/atm-runtime", version = "1.5.3" }
+atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.4" }
+atm-observability = { path = "crates/atm-observability", version = "1.5.4" }
+atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.4" }
+atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.4" }
+atm-error = { path = "crates/atm-error", version = "1.5.4" }
+atm-graft = { path = "crates/atm-graft", version = "1.5.4" }
+atm-herdr = { path = "crates/atm-herdr", version = "1.5.4" }
+atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.4" }
+atm-runtime = { path = "crates/atm-runtime", version = "1.5.4" }
 atm-runtime-test-support = { path = "crates/atm-runtime-test-support" }
-atm-storage = { path = "crates/atm-storage", version = "1.5.3" }
-atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.3" }
-atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.3" }
-peer-tls = { path = "crates/peer-tls", version = "1.5.3" }
+atm-storage = { path = "crates/atm-storage", version = "1.5.4" }
+atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.4" }
+atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.4" }
+peer-tls = { path = "crates/peer-tls", version = "1.5.4" }

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -204,12 +204,6 @@ pub struct GraftNudgeTarget {
     pub recipient_team: TeamName,
     /// Canonical database-resolved `<atm …>` nudge text for the receiver.
     pub rendered_nudge: String,
-    /// Immutable body of the message that triggered this nudge.
-    ///
-    /// Unlike `description`, this preserves the complete admitted content so
-    /// an embedded host never needs to perform a follow-up mailbox read just
-    /// to inject the message it was notified about.
-    pub message_body: String,
 }
 
 /// Target for a bare-CLI queue handoff into the daemon-owned RAM FIFO.

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -48,8 +48,6 @@ pub struct GraftPostSendRequest {
     /// Canonical database-resolved `<atm …>` nudge text. The receiver must
     /// inject this text, never substitute the stored message description.
     pub rendered_nudge: String,
-    /// Immutable message content associated with `rendered_nudge`.
-    pub message_body: String,
 }
 
 const fn default_graft_kind() -> NudgeKind {
@@ -96,7 +94,6 @@ where
         recipient,
         recipient_team,
         rendered_nudge,
-        message_body,
     }) = &dispatch.target
     else {
         return Err(AtmError::validation(
@@ -130,7 +127,6 @@ where
             event: dispatch.event.clone(),
             kind: dispatch.kind,
             rendered_nudge: rendered_nudge.clone(),
-            message_body: message_body.clone(),
         },
         deadline,
     );
@@ -742,7 +738,6 @@ mod tests {
             event: test_event(),
             kind: NudgeKind::Steer,
             rendered_nudge: "<atm>test nudge</atm>".to_string(),
-            message_body: "full immutable body".to_string(),
         };
         let endpoint = listener.local_addr().expect("local addr");
         let capability = listener.capability().clone();
@@ -768,7 +763,6 @@ mod tests {
             .read_request(&mut stream, Duration::from_secs(3))
             .expect("read request");
         assert_eq!(received.rendered_nudge, "<atm>test nudge</atm>");
-        assert_eq!(received.message_body, "full immutable body");
         assert_eq!(received.event.description, "loopback graft transport");
         assert_eq!(received.kind, NudgeKind::Steer);
         listener
@@ -786,8 +780,7 @@ mod tests {
             "capability_base64url": "capability",
             "request": {
                 "event": event,
-                "rendered_nudge": "<atm>legacy</atm>",
-                "message_body": "legacy body"
+                "rendered_nudge": "<atm>legacy</atm>"
             }
         });
         let decoded: GraftPostSendWireRequest =
@@ -801,7 +794,6 @@ mod tests {
             event: test_event(),
             kind: NudgeKind::Queue,
             rendered_nudge: "<atm>queued</atm>".to_owned(),
-            message_body: "queued body".to_owned(),
         };
         let wire = GraftPostSendWireRequest {
             capability_base64url: "capability".to_owned(),
@@ -833,7 +825,6 @@ mod tests {
                     event: test_event(),
                     kind: NudgeKind::Steer,
                     rendered_nudge: "<atm>test nudge</atm>".to_string(),
-                    message_body: "full immutable body".to_string(),
                 },
             };
             super::write_graft_post_send_message(&mut stream, &wire, "write", "oversized")
@@ -932,7 +923,6 @@ mod tests {
                 recipient: event.recipient.clone(),
                 recipient_team: event.recipient_team.clone(),
                 rendered_nudge: "<atm>test nudge</atm>".to_string(),
-                message_body: "full immutable body".to_string(),
             }),
             event,
             kind: NudgeKind::Steer,
@@ -1103,6 +1093,59 @@ mod tests {
                 RequestDeadline::after(Duration::from_secs(3)),
             )
         })
+    }
+
+    fn deliver_through_listener_capturing_request(
+        runtime: &GraftLeaseTestRuntime,
+        listener: &GraftReceiverListener,
+    ) -> (Result<PostSendEmissionPath, AtmError>, GraftPostSendRequest) {
+        std::thread::scope(|scope| {
+            let receiver = scope.spawn(|| {
+                let mut stream = loop {
+                    if let Some(stream) = listener.poll_accept().expect("poll accept") {
+                        break stream;
+                    }
+                    std::thread::yield_now();
+                };
+                let request = listener
+                    .read_request(&mut stream, Duration::from_secs(3))
+                    .expect("read request");
+                listener
+                    .write_response(&mut stream, &GraftPostSendResponse::Delivered)
+                    .expect("write response");
+                request
+            });
+            let outcome = deliver_published_receiver_hook(
+                runtime,
+                &dispatch_for(test_event()),
+                RequestDeadline::after(Duration::from_secs(3)),
+            );
+            (outcome, receiver.join().expect("receiver thread"))
+        })
+    }
+
+    #[test]
+    fn graft_emitter_serializes_only_event_kind_and_rendered_nudge() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let team = TeamName::from_validated(TEST_TEAM);
+        let agent = AgentName::from_validated(TEST_QA);
+        let listener = bind_listener(tempdir.path(), &team, &agent, None).expect("bind listener");
+        let runtime = GraftLeaseTestRuntime::with_lease(Some(lease_for(&listener)));
+
+        let (outcome, request) = deliver_through_listener_capturing_request(&runtime, &listener);
+        assert_eq!(
+            outcome.expect("graft emitter delivery"),
+            PostSendEmissionPath::GraftPort
+        );
+        let serialized = serde_json::to_value(&request).expect("serialize graft request");
+        let object = serialized.as_object().expect("request object");
+        let mut keys = object.keys().map(String::as_str).collect::<Vec<_>>();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["event", "kind", "rendered_nudge"]
+        );
+        assert!(!serialized.to_string().contains("full immutable body"));
     }
 
     // AC1 (PR #1048): delivery through a registered lease succeeds via the

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -1141,10 +1141,7 @@ mod tests {
         let object = serialized.as_object().expect("request object");
         let mut keys = object.keys().map(String::as_str).collect::<Vec<_>>();
         keys.sort_unstable();
-        assert_eq!(
-            keys,
-            vec!["event", "kind", "rendered_nudge"]
-        );
+        assert_eq!(keys, vec!["event", "kind", "rendered_nudge"]);
         assert!(!serialized.to_string().contains("full immutable body"));
     }
 

--- a/crates/atm-core/src/nudge_dispatch.rs
+++ b/crates/atm-core/src/nudge_dispatch.rs
@@ -16,7 +16,7 @@ use crate::delivery_policy::DeliveryPolicyCoordinator;
 use crate::error::AtmError;
 use crate::schema::{AtmMessageId, authenticated_source_host};
 use crate::send::NudgeMode;
-use crate::send::hook::build_built_in_dispatch;
+use crate::send::hook::{build_bare_cli_dispatch, build_built_in_dispatch};
 use crate::service_runtime::LocalServiceRuntime;
 use atm_storage::TaskRow;
 
@@ -147,13 +147,14 @@ pub fn rebuild_received_hook_dispatch(
         NudgeKind::Queue => NudgeMode::Deferred,
     };
 
-    build_built_in_dispatch(
-        runtime,
-        &delivery_snapshot,
-        &event,
-        &message.envelope.text,
-        nudge_mode,
-    )
+    if delivery_snapshot.bare_cli_post_send {
+        return Ok(Some(build_bare_cli_dispatch(
+            &event,
+            &message.envelope.text,
+            nudge_mode,
+        )));
+    }
+    build_built_in_dispatch(runtime, &delivery_snapshot, &event, nudge_mode)
 }
 
 /// Builds a deferred Task reminder without requiring the assignment message
@@ -196,11 +197,5 @@ pub fn build_task_reminder_dispatch(
         task_id: Some(row.task_id.clone()),
         recipient_pane_id: delivery_snapshot.recipient_pane_id.clone(),
     };
-    build_built_in_dispatch(
-        runtime,
-        &delivery_snapshot,
-        &event,
-        &row.description,
-        NudgeMode::Deferred,
-    )
+    build_built_in_dispatch(runtime, &delivery_snapshot, &event, NudgeMode::Deferred)
 }

--- a/crates/atm-core/src/nudge_dispatch.rs
+++ b/crates/atm-core/src/nudge_dispatch.rs
@@ -16,7 +16,7 @@ use crate::delivery_policy::DeliveryPolicyCoordinator;
 use crate::error::AtmError;
 use crate::schema::{AtmMessageId, authenticated_source_host};
 use crate::send::NudgeMode;
-use crate::send::hook::{build_bare_cli_dispatch, build_built_in_dispatch};
+use crate::send::hook::build_built_in_dispatch;
 use crate::service_runtime::LocalServiceRuntime;
 use atm_storage::TaskRow;
 
@@ -147,13 +147,6 @@ pub fn rebuild_received_hook_dispatch(
         NudgeKind::Queue => NudgeMode::Deferred,
     };
 
-    if delivery_snapshot.bare_cli_post_send {
-        return Ok(Some(build_bare_cli_dispatch(
-            &event,
-            &message.envelope.text,
-            nudge_mode,
-        )));
-    }
     build_built_in_dispatch(runtime, &delivery_snapshot, &event, nudge_mode)
 }
 

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -20,7 +20,6 @@ pub(crate) fn build_built_in_dispatch<R>(
     runtime: &R,
     delivery_snapshot: &DeliveryRecipientSnapshot,
     event: &PostSendHookEvent,
-    message_body: &str,
     nudge_mode: NudgeMode,
 ) -> Result<Option<BuiltInPostSendDispatch>, AtmError>
 where
@@ -72,25 +71,33 @@ where
                 recipient: event.recipient.clone(),
                 recipient_team: event.recipient_team.clone(),
                 rendered_nudge,
-                message_body: message_body.to_owned(),
-            }),
-            kind,
-        }));
-    }
-    if delivery_snapshot.bare_cli_post_send {
-        return Ok(Some(BuiltInPostSendDispatch {
-            event: event.clone(),
-            target: PostSendBuiltInTarget::QueuePull(QueuePullTarget {
-                team: event.recipient_team.clone(),
-                agent: event.recipient.clone(),
-                kind,
-                msg_id: event.message_id,
-                body: message_body.to_owned(),
             }),
             kind,
         }));
     }
     Ok(None)
+}
+
+/// Builds the retained bare-CLI queue handoff. This path intentionally keeps
+/// the admitted message body because its governed queue-pull contract has not
+/// yet moved to rendered-template delivery.
+pub(crate) fn build_bare_cli_dispatch(
+    event: &PostSendHookEvent,
+    body: &str,
+    nudge_mode: NudgeMode,
+) -> BuiltInPostSendDispatch {
+    let kind = nudge_kind_for_mode(nudge_mode);
+    BuiltInPostSendDispatch {
+        event: event.clone(),
+        target: PostSendBuiltInTarget::QueuePull(QueuePullTarget {
+            team: event.recipient_team.clone(),
+            agent: event.recipient.clone(),
+            kind,
+            msg_id: event.message_id,
+            body: body.to_owned(),
+        }),
+        kind,
+    }
 }
 
 /// Maps the write-time delivery mode to the dispatch's `NudgeKind`.

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -75,29 +75,23 @@ where
             kind,
         }));
     }
-    Ok(None)
-}
-
-/// Builds the retained bare-CLI queue handoff. This path intentionally keeps
-/// the admitted message body because its governed queue-pull contract has not
-/// yet moved to rendered-template delivery.
-pub(crate) fn build_bare_cli_dispatch(
-    event: &PostSendHookEvent,
-    body: &str,
-    nudge_mode: NudgeMode,
-) -> BuiltInPostSendDispatch {
-    let kind = nudge_kind_for_mode(nudge_mode);
-    BuiltInPostSendDispatch {
-        event: event.clone(),
-        target: PostSendBuiltInTarget::QueuePull(QueuePullTarget {
-            team: event.recipient_team.clone(),
-            agent: event.recipient.clone(),
+    if delivery_snapshot.bare_cli_post_send {
+        let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
+            return Ok(None);
+        };
+        return Ok(Some(BuiltInPostSendDispatch {
+            event: event.clone(),
+            target: PostSendBuiltInTarget::QueuePull(QueuePullTarget {
+                team: event.recipient_team.clone(),
+                agent: event.recipient.clone(),
+                kind,
+                msg_id: event.message_id,
+                body: rendered_nudge,
+            }),
             kind,
-            msg_id: event.message_id,
-            body: body.to_owned(),
-        }),
-        kind,
+        }));
     }
+    Ok(None)
 }
 
 /// Maps the write-time delivery mode to the dispatch's `NudgeKind`.

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -357,7 +357,6 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
         &runtime,
         &tmux_snapshot,
         &event,
-        "message body",
         crate::send::NudgeMode::Immediate,
     )
     .expect("tmux dispatch result")
@@ -369,7 +368,6 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
         &runtime,
         &herdr_snapshot,
         &event,
-        "message body",
         crate::send::NudgeMode::Immediate,
     )
     .expect("Herdr dispatch result")

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -386,6 +386,21 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
     else {
         panic!("expected Herdr target");
     };
+    let mut bare_cli_snapshot = delivery_snapshot(DeliveryHarnessPath::NonClaude);
+    bare_cli_snapshot.bare_cli_post_send = true;
+    let bare_cli = super::hook::build_built_in_dispatch(
+        &runtime,
+        &bare_cli_snapshot,
+        &event,
+        crate::send::NudgeMode::Immediate,
+    )
+    .expect("bare-CLI dispatch result")
+    .expect("bare-CLI dispatch");
+    let PostSendBuiltInTarget::QueuePull(target) = bare_cli.target else {
+        panic!("expected bare-CLI queue-pull target");
+    };
+    assert_eq!(target.body, tmux_text);
+    assert!(!target.body.contains("rendered description"));
     assert_eq!(tmux_text, herdr_text);
 }
 

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -400,7 +400,7 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
         panic!("expected bare-CLI queue-pull target");
     };
     assert_eq!(target.body, tmux_text);
-    assert!(!target.body.contains("rendered description"));
+    assert!(!target.body.contains("full immutable body"));
     assert_eq!(tmux_text, herdr_text);
 }
 

--- a/crates/atm-core/src/write/pipeline.rs
+++ b/crates/atm-core/src/write/pipeline.rs
@@ -266,20 +266,12 @@ impl PreparedWrite {
                 message,
                 post_write.delivery_snapshot.recipient_pane_id.as_ref(),
             )?;
-            let dispatch = if post_write.delivery_snapshot.bare_cli_post_send {
-                Some(crate::send::hook::build_bare_cli_dispatch(
-                    &event,
-                    &message.envelope.text,
-                    self.outbound_request.nudge_mode,
-                ))
-            } else {
-                crate::send::hook::build_built_in_dispatch(
-                    runtime,
-                    &post_write.delivery_snapshot,
-                    &event,
-                    self.outbound_request.nudge_mode,
-                )?
-            };
+            let dispatch = crate::send::hook::build_built_in_dispatch(
+                runtime,
+                &post_write.delivery_snapshot,
+                &event,
+                self.outbound_request.nudge_mode,
+            )?;
             if let Some(dispatch) = dispatch {
                 dispatches.push(dispatch);
             }

--- a/crates/atm-core/src/write/pipeline.rs
+++ b/crates/atm-core/src/write/pipeline.rs
@@ -266,13 +266,21 @@ impl PreparedWrite {
                 message,
                 post_write.delivery_snapshot.recipient_pane_id.as_ref(),
             )?;
-            if let Some(dispatch) = crate::send::hook::build_built_in_dispatch(
-                runtime,
-                &post_write.delivery_snapshot,
-                &event,
-                &message.envelope.text,
-                self.outbound_request.nudge_mode,
-            )? {
+            let dispatch = if post_write.delivery_snapshot.bare_cli_post_send {
+                Some(crate::send::hook::build_bare_cli_dispatch(
+                    &event,
+                    &message.envelope.text,
+                    self.outbound_request.nudge_mode,
+                ))
+            } else {
+                crate::send::hook::build_built_in_dispatch(
+                    runtime,
+                    &post_write.delivery_snapshot,
+                    &event,
+                    self.outbound_request.nudge_mode,
+                )?
+            };
+            if let Some(dispatch) = dispatch {
                 dispatches.push(dispatch);
             }
         }

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -1155,7 +1155,7 @@ mod tests {
         assert_eq!(queue_pull.agent, recipient);
         assert_eq!(queue_pull.team, team);
         assert!(queue_pull.body.starts_with("<atm"));
-        assert!(!queue_pull.body.contains("immediate bare CLI body"));
+        assert!(!queue_pull.body.contains("full immutable body"));
 
         let fifo: atm_http_runtime::BareCliFifo = Default::default();
         let selector = ReplacementReceivedHookSelector::with_herdr_process_and_fifo(

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -823,7 +823,6 @@ mod tests {
             recipient: dispatch.event.recipient.clone(),
             recipient_team: dispatch.event.recipient_team.clone(),
             rendered_nudge: "<atm>queue</atm>".to_owned(),
-            message_body: "queue body".to_owned(),
         });
         assert!(selector.select_emitter(&dispatch).is_some());
     }

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -1001,7 +1001,7 @@ mod tests {
             agent: recipient.clone(),
             kind: NudgeKind::Queue,
             msg_id: message_id,
-            body: "bare CLI body".to_owned(),
+            body: "<atm><action>queue</action></atm>".to_owned(),
         });
         let fifo: atm_http_runtime::BareCliFifo = Default::default();
         let drops: atm_http_runtime::BareCliQueueFullDrops = Default::default();
@@ -1024,6 +1024,7 @@ mod tests {
             atm_http_runtime::drain_bare_cli_messages(&fifo, &member).expect("drain FIFO");
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].msg_id, message_id);
+        assert_eq!(drained[0].body, "<atm><action>queue</action></atm>");
         assert!(
             runtime
                 .pending_nudge_store()
@@ -1050,8 +1051,14 @@ mod tests {
         );
 
         for (message_id, body) in [
-            ("01KZ0000000000000000000001", "steer one"),
-            ("01KZ0000000000000000000002", "steer two"),
+            (
+                "01KZ0000000000000000000001",
+                "<atm><action>steer-one</action></atm>",
+            ),
+            (
+                "01KZ0000000000000000000002",
+                "<atm><action>steer-two</action></atm>",
+            ),
         ] {
             let mut dispatch = tmux_dispatch();
             dispatch.kind = NudgeKind::Steer;
@@ -1073,8 +1080,8 @@ mod tests {
         let drained =
             atm_http_runtime::drain_bare_cli_messages(&fifo, &member).expect("drain steer FIFO");
         assert_eq!(drained.len(), 2, "all steer-kind items drain together");
-        assert_eq!(drained[0].body, "steer one");
-        assert_eq!(drained[1].body, "steer two");
+        assert_eq!(drained[0].body, "<atm><action>steer-one</action></atm>");
+        assert_eq!(drained[1].body, "<atm><action>steer-two</action></atm>");
         assert!(
             drained
                 .iter()
@@ -1147,6 +1154,8 @@ mod tests {
         };
         assert_eq!(queue_pull.agent, recipient);
         assert_eq!(queue_pull.team, team);
+        assert!(queue_pull.body.starts_with("<atm"));
+        assert!(!queue_pull.body.contains("immediate bare CLI body"));
 
         let fifo: atm_http_runtime::BareCliFifo = Default::default();
         let selector = ReplacementReceivedHookSelector::with_herdr_process_and_fifo(
@@ -1208,7 +1217,7 @@ mod tests {
             agent: recipient.clone(),
             kind: NudgeKind::Queue,
             msg_id: message_id,
-            body: "bare CLI body".to_owned(),
+            body: "<atm><action>queue</action></atm>".to_owned(),
         });
         let fifo: atm_http_runtime::BareCliFifo = Default::default();
         let drops: atm_http_runtime::BareCliQueueFullDrops = Default::default();
@@ -1237,6 +1246,7 @@ mod tests {
             "the FIFO append succeeded and must still be observable"
         );
         assert_eq!(drained[0].msg_id, message_id);
+        assert_eq!(drained[0].body, "<atm><action>queue</action></atm>");
         assert_eq!(
             failing_store.clear_calls.load(Ordering::SeqCst),
             2,

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -68,7 +68,6 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
             recipient,
             recipient_team,
             rendered_nudge,
-            message_body,
         }) = &dispatch.target
         else {
             return Err(AtmError::validation(
@@ -81,10 +80,9 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
                 "graft receive hook received an event for a different recipient",
             ));
         }
-        // The agent loop receives the canonical `<atm …>` payload followed by
-        // the exact immutable message body admitted with that event. Telegram's
-        // visible notice remains a separate plain-text rendering so it shows
-        // sender and subject without masquerading as a dispatch.
+        // The agent loop receives only the canonical `<atm …>` payload.
+        // Telegram's visible notice remains a separate plain-text rendering so
+        // it shows sender and subject without masquerading as a dispatch.
         let notice_text = format!(
             "📬 from {}\n{}",
             dispatch.event.source_address(),
@@ -93,7 +91,7 @@ impl MessageReceivedHookEmitter for GraftReceiveHook<'_> {
         self.deliver(HostNudge {
             event: dispatch.event.clone(),
             kind: dispatch.kind,
-            body: format!("{rendered_nudge}\n\n{message_body}"),
+            body: rendered_nudge.clone(),
             notice_text,
         })?;
         Ok(PostSendEmissionPath::GraftPort)
@@ -191,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn graft_nudge_sink_injects_rendered_xml_and_full_message_body() {
+    fn graft_nudge_sink_injects_only_the_rendered_template() {
         let injector = RecordingInjector::default();
         let sink = GraftReceiveHook {
             injector: &injector,
@@ -205,7 +203,6 @@ mod tests {
                 recipient: TEST_ARCH_CTM.parse().expect("recipient"),
                 recipient_team: TEST_TEAM.parse().expect("team"),
                 rendered_nudge: "<atm><action>read atm</action></atm>".to_string(),
-                message_body: "full immutable body".to_string(),
             }),
             kind: NudgeKind::Steer,
         };
@@ -218,10 +215,8 @@ mod tests {
 
         let nudges = injector.nudges.lock().expect("nudges");
         assert_eq!(nudges.len(), 1);
-        assert_eq!(
-            nudges[0].body,
-            "<atm><action>read atm</action></atm>\n\nfull immutable body"
-        );
+        assert_eq!(nudges[0].body, "<atm><action>read atm</action></atm>");
+        assert!(!nudges[0].body.contains("full immutable body"));
         assert_eq!(
             nudges[0].notice_text,
             "📬 from test-lead@test-team\nreview failing smoke lane"

--- a/crates/atm-graft/src/runtime/mod.rs
+++ b/crates/atm-graft/src/runtime/mod.rs
@@ -768,13 +768,11 @@ fn handle_graft_receiver_connection(
     let event = request.event;
     let kind = request.kind;
     let rendered_nudge = request.rendered_nudge;
-    let message_body = request.message_body;
     let dispatch = BuiltInPostSendDispatch {
         target: PostSendBuiltInTarget::Graft(GraftNudgeTarget {
             recipient: event.recipient.clone(),
             recipient_team: event.recipient_team.clone(),
             rendered_nudge,
-            message_body,
         }),
         event,
         kind,
@@ -962,7 +960,6 @@ mod tests {
                 event,
                 kind: NudgeKind::Steer,
                 rendered_nudge: "<atm>test nudge</atm>".to_string(),
-                message_body: "full immutable body".to_string(),
             },
             DELIVER_CONNECT_DEADLINE,
             DELIVER_IO_DEADLINE,

--- a/crates/atm-graft/src/runtime/mod.rs
+++ b/crates/atm-graft/src/runtime/mod.rs
@@ -1263,10 +1263,7 @@ mod tests {
         }
         let nudges = injector.nudges.lock().expect("nudges lock");
         assert_eq!(nudges.len(), 100);
-        assert_eq!(
-            nudges[0].body,
-            "<atm>test nudge</atm>\n\nfull immutable body"
-        );
+        assert_eq!(nudges[0].body, "<atm>test nudge</atm>");
         assert_eq!(
             read_snapshot(&snapshot).expect("snapshot").state,
             GraftSessionState::Listening

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -1924,7 +1924,6 @@ mod tests {
                 recipient: "recipient".parse().expect("recipient"),
                 recipient_team: "test-team".parse().expect("team"),
                 rendered_nudge: "<atm kind=\"nudge\"/>".to_owned(),
-                message_body: "message body".to_owned(),
             }),
             kind: NudgeKind::Steer,
         };
@@ -5280,7 +5279,6 @@ mod tests {
                 recipient: "recipient".parse().expect("recipient"),
                 recipient_team: "test-team".parse().expect("team"),
                 rendered_nudge: "<atm kind=\"nudge\"/>".to_owned(),
-                message_body: "message body".to_owned(),
             }),
             kind: NudgeKind::Steer,
         };

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -2175,7 +2175,7 @@ mod tests {
             QueuedNudgeMessage {
                 kind: NudgeKind::Queue,
                 msg_id: AtmMessageId::new(),
-                body: "queued through the real handler".to_owned(),
+                body: "<atm><action>queue</action></atm>".to_owned(),
             },
         )
         .expect("seed FIFO");
@@ -2196,7 +2196,10 @@ mod tests {
             panic!("expected a QueueGetNext response");
         };
         assert_eq!(response.messages.len(), 1);
-        assert_eq!(response.messages[0].body, "queued through the real handler");
+        assert_eq!(
+            response.messages[0].body,
+            "<atm><action>queue</action></atm>"
+        );
     }
 
     /// AC6 migration case: a stale FIFO entry from an earlier bare-CLI
@@ -2220,7 +2223,7 @@ mod tests {
             QueuedNudgeMessage {
                 kind: NudgeKind::Queue,
                 msg_id: AtmMessageId::new(),
-                body: "queued before the migration".to_owned(),
+                body: "<atm><action>queued-before-migration</action></atm>".to_owned(),
             },
         )
         .expect("seed stale FIFO entry");
@@ -2278,7 +2281,10 @@ mod tests {
             1,
             "the stale FIFO entry still drains after the member's classification inputs changed"
         );
-        assert_eq!(response.messages[0].body, "queued before the migration");
+        assert_eq!(
+            response.messages[0].body,
+            "<atm><action>queued-before-migration</action></atm>"
+        );
     }
 
     #[tokio::test]

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-query"
-version = "1.5.3"
+version = "1.5.4"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -178,8 +178,6 @@ impl GraftNudgeSink {
             event: event.clone(),
             kind: atm_core::boundary::NudgeKind::Steer,
             rendered_nudge: rendered_nudge.to_string(),
-            // This legacy diagnostic command has no admitted message body.
-            message_body: String::new(),
         };
         let response = deliver_graft_post_send(
             lease.endpoint,

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.5.3"
+version = "1.5.4"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
## Summary

Fixes #1281

Both graft and bare-CLI QueuePull post-send paths now carry only the canonical rendered nudge template. Neither receiver path transports an additional admitted message-body payload, preserving REQ-CORE-GRAFT-001, REQ-CORE-COMPAT-003, ADR-043, and the one-emitter rule.

## Changes

- Removed message_body from GraftNudgeTarget and GraftPostSendRequest.
- Removed the message-text parameter from the built-in dispatch helper.
- Bare-CLI QueuePull now renders the built-in template for its dispatch kind and stores that rendered XML in QueuePullTarget.body and QueuedNudgeMessage.body.
- Added graft emitter and bare-CLI dispatch regressions asserting template-only payloads.
- Updated graft sink, queue selector, FIFO, and HTTP queue-get fixtures/assertions.

## QueueGetNext body semantics

QueueGetNextResponse.body for bare-CLI harness consumers now contains the rendered nudge XML, not admitted message text. Consumers must use the nudge message ID and run atm read to retrieve the mailbox message. This is the intentional semantics change required by the same defect.

## Wire compatibility and rollout

The 1.5.3 graft receiver expects message_body, so this fix ships as a paired 1.5.4 daemon and wheel release. Gateways must restart after the wheel is installed. No serde shim or default empty body is used.

## Validation

All required validation passes: cargo fmt, workspace clippy with warnings denied, focused package tests, full workspace tests, function-length, boundary lint, and line-count checks.