### PR TITLE
fix(graft-python): native atm_read marks the message read; atm-daemon --version (1.5.5)

### DIFF
--- a/.just/tests/test_atm_graft_python_models.py
+++ b/.just/tests/test_atm_graft_python_models.py
@@ -78,6 +78,7 @@ class AtmGraftPythonModelTests(unittest.TestCase):
                 "contains",
                 "since",
                 "from_agent",
+                "peek",
             },
             models.AtmListRequest: {
                 "selection",

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.5.4
+PackageVersion: 1.5.5
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.4/atm_1.5.4_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.5/atm_1.5.5_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.5.4
+ManifestVersion: 1.5.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-herdr",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "atm-herdr"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "serde_json",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "atm-observability"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "sc-observability",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -405,14 +405,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "peer-tls"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "atm-storage",
  "rcgen",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1964,7 +1964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sc-lint-attributes",
- "sc-lint-directives 1.5.4",
+ "sc-lint-directives 1.5.5",
  "serde",
  "serde_json",
  "syn 2.0.119",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]
@@ -63,17 +63,17 @@ getrandom = "0.3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 semver = { version = "1", features = ["serde"] }
 async-trait = "0.1"
-atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.4" }
-atm-observability = { path = "crates/atm-observability", version = "1.5.4" }
-atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.4" }
-atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.4" }
-atm-error = { path = "crates/atm-error", version = "1.5.4" }
-atm-graft = { path = "crates/atm-graft", version = "1.5.4" }
-atm-herdr = { path = "crates/atm-herdr", version = "1.5.4" }
-atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.4" }
-atm-runtime = { path = "crates/atm-runtime", version = "1.5.4" }
+atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.5" }
+atm-observability = { path = "crates/atm-observability", version = "1.5.5" }
+atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.5" }
+atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.5" }
+atm-error = { path = "crates/atm-error", version = "1.5.5" }
+atm-graft = { path = "crates/atm-graft", version = "1.5.5" }
+atm-herdr = { path = "crates/atm-herdr", version = "1.5.5" }
+atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.5" }
+atm-runtime = { path = "crates/atm-runtime", version = "1.5.5" }
 atm-runtime-test-support = { path = "crates/atm-runtime-test-support" }
-atm-storage = { path = "crates/atm-storage", version = "1.5.4" }
-atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.4" }
-atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.4" }
-peer-tls = { path = "crates/peer-tls", version = "1.5.4" }
+atm-storage = { path = "crates/atm-storage", version = "1.5.5" }
+atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.5" }
+atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.5" }
+peer-tls = { path = "crates/peer-tls", version = "1.5.5" }

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -4,6 +4,11 @@ use atm_core::error::AtmError;
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    if version_requested(std::env::args().nth(1).as_deref()) {
+        println!("{}", version_string());
+        return ExitCode::SUCCESS;
+    }
+
     match run().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
@@ -11,6 +16,14 @@ async fn main() -> ExitCode {
             ExitCode::from(replacement_exit_code(&error))
         }
     }
+}
+
+fn version_requested(argument: Option<&str>) -> bool {
+    matches!(argument, Some("--version" | "-V"))
+}
+
+fn version_string() -> String {
+    format!("atm-daemon {}", env!("CARGO_PKG_VERSION"))
 }
 
 async fn run() -> Result<(), AtmError> {
@@ -32,5 +45,19 @@ fn replacement_exit_code(error: &AtmError) -> u8 {
         70
     } else {
         1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{version_requested, version_string};
+
+    #[test]
+    fn version_string_matches_the_binary_contract() {
+        assert_eq!(version_string(), "atm-daemon 1.5.5");
+        assert!(version_requested(Some("--version")));
+        assert!(version_requested(Some("-V")));
+        assert!(!version_requested(Some("--help")));
+        assert!(!version_requested(None));
     }
 }

--- a/crates/atm-graft-python/python/atm_graft/models.py
+++ b/crates/atm-graft-python/python/atm_graft/models.py
@@ -61,6 +61,13 @@ class AtmReadRequest(_ToolRequest):
             "'pending_ack' (messages that require your acknowledgement)."
         ),
     )
+    peek: bool = Field(
+        default=False,
+        description=(
+            "Inspect the selected message without marking it read. Defaults to false, "
+            "so atm_read marks the selected message read."
+        ),
+    )
     message_id: str | None = Field(
         default=None,
         description="Exact ATM message identifier to read; omit to let the selection and filters choose a message.",

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -731,7 +731,7 @@ impl PyGraftSession {
         self.send_tool(py, None, reply, false, Some(message_id))
     }
 
-    #[pyo3(signature = (selection="actionable", message_id=None, task=None, contains=None, since=None, from_agent=None))]
+    #[pyo3(signature = (selection="actionable", message_id=None, task=None, contains=None, since=None, from_agent=None, peek=false))]
     #[allow(clippy::too_many_arguments)]
     fn read_tool(
         &self,
@@ -742,6 +742,7 @@ impl PyGraftSession {
         contains: Option<String>,
         since: Option<String>,
         from_agent: Option<String>,
+        peek: bool,
     ) -> PyResult<Py<PyAny>> {
         let query = self.build_tool_read_query(
             selection,
@@ -750,12 +751,13 @@ impl PyGraftSession {
             contains.as_deref(),
             since.as_deref(),
             from_agent.as_deref(),
+            peek,
         )?;
         match Self::tool_error_from_recovery(
             py,
             DaemonRecoveryPolicy::RetryOnce,
             self.with_daemon_recovery(py, DaemonRecoveryPolicy::RetryOnce, "read", || {
-                self.peek_outcome(query.clone())
+                self.tool_read_outcome(query.clone())
             }),
         ) {
             Ok((outcome, status)) => {
@@ -911,6 +913,7 @@ mod tests {
     use atm_core::list::ListOutcome;
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
     use atm_core::read::{BucketCounts, ReadOutcome};
+    use atm_core::schema::AtmMessageId;
     use atm_core::send::{SendCommandOutcome, SendOutcome};
     use atm_core::test_support::EnvGuard;
     use atm_core::transport::testing::FakeClientTransport;
@@ -965,10 +968,28 @@ mod tests {
         }
     }
 
-    fn peek_outcome() -> ReadOutcome {
+    fn native_read_outcome(
+        mutation_applied: bool,
+        unread: usize,
+        pending_ack: usize,
+        history: usize,
+    ) -> ReadOutcome {
         ReadOutcome {
-            action: CommandAction::Peek,
-            ..read_outcome()
+            action: CommandAction::Read,
+            team: TeamName::from_validated(TEST_TEAM),
+            agent: AgentName::from_validated(TEST_SENDER),
+            selection_mode: ReadSelection::Actionable,
+            mutation_applied,
+            count: 1,
+            message: None,
+            selected_message_id: Some(AtmMessageId::new()),
+            match_count: 1,
+            additional_match_count: 0,
+            bucket_counts: BucketCounts {
+                unread,
+                pending_ack,
+                history,
+            },
         }
     }
 
@@ -1837,7 +1858,7 @@ mod tests {
     fn native_read_and_list_retry_once_on_the_refreshed_fake_transport() {
         Python::initialize();
         for (operation, replacement_response) in [
-            ("read", ResponseEnvelope::Peek(Box::new(peek_outcome()))),
+            ("read", ResponseEnvelope::Receive(Box::new(read_outcome()))),
             ("list", ResponseEnvelope::List(list_outcome())),
         ] {
             let initial_calls = Arc::new(AtomicUsize::new(0));
@@ -1846,7 +1867,12 @@ mod tests {
             let replacement_calls_for_transport = Arc::clone(&replacement_calls);
             let initial = Arc::new(FakeClientTransport::new(Box::new(move |request| {
                 match operation {
-                    "read" => assert!(matches!(request, RequestEnvelope::Peek(_))),
+                    "read" => {
+                        let RequestEnvelope::Receive(query) = request else {
+                            panic!("native read must use the mutating receive route")
+                        };
+                        assert!(query.seen_state_update());
+                    }
                     "list" => assert!(matches!(request, RequestEnvelope::List(_))),
                     _ => unreachable!(),
                 }
@@ -1855,7 +1881,12 @@ mod tests {
             })));
             let replacement = Arc::new(FakeClientTransport::new(Box::new(move |request| {
                 match operation {
-                    "read" => assert!(matches!(request, RequestEnvelope::Peek(_))),
+                    "read" => {
+                        let RequestEnvelope::Receive(query) = request else {
+                            panic!("native read must use the mutating receive route")
+                        };
+                        assert!(query.seen_state_update());
+                    }
                     "list" => assert!(matches!(request, RequestEnvelope::List(_))),
                     _ => unreachable!(),
                 }
@@ -1866,11 +1897,13 @@ mod tests {
 
             Python::attach(|py| {
                 let result = match operation {
-                    "read" => session.read_tool(py, "actionable", None, None, None, None, None),
+                    "read" => {
+                        session.read_tool(py, "actionable", None, None, None, None, None, false)
+                    }
                     "list" => session.list_tool(py, "actionable", None, None, None, None, None),
                     _ => unreachable!(),
                 }
-                .expect("read-only operation recovers");
+                .expect("read operation recovers");
                 assert!(
                     !result.bind(py).is_instance_of::<AtmToolError>(),
                     "{operation} returns its success projection after one retry"
@@ -1899,7 +1932,7 @@ mod tests {
     }
 
     #[test]
-    fn native_read_scopes_peek_to_the_callers_chat_qualified_session() {
+    fn native_read_scopes_to_the_callers_chat_qualified_session() {
         let caller = PyAgentAddress::new(
             TEST_RECIPIENT.to_string(),
             TEST_TEAM.to_string(),
@@ -1918,14 +1951,132 @@ mod tests {
             reconnect_fallback_attempts: AtomicUsize::new(0),
         };
 
-        let query = session
-            .build_tool_read_query("all", None, None, None, None, None)
+        let operation = session
+            .build_tool_read_query("all", None, None, None, None, None, false)
             .expect("native read query");
+        let crate::query::ReadOperation::Read(query) = operation else {
+            panic!("default native read must build a mutating read query")
+        };
 
         assert_eq!(
             query.caller_chat_id().map(ToString::to_string).as_deref(),
             Some("recipient-session")
         );
+        assert!(query.seen_state_update());
+    }
+
+    #[test]
+    fn native_read_marks_messages_read_without_changing_ack_state() {
+        Python::initialize();
+        let outcomes = Arc::new(Mutex::new(vec![
+            native_read_outcome(true, 0, 1, 4),
+            native_read_outcome(true, 0, 0, 5),
+        ]));
+        let outcomes_for_transport = Arc::clone(&outcomes);
+        let transport = Arc::new(FakeClientTransport::new(Box::new(move |request| {
+            let RequestEnvelope::Receive(query) = request else {
+                panic!("native read must use the mutating receive route")
+            };
+            assert!(query.seen_state_update());
+            let outcome = outcomes_for_transport
+                .lock()
+                .expect("native read outcome lock")
+                .remove(0);
+            Ok(ResponseEnvelope::Receive(Box::new(outcome)))
+        })));
+        let replacement = Arc::new(FakeClientTransport::new(Box::new(|_| {
+            panic!("native read should not reconnect")
+        })));
+        let session = test_session(transport, replacement);
+
+        for expected_pending_ack in [1, 0] {
+            Python::attach(|py| {
+                let result = session
+                    .read_tool(py, "actionable", None, None, None, None, None, false)
+                    .expect("native read succeeds");
+                let value: serde_json::Value = result
+                    .bind(py)
+                    .call_method0("to_json")
+                    .expect("native read exposes canonical JSON")
+                    .extract::<String>()
+                    .expect("native read JSON is a string")
+                    .parse()
+                    .expect("native read JSON is valid");
+                assert_eq!(value["mutation_applied"], true);
+                assert_eq!(value["bucket_counts"]["unread"], 0);
+                assert_eq!(value["bucket_counts"]["pending_ack"], expected_pending_ack);
+            });
+        }
+    }
+
+    #[test]
+    fn native_read_peek_option_leaves_the_message_unread() {
+        Python::initialize();
+        let transport = Arc::new(FakeClientTransport::new(Box::new(|request| {
+            let RequestEnvelope::Peek(_query) = request else {
+                panic!("native read peek must use the non-mutating peek route")
+            };
+            Ok(ResponseEnvelope::Peek(Box::new(native_read_outcome(
+                false, 1, 0, 4,
+            ))))
+        })));
+        let replacement = Arc::new(FakeClientTransport::new(Box::new(|_| {
+            panic!("native read peek should not reconnect")
+        })));
+        let session = test_session(transport, replacement);
+
+        Python::attach(|py| {
+            let result = session
+                .read_tool(py, "actionable", None, None, None, None, None, true)
+                .expect("native read peek succeeds");
+            let value: serde_json::Value = result
+                .bind(py)
+                .call_method0("to_json")
+                .expect("native read exposes canonical JSON")
+                .extract::<String>()
+                .expect("native read JSON is a string")
+                .parse()
+                .expect("native read JSON is valid");
+            assert_eq!(value["action"], "read");
+            assert_eq!(value["mutation_applied"], false);
+            assert_eq!(value["bucket_counts"]["unread"], 1);
+            assert_eq!(value["bucket_counts"]["pending_ack"], 0);
+        });
+    }
+
+    #[test]
+    fn native_read_does_not_reapply_an_already_read_transition() {
+        Python::initialize();
+        let transport = Arc::new(FakeClientTransport::new(Box::new(|request| {
+            let RequestEnvelope::Receive(query) = request else {
+                panic!("native read must use the mutating receive route")
+            };
+            assert!(query.seen_state_update());
+            Ok(ResponseEnvelope::Receive(Box::new(native_read_outcome(
+                false, 0, 0, 1,
+            ))))
+        })));
+        let replacement = Arc::new(FakeClientTransport::new(Box::new(|_| {
+            panic!("native read should not reconnect")
+        })));
+        let session = test_session(transport, replacement);
+
+        Python::attach(|py| {
+            let result = session
+                .read_tool(py, "actionable", None, None, None, None, None, false)
+                .expect("native read succeeds");
+            let value: serde_json::Value = result
+                .bind(py)
+                .call_method0("to_json")
+                .expect("native read exposes canonical JSON")
+                .extract::<String>()
+                .expect("native read JSON is a string")
+                .parse()
+                .expect("native read JSON is valid");
+            assert_eq!(value["mutation_applied"], false);
+            assert_eq!(value["bucket_counts"]["unread"], 0);
+            assert_eq!(value["bucket_counts"]["pending_ack"], 0);
+        });
     }
 
     #[test]

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -1,12 +1,13 @@
-//! Query construction and read-only execution for the Python graft session.
+//! Query construction and read execution for the Python graft session.
 
 use super::*;
 use atm_core::read::PeekQuery;
 
-/// Read-family operations share one outer Python-to-async bridge.  Native
-/// tools select `Peek` so they cannot mutate mailbox state, while the legacy
-/// Python read API retains its explicit mutating operation.
-enum ReadOperation {
+/// Read-family operations share one outer Python-to-async bridge. Native
+/// `atm_read` defaults to the canonical mutating read, while `peek=true`
+/// selects the existing non-mutating path.
+#[derive(Clone)]
+pub(super) enum ReadOperation {
     Read(ReadQuery),
     Peek(PeekQuery),
 }
@@ -49,7 +50,8 @@ impl PyGraftSession {
         contains: Option<&str>,
         since: Option<&str>,
         from_agent: Option<&str>,
-    ) -> PyResult<PeekQuery> {
+        peek: bool,
+    ) -> PyResult<ReadOperation> {
         let (home_dir, current_dir) = Self::command_paths()?;
         let team = self.caller_team()?;
         let timestamp = since
@@ -60,23 +62,56 @@ impl PyGraftSession {
                     "invalid since timestamp: {error}"
                 )))
             })?;
-        PeekQuery::new(
-            home_dir,
-            current_dir,
-            self.caller.agent().clone(),
-            None,
-            team,
-            Self::read_selection(selection)?,
-            false,
-            message_id,
-            from_agent,
-            timestamp,
-            task,
-            contains,
-            None,
-        )
-        .map_err(atm_error)
-        .map(|query| query.with_caller_chat_id(self.caller.chat_id().cloned()))
+        let selection = Self::read_selection(selection)?;
+        if peek {
+            PeekQuery::new(
+                home_dir,
+                current_dir,
+                self.caller.agent().clone(),
+                None,
+                team,
+                selection,
+                false,
+                message_id,
+                from_agent,
+                timestamp,
+                task,
+                contains,
+                None,
+            )
+            .map_err(atm_error)
+            .map(|query| {
+                ReadOperation::Peek(query.with_caller_chat_id(self.caller.chat_id().cloned()))
+            })
+        } else {
+            ReadQuery::new(
+                home_dir,
+                current_dir,
+                self.caller.agent().clone(),
+                None,
+                team.clone(),
+                selection,
+                false,
+                true,
+                message_id,
+                from_agent,
+                timestamp,
+                task,
+                contains,
+                None,
+            )
+            .map_err(atm_error)
+            .map(|query| {
+                ReadOperation::Read(
+                    query
+                        .with_caller_chat_id(self.caller.chat_id().cloned())
+                        .with_activity_observation(activity_observation_for_resolved_caller(
+                            self.caller.agent(),
+                            &team,
+                        )),
+                )
+            })
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -120,10 +155,6 @@ impl PyGraftSession {
         self.read_operation_raw(ReadOperation::Read(query))
     }
 
-    pub(super) fn peek_raw(&self, query: PeekQuery) -> PyResult<ReadOutcome> {
-        self.read_operation_raw(ReadOperation::Peek(query))
-    }
-
     fn read_operation_raw(&self, operation: ReadOperation) -> PyResult<ReadOutcome> {
         let client = self.client()?;
         python_extension_runtime()?
@@ -142,9 +173,14 @@ impl PyGraftSession {
         self.read_raw(query).and_then(AtmReadResult::from_outcome)
     }
 
-    pub(super) fn peek_outcome(&self, query: PeekQuery) -> PyResult<AtmReadResult> {
-        self.peek_raw(query)
-            .and_then(AtmReadResult::from_peek_outcome)
+    pub(super) fn tool_read_outcome(&self, operation: ReadOperation) -> PyResult<AtmReadResult> {
+        self.read_operation_raw(operation).and_then(|outcome| {
+            if outcome.action == atm_core::types::CommandAction::Peek {
+                AtmReadResult::from_peek_outcome(outcome)
+            } else {
+                AtmReadResult::from_outcome(outcome)
+            }
+        })
     }
 
     pub(super) fn list_outcome(&self, query: ListQuery) -> PyResult<AtmListResult> {

--- a/crates/atm-graft-python/src/tool_types.rs
+++ b/crates/atm-graft-python/src/tool_types.rs
@@ -164,7 +164,7 @@ impl AtmSendResult {
     }
 }
 
-/// Typed, read-only projection of the canonical mailbox read outcome.
+/// Typed projection of the canonical mailbox read outcome.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct AtmReadResult {
@@ -190,8 +190,6 @@ impl AtmReadResult {
         })
     }
 
-    /// Keep the public native-read envelope aligned with the CLI's `read`
-    /// outcome while retaining the native tool's non-mutating peek request.
     pub(crate) fn from_peek_outcome(mut outcome: ReadOutcome) -> PyResult<Self> {
         outcome.action = CommandAction::Read;
         Self::from_outcome(outcome)

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-query"
-version = "1.5.4"
+version = "1.5.5"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/hermes-atm/NATIVE_TOOLS_PROOF.md
+++ b/crates/hermes-atm/NATIVE_TOOLS_PROOF.md
@@ -14,9 +14,10 @@ terminal output, git history, or proof artifacts.
    `atm_send`, `atm_read`, and `atm_list` from `hermes-atm-native-tools`.
 4. Invoke `atm_send` with a distinct ordinary test body and `requires_ack`
    false. Verify the structured success envelope and ordinary mailbox delivery.
-5. Invoke `atm_list` and `atm_read` with a bounded, read-only selection. Before
-   and after each invocation, compare the selected message's read and pending
-   acknowledgement state; neither may change.
+5. Invoke `atm_list` and `atm_read` with a bounded selection. Verify that
+   `atm_read` changes the selected message from unread to read while leaving
+   pending acknowledgement state unchanged; `atm_list` must not mutate either
+   state.
 6. Invoke each tool once with an invalid/unknown argument. Verify a structured
    `kind=error` envelope with `layer=ingress_validation`, and verify no daemon
    mailbox operation occurred.

--- a/crates/hermes-atm/NATIVE_TOOLS_TASKLIST.md
+++ b/crates/hermes-atm/NATIVE_TOOLS_TASKLIST.md
@@ -1,6 +1,6 @@
 # Hermes ATM Native Tools — Worktree Checklist
 
-Scope: `atm_send`, read-only `atm_read`, and `atm_list` in `hermes-atm`.
+Scope: `atm_send`, mutating `atm_read`, and `atm_list` in `hermes-atm`.
 Execution rule: complete and verify each item before marking it done. Do not
 perform live gateway-profile testing until every offline item and the second-pass review
 are complete.

--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -83,7 +83,9 @@ The same installer registers exactly four native Hermes tools through the
 public plugin API: `atm_send`, `atm_read`, `atm_list`, and `atm_ack`. They use
 the typed `atm-graft` client and the installed profile's identity, team, and
 workspace; tool arguments cannot override those profile settings. `atm_read`
-is read-only, `atm_list` returns bounded metadata, and `atm_ack` acknowledges
+marks the selected message read without changing acknowledgement state by
+default; pass `peek=true` to inspect without marking it, `atm_list` returns
+bounded metadata, and `atm_ack` acknowledges
 one pending message through the canonical send path. Successful tool results
 are the same canonical JSON outcome objects emitted by `atm --json`; the
 parity regression test covers list, read, send, and acknowledgement results.

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.5.4"
+version = "1.5.5"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/crates/hermes-atm/src/hermes_atm/native_tools.py
+++ b/crates/hermes-atm/src/hermes_atm/native_tools.py
@@ -148,6 +148,7 @@ class AtmNativeTools:
                     request.contains,
                     request.since,
                     request.from_agent,
+                    request.peek,
                 ),
                 _read_result,
             )
@@ -207,7 +208,7 @@ def register_tools(context: Any, *, identity: str, team: str, chat_id: str) -> N
         (
             "atm_read",
             tools.atm_read,
-            "Read one ATM mailbox message without mutating it; use the ATM CLI for administrative or advanced operations.",
+            "Read one ATM mailbox message and mark it read so it leaves future unread counts; acknowledgement state is unchanged. Pass peek=true to inspect without marking read. Use the ATM CLI for administrative or advanced operations.",
         ),
         (
             "atm_list",


### PR DESCRIPTION
## Summary

Fixes #1286.

- Native `atm_read` now performs the canonical mutating read by default, marking the selected message read through the existing bounded non-blocking state handoff; acknowledgement state is unchanged.
- Native `atm_read` accepts `peek=true` for the existing non-mutating inspection path.
- This supersedes #893 by Rand’s 2026-09-07 ruling: the native read description must match the required read semantics.
- `atm-daemon --version` and `-V` now print `atm-daemon 1.5.5` before daemon bootstrap, even when another daemon is live.
- Workspace and package metadata are bumped to 1.5.5.

## Requirements and boundaries

The read behavior follows docs/requirements.md sections 7.5, 7.11, and 7.13 and ADR-059: the reader lane serves the response, the read transition is offered to the existing bounded handoff without awaiting the writer lane, and acknowledgement state is untouched. CLI `atm read` and `atm peek` paths are unchanged.

## Tests

- Focused Rust tests: `cargo test -p atm-graft-python -p atm-graft -p atm-daemon -p agent-team-mail-core`
- Graft Python harness: `python3 scripts/test_atm_graft_python.py`
- Hermes bridge wheel and tests: `python3 .just/run_hermes_graft_bridge_tests.py` (19 tests)
- Model schema tests: `python3 .just/tests/test_atm_graft_python_models.py`
- Full workspace: `cargo test --workspace`
- Static and release gates: fmt, clippy, function-length, boundaries, line counts, metadata, and `atm-daemon --version`

All listed gates pass.