### PR TITLE
feat(doctor): add all-team scope

### DIFF
--- a/crates/atm-core/src/doctor/ax6.rs
+++ b/crates/atm-core/src/doctor/ax6.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{
-    DoctorFinding, DoctorSeverity, EscalationRecipientsDoctorReport,
+    DoctorFinding, DoctorSeverity, EscalationRecipientSource, EscalationRecipientsDoctorReport,
     TeamEscalationRecipientsDoctorReport,
 };
 use crate::boundary::{DurableRosterStore, TaskState, TaskStore};
@@ -55,10 +55,13 @@ fn doctor_teams(
 fn daemon_recipients(
     task_store: Option<&Arc<dyn TaskStore + Send + Sync>>,
     findings: &mut Vec<DoctorFinding>,
-) -> Vec<String> {
+) -> Vec<crate::types::AgentName> {
     match task_store {
         Some(store) => match store.list_escalation_recipients(&EscalationScope::Daemon) {
-            Ok(recipients) => recipients,
+            Ok(recipients) => recipients
+                .into_iter()
+                .map(crate::types::AgentName::from_validated)
+                .collect(),
             Err(error) => {
                 push_storage_failure(findings, "daemon escalation recipients", error);
                 Vec::new()
@@ -96,11 +99,14 @@ fn team_report(
     Some(TeamEscalationRecipientsDoctorReport {
         team,
         source: if own.is_empty() {
-            "daemon default".to_owned()
+            EscalationRecipientSource::DaemonDefault
         } else {
-            "team".to_owned()
+            EscalationRecipientSource::Team
         },
-        recipients: effective,
+        recipients: effective
+            .into_iter()
+            .map(crate::types::AgentName::from_validated)
+            .collect(),
     })
 }
 

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -75,12 +75,35 @@ pub struct DoctorQuery {
     pub home_dir: PathBuf,
     pub current_dir: PathBuf,
     pub team_override: Option<TeamName>,
+    /// Inspect every team in the canonical roster instead of resolving one.
+    #[serde(default)]
+    pub all_teams: bool,
     /// Caller's `ATM_TEAM`, captured in the invoking CLI process.
     #[serde(default)]
     pub caller_team: Option<TeamName>,
     /// Caller's `ATM_IDENTITY`, captured in the invoking CLI process.
     #[serde(default)]
     pub caller_identity: Option<AgentName>,
+}
+
+/// The effective team scope for one doctor run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DoctorTeamScope {
+    Single(TeamName),
+    AllTeams { resolved_none: bool },
+}
+
+impl DoctorTeamScope {
+    fn report_name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "single",
+            Self::AllTeams { .. } => "all_teams",
+        }
+    }
+
+    fn is_all_teams(&self) -> bool {
+        matches!(self, Self::AllTeams { .. })
+    }
 }
 
 impl DoctorQuery {
@@ -120,6 +143,24 @@ impl std::fmt::Debug for RuntimeDoctorPorts {
 /// trouble remains one global informational finding after member findings.
 #[must_use]
 pub fn presence_findings(observations: &[HerdrEndpointObservation]) -> Vec<DoctorFinding> {
+    presence_findings_with_team(observations, None)
+}
+
+/// Flattens Herdr observations while attributing every finding to its roster
+/// team. This is used by the all-team doctor projection, where otherwise a
+/// presence failure would be ambiguous in the combined report.
+#[must_use]
+pub fn presence_findings_for_team(
+    observations: &[HerdrEndpointObservation],
+    team: &TeamName,
+) -> Vec<DoctorFinding> {
+    presence_findings_with_team(observations, Some(team))
+}
+
+fn presence_findings_with_team(
+    observations: &[HerdrEndpointObservation],
+    team: Option<&TeamName>,
+) -> Vec<DoctorFinding> {
     let mut members = observations
         .iter()
         .flat_map(|observation| observation.members.iter())
@@ -130,21 +171,33 @@ pub fn presence_findings(observations: &[HerdrEndpointObservation]) -> Vec<Docto
     for member in members {
         match &member.outcome {
             HerdrPresenceOutcome::Visible => {}
-            HerdrPresenceOutcome::Finding { finding } => findings.push(finding.clone()),
+            HerdrPresenceOutcome::Finding { finding } => {
+                findings.push(scope_finding(finding.clone(), team))
+            }
             HerdrPresenceOutcome::Infrastructure { code, detail } => {
                 infrastructure.get_or_insert((*code, detail.clone()));
             }
         }
     }
     if let Some((_code, detail)) = infrastructure {
-        findings.push(DoctorFinding {
-            severity: DoctorSeverity::Info,
-            code: AtmErrorCode::HerdrUnavailable,
-            message: format!("Herdr presence probe skipped: {detail}"),
-            remediation: None,
-        });
+        findings.push(scope_finding(
+            DoctorFinding {
+                severity: DoctorSeverity::Info,
+                code: AtmErrorCode::HerdrUnavailable,
+                message: format!("Herdr presence probe skipped: {detail}"),
+                remediation: None,
+            },
+            team,
+        ));
     }
     findings
+}
+
+fn scope_finding(mut finding: DoctorFinding, team: Option<&TeamName>) -> DoctorFinding {
+    if let Some(team) = team {
+        finding.message = format!("team {team}: {}", finding.message);
+    }
+    finding
 }
 
 /// Run the ATM doctor checks for config, roster, and observability health.
@@ -171,25 +224,28 @@ pub fn run_doctor_with_runtime(
     let (observability_health, finding) = doctor_observability_status(observability);
     let mut findings = Vec::new();
     push_obsolete_identity_warning(config.as_ref(), &mut findings);
-    let member_roster = doctor_context.resolved_team.as_ref().and_then(|team| {
-        load_member_roster(
-            runtime,
-            team,
-            doctor_context.environment.atm_identity.as_ref(),
-            Some(query.current_dir.as_path()),
-            &mut findings,
-        )
-    });
-    let graft_receivers = doctor_context
-        .resolved_team
-        .as_ref()
-        .map(|team| graft_receivers_doctor_report(runtime, team, &mut findings))
-        .unwrap_or_default();
+    let teams = teams_for_scope(runtime, &doctor_context.team_scope, &mut findings);
+    let (member_roster, team_rosters) = load_scoped_rosters(
+        runtime,
+        &teams,
+        &doctor_context.team_scope,
+        doctor_context.environment.atm_identity.as_ref(),
+        Some(query.current_dir.as_path()),
+        &mut findings,
+    );
+    let graft_receivers = graft_receivers_for_teams(
+        runtime,
+        &teams,
+        doctor_context.team_scope.is_all_teams(),
+        &mut findings,
+    );
     findings.push(finding);
     Ok(build_doctor_report(
         findings,
         doctor_context.environment,
+        doctor_context.team_scope,
         member_roster,
+        team_rosters,
         graft_receivers,
         PostSendDoctorReport::default(),
         crate::boundary::ConfigDoctorReport::default(),
@@ -219,23 +275,27 @@ pub fn run_doctor_with_runtime_ports(
     let mut drift_findings = Vec::new();
     let mut reports = inspect_runtime_doctor_sections(runtime_doctors, &mut general_findings);
     push_obsolete_identity_finding(config.as_ref(), &mut reports.config);
-    let member_roster = doctor_context.resolved_team.as_ref().and_then(|team| {
-        load_member_roster(
-            runtime,
-            team,
-            doctor_context.environment.atm_identity.as_ref(),
-            Some(query.current_dir.as_path()),
-            &mut drift_findings,
-        )
-    });
-    let graft_receivers = doctor_context
-        .resolved_team
-        .as_ref()
-        .map(|team| graft_receivers_doctor_report(runtime, team, &mut general_findings))
-        .unwrap_or_default();
+    let teams = teams_for_scope(runtime, &doctor_context.team_scope, &mut general_findings);
+    let (member_roster, team_rosters) = load_scoped_rosters(
+        runtime,
+        &teams,
+        &doctor_context.team_scope,
+        doctor_context.environment.atm_identity.as_ref(),
+        Some(query.current_dir.as_path()),
+        &mut drift_findings,
+    );
+    let graft_receivers = graft_receivers_for_teams(
+        runtime,
+        &teams,
+        doctor_context.team_scope.is_all_teams(),
+        &mut general_findings,
+    );
     let escalation_recipients = ax6::task_and_roster_findings(
         runtime,
-        doctor_context.resolved_team.as_ref(),
+        match &doctor_context.team_scope {
+            DoctorTeamScope::Single(team) => Some(team),
+            DoctorTeamScope::AllTeams { .. } => None,
+        },
         &mut general_findings,
     );
     let findings = collect_doctor_findings(
@@ -249,13 +309,18 @@ pub fn run_doctor_with_runtime_ports(
         config.as_ref(),
         member_roster.as_ref(),
         runtime,
-        doctor_context.resolved_team.as_ref(),
+        match &doctor_context.team_scope {
+            DoctorTeamScope::Single(team) => Some(team),
+            DoctorTeamScope::AllTeams { .. } => None,
+        },
     );
 
     Ok(build_doctor_report(
         findings,
         doctor_context.environment,
+        doctor_context.team_scope,
         member_roster,
+        team_rosters,
         graft_receivers,
         post_send,
         reports.config,
@@ -411,7 +476,7 @@ fn legacy_literal_ip_peer_reports(
 }
 
 struct DoctorRunContext {
-    resolved_team: Option<TeamName>,
+    team_scope: DoctorTeamScope,
     environment: DoctorEnvironmentVisibility,
 }
 
@@ -419,8 +484,19 @@ fn doctor_run_context(
     query: &DoctorQuery,
     config: Option<&crate::config::AtmConfig>,
 ) -> DoctorRunContext {
+    let resolved_team = resolved_doctor_team(query, config);
     DoctorRunContext {
-        resolved_team: resolved_doctor_team(query, config),
+        team_scope: if query.all_teams {
+            DoctorTeamScope::AllTeams {
+                resolved_none: false,
+            }
+        } else if let Some(team) = resolved_team.clone() {
+            DoctorTeamScope::Single(team)
+        } else {
+            DoctorTeamScope::AllTeams {
+                resolved_none: true,
+            }
+        },
         environment: health::environment_visibility(
             query.home_dir.clone(),
             query.team_override.clone(),
@@ -434,7 +510,9 @@ fn doctor_run_context(
 fn build_doctor_report(
     findings: Vec<DoctorFinding>,
     environment: DoctorEnvironmentVisibility,
+    team_scope: DoctorTeamScope,
     member_roster: Option<MembersList>,
+    team_rosters: Vec<MembersList>,
     graft_receivers: GraftReceiversDoctorReport,
     post_send: PostSendDoctorReport,
     config: crate::boundary::ConfigDoctorReport,
@@ -458,7 +536,9 @@ fn build_doctor_report(
         client_context: doctor_client_context(&environment),
         daemon_context: None,
         reader_lanes: None,
+        team_scope: team_scope.report_name().to_owned(),
         member_roster,
+        team_rosters,
         graft_receivers,
         observability: observability_health,
         herdr_queue_pump: HerdrQueuePumpDoctorReport {
@@ -487,6 +567,7 @@ const ACTIVE_LEASE_WINDOW_SECONDS: i64 = 15;
 fn graft_receivers_doctor_report(
     runtime: &impl RetainedServiceRuntime,
     team: &TeamName,
+    team_context: bool,
     findings: &mut Vec<DoctorFinding>,
 ) -> GraftReceiversDoctorReport {
     const LEASE_LOOKUP_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
@@ -500,8 +581,13 @@ fn graft_receivers_doctor_report(
                 findings.push(DoctorFinding {
                     severity: DoctorSeverity::Warning,
                     code: atm_storage::AtmErrorCode::DaemonUnavailable,
-                    message: "skipped graft-receiver lease lookups: doctor budget exhausted"
-                        .to_owned(),
+                    message: if team_context {
+                        format!(
+                            "team {team}: skipped graft-receiver lease lookups: doctor budget exhausted"
+                        )
+                    } else {
+                        "skipped graft-receiver lease lookups: doctor budget exhausted".to_owned()
+                    },
                     remediation: Some("Rerun `atm doctor` to inspect remaining leases.".to_owned()),
                 });
                 return None;
@@ -513,7 +599,12 @@ fn graft_receivers_doctor_report(
             ) {
                 Ok(lease) => lease?,
                 Err(error) => {
-                    push_doctor_error(findings, DoctorSeverity::Error, error);
+                    push_doctor_error_for_team(
+                        findings,
+                        DoctorSeverity::Error,
+                        error,
+                        team_context.then_some(team),
+                    );
                     return None;
                 }
             };
@@ -780,6 +871,7 @@ fn resolved_doctor_team(
     query
         .team_override
         .clone()
+        .or_else(|| query.caller_team.clone())
         .or_else(|| config::resolve_team(None, config))
 }
 
@@ -828,10 +920,16 @@ fn load_member_roster(
     team: &TeamName,
     caller_identity: Option<&AgentName>,
     live_cwd: Option<&Path>,
+    team_context: bool,
     findings: &mut Vec<DoctorFinding>,
 ) -> Option<MembersList> {
     if let Err(error) = crate::address::validate_path_segment(team.as_str(), "team") {
-        push_doctor_error(findings, DoctorSeverity::Error, error);
+        push_doctor_error_for_team(
+            findings,
+            DoctorSeverity::Error,
+            error,
+            team_context.then_some(team),
+        );
         return None;
     }
     let roster = runtime.load_team_roster(team);
@@ -842,6 +940,75 @@ fn load_member_roster(
         team: team.clone(),
         members,
     })
+}
+
+fn teams_for_scope(
+    runtime: &LocalServiceRuntime,
+    scope: &DoctorTeamScope,
+    findings: &mut Vec<DoctorFinding>,
+) -> Vec<TeamName> {
+    let mut teams = match scope {
+        DoctorTeamScope::Single(team) => vec![team.clone()],
+        DoctorTeamScope::AllTeams { resolved_none } => {
+            if *resolved_none {
+                findings.push(DoctorFinding {
+                    severity: DoctorSeverity::Info,
+                    code: AtmErrorCode::ObservabilityHealthOk,
+                    message: "no team resolved from --team or ATM_TEAM; inspecting all canonical roster teams"
+                        .to_owned(),
+                    remediation: None,
+                });
+            }
+            runtime.list_roster_teams()
+        }
+    };
+    teams.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    teams.dedup();
+    teams
+}
+
+fn load_scoped_rosters(
+    runtime: &LocalServiceRuntime,
+    teams: &[TeamName],
+    scope: &DoctorTeamScope,
+    caller_identity: Option<&AgentName>,
+    live_cwd: Option<&Path>,
+    findings: &mut Vec<DoctorFinding>,
+) -> (Option<MembersList>, Vec<MembersList>) {
+    let team_context = scope.is_all_teams();
+    let rosters = teams
+        .iter()
+        .filter_map(|team| {
+            load_member_roster(
+                runtime,
+                team,
+                caller_identity,
+                live_cwd,
+                team_context,
+                findings,
+            )
+        })
+        .collect::<Vec<_>>();
+    if team_context {
+        (None, rosters)
+    } else {
+        (rosters.into_iter().next(), Vec::new())
+    }
+}
+
+fn graft_receivers_for_teams(
+    runtime: &LocalServiceRuntime,
+    teams: &[TeamName],
+    team_context: bool,
+    findings: &mut Vec<DoctorFinding>,
+) -> GraftReceiversDoctorReport {
+    let receivers = teams
+        .iter()
+        .flat_map(|team| {
+            graft_receivers_doctor_report(runtime, team, team_context, findings).receivers
+        })
+        .collect();
+    GraftReceiversDoctorReport { receivers }
 }
 
 fn push_mixed_local_backend_warning(
@@ -891,6 +1058,25 @@ fn push_doctor_error(
         message,
         remediation,
     });
+}
+
+fn push_doctor_error_for_team(
+    findings: &mut Vec<DoctorFinding>,
+    severity: DoctorSeverity,
+    error: crate::error::AtmError,
+    team: Option<&TeamName>,
+) {
+    if let Some(team) = team {
+        let remediation = Some(error.remediation().to_owned());
+        findings.push(DoctorFinding {
+            severity,
+            code: error.code(),
+            message: format!("team {team}: {}", error.detail()),
+            remediation,
+        });
+    } else {
+        push_doctor_error(findings, severity, error);
+    }
 }
 
 #[cfg(test)]
@@ -973,7 +1159,7 @@ mod tests {
 
     use super::{
         legacy_literal_ip_peer_reports, ordered_member_summaries, peer_config_doctor_report,
-        presence_findings,
+        presence_findings, presence_findings_for_team,
     };
     use crate::config::AtmConfig;
     use crate::config::types::{HookRecipient, PostSendHookRule};
@@ -1108,6 +1294,12 @@ mod tests {
         );
         assert_eq!(findings[2].severity, DoctorSeverity::Info);
         assert_eq!(findings[2].code, AtmErrorCode::HerdrUnavailable);
+        let scoped = presence_findings_for_team(&observations, &"team-a".parse().expect("team"));
+        assert!(
+            scoped
+                .iter()
+                .all(|finding| finding.message.starts_with("team team-a: "))
+        );
         let member_json =
             serde_json::to_value(&observations[0].members[0]).expect("member presence serializes");
         assert_eq!(
@@ -1265,7 +1457,12 @@ mod tests {
         fn load_roster(&self, team: &TeamName) -> Result<atm_storage::RosterSnapshot, AtmError> {
             Ok(atm_storage::RosterSnapshot {
                 team_name: team.clone(),
-                members: self.members.clone(),
+                members: self
+                    .members
+                    .iter()
+                    .filter(|member| &member.team_name == team)
+                    .cloned()
+                    .collect(),
                 refreshed_at: None,
             })
         }
@@ -1332,17 +1529,30 @@ mod tests {
         TestRosterStore {
             members: members
                 .iter()
-                .map(|member| atm_storage::RosterMember {
-                    team_name: TEST_TEAM.parse().expect("team"),
-                    agent_name: AgentName::from_validated(*member),
-                    member_kind: atm_storage::RosterMemberKind::Permanent,
-                    harness: atm_storage::RosterHarness::ClaudeCode,
-                    agent_type: atm_storage::contract::AgentType::default(),
-                    model: atm_storage::ModelName::default(),
-                    recipient_pane_id: None,
-                    metadata_json: serde_json::Map::new(),
-                })
+                .map(|member| roster_member(TEST_TEAM, member))
                 .collect(),
+        }
+    }
+
+    fn roster_store_for_teams(members: &[(&str, &str)]) -> TestRosterStore {
+        TestRosterStore {
+            members: members
+                .iter()
+                .map(|(team, member)| roster_member(team, member))
+                .collect(),
+        }
+    }
+
+    fn roster_member(team: &str, member: &str) -> atm_storage::RosterMember {
+        atm_storage::RosterMember {
+            team_name: team.parse().expect("team"),
+            agent_name: AgentName::from_validated(member),
+            member_kind: atm_storage::RosterMemberKind::Permanent,
+            harness: atm_storage::RosterHarness::ClaudeCode,
+            agent_type: atm_storage::contract::AgentType::default(),
+            model: atm_storage::ModelName::default(),
+            recipient_pane_id: None,
+            metadata_json: serde_json::Map::new(),
         }
     }
 
@@ -1398,7 +1608,7 @@ mod tests {
             .with_graft_receiver_endpoint_store(store);
 
         let mut findings = Vec::new();
-        let report = super::graft_receivers_doctor_report(&runtime, &team, &mut findings);
+        let report = super::graft_receivers_doctor_report(&runtime, &team, false, &mut findings);
 
         assert!(findings.is_empty(), "{findings:#?}");
         assert_eq!(report.receivers.len(), 2);
@@ -1539,11 +1749,13 @@ mod tests {
     }
 
     fn test_runtime_with_roster(members: &[&str]) -> LocalServiceRuntime {
+        test_runtime_from_store(roster_store(members))
+    }
+
+    fn test_runtime_from_store(store: TestRosterStore) -> LocalServiceRuntime {
         let (roster_store, roster_runtime_mirror) =
-            atm_runtime_test_support::build_write_through_roster_for_test(Arc::new(roster_store(
-                members,
-            )))
-            .expect("write-through roster fixture hydrates from the in-memory fake");
+            atm_runtime_test_support::build_write_through_roster_for_test(Arc::new(store))
+                .expect("write-through roster fixture hydrates from the in-memory fake");
         LocalServiceRuntime::new_with_delivery_boundaries(
             Arc::new(UnusedMailStore),
             roster_store,
@@ -1654,6 +1866,68 @@ mod tests {
         assert_eq!(report.summary.status, DoctorStatus::Healthy);
         assert_eq!(report.findings[0].severity, DoctorSeverity::Info);
         assert_eq!(report.findings[0].code, AtmErrorCode::ObservabilityHealthOk);
+        assert_eq!(report.team_scope, "single");
+    }
+
+    #[test]
+    fn run_doctor_all_teams_projects_one_roster_per_canonical_team() {
+        let paths = TestPaths::new();
+        let runtime = test_runtime_from_store(roster_store_for_teams(&[
+            ("team-c", "member-c"),
+            ("team-a", "member-a"),
+            ("team-b", "member-b"),
+        ]));
+        let query = DoctorQuery {
+            home_dir: paths.home_dir.clone(),
+            current_dir: paths.current_dir.clone(),
+            all_teams: true,
+            ..DoctorQuery::default()
+        };
+
+        let report = run_doctor_with_runtime(query, &healthy_observability(&paths), &runtime)
+            .expect("all-team doctor report");
+
+        assert_eq!(report.team_scope, "all_teams");
+        assert!(report.member_roster.is_none());
+        assert_eq!(
+            report
+                .team_rosters
+                .iter()
+                .map(|roster| roster.team.as_str())
+                .collect::<Vec<_>>(),
+            ["team-a", "team-b", "team-c"]
+        );
+        assert!(
+            report
+                .team_rosters
+                .iter()
+                .all(|roster| roster.members.len() == 1)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn run_doctor_without_team_falls_back_to_all_with_info_finding() {
+        let paths = TestPaths::new();
+        let runtime = test_runtime_from_store(roster_store_for_teams(&[
+            ("team-a", "member-a"),
+            ("team-b", "member-b"),
+        ]));
+        let _env = crate::test_support::EnvGuard::set_many([("ATM_TEAM", None)]);
+        let query = DoctorQuery {
+            home_dir: paths.home_dir.clone(),
+            current_dir: paths.current_dir.clone(),
+            ..DoctorQuery::default()
+        };
+
+        let report = run_doctor_with_runtime(query, &healthy_observability(&paths), &runtime)
+            .expect("fallback all-team doctor report");
+
+        assert_eq!(report.team_scope, "all_teams");
+        assert_eq!(report.team_rosters.len(), 2);
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == DoctorSeverity::Info && finding.message.contains("no team resolved")
+        }));
     }
 
     #[test]
@@ -2128,6 +2402,7 @@ mod tests {
             home_dir: paths.home_dir.clone(),
             current_dir: paths.current_dir.clone(),
             team_override: None,
+            all_teams: false,
             caller_team: Some(TEST_TEAM.parse().expect("team")),
             caller_identity: Some(TEST_SENDER.parse().expect("identity")),
         };
@@ -2165,6 +2440,7 @@ mod tests {
             home_dir: paths.home_dir.clone(),
             current_dir: paths.current_dir.clone(),
             team_override: Some(override_team.parse().expect("team override")),
+            all_teams: false,
             caller_team: Some(TEST_TEAM.parse().expect("team")),
             caller_identity: Some(TEST_SENDER.parse().expect("identity")),
         };

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -2,6 +2,7 @@ mod ax6;
 pub mod health;
 mod herdr_state;
 pub mod report;
+mod team_scope;
 
 #[cfg(test)]
 use std::collections::BTreeSet;
@@ -26,6 +27,10 @@ use crate::types::{AgentName, TeamName};
 use atm_storage::PeerConfigStore;
 use std::sync::Arc;
 
+use team_scope::{
+    graft_receivers_for_teams, load_scoped_rosters, push_doctor_error_for_team, teams_for_scope,
+};
+
 pub use crate::boundary::HerdrEndpointDoctor;
 pub use herdr_state::{
     HerdrBinaryProvenance, HerdrBinaryResolution, HerdrDoctorState, HerdrEndpointDisplay,
@@ -45,6 +50,7 @@ pub use report::{
     ReaderPoolDoctorReport, ReaderPoolMetricsDoctorReport, RecipientDeliveryPath,
     RecipientDeliveryPathReport, TeamEscalationRecipientsDoctorReport,
 };
+pub use team_scope::DoctorTeamScope;
 
 #[derive(Debug, Default)]
 pub struct ClosedHerdrEndpointDoctor;
@@ -84,26 +90,6 @@ pub struct DoctorQuery {
     /// Caller's `ATM_IDENTITY`, captured in the invoking CLI process.
     #[serde(default)]
     pub caller_identity: Option<AgentName>,
-}
-
-/// The effective team scope for one doctor run.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DoctorTeamScope {
-    Single(TeamName),
-    AllTeams { resolved_none: bool },
-}
-
-impl DoctorTeamScope {
-    fn report_name(&self) -> &'static str {
-        match self {
-            Self::Single(_) => "single",
-            Self::AllTeams { .. } => "all_teams",
-        }
-    }
-
-    fn is_all_teams(&self) -> bool {
-        matches!(self, Self::AllTeams { .. })
-    }
 }
 
 impl DoctorQuery {
@@ -942,75 +928,6 @@ fn load_member_roster(
     })
 }
 
-fn teams_for_scope(
-    runtime: &LocalServiceRuntime,
-    scope: &DoctorTeamScope,
-    findings: &mut Vec<DoctorFinding>,
-) -> Vec<TeamName> {
-    let mut teams = match scope {
-        DoctorTeamScope::Single(team) => vec![team.clone()],
-        DoctorTeamScope::AllTeams { resolved_none } => {
-            if *resolved_none {
-                findings.push(DoctorFinding {
-                    severity: DoctorSeverity::Info,
-                    code: AtmErrorCode::ObservabilityHealthOk,
-                    message: "no team resolved from --team or ATM_TEAM; inspecting all canonical roster teams"
-                        .to_owned(),
-                    remediation: None,
-                });
-            }
-            runtime.list_roster_teams()
-        }
-    };
-    teams.sort_by(|left, right| left.as_str().cmp(right.as_str()));
-    teams.dedup();
-    teams
-}
-
-fn load_scoped_rosters(
-    runtime: &LocalServiceRuntime,
-    teams: &[TeamName],
-    scope: &DoctorTeamScope,
-    caller_identity: Option<&AgentName>,
-    live_cwd: Option<&Path>,
-    findings: &mut Vec<DoctorFinding>,
-) -> (Option<MembersList>, Vec<MembersList>) {
-    let team_context = scope.is_all_teams();
-    let rosters = teams
-        .iter()
-        .filter_map(|team| {
-            load_member_roster(
-                runtime,
-                team,
-                caller_identity,
-                live_cwd,
-                team_context,
-                findings,
-            )
-        })
-        .collect::<Vec<_>>();
-    if team_context {
-        (None, rosters)
-    } else {
-        (rosters.into_iter().next(), Vec::new())
-    }
-}
-
-fn graft_receivers_for_teams(
-    runtime: &LocalServiceRuntime,
-    teams: &[TeamName],
-    team_context: bool,
-    findings: &mut Vec<DoctorFinding>,
-) -> GraftReceiversDoctorReport {
-    let receivers = teams
-        .iter()
-        .flat_map(|team| {
-            graft_receivers_doctor_report(runtime, team, team_context, findings).receivers
-        })
-        .collect();
-    GraftReceiversDoctorReport { receivers }
-}
-
 fn push_mixed_local_backend_warning(
     team: &TeamName,
     roster: &[crate::boundary::RosterEntry],
@@ -1058,25 +975,6 @@ fn push_doctor_error(
         message,
         remediation,
     });
-}
-
-fn push_doctor_error_for_team(
-    findings: &mut Vec<DoctorFinding>,
-    severity: DoctorSeverity,
-    error: crate::error::AtmError,
-    team: Option<&TeamName>,
-) {
-    if let Some(team) = team {
-        let remediation = Some(error.remediation().to_owned());
-        findings.push(DoctorFinding {
-            severity,
-            code: error.code(),
-            message: format!("team {team}: {}", error.detail()),
-            remediation,
-        });
-    } else {
-        push_doctor_error(findings, severity, error);
-    }
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -41,9 +41,9 @@ pub use report::{
     BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
     BootstrapTraceReport, ClosedHerdrBreakerDoctor, DaemonRuntimeDoctorReport,
     DoctorEnvironmentVisibility, DoctorExecutionContext, DoctorFinding, DoctorReport,
-    DoctorSeverity, DoctorStatus, DoctorSummary, EscalationRecipientsDoctorReport,
-    GraftReceiverLeaseDoctorReport, GraftReceiversDoctorReport, HerdrBreakerDoctor,
-    HerdrBreakerDoctorReport, HerdrBreakerDoctorState, HerdrDoctorReport,
+    DoctorSeverity, DoctorStatus, DoctorSummary, EscalationRecipientSource,
+    EscalationRecipientsDoctorReport, GraftReceiverLeaseDoctorReport, GraftReceiversDoctorReport,
+    HerdrBreakerDoctor, HerdrBreakerDoctorReport, HerdrBreakerDoctorState, HerdrDoctorReport,
     HerdrEndpointCapabilitiesDoctorReport, HerdrEndpointDoctorReport, HerdrQueuePumpDoctorReport,
     LegacyLiteralIpPeerDoctorReport, PeerAuthorityDoctorReport, PeerConfigDoctorReport,
     PeerWireSecurityStatus, PostSendDoctorReport, PostSendHookRuleIndex, PostSendHookRuleReport,
@@ -181,7 +181,7 @@ fn presence_findings_with_team(
 
 fn scope_finding(mut finding: DoctorFinding, team: Option<&TeamName>) -> DoctorFinding {
     if let Some(team) = team {
-        finding.message = format!("team {team}: {}", finding.message);
+        finding.message = team_scope::team_message(team, finding.message);
     }
     finding
 }
@@ -523,6 +523,7 @@ fn build_doctor_report(
         daemon_context: None,
         reader_lanes: None,
         team_scope: team_scope.report_name().to_owned(),
+        resolved_team_scope: team_scope,
         member_roster,
         team_rosters,
         graft_receivers,
@@ -568,8 +569,9 @@ fn graft_receivers_doctor_report(
                     severity: DoctorSeverity::Warning,
                     code: atm_storage::AtmErrorCode::DaemonUnavailable,
                     message: if team_context {
-                        format!(
-                            "team {team}: skipped graft-receiver lease lookups: doctor budget exhausted"
+                        team_scope::team_message(
+                            team,
+                            "skipped graft-receiver lease lookups: doctor budget exhausted",
                         )
                     } else {
                         "skipped graft-receiver lease lookups: doctor budget exhausted".to_owned()
@@ -2323,6 +2325,35 @@ mod tests {
         assert_eq!(
             report.environment.atm_team.as_ref().map(TeamName::as_str),
             Some(TEST_TEAM)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn caller_team_precedes_ambient_team_for_doctor_scope() {
+        let paths = TestPaths::new();
+        paths.write_team_layout(&[TEST_SENDER]);
+        let _env = crate::test_support::EnvGuard::set_many([
+            ("ATM_TEAM", Some("config-resolved-team")),
+            ("ATM_IDENTITY", None),
+        ]);
+        let caller_team: TeamName = TEST_TEAM.parse().expect("caller team");
+        let report = run_doctor(
+            &paths,
+            DoctorQuery {
+                home_dir: paths.home_dir.clone(),
+                current_dir: paths.current_dir.clone(),
+                caller_team: Some(caller_team.clone()),
+                ..DoctorQuery::default()
+            },
+            &healthy_observability(&paths),
+        )
+        .expect("doctor report");
+
+        assert_eq!(report.team_scope, "single");
+        assert_eq!(
+            report.member_roster.expect("caller roster").team,
+            caller_team
         );
     }
 

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -400,8 +400,14 @@ pub struct DoctorReport {
     pub daemon_context: Option<DoctorExecutionContext>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reader_lanes: Option<ReaderPoolDoctorReport>,
+    /// Effective doctor scope: `single` or `all_teams`.
+    #[serde(default)]
+    pub team_scope: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member_roster: Option<MembersList>,
+    /// One roster block for every team when the effective scope is all teams.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub team_rosters: Vec<MembersList>,
     #[serde(default)]
     pub graft_receivers: GraftReceiversDoctorReport,
     pub observability: AtmObservabilityHealth,

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -224,13 +224,29 @@ pub struct PostSendDoctorReport {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TeamEscalationRecipientsDoctorReport {
     pub team: TeamName,
-    pub recipients: Vec<String>,
-    pub source: String,
+    pub recipients: Vec<AgentName>,
+    pub source: EscalationRecipientSource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationRecipientSource {
+    DaemonDefault,
+    Team,
+}
+
+impl std::fmt::Display for EscalationRecipientSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::DaemonDefault => "daemon default",
+            Self::Team => "team",
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct EscalationRecipientsDoctorReport {
-    pub daemon: Vec<String>,
+    pub daemon: Vec<AgentName>,
     pub teams: Vec<TeamEscalationRecipientsDoctorReport>,
 }
 
@@ -403,6 +419,10 @@ pub struct DoctorReport {
     /// Effective doctor scope: `single` or `all_teams`.
     #[serde(default)]
     pub team_scope: String,
+    /// The authoritative scope decision consumed by runtime projections.
+    /// This is not serialized; `team_scope` remains the stable wire field.
+    #[serde(skip, default)]
+    pub resolved_team_scope: super::DoctorTeamScope,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member_roster: Option<MembersList>,
     /// One roster block for every team when the effective scope is all teams.

--- a/crates/atm-core/src/doctor/team_scope.rs
+++ b/crates/atm-core/src/doctor/team_scope.rs
@@ -1,0 +1,114 @@
+use super::{DoctorFinding, DoctorSeverity, load_member_roster, push_doctor_error};
+use crate::error_codes::AtmErrorCode;
+use crate::service_runtime::LocalServiceRuntime;
+use crate::team_admin::MembersList;
+use crate::types::{AgentName, TeamName};
+use std::path::Path;
+
+/// The effective team scope for one doctor run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DoctorTeamScope {
+    Single(TeamName),
+    AllTeams { resolved_none: bool },
+}
+
+impl DoctorTeamScope {
+    pub(super) fn report_name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "single",
+            Self::AllTeams { .. } => "all_teams",
+        }
+    }
+
+    pub(super) fn is_all_teams(&self) -> bool {
+        matches!(self, Self::AllTeams { .. })
+    }
+}
+
+pub(super) fn teams_for_scope(
+    runtime: &LocalServiceRuntime,
+    scope: &DoctorTeamScope,
+    findings: &mut Vec<DoctorFinding>,
+) -> Vec<TeamName> {
+    let mut teams = match scope {
+        DoctorTeamScope::Single(team) => vec![team.clone()],
+        DoctorTeamScope::AllTeams { resolved_none } => {
+            if *resolved_none {
+                findings.push(DoctorFinding {
+                    severity: DoctorSeverity::Info,
+                    code: AtmErrorCode::ObservabilityHealthOk,
+                    message: "no team resolved from --team or ATM_TEAM; inspecting all canonical roster teams"
+                        .to_owned(),
+                    remediation: None,
+                });
+            }
+            runtime.list_roster_teams()
+        }
+    };
+    teams.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    teams.dedup();
+    teams
+}
+
+pub(super) fn load_scoped_rosters(
+    runtime: &LocalServiceRuntime,
+    teams: &[TeamName],
+    scope: &DoctorTeamScope,
+    caller_identity: Option<&AgentName>,
+    live_cwd: Option<&Path>,
+    findings: &mut Vec<DoctorFinding>,
+) -> (Option<MembersList>, Vec<MembersList>) {
+    let team_context = scope.is_all_teams();
+    let rosters = teams
+        .iter()
+        .filter_map(|team| {
+            load_member_roster(
+                runtime,
+                team,
+                caller_identity,
+                live_cwd,
+                team_context,
+                findings,
+            )
+        })
+        .collect::<Vec<_>>();
+    if team_context {
+        (None, rosters)
+    } else {
+        (rosters.into_iter().next(), Vec::new())
+    }
+}
+
+pub(super) fn graft_receivers_for_teams(
+    runtime: &LocalServiceRuntime,
+    teams: &[TeamName],
+    team_context: bool,
+    findings: &mut Vec<DoctorFinding>,
+) -> super::GraftReceiversDoctorReport {
+    let receivers = teams
+        .iter()
+        .flat_map(|team| {
+            super::graft_receivers_doctor_report(runtime, team, team_context, findings).receivers
+        })
+        .collect();
+    super::GraftReceiversDoctorReport { receivers }
+}
+
+pub(super) fn push_doctor_error_for_team(
+    findings: &mut Vec<DoctorFinding>,
+    severity: DoctorSeverity,
+    error: crate::error::AtmError,
+    team: Option<&TeamName>,
+) {
+    if let Some(team) = team {
+        let remediation = Some(error.remediation().to_owned());
+        findings.push(DoctorFinding {
+            severity,
+            code: error.code(),
+            message: format!("team {team}: {}", error.detail()),
+            remediation,
+        });
+    } else {
+        push_doctor_error(findings, severity, error);
+    }
+}

--- a/crates/atm-core/src/doctor/team_scope.rs
+++ b/crates/atm-core/src/doctor/team_scope.rs
@@ -12,6 +12,14 @@ pub enum DoctorTeamScope {
     AllTeams { resolved_none: bool },
 }
 
+impl Default for DoctorTeamScope {
+    fn default() -> Self {
+        Self::AllTeams {
+            resolved_none: false,
+        }
+    }
+}
+
 impl DoctorTeamScope {
     pub(super) fn report_name(&self) -> &'static str {
         match self {
@@ -20,9 +28,13 @@ impl DoctorTeamScope {
         }
     }
 
-    pub(super) fn is_all_teams(&self) -> bool {
+    pub fn is_all_teams(&self) -> bool {
         matches!(self, Self::AllTeams { .. })
     }
+}
+
+pub(super) fn team_message(team: &TeamName, message: impl AsRef<str>) -> String {
+    format!("team {team}: {}", message.as_ref())
 }
 
 pub(super) fn teams_for_scope(
@@ -105,7 +117,7 @@ pub(super) fn push_doctor_error_for_team(
         findings.push(DoctorFinding {
             severity,
             code: error.code(),
-            message: format!("team {team}: {}", error.detail()),
+            message: team_message(team, error.detail()),
             remediation,
         });
     } else {

--- a/crates/atm-runtime/src/doctor_projection.rs
+++ b/crates/atm-runtime/src/doctor_projection.rs
@@ -12,7 +12,7 @@ use atm_core::api::RequestDeadline;
 use atm_core::doctor::{
     DoctorExecutionContext, DoctorFinding, DoctorQuery, DoctorReport, DoctorSeverity,
     HerdrEndpointDoctor, ReaderPoolDoctorReport, RuntimeDoctorPorts, append_doctor_findings,
-    presence_findings, run_doctor_with_runtime_ports,
+    presence_findings_for_team, run_doctor_with_runtime_ports,
 };
 use atm_core::herdr_configured::herdr_is_configured;
 use atm_core::observability::ObservabilityPort;
@@ -153,14 +153,23 @@ impl DoctorProjection for StorageDoctorProjection {
             .await
             .map_err(|_| AtmError::daemon_unavailable("doctor request deadline expired"))?
             .map_err(|_| AtmError::daemon_unavailable("doctor control lane stopped"))??;
-        if let Some(roster) = report.member_roster.clone() {
-            self.append_herdr_report(&mut report, &roster, deadline)
-                .await?;
-        } else {
+        let rosters = report
+            .member_roster
+            .clone()
+            .into_iter()
+            .chain(report.team_rosters.clone())
+            .collect::<Vec<_>>();
+        let team_context = !report.team_rosters.is_empty();
+        if rosters.is_empty() {
             // Without a resolved team there is no Herdr-backed member to
             // inspect. This is a known, unconfigured state rather than a
             // guessed endpoint result.
             report.herdr.configured = Some(false);
+        } else {
+            for roster in rosters {
+                self.append_herdr_report(&mut report, &roster, team_context, deadline)
+                    .await?;
+            }
         }
         append_context_findings(&mut report, context);
         report.reader_lanes = self.reader_lanes;
@@ -173,17 +182,26 @@ impl StorageDoctorProjection {
         &self,
         report: &mut DoctorReport,
         roster: &atm_core::team_admin::MembersList,
+        team_context: bool,
         deadline: RequestDeadline,
     ) -> Result<(), AtmError> {
         let remaining = deadline.remaining().ok_or_else(|| {
             AtmError::daemon_unavailable("doctor request deadline expired before Herdr projection")
         })?;
-        report.herdr.configured = Some(herdr_is_configured(roster));
+        let configured = herdr_is_configured(roster);
+        report.herdr.configured = Some(report.herdr.configured.unwrap_or(false) || configured);
         match tokio::time::timeout(remaining, self.endpoint_doctor.observe(roster, deadline)).await
         {
             Ok(observations) => {
-                let findings = presence_findings(&observations);
-                report.herdr.endpoints = observations.into_iter().map(Into::into).collect();
+                let findings = if team_context {
+                    presence_findings_for_team(&observations, &roster.team)
+                } else {
+                    atm_core::doctor::presence_findings(&observations)
+                };
+                report
+                    .herdr
+                    .endpoints
+                    .extend(observations.into_iter().map(Into::into));
                 append_doctor_findings(report, findings);
             }
             Err(_) => {

--- a/crates/atm-runtime/src/doctor_projection.rs
+++ b/crates/atm-runtime/src/doctor_projection.rs
@@ -11,8 +11,8 @@ use atm_core::LocalServiceRuntime;
 use atm_core::api::RequestDeadline;
 use atm_core::doctor::{
     DoctorExecutionContext, DoctorFinding, DoctorQuery, DoctorReport, DoctorSeverity,
-    HerdrEndpointDoctor, ReaderPoolDoctorReport, RuntimeDoctorPorts, append_doctor_findings,
-    presence_findings_for_team, run_doctor_with_runtime_ports,
+    DoctorTeamScope, HerdrEndpointDoctor, ReaderPoolDoctorReport, RuntimeDoctorPorts,
+    append_doctor_findings, presence_findings_for_team, run_doctor_with_runtime_ports,
 };
 use atm_core::herdr_configured::herdr_is_configured;
 use atm_core::observability::ObservabilityPort;
@@ -95,12 +95,16 @@ impl StorageDoctorProjection {
         observability: Arc<dyn ObservabilityPort + Send + Sync>,
     ) -> Result<Self, AtmError> {
         if config.worker_count == 0 || config.queue_depth == 0 {
-            return Err(AtmError::validation(
+            return Err(AtmError::validation_with_recovery(
                 "doctor projection worker count and queue depth must be non-zero",
+                "configure at least one doctor worker and one queue slot, then restart the runtime.",
             ));
         }
         tokio::runtime::Handle::try_current().map_err(|_| {
-            AtmError::daemon_unavailable("doctor projection must start inside the Tokio runtime")
+            AtmError::daemon_unavailable_with_recovery(
+                "doctor projection must start inside the Tokio runtime",
+                "start the HTTP runtime under Tokio and retry the doctor request.",
+            )
         })?;
         let (sender, receiver) = tokio::sync::mpsc::channel(config.queue_depth);
         let endpoint_doctor = Arc::clone(&doctor_ports.herdr_endpoint);
@@ -134,8 +138,9 @@ impl DoctorProjection for StorageDoctorProjection {
         deadline: RequestDeadline,
     ) -> Result<DoctorReport, AtmError> {
         let remaining = deadline.remaining().ok_or_else(|| {
-            AtmError::daemon_unavailable(
+            AtmError::daemon_unavailable_with_recovery(
                 "doctor request deadline expired before control-lane admission",
+                "increase the request deadline or retry when the daemon is ready.",
             )
         })?;
         let (response, response_receiver) = tokio::sync::oneshot::channel();
@@ -143,32 +148,58 @@ impl DoctorProjection for StorageDoctorProjection {
             .try_send(DoctorJob { query, response })
             .map_err(|error| match error {
                 tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                    AtmError::daemon_connection_saturated("doctor control lane is saturated")
+                    AtmError::daemon_connection_saturated_with_recovery(
+                        "doctor control lane is saturated",
+                        "wait for an in-flight doctor request to finish, then retry.",
+                    )
                 }
                 tokio::sync::mpsc::error::TrySendError::Closed(_) => {
-                    AtmError::daemon_unavailable("doctor control lane is unavailable")
+                    AtmError::daemon_unavailable_with_recovery(
+                        "doctor control lane is unavailable",
+                        "restart the HTTP runtime and retry the doctor request.",
+                    )
                 }
             })?;
         let mut report = tokio::time::timeout(remaining, response_receiver)
             .await
-            .map_err(|_| AtmError::daemon_unavailable("doctor request deadline expired"))?
-            .map_err(|_| AtmError::daemon_unavailable("doctor control lane stopped"))??;
+            .map_err(|_| {
+                AtmError::daemon_unavailable_with_recovery(
+                    "doctor request deadline expired",
+                    "increase the request deadline or retry when the daemon is ready.",
+                )
+            })?
+            .map_err(|_| {
+                AtmError::daemon_unavailable_with_recovery(
+                    "doctor control lane stopped",
+                    "restart the HTTP runtime and retry the doctor request.",
+                )
+            })??;
         let rosters = report
             .member_roster
             .clone()
             .into_iter()
             .chain(report.team_rosters.clone())
             .collect::<Vec<_>>();
-        let team_context = !report.team_rosters.is_empty();
         if rosters.is_empty() {
             // Without a resolved team there is no Herdr-backed member to
             // inspect. This is a known, unconfigured state rather than a
             // guessed endpoint result.
             report.herdr.configured = Some(false);
         } else {
+            let per_team_budget = deadline
+                .remaining()
+                .map(|remaining| remaining / rosters.len() as u32);
+            let scope = report.resolved_team_scope.clone();
             for roster in rosters {
-                self.append_herdr_report(&mut report, &roster, team_context, deadline)
-                    .await?;
+                if deadline.expired() {
+                    append_deadline_finding(
+                        &mut report,
+                        "doctor request deadline expired before the next Herdr team projection",
+                    );
+                    break;
+                }
+                self.append_herdr_report(&mut report, &roster, &scope, deadline, per_team_budget)
+                    .await;
             }
         }
         append_context_findings(&mut report, context);
@@ -182,18 +213,28 @@ impl StorageDoctorProjection {
         &self,
         report: &mut DoctorReport,
         roster: &atm_core::team_admin::MembersList,
-        team_context: bool,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError> {
-        let remaining = deadline.remaining().ok_or_else(|| {
-            AtmError::daemon_unavailable("doctor request deadline expired before Herdr projection")
-        })?;
+        scope: &DoctorTeamScope,
+        caller_deadline: RequestDeadline,
+        budget: Option<std::time::Duration>,
+    ) {
         let configured = herdr_is_configured(roster);
         report.herdr.configured = Some(report.herdr.configured.unwrap_or(false) || configured);
-        match tokio::time::timeout(remaining, self.endpoint_doctor.observe(roster, deadline)).await
+        let Some(remaining) = caller_deadline.remaining() else {
+            append_deadline_finding(
+                report,
+                "doctor request deadline expired before Herdr projection",
+            );
+            return;
+        };
+        let timeout_budget = budget.map_or(remaining, |budget| budget.min(remaining));
+        match tokio::time::timeout(
+            timeout_budget,
+            self.endpoint_doctor.observe(roster, caller_deadline),
+        )
+        .await
         {
             Ok(observations) => {
-                let findings = if team_context {
+                let findings = if scope.is_all_teams() {
                     presence_findings_for_team(&observations, &roster.team)
                 } else {
                     atm_core::doctor::presence_findings(&observations)
@@ -205,21 +246,34 @@ impl StorageDoctorProjection {
                 append_doctor_findings(report, findings);
             }
             Err(_) => {
-                let finding = DoctorFinding {
-                    severity: DoctorSeverity::Warning,
-                    code: atm_storage::AtmErrorCode::DaemonUnavailable,
-                    message: "Herdr presence projection exceeded the doctor request deadline"
-                        .to_owned(),
-                    remediation: Some(
-                        "Inspect the Herdr service, then rerun `atm doctor`.".to_owned(),
-                    ),
-                };
+                let finding = herdr_deadline_finding();
                 report.herdr.error = Some(finding.clone());
                 append_doctor_findings(report, vec![finding]);
             }
         }
-        Ok(())
     }
+}
+
+fn herdr_deadline_finding() -> DoctorFinding {
+    DoctorFinding {
+        severity: DoctorSeverity::Warning,
+        code: atm_storage::AtmErrorCode::DaemonUnavailable,
+        message: "Herdr presence projection exceeded its per-team doctor budget".to_owned(),
+        remediation: Some("Inspect the Herdr service, then rerun `atm doctor`.".to_owned()),
+    }
+}
+
+fn append_deadline_finding(report: &mut DoctorReport, message: &str) {
+    let finding = DoctorFinding {
+        severity: DoctorSeverity::Warning,
+        code: atm_storage::AtmErrorCode::DaemonUnavailable,
+        message: message.to_owned(),
+        remediation: Some(
+            "Increase the doctor request deadline, then rerun `atm doctor`.".to_owned(),
+        ),
+    };
+    report.herdr.error = Some(finding.clone());
+    append_doctor_findings(report, vec![finding]);
 }
 
 fn append_context_findings(report: &mut DoctorReport, context: DoctorProjectionContext) {
@@ -291,7 +345,124 @@ async fn run_doctor_worker(
             )
         })
         .await
-        .map_err(|error| AtmError::daemon_unavailable(format!("doctor worker failed: {error}")));
+        .map_err(|error| {
+            AtmError::daemon_unavailable_with_recovery(
+                format!("doctor worker failed: {error}"),
+                "restart the HTTP runtime and retry the doctor request.",
+            )
+        });
         let _ = job.response.send(result.and_then(|report| report));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use atm_core::api::RequestDeadline;
+    use atm_core::doctor::{DoctorQuery, HerdrEndpointDoctor, RuntimeDoctorPorts};
+    use atm_core::observability::NullObservability;
+    use atm_core::team_admin::MembersList;
+    use atm_core::types::{AgentName, TeamName};
+    use atm_runtime_test_support::open_isolated_sqlite_boundary;
+    use atm_storage::{RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot};
+
+    use super::{
+        DoctorProjection, DoctorProjectionConfig, DoctorProjectionContext, StorageDoctorProjection,
+    };
+
+    #[derive(Clone)]
+    struct CountingEndpoint {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl atm_core::boundary::sealed::Sealed for CountingEndpoint {}
+
+    impl HerdrEndpointDoctor for CountingEndpoint {
+        fn observe<'a>(
+            &'a self,
+            _roster: &'a MembersList,
+            _caller_deadline: RequestDeadline,
+        ) -> Pin<
+            Box<dyn Future<Output = Vec<atm_core::doctor::HerdrEndpointObservation>> + Send + 'a>,
+        > {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Vec::new() })
+        }
+    }
+
+    fn roster(team: &str) -> RosterSnapshot {
+        let team = TeamName::from_validated(team);
+        RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![RosterMember {
+                team_name: team,
+                agent_name: AgentName::from_validated("member"),
+                member_kind: RosterMemberKind::Permanent,
+                harness: RosterHarness::ClaudeCode,
+                agent_type: atm_storage::AgentType::Worker,
+                model: Default::default(),
+                recipient_pane_id: None,
+                metadata_json: serde_json::Map::new(),
+            }],
+            refreshed_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn all_team_projection_aggregates_each_roster_through_the_async_loop() {
+        let root = std::env::temp_dir().join(format!(
+            "atm-runtime-doctor-projection-{}",
+            atm_storage::AtmMessageId::new()
+        ));
+        std::fs::create_dir_all(&root).expect("temporary runtime root");
+        let assembly = open_isolated_sqlite_boundary(&root).expect("runtime assembly");
+        let roster_store = assembly.shared_roster_store_arc();
+        roster_store
+            .save_roster(&roster("team-a"))
+            .expect("team-a roster");
+        roster_store
+            .save_roster(&roster("team-b"))
+            .expect("team-b roster");
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let endpoint = Arc::new(CountingEndpoint {
+            calls: Arc::clone(&calls),
+        });
+        let ports = RuntimeDoctorPorts {
+            config_doctor: Arc::clone(&assembly.doctor_ports.config_doctor),
+            mail_store_doctor: Arc::clone(&assembly.doctor_ports.mail_store_doctor),
+            roster_store_doctor: Arc::clone(&assembly.doctor_ports.roster_store_doctor),
+            herdr_breaker: Arc::clone(&assembly.doctor_ports.herdr_breaker),
+            herdr_endpoint: endpoint,
+        };
+        let projection = StorageDoctorProjection::start(
+            DoctorProjectionConfig::default(),
+            assembly.service_runtime.clone(),
+            ports,
+            Arc::new(NullObservability),
+        )
+        .expect("doctor projection");
+
+        let report = projection
+            .project(
+                DoctorQuery {
+                    home_dir: root.clone(),
+                    current_dir: root.clone(),
+                    all_teams: true,
+                    ..DoctorQuery::default()
+                },
+                DoctorProjectionContext::default(),
+                RequestDeadline::after(std::time::Duration::from_secs(5)),
+            )
+            .await
+            .expect("all-team projection");
+
+        assert_eq!(report.team_rosters.len(), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        std::fs::remove_dir_all(root).expect("remove temporary runtime root");
     }
 }

--- a/crates/atm-runtime/src/doctor_projection.rs
+++ b/crates/atm-runtime/src/doctor_projection.rs
@@ -463,6 +463,22 @@ mod tests {
 
         assert_eq!(report.team_rosters.len(), 2);
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        // Release every SQLite handle before deleting the root: Windows
+        // refuses to remove a directory whose files are still open. The
+        // worker tasks own port clones, so wait (bounded) for the aborted
+        // tasks to drop them before the assembly itself goes away.
+        drop(projection);
+        drop(roster_store);
+        let release_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while Arc::strong_count(&assembly.doctor_ports.roster_store_doctor) > 1 {
+            assert!(
+                std::time::Instant::now() < release_deadline,
+                "doctor workers still hold roster ports after 5s"
+            );
+            tokio::task::yield_now().await;
+        }
+        drop(assembly);
         std::fs::remove_dir_all(root).expect("remove temporary runtime root");
     }
 }

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -23,6 +23,18 @@ impl AtmError {
         }
     }
 
+    fn with_recovery(
+        code: AtmErrorCode,
+        detail: impl Into<String>,
+        recovery: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            message: format!("{}\n  Recovery: {}", detail.into(), recovery.into()),
+            cause: None,
+        }
+    }
+
     /// Constructs the canonical error using the catalog's code-owned text.
     pub fn for_code(code: AtmErrorCode) -> Self {
         Self {
@@ -170,6 +182,13 @@ impl AtmError {
         Self::new(AtmErrorCode::DaemonUnavailable, message)
     }
 
+    pub fn daemon_unavailable_with_recovery(
+        message: impl Into<String>,
+        recovery: impl Into<String>,
+    ) -> Self {
+        Self::with_recovery(AtmErrorCode::DaemonUnavailable, message, recovery)
+    }
+
     /// Local persistence completed, but the peer did not accept the immutable
     /// write before the caller's shared deadline. Retrying uses the same ULID.
     pub fn remote_delivery_unconfirmed(message: impl Into<String>) -> Self {
@@ -287,6 +306,13 @@ impl AtmError {
         Self::new(AtmErrorCode::DaemonConnectionSaturated, message)
     }
 
+    pub fn daemon_connection_saturated_with_recovery(
+        message: impl Into<String>,
+        recovery: impl Into<String>,
+    ) -> Self {
+        Self::with_recovery(AtmErrorCode::DaemonConnectionSaturated, message, recovery)
+    }
+
     pub fn help_topic_not_found(message: impl Into<String>) -> Self {
         Self::new(AtmErrorCode::HelpTopicNotFound, message)
     }
@@ -352,11 +378,7 @@ impl AtmError {
         message: impl Into<String>,
         recovery: impl Into<String>,
     ) -> Self {
-        Self {
-            code: AtmErrorCode::MessageValidationFailed,
-            message: format!("{}\n  Recovery: {}", message.into(), recovery.into()),
-            cause: None,
-        }
+        Self::with_recovery(AtmErrorCode::MessageValidationFailed, message, recovery)
     }
 
     pub fn local_http_capability_invalid(message: impl Into<String>) -> Self {

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -18,6 +18,13 @@ pub struct DoctorCommand {
     #[arg(long, help = "Override the resolved team for the doctor check.")]
     team: Option<String>,
 
+    #[arg(
+        long,
+        conflicts_with = "team",
+        help = "Inspect every team in the canonical roster."
+    )]
+    all_teams: bool,
+
     #[arg(long, help = "Emit the doctor report as JSON.")]
     json: bool,
 }
@@ -65,6 +72,7 @@ impl DoctorCommand {
             home_dir,
             current_dir,
             team_override,
+            all_teams: self.all_teams,
             caller_team,
             caller_identity,
         })
@@ -122,11 +130,26 @@ impl DoctorCommand {
 mod tests {
     use atm_core::error::AtmError;
     use atm_core::test_support::EnvGuard;
+    use clap::{Parser, error::ErrorKind};
     use serial_test::serial;
     use tempfile::TempDir;
 
     use super::DoctorCommand;
     use crate::observability::CliObservability;
+
+    #[derive(Debug, Parser)]
+    struct DoctorCli {
+        #[command(flatten)]
+        doctor: DoctorCommand,
+    }
+
+    #[test]
+    fn all_teams_conflicts_with_team_override() {
+        let error = DoctorCli::try_parse_from(["doctor", "--team", "team-a", "--all-teams"])
+            .expect_err("team and all-teams must conflict");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
 
     fn test_paths() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
         let tempdir = TempDir::new().expect("tempdir");
@@ -139,6 +162,7 @@ mod tests {
     fn build_query_preserves_team_override() {
         let command = DoctorCommand {
             team: Some("test-team".to_string()),
+            all_teams: false,
             json: true,
         };
 
@@ -155,6 +179,7 @@ mod tests {
     fn build_query_adds_recovery_for_invalid_team_override() {
         let command = DoctorCommand {
             team: Some("bad team".to_string()),
+            all_teams: false,
             json: false,
         };
 
@@ -173,6 +198,7 @@ mod tests {
         let observability = CliObservability::fallback();
         let command = DoctorCommand {
             team: None,
+            all_teams: false,
             json: false,
         };
         let (_tempdir, home_dir, current_dir) = test_paths();

--- a/crates/atm/src/commands/members.rs
+++ b/crates/atm/src/commands/members.rs
@@ -72,6 +72,7 @@ impl MembersCommand {
             home_dir,
             current_dir,
             team_override: Some(team.clone()),
+            all_teams: false,
             caller_team,
             caller_identity,
         };

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -299,6 +299,7 @@ impl TeamsCommand {
             home_dir,
             current_dir,
             team_override: Some(team.clone()),
+            all_teams: false,
             caller_team: atm_core::caller_context::read_cli_team_from_env_or_warn(
                 "atm::teams::members::runtime",
             ),

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -620,21 +620,32 @@ fn print_doctor_escalation_recipients(report: &DoctorReport) {
 }
 
 fn print_doctor_roster(report: &DoctorReport) {
-    if let Some(roster) = &report.member_roster {
-        print_doctor_roster_block(roster);
-    }
-    for roster in &report.team_rosters {
-        print_doctor_roster_block(roster);
-    }
+    print!(
+        "{}",
+        render_doctor_rosters(report.member_roster.as_ref(), &report.team_rosters)
+    );
 }
 
-fn print_doctor_roster_block(roster: &atm_core::team_admin::MembersList) {
-    println!();
-    println!("Members: {}", roster.team);
+fn render_doctor_rosters(
+    member_roster: Option<&atm_core::team_admin::MembersList>,
+    team_rosters: &[atm_core::team_admin::MembersList],
+) -> String {
+    let mut rendered = String::new();
+    if let Some(roster) = member_roster {
+        rendered.push_str(&render_doctor_roster_block(roster));
+    }
+    for roster in team_rosters {
+        rendered.push_str(&render_doctor_roster_block(roster));
+    }
+    rendered
+}
+
+fn render_doctor_roster_block(roster: &atm_core::team_admin::MembersList) -> String {
+    let mut rendered = format!("\nMembers: {}\n", roster.team);
     for member in &roster.members {
         let home_dir = member.home_dir.as_path().display().to_string();
-        println!(
-            "  {} | type={} harness={} model={} home_dir={} live_cwd={} pane={}",
+        rendered.push_str(&format!(
+            "  {} | type={} harness={} model={} home_dir={} live_cwd={} pane={}\n",
             member.name,
             empty_dash(&member.agent_type),
             member.harness,
@@ -642,8 +653,9 @@ fn print_doctor_roster_block(roster: &atm_core::team_admin::MembersList) {
             empty_dash(&home_dir),
             empty_dash_opt(member.live_cwd.as_deref()),
             empty_dash_opt(member.tmux_pane_id.as_deref())
-        );
+        ));
     }
+    rendered
 }
 
 fn print_doctor_graft_receivers(report: &DoctorReport) {
@@ -1051,6 +1063,7 @@ mod tests {
         PeerConfigDoctorReport,
     };
     use atm_core::error_codes::AtmErrorCode;
+    use atm_core::team_admin::MembersList;
     use atm_core::types::HostName;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -1058,7 +1071,7 @@ mod tests {
 
     use super::{
         render_bootstrap_trace_section, render_doctor_herdr, render_doctor_peer_config,
-        render_send_stdout, render_warnings_to_stderr,
+        render_doctor_rosters, render_send_stdout, render_warnings_to_stderr,
     };
 
     #[test]
@@ -1090,6 +1103,22 @@ mod tests {
         assert!(rendered.contains("Remedy: Configure Herdr only if desired"));
         assert_eq!(json["endpoints"][0]["capabilities"]["live_handoff"], true);
         assert!(json["endpoints"][0].get("live_handoff").is_none());
+    }
+
+    #[test]
+    fn doctor_roster_rendering_prints_one_heading_per_team() {
+        let rosters = ["team-a", "team-b"]
+            .into_iter()
+            .map(|team| MembersList {
+                team: team.parse().expect("team"),
+                members: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        let rendered = render_doctor_rosters(None, &rosters);
+
+        assert_eq!(rendered.matches("Members: ").count(), 2);
+        assert!(rendered.contains("Members: team-a"));
+        assert!(rendered.contains("Members: team-b"));
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -620,9 +620,15 @@ fn print_doctor_escalation_recipients(report: &DoctorReport) {
 }
 
 fn print_doctor_roster(report: &DoctorReport) {
-    let Some(roster) = &report.member_roster else {
-        return;
-    };
+    if let Some(roster) = &report.member_roster {
+        print_doctor_roster_block(roster);
+    }
+    for roster in &report.team_rosters {
+        print_doctor_roster_block(roster);
+    }
+}
+
+fn print_doctor_roster_block(roster: &atm_core::team_admin::MembersList) {
     println!();
     println!("Members: {}", roster.team);
     for member in &roster.members {

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -408,6 +408,17 @@
       "args": [
         {
           "has_default": true,
+          "id": "all_teams",
+          "long": "all-teams",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
           "id": "json",
           "long": "json",
           "num_args": {

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -387,6 +387,21 @@ Error codes should describe the failure class, not a specific prose message.
       Remount or move the ATM home to a writable filesystem, then retry the ATM command.
       ```
 
+### `atm doctor` team scope
+
+`atm doctor` resolves its roster scope using the following precedence:
+
+| Invocation | Scope |
+| --- | --- |
+| `--team <team>` | The explicitly named team; this overrides `ATM_TEAM`. |
+| `ATM_TEAM=<team>` | Only the ambient caller team when no `--team` is supplied. |
+| `--all-teams` | Every team in the canonical roster store. |
+| Neither a team nor `--all-teams` | Every canonical roster team, plus an informational finding explaining that no team was resolved. |
+
+`--team` and `--all-teams` are mutually exclusive and return an argument
+conflict (exit status 2). JSON reports identify the effective scope in
+`team_scope`; all-team reports contain one roster in `team_rosters` per team.
+
 ### 5.10 Runtime Families
 
 The following families are part of the current runtime line. Store codes are

--- a/docs/atm/cli-reference-1-5-6.md
+++ b/docs/atm/cli-reference-1-5-6.md
@@ -625,5 +625,3 @@ Show the stored schema/frontmatter for one exact immutable SHA
 | `<sha>` |  | yes |  |
 | `--json` |  | no |  |
 | `--stderr-logs` |  | no | Route retained observability console logs to stderr |
-
-

--- a/docs/atm/cli-reference-1-5-6.md
+++ b/docs/atm/cli-reference-1-5-6.md
@@ -1,0 +1,629 @@
+# ATM CLI Reference
+
+This document is generated from the live `clap` command tree. Do not hand-edit it — regenerate with `cargo run -p agent-team-mail --features cli-surface-dump --example gen_cli_docs` (see `crates/atm/src/cli_surface.rs`).
+
+## `atm`
+
+ATM CLI
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm ack`
+
+Acknowledge one pending-ack message and emit a reply when required
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<message_id>` |  | yes |  |
+| `<reply>` |  | yes |  |
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm api`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm api spec`
+
+Print the versioned daemon OpenAPI contract
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--format` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm clear`
+
+Clear read or acknowledged messages from a mailbox
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--older-than` |  | no |  |
+| `--idle-only` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm compose`
+
+Render a template through the core renderer port and print the exact body
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--template` |  | yes | Template file to validate and render |
+| `--vars` |  | no | JSON object providing template variables; `-` reads stdin |
+| `--var` |  | no | One template variable; may be repeated |
+| `--env-prefix` |  | no | Capture environment variables with this prefix |
+| `--dry-run` |  | no | Validate and render without any side effects (the default operation is already side-effect free; the flag makes scripts self-documenting) |
+| `--json` |  | no | Emit a structured result instead of the byte-identical rendered body |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Composition is local and never reads or writes the mailbox. Use `atm send <agent> --template <path> --vars <file>` to deliver the same template after previewing it.
+
+### `atm doctor`
+
+Run ATM health and configuration diagnostics
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no | Override the resolved team for the doctor check. |
+| `--all-teams` |  | no | Inspect every team in the canonical roster. |
+| `--json` |  | no | Emit the doctor report as JSON. |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm escalation`
+
+Manage daemon-wide and per-team escalation recipients
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm escalation add`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<address>` |  | yes |  |
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm escalation list`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm escalation remove`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<address>` |  | yes |  |
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm help`
+
+Show ATM-owned conceptual help or delegated clap subcommand help
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--list` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm list`
+
+List one ATM mailbox surface as bounded metadata rows
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--limit` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--tasks` |  | no | List the durable task ledger for the selected team |
+| `--task-events` |  | no | List the append-only audit events for one task identifier |
+| `--member` |  | no | Restrict a task-ledger view to one assignee |
+| `--json` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm log`
+
+Query or follow ATM retained observability records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log filter`
+
+Query ATM log records using explicit field filters
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--source` |  | no | Select the retained-log source. JSONL is the byte-compatible default |
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--until` |  | no | Inclusive upper time bound as RFC3339 or a relative duration |
+| `--component` |  | no | Restrict timeline records to a component prefix |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log snapshot`
+
+Query recent ATM log records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--source` |  | no | Select the retained-log source. JSONL is the byte-compatible default |
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--until` |  | no | Inclusive upper time bound as RFC3339 or a relative duration |
+| `--component` |  | no | Restrict timeline records to a component prefix |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log tail`
+
+Follow new ATM log records as they arrive
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--source` |  | no | Select the retained-log source. JSONL is the byte-compatible default |
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--until` |  | no | Inclusive upper time bound as RFC3339 or a relative duration |
+| `--component` |  | no | Restrict timeline records to a component prefix |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--poll-interval-ms` |  | no | Poll interval in milliseconds between follow polls |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm members`
+
+List the current member roster for one ATM team
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm peek`
+
+Inspect one ATM mailbox message without mutating mailbox state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm peer`
+
+Manage durable cross-host HTTPS control-plane configuration
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer certificate`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer certificate init`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--fingerprint` |  | yes |  |
+| `--private-key-ref` |  | yes |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer certificate show`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer interface`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface list`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface remove`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--bind` |  | yes |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface set`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--bind` |  | yes |  |
+| `--advertise-host` |  | yes |  |
+| `--enabled` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer trust`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust add`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--fingerprint` |  | yes |  |
+| `--https-port` |  | no |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust list`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust migrate`
+
+Migrate or retire legacy literal-IP trusted-peer entries.
+
+Without `--yes`, prints the migration plan (one line per legacy literal-IP row: enabled/disabled, fingerprint, port, and the action) and makes no changes. With `--yes`, applies the plan: rows named by `--map IP=HOSTNAME` convert to the durable hostname, preserving their fingerprint and port; every other legacy literal-IP row is revoked.
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--map` |  | no | Convert the legacy literal-IP entry `IP` to durable hostname `HOSTNAME`, keeping its fingerprint and port. May be repeated |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust replace`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--fingerprint` |  | yes |  |
+| `--https-port` |  | no |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust revoke`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm queue`
+
+Queue one ATM mailbox message for deferred recipient notification
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<to>` |  | no |  |
+| `<message>` |  | no |  |
+| `--team` |  | no |  |
+| `--host` |  | no | Route this send through the explicitly named host |
+| `--chat-id` |  | no |  |
+| `--as` |  | no |  |
+| `--file` |  | no |  |
+| `--stdin` |  | no |  |
+| `--template` |  | no | Render and send a locally loaded template through the daemon-owned template admission path |
+| `--vars` |  | no | JSON object providing template variables. `-` reads this object from stdin; it is distinct from `--stdin`, which is a plain message source |
+| `--var` |  | no | One template variable. May be repeated; values parse as JSON when possible and otherwise remain strings |
+| `--env-prefix` |  | no | Capture current environment variables with this prefix at CLI composition time |
+| `--attach` |  | no | Attach a local file for Send-To delivery (ADR-055). May be repeated. A same-host recipient's files are staged under `$ATM_TEMP/send-to/<id>/`; a remote recipient's files are routed through that host's configured transfer script (see `docs/cross-host-file-transfer.md`). The landed path rides in the message text; there is no envelope change. Mutually exclusive with `--template` (structured template content and free-form attachment notes are not composed in this phase) |
+| `--from-json` |  | no | Read one `PickerOutput` JSON document (`{"schema_version":1,"recipients":[...],"note":"..."}`) from stdin and send one immutable message per recipient (ADR-055). Mutually exclusive with the positional recipient/message text, `--stdin`, `--file`, `--template`, and `--env-prefix` |
+| `--category` |  | no |  |
+| `--tag` |  | no |  |
+| `--content-format` |  | no |  |
+| `--summary` |  | no |  |
+| `--requires-ack` |  | no |  |
+| `--task-id` |  | no |  |
+| `--task-complete` |  | no | Complete a previously assigned task as its assigner or assignee |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Path-only bodies are admitted for compatibility but recorded as content_format=path-ref and warned on stderr; use `atm send --template <path> --vars <file>` to send rendered content, and `atm compose --template <path>` to preview it. Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = "name-or-*" and command = ["argv", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr.
+
+### `atm read`
+
+Read one ATM mailbox message and optionally update read state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<message_id_positional>` |  | no | Positional message IDs are rejected with a migration hint. Keeping this parser slot lets the CLI explain the supported option instead of returning clap's generic unexpected-argument error |
+| `--team` |  | no |  |
+| `--chat-id` |  | no |  |
+| `--as` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm search`
+
+Search locally indexed ATM messages through the daemon's typed query API
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<text>` |  | no | Literal phrase by default, or an ATM advanced expression with --raw-match |
+| `--raw-match` |  | no | Parse the positional text with ATM's documented bounded advanced grammar |
+| `--template-meta` |  | no | Filter stored template frontmatter metadata; a trailing * is a prefix match |
+| `--type` |  | no | Shorthand for --template-meta type=VALUE |
+| `--template-sha` |  | no | Filter the exact immutable template revision |
+| `--var` |  | no | Filter one stored template variable; may be repeated |
+| `--tag` |  | no |  |
+| `--effective-tag` |  | no | Filter ATM's immutable effective-tag projection; may be repeated |
+| `--category` |  | no |  |
+| `--from` |  | no |  |
+| `--team` |  | no |  |
+| `--agent` |  | no |  |
+| `--workflow-scope-kind` |  | no |  |
+| `--workflow-scope-id` |  | no |  |
+| `--workflow-state` |  | no |  |
+| `--workflow-stage` |  | no |  |
+| `--workflow-transition` |  | no |  |
+| `--workflow-iteration` |  | no |  |
+| `--lifecycle-scope-kind` |  | no | Project generic lifecycle observations over the local search result set |
+| `--lifecycle-scope-id` |  | no |  |
+| `--lifecycle-start-state` |  | no |  |
+| `--lifecycle-start-stage` |  | no |  |
+| `--lifecycle-start-transition` |  | no |  |
+| `--lifecycle-end-state` |  | no |  |
+| `--lifecycle-end-stage` |  | no |  |
+| `--lifecycle-end-transition` |  | no |  |
+| `--since` |  | no |  |
+| `--until` |  | no |  |
+| `--limit` |  | no |  |
+| `--cursor` |  | no |  |
+| `--per-mailbox` |  | no | Preserve per-mailbox compound-key identities rather than default deduplication |
+| `--count` |  | no |  |
+| `--group-by` |  | no |  |
+| `--min` |  | no |  |
+| `--max` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Plain positional text is always a literal phrase. --raw-match enables ATM's bounded advanced grammar (words, quoted phrases, NEAR(term term[, distance]), AND, OR, NOT); it never passes raw SQLite FTS syntax.
+
+### `atm send`
+
+Send one ATM mailbox message
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<to>` |  | no |  |
+| `<message>` |  | no |  |
+| `--team` |  | no |  |
+| `--host` |  | no | Route this send through the explicitly named host |
+| `--chat-id` |  | no |  |
+| `--as` |  | no |  |
+| `--file` |  | no |  |
+| `--stdin` |  | no |  |
+| `--template` |  | no | Render and send a locally loaded template through the daemon-owned template admission path |
+| `--vars` |  | no | JSON object providing template variables. `-` reads this object from stdin; it is distinct from `--stdin`, which is a plain message source |
+| `--var` |  | no | One template variable. May be repeated; values parse as JSON when possible and otherwise remain strings |
+| `--env-prefix` |  | no | Capture current environment variables with this prefix at CLI composition time |
+| `--attach` |  | no | Attach a local file for Send-To delivery (ADR-055). May be repeated. A same-host recipient's files are staged under `$ATM_TEMP/send-to/<id>/`; a remote recipient's files are routed through that host's configured transfer script (see `docs/cross-host-file-transfer.md`). The landed path rides in the message text; there is no envelope change. Mutually exclusive with `--template` (structured template content and free-form attachment notes are not composed in this phase) |
+| `--from-json` |  | no | Read one `PickerOutput` JSON document (`{"schema_version":1,"recipients":[...],"note":"..."}`) from stdin and send one immutable message per recipient (ADR-055). Mutually exclusive with the positional recipient/message text, `--stdin`, `--file`, `--template`, and `--env-prefix` |
+| `--category` |  | no |  |
+| `--tag` |  | no |  |
+| `--content-format` |  | no |  |
+| `--summary` |  | no |  |
+| `--requires-ack` |  | no |  |
+| `--task-id` |  | no |  |
+| `--task-complete` |  | no | Complete a previously assigned task as its assigner or assignee |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Path-only bodies are admitted for compatibility but recorded as content_format=path-ref and warned on stderr; use `atm send --template <path> --vars <file>` to send rendered content, and `atm compose --template <path>` to preview it. Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = "name-or-*" and command = ["argv", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr.
+
+### `atm teams`
+
+List teams or run one team-administration subcommand
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--members` |  | no | Emit the picker member projection (ADR-055 decision (e), PRD §4.2/§5a) instead of the team-count list: per-member `{"id","name", "host","cwd","status"}`, consumed by `atm send --from-json`'s `recipients`. Only valid without a subcommand |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams add-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--home-dir` |  | no |  |
+| `--backend` |  | no | local receiver backend: tmux or herdr |
+| `--target` |  | no | tmux pane target; required for --backend tmux |
+| `--session` |  | no | Herdr session name; only valid with --backend herdr |
+| `--pane-id` |  | no | deprecated compatibility spelling for --backend tmux --target |
+| `--host` |  | no | this member's registered host (ADR-055 decision (e)); used for Send-To same-host/remote routing, never inferred |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams backup`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams clear-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes | template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams disable-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes | template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams remove-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams restore`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--from` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams set-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes | template kind: delivery, delivery_ack, queue, queue_ack, task, acknowledge, acknowledge_task |
+| `--template-body` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams update-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--home-dir` |  | no |  |
+| `--workspace-root` |  | no |  |
+| `--harness` |  | no |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--backend` |  | no | local receiver backend: tmux or herdr |
+| `--target` |  | no | tmux pane target; required for --backend tmux |
+| `--session` |  | no | Herdr session name; only valid with --backend herdr |
+| `--pane-id` |  | no | deprecated compatibility spelling for --backend tmux --target |
+| `--host` |  | no | this member's registered host (ADR-055 decision (e)); used for Send-To same-host/remote routing, never inferred |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm templates`
+
+Inspect immutable templates registered by decomposed-message admission
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm templates list`
+
+List every known immutable template revision, optionally by metadata type
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--type` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm templates schema`
+
+Show the stored schema/frontmatter for one exact immutable SHA
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<sha>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+

--- a/docs/plans/phase-ay/sprint-AY.13-doctor-team-scope.md
+++ b/docs/plans/phase-ay/sprint-AY.13-doctor-team-scope.md
@@ -80,6 +80,10 @@ filesystem or from `~/.claude/teams/`.
 - D4 `crates/atm/src/output.rs`: text rendering prints one roster block per
   team in scope with the team name as the block heading; single-team output
   is unchanged.
+- D4a Supporting scope plumbing: `crates/atm/src/commands/members.rs`,
+  `crates/atm/src/commands/teams.rs`, and
+  `crates/atm-runtime/src/doctor_projection.rs` carry the all-teams query and
+  project each scoped roster without re-reading caller state.
 - D5 Tests (`crates/atm-core/src/doctor/` unit tests against the existing
   stub roster store, never the live database): single team unchanged;
   `all_teams` with three teams yields three roster sections and presence


### PR DESCRIPTION
## Summary\n- add  with explicit team/all-team conflict handling\n- preserve single-team output and expose per-team rosters in JSON/text\n- attribute all-team Herdr presence findings and document scope precedence\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- focused doctor tests\n