### PR TITLE
feat(daemon-switch): coordinate Herdr endpoint restart

### DIFF
--- a/.claude/skills/daemon-switch/SKILL.md
+++ b/.claude/skills/daemon-switch/SKILL.md
@@ -117,6 +117,40 @@ JSON result on stdout (exit 0 success, 3 refusal, 4 operational failure).
 On systems without Homebrew, provide `--default-cli` and `--default-daemon` to
 `restore`. Use `--dry-run` before the first switch on an unfamiliar host.
 
+## Explicit Herdr endpoint restart
+
+Herdr upgrades remain operator-owned. After the operator has installed a newer
+Herdr client, use this explicit, one-endpoint coordinator to resolve a
+client/server mismatch. It never runs `herdr update`, never restarts ATM, and
+never runs as part of pair switching or ordinary ATM restart.
+
+```sh
+# Read the privacy-safe native doctor projection first. The selected endpoint
+# must have an AY.5 owned, complete start-at-login entry.
+atm doctor --json
+
+# When exactly one endpoint is configured, omit ENDPOINT. A session must be
+# selected explicitly when several are configured.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py restart \
+  --restart-herdr [ENDPOINT]
+
+# Use this only after accepting that a stop exits the selected session's panes.
+# The coordinator relaunches exactly its already-owned native entry and proves
+# that a fresh doctor read reports `ok`.
+python3 .claude/skills/daemon-switch/scripts/daemon-switch.py restart \
+  --restart-herdr work --stop-herdr-panes
+```
+
+If `capabilities.live_handoff` is exactly true and doctor identifies a newer
+client than running server, the first command uses scoped live handoff and
+preserves panes. Otherwise it refuses with a pane-loss acknowledgement code.
+Socket-path endpoints are externally owned and must be restarted by their
+external owner. The 120-second overall and 30-second per-command limits are
+intentional; failures return one JSON object on stdout and leave ATM untouched.
+Ordinary `restart --yes` refuses while any doctor endpoint remains
+`client_server_mismatch`; restart those endpoints individually before
+restarting ATM.
+
 ## Self-signed development identity
 
 The signing resolver accepts the synced `atm-daemon-dev` self-signed identity

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -729,7 +729,14 @@ def restart(args: argparse.Namespace) -> None:
     pending = herdr_restart_pending_endpoints(cli)
     if pending:
         names = ", ".join(endpoint.name for endpoint in pending)
-        raise SwitchError(f"HERDR_RESTART_ENDPOINTS_PENDING: restart Herdr endpoints first: {names}")
+        error = HerdrEntryError(
+            "HERDR_RESTART_ENDPOINTS_PENDING",
+            f"restart Herdr endpoints first: {names}",
+            "Restart every listed Herdr endpoint first, then rerun the ordinary ATM restart",
+            3,
+        )
+        error.entries = _restart_entries(pending)
+        raise error
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
     run_service(args, "start")

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -1143,7 +1143,15 @@ def run_herdr_restart(args: argparse.Namespace) -> None:
             raise HerdrEntryError(code, "stopping Herdr terminates the selected endpoint panes", "Accept impact and pass --stop-herdr-panes", 3)
         print("warning: stopping Herdr exits panes for the selected endpoint", file=sys.stderr)
         _restart_command(scoped_herdr_command(selected, "stop"), deadline)
-        manager.start_owned(selected.entry)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise HerdrEntryError("HERDR_RESTART_TIMEOUT", "restart deadline expired before entry start", "Retry the explicit restart", 4)
+        try:
+            manager.start_owned(selected.entry, min(HERDR_RESTART_COMMAND_TIMEOUT, remaining))
+        except HerdrEntryError as error:
+            if isinstance(error.__cause__, subprocess.TimeoutExpired):
+                raise HerdrEntryError("HERDR_RESTART_TIMEOUT", "timed out running entry start", "Retry the explicit restart", 4) from error
+            raise HerdrEntryError("HERDR_RESTART_HERDR_FAILED", f"entry start failed: {error.message}", "Correct the owned entry and retry", 4) from error
     _verify_herdr_restart(cli, selected, deadline)
     herdr_entry_result(True, "HERDR_RESTARTED", "selected Herdr endpoint restarted and verified", "none", _restart_entries([selected]))
 

--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -90,6 +90,9 @@ from herdr_entry import (  # noqa: E402
 
 
 LIVE_PAIR_READINESS_ATTEMPTS = 200
+HERDR_RESTART_OVERALL_TIMEOUT = 120.0
+HERDR_RESTART_COMMAND_TIMEOUT = 30.0
+HERDR_RESTART_VERIFY_DELAYS = (0.0, 2.0, 4.0, 8.0, 8.0)
 MACOS_LAUNCH_AGENT_PATH = re.compile(r"^path = (.+)$")
 # [cass: helpful starter-rust-logging] - retains the bounded readiness state
 # as one named operational contract rather than an unexplained retry literal.
@@ -713,6 +716,9 @@ def restore_pair(args: argparse.Namespace) -> tuple[Path, Path]:
 
 
 def restart(args: argparse.Namespace) -> None:
+    if getattr(args, "restart_herdr", None) is not None:
+        run_herdr_restart(args)
+        return
     if not args.yes:
         raise SwitchError("restart changes the singleton daemon; re-run with --yes")
     require_no_active_temporary_launch_session()
@@ -720,6 +726,10 @@ def restart(args: argparse.Namespace) -> None:
     cli = require_executable(cli, "selected atm CLI")
     daemon = require_executable(daemon, "selected atm daemon")
     require_macos_development_signatures(cli, daemon)
+    pending = herdr_restart_pending_endpoints(cli)
+    if pending:
+        names = ", ".join(endpoint.name for endpoint in pending)
+        raise SwitchError(f"HERDR_RESTART_ENDPOINTS_PENDING: restart Herdr endpoints first: {names}")
     run_service(args, "stop", allow_absent=True)
     require_stopped_daemon(args, cli)
     run_service(args, "start")
@@ -933,9 +943,7 @@ def herdr_entry_endpoints(cli: Path, *, install: bool) -> list[HerdrEndpoint]:
     for value in values:
         if not isinstance(value, dict):
             raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor endpoint was malformed", "Fix native doctor and rerun", 4)
-        name = value.get("endpoint", value.get("session", "default"))
-        if name is None:
-            name = "default"
+        name = value.get("session") or value.get("endpoint") or "default"
         if not isinstance(name, str) or not name or not re.fullmatch(r"[A-Za-z0-9_.-]+", name):
             raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor endpoint identifier was invalid", "Fix native doctor and rerun", 4)
         socket_path = value.get("socket_path")
@@ -983,6 +991,172 @@ def run_herdr_entry(args: argparse.Namespace) -> None:
     herdr_entry_result(True, success, "Herdr entries processed", "none", entries)
 
 
+class HerdrRestartEndpoint:
+    """One validated, privacy-safe AY.3 doctor endpoint for restart control."""
+
+    def __init__(
+        self,
+        entry: HerdrEndpoint,
+        provenance: str,
+        state_kind: str,
+        client_version: str | None,
+        running_server: str | None,
+        live_handoff: bool | None,
+    ) -> None:
+        self.entry = entry
+        self.provenance = provenance
+        self.state_kind = state_kind
+        self.client_version = client_version
+        self.running_server = running_server
+        self.live_handoff = live_handoff
+
+    @property
+    def name(self) -> str:
+        return self.entry.name
+
+
+def herdr_restart_endpoints(cli: Path) -> list[HerdrRestartEndpoint]:
+    """Validate the AY.3 doctor projection used by the explicit coordinator."""
+    payload = doctor(cli)
+    if not isinstance(payload, dict) or "error" in payload:
+        raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native atm doctor --json could not be read", "Fix native doctor and rerun", 4)
+    herdr = payload.get("herdr")
+    if not isinstance(herdr, dict) or herdr.get("configured") is None:
+        raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor did not provide herdr.configured", "Fix native doctor and rerun", 4)
+    if herdr.get("configured") is not True:
+        raise HerdrEntryError("HERDR_NOT_CONFIGURED", "native doctor reports Herdr is not configured", "Configure Herdr or omit restart request", 3)
+    raw_endpoints = herdr.get("endpoints")
+    if not isinstance(raw_endpoints, list):
+        raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor did not provide herdr.endpoints", "Fix native doctor and rerun", 4)
+    endpoints: list[HerdrRestartEndpoint] = []
+    for raw in raw_endpoints:
+        if not isinstance(raw, dict):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor endpoint was malformed", "Fix native doctor and rerun", 4)
+        name = raw.get("session") or raw.get("endpoint") or "default"
+        state = raw.get("state")
+        capabilities = raw.get("capabilities")
+        provenance = raw.get("provenance")
+        if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+", name) or not isinstance(state, dict) or not isinstance(state.get("kind"), str) or not isinstance(capabilities, dict) or not isinstance(provenance, str):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor restart fields were malformed", "Fix native doctor and rerun", 4)
+        live_handoff = capabilities.get("live_handoff")
+        if live_handoff is not None and not isinstance(live_handoff, bool):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor handoff capability was malformed", "Fix native doctor and rerun", 4)
+        client = state.get("client")
+        server = state.get("server")
+        if client is not None and not isinstance(client, str) or server is not None and not isinstance(server, str):
+            raise HerdrEntryError("HERDR_DOCTOR_UNREADABLE", "native doctor version data was malformed", "Fix native doctor and rerun", 4)
+        socket_path = raw.get("endpoint") if provenance == "socket_path" else None
+        endpoints.append(HerdrRestartEndpoint(HerdrEndpoint(name, socket_path if isinstance(socket_path, str) else "socket-path" if provenance == "socket_path" else None), provenance, str(state["kind"]), client, server, live_handoff))
+    return endpoints
+
+
+def select_herdr_restart_endpoint(cli: Path, selector: str | None) -> HerdrRestartEndpoint:
+    endpoints = herdr_restart_endpoints(cli)
+    entries = [{"endpoint": endpoint.name, "identifier": identifier(platform.system(), endpoint.name)} for endpoint in endpoints]
+    if selector is None:
+        if len(endpoints) != 1:
+            error = HerdrEntryError("HERDR_RESTART_ENDPOINT_REQUIRED", "more than one Herdr endpoint is configured", "rerun with --restart-herdr <default-or-session>", 3)
+            error.entries = entries
+            raise error
+        selected = endpoints[0]
+    else:
+        selected = next((endpoint for endpoint in endpoints if endpoint.name == selector), None)
+        if selected is None:
+            error = HerdrEntryError("HERDR_RESTART_ENDPOINT_UNKNOWN", "requested Herdr endpoint is not configured", "Use a returned default or session endpoint", 3)
+            error.entries = entries
+            raise error
+    if selected.provenance == "socket_path" or selected.entry.socket_path is not None:
+        raise HerdrEntryError("HERDR_RESTART_SOCKET_PATH", "socket-path endpoint is externally owned", "Restart through the external owner", 3)
+    return selected
+
+
+def _version_key(value: str | None) -> tuple[int, ...] | None:
+    if value is None or not re.fullmatch(r"\d+(?:\.\d+){1,2}", value):
+        return None
+    return tuple(int(part) for part in value.split("."))
+
+
+def restart_uses_live_handoff(endpoint: HerdrRestartEndpoint) -> bool:
+    client = _version_key(endpoint.client_version)
+    server = _version_key(endpoint.running_server)
+    return client is not None and server is not None and client > server and endpoint.live_handoff is True
+
+
+def scoped_herdr_command(endpoint: HerdrRestartEndpoint, action: str) -> list[str]:
+    prefix = ["herdr"] if endpoint.name == "default" else ["herdr", "--session", endpoint.name]
+    return [*prefix, "server", action]
+
+
+def _restart_entries(endpoints: list[HerdrRestartEndpoint]) -> list[dict[str, object]]:
+    return [{"endpoint": endpoint.name, "identifier": identifier(platform.system(), endpoint.name)} for endpoint in endpoints]
+
+
+def _restart_command(command: list[str], deadline: float) -> None:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise HerdrEntryError("HERDR_RESTART_TIMEOUT", f"restart deadline expired before {' '.join(command[-2:])}", "Retry the explicit restart", 4)
+    try:
+        result = run(command, timeout=min(HERDR_RESTART_COMMAND_TIMEOUT, remaining))
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise HerdrEntryError("HERDR_RESTART_TIMEOUT", f"timed out running {' '.join(command[-2:])}", "Retry the explicit restart", 4) from error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or "Herdr command failed"
+        raise HerdrEntryError("HERDR_RESTART_HERDR_FAILED", f"{' '.join(command[-2:])} failed: {detail}", "Correct Herdr and retry", 4)
+
+
+def _verify_herdr_restart(cli: Path, selected: HerdrRestartEndpoint, deadline: float) -> None:
+    last_state = "unreadable"
+    for delay in HERDR_RESTART_VERIFY_DELAYS:
+        if delay:
+            if time.monotonic() + delay >= deadline:
+                break
+            time.sleep(delay)
+        try:
+            observed = next(endpoint for endpoint in herdr_restart_endpoints(cli) if endpoint.name == selected.name)
+            last_state = observed.state_kind
+            if observed.state_kind == "ok":
+                return
+        except (HerdrEntryError, StopIteration):
+            last_state = "unreadable"
+    raise HerdrEntryError("HERDR_RESTART_VERIFY_TIMEOUT", f"endpoint did not become ok; last state={last_state}", "Inspect Herdr health and retry", 4)
+
+
+def run_herdr_restart(args: argparse.Namespace) -> None:
+    cli, _daemon = selected_links(args)
+    selector = args.restart_herdr or None
+    selected = select_herdr_restart_endpoint(cli, selector)
+    if args.restart_timeout_secs <= 0:
+        raise HerdrEntryError("HERDR_RESTART_TIMEOUT", "restart timeout must be positive", "Pass a positive --restart-timeout-secs value", 4)
+    manager = herdr_entry_manager()
+    status = manager.entry_status(selected.entry)
+    if status["journal_phase"] is not None:
+        raise HerdrEntryError("HERDR_ENTRY_JOURNAL_ACTIVE", "an entry transaction is incomplete", "Run herdr-entry status --repair", 3)
+    if not status["owned"]:
+        raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "selected entry is missing or unowned", "Install the owned entry before restarting Herdr", 3)
+    deadline = time.monotonic() + args.restart_timeout_secs
+    if restart_uses_live_handoff(selected):
+        _restart_command(scoped_herdr_command(selected, "live-handoff"), deadline)
+    else:
+        if not args.stop_herdr_panes:
+            print("warning: stopping Herdr exits panes for the selected endpoint", file=sys.stderr)
+            code = "HERDR_RESTART_NO_LIVE_HANDOFF" if selected.state_kind == "client_server_mismatch" else "HERDR_RESTART_PANES_ACK_REQUIRED"
+            raise HerdrEntryError(code, "stopping Herdr terminates the selected endpoint panes", "Accept impact and pass --stop-herdr-panes", 3)
+        print("warning: stopping Herdr exits panes for the selected endpoint", file=sys.stderr)
+        _restart_command(scoped_herdr_command(selected, "stop"), deadline)
+        manager.start_owned(selected.entry)
+    _verify_herdr_restart(cli, selected, deadline)
+    herdr_entry_result(True, "HERDR_RESTARTED", "selected Herdr endpoint restarted and verified", "none", _restart_entries([selected]))
+
+
+def herdr_restart_pending_endpoints(cli: Path) -> list[HerdrRestartEndpoint]:
+    try:
+        return [endpoint for endpoint in herdr_restart_endpoints(cli) if endpoint.state_kind == "client_server_mismatch"]
+    except HerdrEntryError as error:
+        if error.code == "HERDR_NOT_CONFIGURED":
+            return []
+        raise SwitchError(f"{error.code}: {error.message}") from error
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     selectors = argparse.ArgumentParser(add_help=False)
@@ -1021,6 +1195,9 @@ def parser() -> argparse.ArgumentParser:
     restore.add_argument("--dry-run", action="store_true")
     restart_parser = sub.add_parser("restart", parents=[selectors])
     restart_parser.add_argument("--yes", action="store_true")
+    restart_parser.add_argument("--restart-herdr", nargs="?", const="", metavar="ENDPOINT")
+    restart_parser.add_argument("--stop-herdr-panes", action="store_true")
+    restart_parser.add_argument("--restart-timeout-secs", type=float, default=HERDR_RESTART_OVERALL_TIMEOUT)
     quiesce_parser = sub.add_parser("quiesce", parents=[selectors])
     quiesce_parser.add_argument("--yes", action="store_true")
     temporary = sub.add_parser("temporary-launch", parents=[selectors])
@@ -1095,7 +1272,7 @@ def main() -> int:
         else:
             quiesce(args)
     except HerdrEntryError as error:
-        herdr_entry_result(False, error.code, error.message, error.remedy, [])
+        herdr_entry_result(False, error.code, error.message, error.remedy, getattr(error, "entries", []))
         return error.exit_code
     except SwitchError as error:
         print(f"daemon-switch: {error}", file=sys.stderr)

--- a/.claude/skills/daemon-switch/scripts/herdr_entry.py
+++ b/.claude/skills/daemon-switch/scripts/herdr_entry.py
@@ -55,6 +55,7 @@ class EntryPlatform(Protocol):
     def register(self, identifier: str, object_path: Path) -> None: ...
     def unregister(self, identifier: str) -> None: ...
     def is_registered(self, identifier: str) -> bool: ...
+    def start(self, identifier: str) -> None: ...
     def account_matches(self, identifier: str) -> bool: ...
 
 
@@ -220,6 +221,22 @@ class HerdrEntryManager:
         owned, matching = self._owned(path, digest)
         return {"endpoint": endpoint.name, "identifier": entry_id, "owned": owned, "registered": self.platform.is_registered(entry_id), "digest_matches": matching if owned else False, "journal_phase": (self._load_journal().phase if self._load_journal() else None)}
 
+    def start_owned(self, endpoint: HerdrEndpoint) -> dict[str, object]:
+        """Explicitly relaunch one verified AY.5 entry; never create or repair it."""
+        self._assert_no_active_journal()
+        status = self.entry_status(endpoint)
+        if not status["owned"]:
+            raise HerdrEntryError("HERDR_ENTRY_FOREIGN", "entry is missing or not owned", "Install the owned entry before restarting Herdr", 3)
+        if not status["digest_matches"]:
+            raise HerdrEntryError("HERDR_ENTRY_DIGEST_MISMATCH", "owned entry has a different canonical digest", "Inspect and explicitly repair the entry", 3)
+        if not status["registered"]:
+            raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "owned entry is not registered", "Repair the entry before restarting Herdr", 4)
+        try:
+            self.platform.start(str(status["identifier"]))
+        except Exception as error:
+            raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "owned entry could not be relaunched", "Correct the native entry and retry", 4) from error
+        return status
+
 
 class NativeEntryPlatform:
     """Native file/registration adapter; all calls are explicit operator actions."""
@@ -259,6 +276,17 @@ class NativeEntryPlatform:
         # time. The object cannot be assumed registered merely because it exists.
         command = (["launchctl", "print", f"gui/{os.getuid()}/{entry_id}"] if self.name == "Darwin" else (["schtasks.exe", "/Query", "/TN", entry_id] if self.name == "Windows" else ["systemctl", "--user", "is-enabled", entry_id]))
         return getattr(self.runner(command, timeout=5.0), "returncode", 1) == 0
+
+    def start(self, entry_id: str) -> None:
+        if self.name == "Darwin":
+            command = ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{entry_id}"]
+        elif self.name == "Windows":
+            command = ["schtasks.exe", "/Run", "/TN", entry_id]
+        else:
+            command = ["systemctl", "--user", "restart", entry_id]
+        result = self.runner(command, timeout=30.0)
+        if getattr(result, "returncode", 1) != 0:
+            raise RuntimeError(getattr(result, "stderr", "platform entry start failed"))
 
     def account_matches(self, _entry_id: str) -> bool:
         return True

--- a/.claude/skills/daemon-switch/scripts/herdr_entry.py
+++ b/.claude/skills/daemon-switch/scripts/herdr_entry.py
@@ -55,7 +55,7 @@ class EntryPlatform(Protocol):
     def register(self, identifier: str, object_path: Path) -> None: ...
     def unregister(self, identifier: str) -> None: ...
     def is_registered(self, identifier: str) -> bool: ...
-    def start(self, identifier: str) -> None: ...
+    def start(self, identifier: str, timeout: float) -> None: ...
     def account_matches(self, identifier: str) -> bool: ...
 
 
@@ -221,7 +221,7 @@ class HerdrEntryManager:
         owned, matching = self._owned(path, digest)
         return {"endpoint": endpoint.name, "identifier": entry_id, "owned": owned, "registered": self.platform.is_registered(entry_id), "digest_matches": matching if owned else False, "journal_phase": (self._load_journal().phase if self._load_journal() else None)}
 
-    def start_owned(self, endpoint: HerdrEndpoint) -> dict[str, object]:
+    def start_owned(self, endpoint: HerdrEndpoint, timeout: float = 30.0) -> dict[str, object]:
         """Explicitly relaunch one verified AY.5 entry; never create or repair it."""
         self._assert_no_active_journal()
         status = self.entry_status(endpoint)
@@ -232,7 +232,7 @@ class HerdrEntryManager:
         if not status["registered"]:
             raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "owned entry is not registered", "Repair the entry before restarting Herdr", 4)
         try:
-            self.platform.start(str(status["identifier"]))
+            self.platform.start(str(status["identifier"]), timeout)
         except Exception as error:
             raise HerdrEntryError("HERDR_ENTRY_REGISTER_FAILED", "owned entry could not be relaunched", "Correct the native entry and retry", 4) from error
         return status
@@ -277,14 +277,14 @@ class NativeEntryPlatform:
         command = (["launchctl", "print", f"gui/{os.getuid()}/{entry_id}"] if self.name == "Darwin" else (["schtasks.exe", "/Query", "/TN", entry_id] if self.name == "Windows" else ["systemctl", "--user", "is-enabled", entry_id]))
         return getattr(self.runner(command, timeout=5.0), "returncode", 1) == 0
 
-    def start(self, entry_id: str) -> None:
+    def start(self, entry_id: str, timeout: float) -> None:
         if self.name == "Darwin":
             command = ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{entry_id}"]
         elif self.name == "Windows":
             command = ["schtasks.exe", "/Run", "/TN", entry_id]
         else:
             command = ["systemctl", "--user", "restart", entry_id]
-        result = self.runner(command, timeout=30.0)
+        result = self.runner(command, timeout=timeout)
         if getattr(result, "returncode", 1) != 0:
             raise RuntimeError(getattr(result, "stderr", "platform entry start failed"))
 

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1829,18 +1829,43 @@ class HerdrRestartTests(unittest.TestCase):
         self.assertEqual(sleeper.call_args_list, [mock.call(2.0), mock.call(4.0)])
 
     def test_ordinary_restart_refuses_every_protocol_mismatch_before_service_mutation(self) -> None:
-        args = argparse.Namespace(yes=True)
+        args = argparse.Namespace(command="restart", yes=True)
         payload = self.doctor_payload(self.endpoint(), self.endpoint("blue"), self.endpoint("green", state="ok", client=None, server=None))
+        stdout = io.StringIO()
+        stderr = io.StringIO()
         with (
             mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
             mock.patch.object(DAEMON_SWITCH, "require_executable", side_effect=[self.cli, Path("/selected/atm-daemon")]),
             mock.patch.object(DAEMON_SWITCH, "require_macos_development_signatures"),
             mock.patch.object(DAEMON_SWITCH, "doctor", return_value=payload),
             mock.patch.object(DAEMON_SWITCH, "run_service") as service,
+            mock.patch.object(
+                DAEMON_SWITCH,
+                "parser",
+                return_value=mock.Mock(parse_args=mock.Mock(return_value=args)),
+            ),
         ):
-            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "default, blue"):
-                DAEMON_SWITCH.restart(args)
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = DAEMON_SWITCH.main()
         service.assert_not_called()
+        self.assertEqual(exit_code, 3)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {
+                "ok": False,
+                "code": "HERDR_RESTART_ENDPOINTS_PENDING",
+                "message": "restart Herdr endpoints first: default, blue",
+                "remedy": "Restart every listed Herdr endpoint first, then rerun the ordinary ATM restart",
+                "entries": [
+                    {
+                        "endpoint": name,
+                        "identifier": DAEMON_SWITCH.identifier(DAEMON_SWITCH.platform.system(), name),
+                    }
+                    for name in ("default", "blue")
+                ],
+            },
+        )
 
     def test_restart_refusal_envelope_has_only_safe_endpoint_identifiers(self) -> None:
         with mock.patch.object(DAEMON_SWITCH, "doctor", return_value=self.doctor_payload(self.endpoint(), self.endpoint("blue"))):

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1591,7 +1591,7 @@ class HerdrEntryPlatformFake:
     def is_registered(self, identifier: str) -> bool:
         return identifier in self.registered
 
-    def start(self, identifier: str) -> None:
+    def start(self, identifier: str, _timeout: float = 30.0) -> None:
         if identifier not in self.registered:
             raise RuntimeError("entry is not registered")
         self.started.append(identifier)
@@ -1764,7 +1764,7 @@ class HerdrRestartTests(unittest.TestCase):
                 adapter = DAEMON_SWITCH.NativeEntryPlatform(self.root / platform_name, runner)
                 adapter.name = platform_name
                 self.assertEqual(DAEMON_SWITCH.identifier(platform_name, "blue"), entry_id)
-                adapter.start(entry_id)
+                adapter.start(entry_id, 30.0)
                 self.assertEqual(runner.call_args.args[0], expected)
 
     def test_live_handoff_scopes_default_and_never_restarts_atm(self) -> None:

--- a/.claude/skills/daemon-switch/tests/test_daemon_switch.py
+++ b/.claude/skills/daemon-switch/tests/test_daemon_switch.py
@@ -1520,7 +1520,7 @@ class LegacyDaemonSwitchRegressionTests(unittest.TestCase):
 
     def test_restart_requires_a_single_live_pair_after_controlled_stop(self) -> None:
         args = argparse.Namespace(yes=True)
-        with (mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)), mock.patch.object(self.module, "require_executable", side_effect=[self.old_cli, self.old_daemon]), mock.patch.object(self.module, "require_macos_development_signatures"), mock.patch.object(self.module, "run_service") as service, mock.patch.object(self.module, "require_stopped_daemon") as stopped, mock.patch.object(self.module, "live_pair_matches", return_value=(True, "matched"))):
+        with (mock.patch.object(self.module, "selected_links", return_value=(self.old_cli, self.old_daemon)), mock.patch.object(self.module, "require_executable", side_effect=[self.old_cli, self.old_daemon]), mock.patch.object(self.module, "require_macos_development_signatures"), mock.patch.object(self.module, "herdr_restart_pending_endpoints", return_value=[]), mock.patch.object(self.module, "run_service") as service, mock.patch.object(self.module, "require_stopped_daemon") as stopped, mock.patch.object(self.module, "live_pair_matches", return_value=(True, "matched"))):
             self.module.restart(args)
         stopped.assert_called_once_with(args, self.old_cli)
         self.assertEqual(service.call_args_list, [mock.call(args, "stop", allow_absent=True), mock.call(args, "start")])
@@ -1577,6 +1577,7 @@ class HerdrEntryPlatformFake:
         self.name = name
         self.registered: set[str] = set()
         self.account_is_current = True
+        self.started: list[str] = []
 
     def path_for(self, identifier: str) -> Path:
         return self.root / identifier
@@ -1589,6 +1590,11 @@ class HerdrEntryPlatformFake:
 
     def is_registered(self, identifier: str) -> bool:
         return identifier in self.registered
+
+    def start(self, identifier: str) -> None:
+        if identifier not in self.registered:
+            raise RuntimeError("entry is not registered")
+        self.started.append(identifier)
 
     def account_matches(self, _identifier: str) -> bool:
         return self.account_is_current
@@ -1701,6 +1707,152 @@ class HerdrEntryTests(unittest.TestCase):
         self.assertNotIn("run_herdr_entry", switch_block)
         self.assertNotIn("run_herdr_entry", restore_block)
         self.assertNotIn("run_herdr_entry", restart_block)
+
+
+class HerdrRestartTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.platform = HerdrEntryPlatformFake(self.root / "objects")
+        self.manager = DAEMON_SWITCH.HerdrEntryManager(self.root / "journal", self.platform)
+        self.default = DAEMON_SWITCH.HerdrEndpoint("default")
+        self.session = DAEMON_SWITCH.HerdrEndpoint("blue")
+        self.manager.install(self.default)
+        self.manager.install(self.session)
+        self.args = argparse.Namespace(restart_herdr="", stop_herdr_panes=False, restart_timeout_secs=120.0)
+        self.cli = Path("/selected/atm")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def endpoint(name: str = "default", *, state: str = "client_server_mismatch", handoff: bool | None = True, client: str | None = "0.8.2", server: str | None = "0.8.0", provenance: str = "herdr_default") -> dict[str, object]:
+        return {
+            "session": name,
+            "provenance": provenance,
+            "endpoint": "/safe/socket" if provenance == "socket_path" else None,
+            "state": {"kind": state, "client": client, "server": server},
+            "capabilities": {"live_handoff": handoff},
+        }
+
+    @classmethod
+    def doctor_payload(cls, *endpoints: dict[str, object]) -> dict[str, object]:
+        return {"herdr": {"configured": True, "endpoints": list(endpoints)}}
+
+    def test_selector_refusals_and_socket_path_are_exact(self) -> None:
+        with mock.patch.object(DAEMON_SWITCH, "doctor", return_value=self.doctor_payload(self.endpoint(), self.endpoint("blue"))):
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "more than one") as error:
+                DAEMON_SWITCH.select_herdr_restart_endpoint(self.cli, None)
+            self.assertEqual(error.exception.code, "HERDR_RESTART_ENDPOINT_REQUIRED")
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "not configured") as error:
+                DAEMON_SWITCH.select_herdr_restart_endpoint(self.cli, "missing")
+            self.assertEqual(error.exception.code, "HERDR_RESTART_ENDPOINT_UNKNOWN")
+        with mock.patch.object(DAEMON_SWITCH, "doctor", return_value=self.doctor_payload(self.endpoint(provenance="socket_path"))):
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "externally owned") as error:
+                DAEMON_SWITCH.select_herdr_restart_endpoint(self.cli, None)
+            self.assertEqual(error.exception.code, "HERDR_RESTART_SOCKET_PATH")
+
+    def test_restart_entry_argv_and_identifiers_are_platform_specific(self) -> None:
+        cases = {
+            "Darwin": ("com.randlee.atm.herdr-server.blue", ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/com.randlee.atm.herdr-server.blue"]),
+            "Linux": ("atm-herdr-server@blue.service", ["systemctl", "--user", "restart", "atm-herdr-server@blue.service"]),
+            "Windows": ("ATM Herdr Server (blue)", ["schtasks.exe", "/Run", "/TN", "ATM Herdr Server (blue)"]),
+        }
+        for platform_name, (entry_id, expected) in cases.items():
+            with self.subTest(platform=platform_name):
+                runner = mock.Mock(return_value=subprocess.CompletedProcess([], 0, "", ""))
+                adapter = DAEMON_SWITCH.NativeEntryPlatform(self.root / platform_name, runner)
+                adapter.name = platform_name
+                self.assertEqual(DAEMON_SWITCH.identifier(platform_name, "blue"), entry_id)
+                adapter.start(entry_id)
+                self.assertEqual(runner.call_args.args[0], expected)
+
+    def test_live_handoff_scopes_default_and_never_restarts_atm(self) -> None:
+        mismatch = self.doctor_payload(self.endpoint())
+        ready = self.doctor_payload(self.endpoint(state="ok", client=None, server=None))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "herdr_entry_manager", return_value=self.manager),
+            mock.patch.object(DAEMON_SWITCH, "doctor", side_effect=[mismatch, ready]),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=subprocess.CompletedProcess([], 0, "", "")) as runner,
+            mock.patch.object(DAEMON_SWITCH, "run_service") as service,
+        ):
+            DAEMON_SWITCH.run_herdr_restart(self.args)
+        runner.assert_called_once_with(["herdr", "server", "live-handoff"], timeout=mock.ANY)
+        service.assert_not_called()
+        self.assertEqual(self.platform.started, [])
+
+    def test_stop_requires_ack_then_relaunches_scoped_session_and_verifies(self) -> None:
+        self.args.restart_herdr = "blue"
+        mismatch = self.doctor_payload(self.endpoint("blue", handoff=None))
+        ready = self.doctor_payload(self.endpoint("blue", state="ok", handoff=None, client=None, server=None))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "herdr_entry_manager", return_value=self.manager),
+            mock.patch.object(DAEMON_SWITCH, "doctor", return_value=mismatch),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "terminates") as error:
+                DAEMON_SWITCH.run_herdr_restart(self.args)
+        self.assertEqual(error.exception.code, "HERDR_RESTART_NO_LIVE_HANDOFF")
+        self.args.stop_herdr_panes = True
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "herdr_entry_manager", return_value=self.manager),
+            mock.patch.object(DAEMON_SWITCH, "doctor", side_effect=[mismatch, ready]),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=subprocess.CompletedProcess([], 0, "", "")) as runner,
+        ):
+            DAEMON_SWITCH.run_herdr_restart(self.args)
+        runner.assert_called_once_with(["herdr", "--session", "blue", "server", "stop"], timeout=mock.ANY)
+        self.assertEqual(self.platform.started, ["atm-herdr-server@blue.service"])
+
+    def test_hung_command_and_slow_ready_fixture_are_bounded_without_real_sleep(self) -> None:
+        mismatch = self.doctor_payload(self.endpoint(handoff=True))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "herdr_entry_manager", return_value=self.manager),
+            mock.patch.object(DAEMON_SWITCH, "doctor", return_value=mismatch),
+            mock.patch.object(DAEMON_SWITCH, "run", side_effect=subprocess.TimeoutExpired(["herdr"], 30)),
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.HerdrEntryError, "timed out") as error:
+                DAEMON_SWITCH.run_herdr_restart(self.args)
+        self.assertEqual(error.exception.code, "HERDR_RESTART_TIMEOUT")
+
+        ready = self.doctor_payload(self.endpoint(state="ok", client=None, server=None))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "herdr_entry_manager", return_value=self.manager),
+            mock.patch.object(DAEMON_SWITCH, "doctor", side_effect=[mismatch, mismatch, mismatch, ready]),
+            mock.patch.object(DAEMON_SWITCH, "run", return_value=subprocess.CompletedProcess([], 0, "", "")),
+            mock.patch.object(DAEMON_SWITCH.time, "sleep") as sleeper,
+        ):
+            DAEMON_SWITCH.run_herdr_restart(self.args)
+        self.assertEqual(sleeper.call_args_list, [mock.call(2.0), mock.call(4.0)])
+
+    def test_ordinary_restart_refuses_every_protocol_mismatch_before_service_mutation(self) -> None:
+        args = argparse.Namespace(yes=True)
+        payload = self.doctor_payload(self.endpoint(), self.endpoint("blue"), self.endpoint("green", state="ok", client=None, server=None))
+        with (
+            mock.patch.object(DAEMON_SWITCH, "selected_links", return_value=(self.cli, Path("/selected/atm-daemon"))),
+            mock.patch.object(DAEMON_SWITCH, "require_executable", side_effect=[self.cli, Path("/selected/atm-daemon")]),
+            mock.patch.object(DAEMON_SWITCH, "require_macos_development_signatures"),
+            mock.patch.object(DAEMON_SWITCH, "doctor", return_value=payload),
+            mock.patch.object(DAEMON_SWITCH, "run_service") as service,
+        ):
+            with self.assertRaisesRegex(DAEMON_SWITCH.SwitchError, "default, blue"):
+                DAEMON_SWITCH.restart(args)
+        service.assert_not_called()
+
+    def test_restart_refusal_envelope_has_only_safe_endpoint_identifiers(self) -> None:
+        with mock.patch.object(DAEMON_SWITCH, "doctor", return_value=self.doctor_payload(self.endpoint(), self.endpoint("blue"))):
+            with self.assertRaises(DAEMON_SWITCH.HerdrEntryError) as captured:
+                DAEMON_SWITCH.select_herdr_restart_endpoint(self.cli, None)
+        self.assertEqual(
+            captured.exception.entries,
+            [
+                {"endpoint": "default", "identifier": DAEMON_SWITCH.identifier(DAEMON_SWITCH.platform.system(), "default")},
+                {"endpoint": "blue", "identifier": DAEMON_SWITCH.identifier(DAEMON_SWITCH.platform.system(), "blue")},
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/.codex/AY6-task-list.md
+++ b/.codex/AY6-task-list.md
@@ -7,5 +7,5 @@
 - [x] D3: Implement bounded live-handoff or acknowledged stop/relaunch.
 - [x] D4: Verify fresh doctor success and preflight ordinary ATM restart.
 - [x] D5: Add platform/doctor/JSON/grep fixtures and operator documentation.
-- [ ] Run all required local gates, push, and open the AY6 draft PR.
-- [ ] Merge-forward AY7 and send completion to team-lead and Fenix.
+- [x] Run all required local gates, push, and open the AY6 draft PR.
+- [x] Merge-forward AY7 and send completion to team-lead and Fenix.

--- a/.codex/AY6-task-list.md
+++ b/.codex/AY6-task-list.md
@@ -2,10 +2,10 @@
 
 - [x] Confirm `triage:a7` assignment and no AY6 completion event.
 - [x] Merge the AY5 parent and AY events/triage baseline.
-- [ ] D1: Document the C1–C4 restart/preflight contract and error inventory.
-- [ ] D2: Add explicit `--restart-herdr [endpoint]` endpoint selection.
-- [ ] D3: Implement bounded live-handoff or acknowledged stop/relaunch.
-- [ ] D4: Verify fresh doctor success and preflight ordinary ATM restart.
-- [ ] D5: Add platform/doctor/JSON/grep fixtures and operator documentation.
+- [x] D1: Document the C1–C4 restart/preflight contract and error inventory.
+- [x] D2: Add explicit `--restart-herdr [endpoint]` endpoint selection.
+- [x] D3: Implement bounded live-handoff or acknowledged stop/relaunch.
+- [x] D4: Verify fresh doctor success and preflight ordinary ATM restart.
+- [x] D5: Add platform/doctor/JSON/grep fixtures and operator documentation.
 - [ ] Run all required local gates, push, and open the AY6 draft PR.
 - [ ] Merge-forward AY7 and send completion to team-lead and Fenix.

--- a/.codex/AY6-task-list.md
+++ b/.codex/AY6-task-list.md
@@ -1,0 +1,11 @@
+# AY6 — coordinated Herdr endpoint restart
+
+- [x] Confirm `triage:a7` assignment and no AY6 completion event.
+- [x] Merge the AY5 parent and AY events/triage baseline.
+- [ ] D1: Document the C1–C4 restart/preflight contract and error inventory.
+- [ ] D2: Add explicit `--restart-herdr [endpoint]` endpoint selection.
+- [ ] D3: Implement bounded live-handoff or acknowledged stop/relaunch.
+- [ ] D4: Verify fresh doctor success and preflight ordinary ATM restart.
+- [ ] D5: Add platform/doctor/JSON/grep fixtures and operator documentation.
+- [ ] Run all required local gates, push, and open the AY6 draft PR.
+- [ ] Merge-forward AY7 and send completion to team-lead and Fenix.

--- a/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
+++ b/docs/adr/ADR-053-typed-temporary-daemon-service-launch-overlay.md
@@ -186,3 +186,32 @@ closed. Repair is explicit: it completes a verified registration or rolls back
 only the marker-bearing partial object. The public machine contract is exactly
 one JSON envelope on stdout and exit 0 (success), 3 (safe refusal), or 4
 (operational failure).
+
+## Addendum 2026-09-07 — coordinated Herdr endpoint restart
+
+`daemon-switch restart --restart-herdr [<default-or-session>]` is the only
+restart coordinator. It is never part of `switch`, `restore`, ordinary
+`restart`, daemon startup, or an entry install. It reads one native doctor
+projection to select a configured endpoint, resolves the AY.5 deterministic
+identifier and owned/complete entry, and rejects socket-path or unowned
+endpoints without mutation. A default is inferred only when doctor returns one
+endpoint.
+
+When the installed client is newer than the reported running server and the
+endpoint advertises `capabilities.live_handoff: true`, the coordinator invokes
+the endpoint-scoped `herdr server live-handoff` command. Capability `false` or
+`null`, equal/unknown versions, and every other condition take the destructive
+stop path: stdout remains machine JSON, stderr warns that agent panes exit,
+and `--stop-herdr-panes` is required before scoped `server stop` and the
+already-owned native entry is relaunched. The coordinator neither updates
+Herdr nor supervises it. A failed handoff stops immediately because Herdr owns
+its own rollback.
+
+The operation has one 120-second overall deadline, 30-second child-command
+deadline, and injected-time bounded verification reads; only fresh doctor
+state `ok` yields success. Timeout, selection, acknowledgement, doctor, and
+entry failures retain a stable code and the 0/3/4 JSON exit classes. Ordinary
+ATM restart has a separate read-only preflight: it refuses before any service
+mutation while any configured endpoint is `client_server_mismatch`, listing
+only endpoint names and identifiers. No daemon code, transport selection,
+polling loop, startup dependency, or process ownership is introduced.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -373,6 +373,29 @@ Satisfied by:
   native `atm doctor --json`: `configured: true` is required for install,
   `false` is a safe refusal, and null, missing, malformed, or nonzero doctor
   output is `HERDR_DOCTOR_UNREADABLE` (exit 4), never a Python fallback.
+  
+  Herdr restart-coordination addendum (AY.6): `restart --restart-herdr
+  [<default-or-session>]` is a distinct, explicit operator action. It selects
+  exactly one endpoint from native doctor data and the AY.5 owned-entry
+  projection; an omitted selector is valid only for one configured endpoint.
+  Socket-path, foreign/missing, or journal-active entries fail closed. When
+  the doctor reports that the installed client is newer than the running
+  server and `capabilities.live_handoff` is exactly true, it invokes the
+  selected scoped `herdr server live-handoff`; otherwise it emits a pane-loss
+  warning and requires `--stop-herdr-panes` before scoped `server stop` and
+  entry-owned relaunch. It never invokes `herdr update`, starts or restarts
+  ATM, takes ownership of Herdr, or runs implicitly during switch, restore, or
+  ordinary restart. Every command and the whole operation are deadline-bound;
+  a fresh native doctor read must report the selected endpoint `ok` before
+  success. The single JSON envelope uses exit 0/3/4. Exact refusals are
+  `HERDR_NOT_CONFIGURED`, `HERDR_DOCTOR_UNREADABLE`,
+  `HERDR_RESTART_ENDPOINT_REQUIRED`, `HERDR_RESTART_ENDPOINT_UNKNOWN`,
+  `HERDR_RESTART_SOCKET_PATH`, `HERDR_RESTART_PANES_ACK_REQUIRED`,
+  `HERDR_RESTART_NO_LIVE_HANDOFF`, `HERDR_RESTART_TIMEOUT`, and
+  `HERDR_RESTART_VERIFY_TIMEOUT`; an Herdr/entry failure is
+  `HERDR_RESTART_HERDR_FAILED`. Before an ordinary ATM restart mutates its
+  managed service, daemon-switch re-reads doctor and refuses all
+  `client_server_mismatch` endpoints with `HERDR_RESTART_ENDPOINTS_PENDING`.
   Default and named sessions receive deterministic per-user native entry
   identifiers; an endpoint configured with explicit socket-path provenance is
   externally owned and is refused. Every owned object carries


### PR DESCRIPTION
Implements AY6 explicit one-endpoint Herdr restart coordination on top of AY5. Local gates: daemon-switch tests, spell, ADR index, full validate, fmt, clippy, and boundaries.