### PR TITLE
fix: restore native loopback reliability for 1.5.7

### DIFF
--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.5.6
+PackageVersion: 1.5.7
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.6/atm_1.5.6_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.5.7/atm_1.5.7_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.5.6
+ManifestVersion: 1.5.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-herdr",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-http-runtime",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "atm-herdr"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "serde_json",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "atm-http-runtime"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "atm-observability"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "sc-observability",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "atm-peer-tls-interop"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "atm-query-python"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "atm-storage",
  "atm-storage-rusqlite",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "async-trait",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "async-trait",
  "atm-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "async-trait",
  "atm-storage",
@@ -405,14 +405,14 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "atm-storage",
 ]
 
 [[package]]
 name = "atm-template-sc-compose"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "peer-tls"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "atm-storage",
  "rcgen",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-boundary"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1964,7 +1964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sc-lint-attributes",
- "sc-lint-directives 1.5.6",
+ "sc-lint-directives 1.5.7",
  "serde",
  "serde_json",
  "syn 2.0.119",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "sc-lint-directives"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.6"
+version = "1.5.7"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]
@@ -63,17 +63,17 @@ getrandom = "0.3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 semver = { version = "1", features = ["serde"] }
 async-trait = "0.1"
-atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.6" }
-atm-observability = { path = "crates/atm-observability", version = "1.5.6" }
-atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.6" }
-atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.6" }
-atm-error = { path = "crates/atm-error", version = "1.5.6" }
-atm-graft = { path = "crates/atm-graft", version = "1.5.6" }
-atm-herdr = { path = "crates/atm-herdr", version = "1.5.6" }
-atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.6" }
-atm-runtime = { path = "crates/atm-runtime", version = "1.5.6" }
+atm-core = { package = "agent-team-mail-core", path = "crates/atm-core", version = "1.5.7" }
+atm-observability = { path = "crates/atm-observability", version = "1.5.7" }
+atm-daemon-bootstrap = { path = "crates/atm-daemon-bootstrap", version = "1.5.7" }
+atm-daemon-client = { path = "crates/atm-daemon-client", version = "1.5.7" }
+atm-error = { path = "crates/atm-error", version = "1.5.7" }
+atm-graft = { path = "crates/atm-graft", version = "1.5.7" }
+atm-herdr = { path = "crates/atm-herdr", version = "1.5.7" }
+atm-http-runtime = { path = "crates/atm-http-runtime", version = "1.5.7" }
+atm-runtime = { path = "crates/atm-runtime", version = "1.5.7" }
 atm-runtime-test-support = { path = "crates/atm-runtime-test-support" }
-atm-storage = { path = "crates/atm-storage", version = "1.5.6" }
-atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.6" }
-atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.6" }
-peer-tls = { path = "crates/peer-tls", version = "1.5.6" }
+atm-storage = { path = "crates/atm-storage", version = "1.5.7" }
+atm-storage-rusqlite = { path = "crates/atm-storage-rusqlite", version = "1.5.7" }
+atm-template-sc-compose = { path = "crates/atm-template-sc-compose", version = "1.5.7" }
+peer-tls = { path = "crates/peer-tls", version = "1.5.7" }

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -263,9 +263,6 @@ impl PeekQuery {
     /// A present chat ID scopes a read-only mailbox query to that session.
     /// `None` removes chat scoping, leaving mailbox ownership as the only
     /// recipient scope.
-    /// A present chat ID scopes a read-only mailbox query to that session.
-    /// `None` removes chat scoping, leaving mailbox ownership as the only
-    /// recipient scope.
     #[must_use]
     pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
         self.mailbox.participant_filter =
@@ -391,6 +388,9 @@ impl ReadQuery {
     pub fn caller_chat_id(&self) -> Option<&ChatId> {
         self.caller_chat_id.as_ref()
     }
+    /// A present chat ID scopes a read-only mailbox query to that session.
+    /// For an exact ID in the caller's own mailbox, `None` clears the
+    /// participant filter so ownership is the only recipient scope.
     #[must_use]
     pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
         self.mailbox.participant_filter =

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -260,9 +260,12 @@ impl PeekQuery {
         self.caller_chat_id.as_ref()
     }
 
-    /// Scope a read-only mailbox query to the caller's identity. A present
-    /// chat ID selects that exact session; `None` selects only the bare-agent
-    /// identity.
+    /// A present chat ID scopes a read-only mailbox query to that session.
+    /// `None` removes chat scoping, leaving mailbox ownership as the only
+    /// recipient scope.
+    /// A present chat ID scopes a read-only mailbox query to that session.
+    /// `None` removes chat scoping, leaving mailbox ownership as the only
+    /// recipient scope.
     #[must_use]
     pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
         self.mailbox.participant_filter =

--- a/crates/atm-daemon-client/src/local_transport.rs
+++ b/crates/atm-daemon-client/src/local_transport.rs
@@ -54,8 +54,14 @@ impl LocalDaemonTransport {
 pub fn local_daemon_transport() -> Result<LocalDaemonTransport, AtmError> {
     let value = std::env::var("ATM_LOCAL_TRANSPORT").ok();
     let transport = LocalDaemonTransport::resolve(value.as_deref())?;
+    let override_state = match value.as_deref() {
+        None => "unset",
+        Some("") => "explicitly_empty",
+        Some(_) => "explicit",
+    };
     tracing::debug!(
         transport = transport.label(),
+        local_transport_override = override_state,
         "selected daemon local transport"
     );
     Ok(transport)

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -1966,6 +1966,49 @@ mod tests {
     }
 
     #[test]
+    fn native_exact_message_id_peek_ignores_session_chat_scope() {
+        let caller = PyAgentAddress::new(
+            TEST_RECIPIENT.to_string(),
+            TEST_TEAM.to_string(),
+            Some("recipient-session".to_owned()),
+        )
+        .expect("caller");
+        let session = PyGraftSession {
+            caller: caller.to_typed().expect("typed caller"),
+            client: Mutex::new(None),
+            receiver: Mutex::new(None),
+            fallback_logger: Arc::new(observability::GraftFallbackLogger::new(
+                atm_core::observability::graft_fallback_log_path(&leaked_fallback_dir()),
+            )),
+            reconnect_replacement: Mutex::new(None),
+            reconnect_attempts: AtomicUsize::new(0),
+            reconnect_fallback_attempts: AtomicUsize::new(0),
+        };
+
+        let operation = session
+            .build_tool_read_query(
+                "all",
+                Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S"),
+                None,
+                None,
+                None,
+                None,
+                true,
+            )
+            .expect("native peek query");
+        let crate::query::ReadOperation::Peek(query) = operation else {
+            panic!("peek option must build a non-mutating query")
+        };
+        let query_json = serde_json::to_value(&query).expect("serialized query");
+
+        assert_eq!(
+            query_json["mailbox"]["message_id_filter"],
+            serde_json::json!("01KRFK5QTF2R6NRS3Q0F8Z9K0S")
+        );
+        assert!(query_json["mailbox"]["participant_filter"].is_null());
+    }
+
+    #[test]
     fn native_read_marks_messages_read_without_changing_ack_state() {
         Python::initialize();
         let outcomes = Arc::new(Mutex::new(vec![

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -63,6 +63,12 @@ impl PyGraftSession {
                 )))
             })?;
         let selection = Self::read_selection(selection)?;
+        // `list_tool` and the CLI resolve an exact message ID within the
+        // caller's mailbox scope, irrespective of the host session's chat
+        // identifier. Preserve that parity for native exact-ID reads: the
+        // session-chat filter is appropriate for bucket scans, but would hide
+        // a bare-agent-addressed message that list just returned.
+        let exact_message_id = message_id.is_some();
         if peek {
             PeekQuery::new(
                 home_dir,
@@ -81,7 +87,12 @@ impl PyGraftSession {
             )
             .map_err(atm_error)
             .map(|query| {
-                ReadOperation::Peek(query.with_caller_chat_id(self.caller.chat_id().cloned()))
+                let query = if exact_message_id {
+                    query
+                } else {
+                    query.with_caller_chat_id(self.caller.chat_id().cloned())
+                };
+                ReadOperation::Peek(query)
             })
         } else {
             ReadQuery::new(
@@ -102,14 +113,14 @@ impl PyGraftSession {
             )
             .map_err(atm_error)
             .map(|query| {
-                ReadOperation::Read(
+                let query = if exact_message_id {
                     query
-                        .with_caller_chat_id(self.caller.chat_id().cloned())
-                        .with_activity_observation(activity_observation_for_resolved_caller(
-                            self.caller.agent(),
-                            &team,
-                        )),
-                )
+                } else {
+                    query.with_caller_chat_id(self.caller.chat_id().cloned())
+                };
+                ReadOperation::Read(query.with_activity_observation(
+                    activity_observation_for_resolved_caller(self.caller.agent(), &team),
+                ))
             })
         }
     }

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -63,9 +63,8 @@ impl PyGraftSession {
                 )))
             })?;
         let selection = Self::read_selection(selection)?;
-        // `list_tool` and the CLI resolve an exact message ID within the
-        // caller's mailbox scope, irrespective of the host session's chat
-        // identifier. Preserve that parity for native exact-ID reads: the
+        // Exact-ID reads resolve within the caller's mailbox scope,
+        // irrespective of the host session's chat identifier. The
         // session-chat filter is appropriate for bucket scans, but would hide
         // a bare-agent-addressed message that list just returned.
         let exact_message_id = message_id.is_some();

--- a/crates/atm-graft-python/src/query.rs
+++ b/crates/atm-graft-python/src/query.rs
@@ -67,7 +67,10 @@ impl PyGraftSession {
         // irrespective of the host session's chat identifier. The
         // session-chat filter is appropriate for bucket scans, but would hide
         // a bare-agent-addressed message that list just returned.
-        let exact_message_id = message_id.is_some();
+        let caller_chat_id = message_id
+            .is_none()
+            .then(|| self.caller.chat_id().cloned())
+            .flatten();
         if peek {
             PeekQuery::new(
                 home_dir,
@@ -85,14 +88,7 @@ impl PyGraftSession {
                 None,
             )
             .map_err(atm_error)
-            .map(|query| {
-                let query = if exact_message_id {
-                    query
-                } else {
-                    query.with_caller_chat_id(self.caller.chat_id().cloned())
-                };
-                ReadOperation::Peek(query)
-            })
+            .map(|query| ReadOperation::Peek(query.with_caller_chat_id(caller_chat_id)))
         } else {
             ReadQuery::new(
                 home_dir,
@@ -112,14 +108,14 @@ impl PyGraftSession {
             )
             .map_err(atm_error)
             .map(|query| {
-                let query = if exact_message_id {
+                ReadOperation::Read(
                     query
-                } else {
-                    query.with_caller_chat_id(self.caller.chat_id().cloned())
-                };
-                ReadOperation::Read(query.with_activity_observation(
-                    activity_observation_for_resolved_caller(self.caller.agent(), &team),
-                ))
+                        .with_caller_chat_id(caller_chat_id)
+                        .with_activity_observation(activity_observation_for_resolved_caller(
+                            self.caller.agent(),
+                            &team,
+                        )),
+                )
             })
         }
     }

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -531,6 +531,44 @@ class CliParityTests(unittest.TestCase):
         self.assertEqual(read["count"], 1)
         self.assertTrue(read["mutation_applied"])
 
+    def test_native_peek_by_listed_id_reaches_bare_agent_message_from_chat(self) -> None:
+        sent = self._native(
+            self.second_native_tools,
+            "atm_send",
+            {
+                "to": f"{self.identity}@{self.team}",
+                "body": "native-exact-peek-regression",
+            },
+        )
+        message_id = sent["message_id"]
+        listed = self._native(self.native_tools, "atm_list", {"selection": "all"})
+        self.assertIn(message_id, {row["message_id"] for row in listed["rows"]})
+
+        peek = self._native(
+            self.native_tools,
+            "atm_read",
+            {"selection": "all", "message_id": message_id, "peek": True},
+        )
+        self.assertEqual(peek["count"], 1)
+        self.assertFalse(peek["mutation_applied"])
+
+    def test_cli_peek_by_listed_id_reaches_bare_agent_message_from_chat(self) -> None:
+        sent = self._native(
+            self.second_native_tools,
+            "atm_send",
+            {
+                "to": f"{self.identity}@{self.team}",
+                "body": "cli-exact-peek-regression",
+            },
+        )
+        message_id = sent["message_id"]
+        listed = self._native(self.native_tools, "atm_list", {"selection": "all"})
+        self.assertIn(message_id, {row["message_id"] for row in listed["rows"]})
+
+        peek = self._cli("peek", "--message-id", message_id, identity=self.identity)
+        self.assertEqual(peek["count"], 1)
+        self.assertFalse(peek["mutation_applied"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -552,18 +552,16 @@ class CliParityTests(unittest.TestCase):
         self.assertEqual(peek["count"], 1)
         self.assertFalse(peek["mutation_applied"])
 
-    def test_cli_peek_by_listed_id_reaches_bare_agent_message_from_chat(self) -> None:
+    def test_cli_peek_by_id_reaches_other_session_message_from_chat(self) -> None:
         sent = self._native(
             self.second_native_tools,
             "atm_send",
             {
-                "to": f"{self.identity}@{self.team}",
+                "to": f"{self.identity}:other-session@{self.team}",
                 "body": "cli-exact-peek-regression",
             },
         )
         message_id = sent["message_id"]
-        listed = self._native(self.native_tools, "atm_list", {"selection": "all"})
-        self.assertIn(message_id, {row["message_id"] for row in listed["rows"]})
 
         peek = self._cli("peek", "--message-id", message_id, identity=self.identity)
         self.assertEqual(peek["count"], 1)

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -104,6 +104,10 @@ class _GeneratedParityFixture:
             "ATM_TEST_RUNTIME_HOME": str(home),
             "ATM_TEAM": self.team,
             "ATM_CHAT_ID": self.chat_id,
+            # Exercise the capability-authenticated loopback client even on
+            # Unix, where UDS is normally preferred. The regressions below
+            # require a real daemon and specifically cover TCP keep-alive.
+            "ATM_LOCAL_TRANSPORT": "tcp",
             "ATM_LOG_DIR": str(log_dir),
             "TMPDIR": str(temp_dir),
             "TMP": str(temp_dir),
@@ -461,6 +465,55 @@ class CliParityTests(unittest.TestCase):
             pending_ids = {row["message_id"] for row in pending["rows"]}
             self.assertNotIn(native_send["message_id"], pending_ids)
             self.assertNotIn(cli_send["message_id"], pending_ids)
+
+    def test_native_loopback_write_survives_idle_server_header_timeout(self) -> None:
+        # Warm this session's reqwest client, then exceed the daemon's default
+        # three-second HTTP/1 header timer. The next native request must open
+        # a fresh loopback connection rather than write to the stale pool.
+        self._native(self.native_tools, "atm_list", {"selection": "all"})
+        time.sleep(4)
+        result = self._native(
+            self.native_tools,
+            "atm_send",
+            {
+                "to": f"{self.second_identity}@{self.team}",
+                "body": "idle-loopback-regression",
+            },
+        )
+        self.assertIn("message_id", result)
+
+    def test_native_read_by_listed_id_marks_bare_agent_message_read(self) -> None:
+        sent = self._native(
+            self.second_native_tools,
+            "atm_send",
+            {
+                "to": f"{self.identity}@{self.team}",
+                "body": "native-exact-read-regression",
+            },
+        )
+        message_id = sent["message_id"]
+        listed = self._native(self.native_tools, "atm_list", {"selection": "all"})
+        self.assertIn(message_id, {row["message_id"] for row in listed["rows"]})
+
+        read = self._native(
+            self.native_tools,
+            "atm_read",
+            {"selection": "all", "message_id": message_id},
+        )
+        self.assertEqual(read["count"], 1)
+        self.assertTrue(read["mutation_applied"])
+
+        # Read acceptance is intentionally asynchronous; poll only the
+        # disposable daemon's list projection for the bounded handoff.
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            current = self._native(self.native_tools, "atm_list", {"selection": "all"})
+            matching = [row for row in current["rows"] if row["message_id"] == message_id]
+            if matching and matching[0]["read"]:
+                break
+            time.sleep(0.05)
+        else:
+            self.fail("native exact-ID read was not visible after the bounded handoff")
 
 
 if __name__ == "__main__":

--- a/crates/atm-graft-python/tests/test_cli_parity.py
+++ b/crates/atm-graft-python/tests/test_cli_parity.py
@@ -104,10 +104,6 @@ class _GeneratedParityFixture:
             "ATM_TEST_RUNTIME_HOME": str(home),
             "ATM_TEAM": self.team,
             "ATM_CHAT_ID": self.chat_id,
-            # Exercise the capability-authenticated loopback client even on
-            # Unix, where UDS is normally preferred. The regressions below
-            # require a real daemon and specifically cover TCP keep-alive.
-            "ATM_LOCAL_TRANSPORT": "tcp",
             "ATM_LOG_DIR": str(log_dir),
             "TMPDIR": str(temp_dir),
             "TMP": str(temp_dir),
@@ -466,10 +462,13 @@ class CliParityTests(unittest.TestCase):
             self.assertNotIn(native_send["message_id"], pending_ids)
             self.assertNotIn(cli_send["message_id"], pending_ids)
 
-    def test_native_loopback_write_survives_idle_server_header_timeout(self) -> None:
+    def test_native_default_uds_write_survives_idle_server_header_timeout(self) -> None:
         # Warm this session's reqwest client, then exceed the daemon's default
-        # three-second HTTP/1 header timer. The next native request must open
-        # a fresh loopback connection rather than write to the stale pool.
+        # three-second HTTP/1 header timer. This generated fixture deliberately
+        # leaves ATM_LOCAL_TRANSPORT unset, so Unix exercises the production
+        # UDS connector. The next native request must open a fresh connection
+        # rather than write to the stale pool.
+        self.assertNotIn("ATM_LOCAL_TRANSPORT", self.environment)
         self._native(self.native_tools, "atm_list", {"selection": "all"})
         time.sleep(4)
         result = self._native(
@@ -514,6 +513,23 @@ class CliParityTests(unittest.TestCase):
             time.sleep(0.05)
         else:
             self.fail("native exact-ID read was not visible after the bounded handoff")
+
+    def test_cli_read_by_listed_id_reaches_bare_agent_message_from_chat(self) -> None:
+        sent = self._native(
+            self.second_native_tools,
+            "atm_send",
+            {
+                "to": f"{self.identity}@{self.team}",
+                "body": "cli-exact-read-regression",
+            },
+        )
+        message_id = sent["message_id"]
+        listed = self._native(self.native_tools, "atm_list", {"selection": "all"})
+        self.assertIn(message_id, {row["message_id"] for row in listed["rows"]})
+
+        read = self._cli("read", "--message-id", message_id, identity=self.identity)
+        self.assertEqual(read["count"], 1)
+        self.assertTrue(read["mutation_applied"])
 
 
 if __name__ == "__main__":

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -370,20 +370,6 @@ pub fn preferred_local_client(
 ) -> Result<Arc<dyn DaemonApiClient>, AtmError> {
     #[cfg(unix)]
     {
-        match std::env::var("ATM_LOCAL_TRANSPORT").as_deref() {
-            Ok("tcp") => return loopback_tcp_client(endpoint_record_path, request_timeout),
-            Ok("") | Ok("uds") | Err(std::env::VarError::NotPresent) => {}
-            Ok(value) => {
-                return Err(AtmError::validation(format!(
-                    "ATM_LOCAL_TRANSPORT must be `uds` or `tcp`; received `{value}`"
-                )));
-            }
-            Err(std::env::VarError::NotUnicode(_)) => {
-                return Err(AtmError::validation(
-                    "ATM_LOCAL_TRANSPORT must be valid Unicode when set",
-                ));
-            }
-        }
         let runtime_directory = endpoint_record_path.as_ref().parent().ok_or_else(|| {
             AtmError::daemon_unavailable(
                 "local HTTP endpoint record has no runtime directory for Unix socket selection",
@@ -393,14 +379,7 @@ pub fn preferred_local_client(
         // root-owned runtime because `UnixSocketOwnerUid` rejects uid 0. This
         // is a configuration-selected loopback path, not a fallback after a
         // UDS failure.
-        if std::fs::metadata(runtime_directory)
-            .map_err(|source| {
-                AtmError::daemon_unavailable("failed to inspect local runtime directory")
-                    .with_cause(source)
-            })?
-            .uid()
-            == 0
-        {
+        if runtime_directory_is_root_owned(runtime_directory)? {
             return loopback_tcp_client(endpoint_record_path, request_timeout);
         }
         let socket_path = endpoint_record_path
@@ -414,6 +393,20 @@ pub fn preferred_local_client(
     {
         loopback_tcp_client(endpoint_record_path, request_timeout)
     }
+}
+
+/// Performs the one bounded local ownership check used while constructing a
+/// preferred Unix client. This synchronous metadata read happens before any
+/// async request exchange and never performs daemon I/O.
+#[cfg(unix)]
+fn runtime_directory_is_root_owned(runtime_directory: &Path) -> Result<bool, AtmError> {
+    Ok(std::fs::metadata(runtime_directory)
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to inspect local runtime directory")
+                .with_cause(source)
+        })?
+        .uid()
+        == 0)
 }
 
 /// Reqwest-backed physical loopback connector. It adds exactly the local
@@ -469,29 +462,35 @@ enum TransportGeneration {
 /// request budget for the server itself.
 const LOOPBACK_CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
 
+/// Maximum age of an idle same-host HTTP connection.
+///
+/// The daemon's HTTP/1 header timer is its three-second request budget. No
+/// local client may retain an idle connection longer than that timer: after
+/// this bounded interval reqwest opens a fresh connection rather than writing
+/// to one the daemon may already have closed. This policy intentionally keeps
+/// short-lived keep-alive reuse and is restricted to same-host connectors;
+/// peer clients preserve their distinct pooling and delivery contract.
+const LOCAL_CLIENT_IDLE_POOL_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Builds a reqwest client builder with the shared same-host connection policy.
+///
+/// Both loopback TCP and Unix-domain clients use this helper so neither can
+/// retain an idle connection beyond the daemon header timer.
+pub(crate) fn local_reqwest_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
+        .pool_idle_timeout(LOCAL_CLIENT_IDLE_POOL_TIMEOUT)
+}
+
 /// Builds one loopback `reqwest::Client` bound to no particular daemon
 /// generation yet. Callers must pair the result with the
 /// [`Ulid`] read from the same [`LocalHttpEndpointRecord`] exchange that
 /// motivated the build.
 fn build_loopback_reqwest_client() -> Result<reqwest::Client, HttpRuntimeClientFailure> {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
-        // The HTTP/1 server bounds the time it waits for the next request
-        // header on a keep-alive connection by its request budget. Retaining
-        // an idle loopback socket longer than that would let reqwest attempt
-        // the next write on a connection the daemon has already closed. A
-        // loopback exchange instead opens a fresh connection, so a failure
-        // before dispatch remains a reconnect-safe connection failure. This
-        // is deliberately local-only: peer clients retain their pool and
-        // post-write uncertainty contract.
-        .pool_max_idle_per_host(0)
-        .build()
-        .map_err(|source| {
-            HttpRuntimeClientFailure::Connect(format!(
-                "failed to build loopback HTTP client: {source}"
-            ))
-        })
+    local_reqwest_client_builder().build().map_err(|source| {
+        HttpRuntimeClientFailure::Connect(format!("failed to build loopback HTTP client: {source}"))
+    })
 }
 
 /// Reqwest owns DNS, connection and HTTP. This adapter owns only the

--- a/crates/atm-http-runtime/src/client.rs
+++ b/crates/atm-http-runtime/src/client.rs
@@ -370,6 +370,20 @@ pub fn preferred_local_client(
 ) -> Result<Arc<dyn DaemonApiClient>, AtmError> {
     #[cfg(unix)]
     {
+        match std::env::var("ATM_LOCAL_TRANSPORT").as_deref() {
+            Ok("tcp") => return loopback_tcp_client(endpoint_record_path, request_timeout),
+            Ok("") | Ok("uds") | Err(std::env::VarError::NotPresent) => {}
+            Ok(value) => {
+                return Err(AtmError::validation(format!(
+                    "ATM_LOCAL_TRANSPORT must be `uds` or `tcp`; received `{value}`"
+                )));
+            }
+            Err(std::env::VarError::NotUnicode(_)) => {
+                return Err(AtmError::validation(
+                    "ATM_LOCAL_TRANSPORT must be valid Unicode when set",
+                ));
+            }
+        }
         let runtime_directory = endpoint_record_path.as_ref().parent().ok_or_else(|| {
             AtmError::daemon_unavailable(
                 "local HTTP endpoint record has no runtime directory for Unix socket selection",
@@ -463,6 +477,15 @@ fn build_loopback_reqwest_client() -> Result<reqwest::Client, HttpRuntimeClientF
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
+        // The HTTP/1 server bounds the time it waits for the next request
+        // header on a keep-alive connection by its request budget. Retaining
+        // an idle loopback socket longer than that would let reqwest attempt
+        // the next write on a connection the daemon has already closed. A
+        // loopback exchange instead opens a fresh connection, so a failure
+        // before dispatch remains a reconnect-safe connection failure. This
+        // is deliberately local-only: peer clients retain their pool and
+        // post-write uncertainty contract.
+        .pool_max_idle_per_host(0)
         .build()
         .map_err(|source| {
             HttpRuntimeClientFailure::Connect(format!(

--- a/crates/atm-http-runtime/src/client_tail.rs
+++ b/crates/atm-http-runtime/src/client_tail.rs
@@ -107,10 +107,8 @@ impl UnixSocketConnector {
 fn build_unix_socket_reqwest_client(
     socket_path: &Path,
 ) -> Result<reqwest::Client, HttpRuntimeClientFailure> {
-    reqwest::Client::builder()
+    super::local_reqwest_client_builder()
         .unix_socket(socket_path)
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
         .build()
         .map_err(|source| {
             HttpRuntimeClientFailure::Connect(format!("failed to build Unix HTTP client: {source}"))

--- a/crates/atm-query-python/pyproject.toml
+++ b/crates/atm-query-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-query"
-version = "1.5.6"
+version = "1.5.7"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/atm/src/commands/peek.rs
+++ b/crates/atm/src/commands/peek.rs
@@ -130,6 +130,13 @@ impl PeekCommand {
             !self.no_since_last_seen && selection_mode != ReadSelection::All,
             filters,
         )
+        .map(|query| {
+            if self.message_id.is_some() {
+                query.with_caller_chat_id(None)
+            } else {
+                query
+            }
+        })
         .map_err(Into::into)
     }
 
@@ -251,6 +258,27 @@ mod tests {
             query_json["mailbox"]["message_id_filter"],
             json!("01KRFK5QTF2R6NRS3Q0F8Z9K0S")
         );
+    }
+
+    #[test]
+    #[serial(env)]
+    fn exact_message_id_does_not_apply_session_chat_scope() {
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", Some("sender-a")),
+            ("ATM_CHAT_ID", Some("session-a")),
+            ("ATM_TEAM", Some("env-team")),
+        ]);
+        let mut command = base_command();
+        command.message_id = Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S".to_string());
+
+        let query = command.build_query(".".into(), ".".into()).expect("query");
+        let query_json = serde_json::to_value(&query).expect("serialized query");
+
+        assert_eq!(
+            query_json["mailbox"]["message_id_filter"],
+            json!("01KRFK5QTF2R6NRS3Q0F8Z9K0S")
+        );
+        assert!(query_json["mailbox"]["participant_filter"].is_null());
     }
 
     #[test]

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -145,9 +145,15 @@ impl ReadCommand {
             filters,
         )
         .map(|query| {
-            query
-                .with_caller_chat_id(caller_context.caller_chat_id)
-                .with_activity_observation(caller_context.activity_observation)
+            // A message ID already identifies a mailbox row within the
+            // caller's agent/team scope. A session-chat filter would hide a
+            // bare-agent message that `atm list` can return by that ID.
+            let query = if self.message_id.is_some() {
+                query
+            } else {
+                query.with_caller_chat_id(caller_context.caller_chat_id)
+            };
+            query.with_activity_observation(caller_context.activity_observation)
         })
         .map_err(Into::into)
     }
@@ -247,6 +253,23 @@ mod tests {
         assert!(query.seen_state_update());
         assert_eq!(query.timeout_secs(), Some(9));
         assert!(query.message_id_filter().is_some());
+    }
+
+    #[test]
+    #[serial(env)]
+    fn exact_message_id_does_not_apply_session_chat_scope() {
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", Some(TEST_SENDER)),
+            ("ATM_TEAM", Some(TEST_TEAM)),
+        ]);
+        let mut command = base_command();
+        command.chat_id = Some("session-a".to_string());
+        command.message_id = Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S".to_string());
+
+        let query = command.build_query(".".into(), ".".into()).expect("query");
+
+        assert!(query.message_id_filter().is_some());
+        assert_eq!(query.caller_chat_id(), None);
     }
 
     #[test]

--- a/crates/hermes-atm/pyproject.toml
+++ b/crates/hermes-atm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-atm"
-version = "1.5.6"
+version = "1.5.7"
 description = "Hermes gateway integration for the generic ATM graft receiver"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
## Summary

- Fixes #1297: both same-host reqwest connectors apply the same bounded two-second idle-pool timeout, below the daemon three-second HTTP/1 header timer. This retains short keep-alive reuse while preventing reuse of a connection the daemon may have closed. Direct-peer pooling and its post-write uncertainty contract are unchanged.
- Fixes #1298: exact-ID reads and peeks resolve the caller-owned mailbox row without a chat-session filter. Agent/team mailbox ownership remains enforced.
- R3 made an intentional behavior change, not a pure refactor: native exact-ID peek now removes PeekQuerys bare-agent chat restriction so an owned message resolves regardless of session chat ID. R4 aligns CLI peek with that ruling. R5 proves the CLI behavior with a different destination session and states the shared query contract once on ReadQuery.
- The HTTP runtime does not select transports. Canonical ATM_LOCAL_TRANSPORT selection remains in atm-daemon-client.
- All release metadata remains at 1.5.7.

## Exact-ID ruling and disposition

An exact message ID in the callers own mailbox is resolved by ownership only, never by chat scope, identically for read and peek, CLI and native.

| Finding | Disposition |
| --- | --- |
| QA-B1 / QA-I2 | Closed: one two-second bounded idle-pool policy covers loopback TCP and UDS. |
| QA-I1 | Closed: CLI exact-ID read bypasses session-chat scope. |
| QA-3-B1 / QA-3-I2 / QA4-I1 | Closed: native and CLI exact-ID peek remove chat scope intentionally; the CLI regression uses a message addressed to a different session and fails with AssertionError: 0 != 1 if the R4 hunk is reverted. |
| QA-3-I1 / QA4-I2 | Closed: the corrected with_caller_chat_id contract appears once on ReadQuery; it states that None clears the participant filter for an exact ID, leaving ownership as the recipient scope. |
| QA-001 | Superseded by the architecture ruling: runtime parser removed; no runtime selection branch remains. |
| RSH-001 / RSH-003 | Closed/accepted: canonical resolver records unset versus empty override state; the construction-time metadata read is isolated and documented. |

## Real-daemon regressions

The generated disposable daemon fixture leaves ATM_LOCAL_TRANSPORT unset. It proves default-UDS idle-write recovery and that native and CLI exact-ID read and peek each resolve an owned message regardless of session chat scope.

## Validation

- cargo fmt --check — PASS
- cargo clippy --workspace --all-targets -- -D warnings — PASS
- cargo test --workspace --quiet — PASS, including atm-daemon
- python3 .just/run_lint.py function-length, lines, boundaries, and version — PASS
- rebuilt debug binding plus ATM_CLI_PARITY_CI=1 parity suite — PASS, 6 tests

Before each push, the PR diff was reviewed against f20441cc7. Each change is exercised by the corresponding production path or regression test.