### PR TITLE
feature/ay14 herdr agent name mapping

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -55,6 +55,7 @@ layout = "even-horizontal"
 
 [[rmux.windows.panes]]
 name = "team-lead"
+alias = "atm-lead"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
@@ -66,6 +67,7 @@ env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_I
 
 [[rmux.windows.panes]]
 name = "quality-mgr"
+alias = "atm-quality"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
@@ -92,6 +94,7 @@ layout = "even-horizontal"
 
 [[rmux.windows.panes]]
 name = "publisher"
+alias = "atm-publisher"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "publisher", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -127,7 +127,7 @@ toml_glob = "boundaries/*/*.toml"
 # by one named implementation seam.
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm/Cargo.toml"
-allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-graft", "atm-http-runtime", "atm-observability", "atm-runtime-test-support", "atm-storage", "chrono", "clap", "sc-observability", "sc-observability-types", "serde", "serde_json", "serde_yaml", "serial_test", "tempfile", "time", "tokio", "tracing", "tracing-subscriber", "ulid"]
+allowed_dependencies = ["anyhow", "async-trait", "atm-core", "atm-daemon-bootstrap", "atm-daemon-client", "atm-graft", "atm-http-runtime", "atm-observability", "atm-runtime-test-support", "atm-storage", "chrono", "clap", "sc-observability", "sc-observability-types", "serde", "serde_json", "serde_yaml", "serial_test", "tempfile", "time", "toml", "tokio", "tracing", "tracing-subscriber", "ulid"]
 
 [[boundaries.manifest_dependency_allowlists]]
 owner_manifest_path = "crates/atm-core/Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "ulid",

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -184,11 +184,11 @@ pub struct LocalTmuxNudgeTarget {
     pub rendered_nudge: String,
 }
 
-/// Target metadata for a Herdr prompt. The live agent name is carried by the
-/// dispatch event; the optional per-member session and rendered template are
-/// resolved before the dispatch crosses into the process adapter.
+/// Target metadata for a Herdr prompt, resolved from durable roster data
+/// before the dispatch crosses into the process adapter.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct HerdrNudgeTarget {
+    pub agent: crate::HerdrAgentName,
     pub session: Option<crate::HerdrSession>,
     pub rendered_nudge: String,
 }

--- a/crates/atm-core/src/caller_context.rs
+++ b/crates/atm-core/src/caller_context.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 
+use crate::boundary::RosterEntry;
 use crate::error::AtmError;
 use crate::types::{
     AgentIdentity, AgentName, ChatId, SessionId, TeamName, deserialize_optional_session_id,
@@ -47,6 +48,55 @@ pub struct CallerContextOverrides<'a> {
     pub identity_override: Option<CallerIdentityOverride<'a>>,
     pub chat_id_override: Option<CallerChatIdOverride<'a>>,
     pub team_override: Option<CallerTeamOverride<'a>>,
+}
+
+/// Resolves a team-scoped durable roster alias at an ATM ingress boundary.
+///
+/// Canonical member names take precedence, so corrupt historical metadata
+/// cannot shadow a real identity. The returned value is always suitable for
+/// mailbox, storage, and audit paths.
+#[must_use]
+pub fn resolve_roster_alias(
+    candidate: &AgentName,
+    team: &TeamName,
+    roster: &[RosterEntry],
+) -> AgentName {
+    if roster
+        .iter()
+        .any(|member| member.team_name == *team && member.agent_name == *candidate)
+    {
+        return candidate.clone();
+    }
+
+    roster
+        .iter()
+        .find(|member| {
+            member.team_name == *team
+                && member
+                    .metadata_json
+                    .get("alias")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(candidate.as_str())
+        })
+        .map_or_else(|| candidate.clone(), |member| member.agent_name.clone())
+}
+
+/// Replaces a caller alias with its canonical durable roster identity before
+/// the caller crosses an ATM storage or mailbox boundary.
+#[must_use]
+pub fn canonicalize_caller_context(
+    mut caller: CallerContext,
+    roster: &[RosterEntry],
+) -> CallerContext {
+    let canonical = resolve_roster_alias(&caller.caller_identity, &caller.caller_team, roster);
+    if canonical != caller.caller_identity {
+        // The ambient observation attested to the alias, not the canonical
+        // principal. Never carry that unverified attribution into a durable
+        // operation after resolving the ingress identity.
+        caller.activity_observation = None;
+    }
+    caller.caller_identity = canonical;
+    caller
 }
 
 pub fn resolve_cli_inspection_caller_context(
@@ -301,18 +351,59 @@ fn parse_team(raw: String) -> Result<TeamName, AtmError> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
+    use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind};
     use crate::error_codes::AtmErrorCode;
     use crate::roles::ROLE_TEAM_LEAD;
     use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
-    use crate::types::{AgentIdentity, ChatId, SESSION_ID_MAX_BYTES};
+    use crate::types::{
+        AgentIdentity, AgentName, ChatId, ModelName, SESSION_ID_MAX_BYTES, TeamName,
+    };
 
     use super::{
         CallerChatIdOverride, CallerContextOverrides, CallerIdentityOverride, CallerTeamOverride,
-        read_cli_agent_name_from_env, read_cli_identity_from_env_or_warn, read_cli_pid_from_env,
-        read_cli_session_id_from_env, read_cli_team_from_env, read_cli_team_from_env_or_warn,
-        resolve_caller_chat_id, resolve_cli_inspection_caller_context,
-        resolve_cli_mutation_caller_context,
+        canonicalize_caller_context, read_cli_agent_name_from_env,
+        read_cli_identity_from_env_or_warn, read_cli_pid_from_env, read_cli_session_id_from_env,
+        read_cli_team_from_env, read_cli_team_from_env_or_warn, resolve_caller_chat_id,
+        resolve_cli_inspection_caller_context, resolve_cli_mutation_caller_context,
     };
+
+    fn aliased_member() -> RosterEntry {
+        let team = TeamName::from_validated(TEST_TEAM);
+        let mut metadata_json = serde_json::Map::new();
+        metadata_json.insert("alias".to_owned(), json!("atm-lead"));
+        RosterEntry {
+            team_name: team,
+            agent_name: AgentName::from_validated(ROLE_TEAM_LEAD),
+            member_kind: RosterMemberKind::Permanent,
+            harness: RosterHarness::ClaudeCode,
+            agent_type: crate::schema::AgentType::Lead,
+            model: ModelName::default(),
+            recipient_pane_id: None,
+            metadata_json,
+        }
+    }
+
+    #[test]
+    fn canonicalize_caller_context_replaces_an_ingress_alias_and_drops_alias_attestation() {
+        let caller = super::CallerContext {
+            caller_identity: AgentName::from_validated("atm-lead"),
+            caller_chat_id: None,
+            caller_team: TeamName::from_validated(TEST_TEAM),
+            activity_observation: Some(super::ActivityObservation {
+                team: TeamName::from_validated(TEST_TEAM),
+                member: AgentName::from_validated("atm-lead"),
+                session_id: None,
+                pid: None,
+            }),
+        };
+
+        let canonical = canonicalize_caller_context(caller, &[aliased_member()]);
+
+        assert_eq!(canonical.caller_identity.as_str(), ROLE_TEAM_LEAD);
+        assert!(canonical.activity_observation.is_none());
+    }
 
     #[test]
     #[serial_test::serial(env)]

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -63,7 +63,6 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         default_team: parse_default_team(parsed.atm.default_team.or(parsed.default_team), &path)?,
         team_members: normalize_team_members(parsed.atm.team_members, &path)?,
         aliases: normalize_aliases(parsed.atm.aliases),
-        rmux_pane_aliases: normalize_rmux_pane_aliases(parsed.rmux),
         post_send_hooks: normalize_post_send_hooks(parsed.atm.post_send_hooks, &config_root)?,
         max_message_bytes: normalize_max_message_bytes(parsed.atm.max_message_bytes, &path)?,
         claude_jsonl_body_export_max_bytes: normalize_claude_jsonl_body_export_max_bytes(
@@ -215,28 +214,6 @@ struct RawConfigFile {
     identity: Option<String>,
     #[serde(default)]
     default_team: Option<String>,
-    #[serde(default)]
-    rmux: RawRmuxSection,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct RawRmuxSection {
-    #[serde(default)]
-    windows: Vec<RawRmuxWindow>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct RawRmuxWindow {
-    #[serde(default)]
-    panes: Vec<RawRmuxPane>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct RawRmuxPane {
-    #[serde(default)]
-    name: String,
-    #[serde(default)]
-    alias: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -394,18 +371,6 @@ fn normalize_aliases(
         .collect()
 }
 
-fn normalize_rmux_pane_aliases(raw: RawRmuxSection) -> std::collections::BTreeMap<String, String> {
-    raw.windows
-        .into_iter()
-        .flat_map(|window| window.panes)
-        .filter_map(|pane| {
-            let alias = pane.alias?.trim().to_string();
-            let name = pane.name.trim().to_string();
-            (!name.is_empty() && !alias.is_empty()).then_some((name, alias))
-        })
-        .collect()
-}
-
 #[cfg(test)]
 fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
     let root: Value = serde_json::from_str(raw).map_err(|error| {
@@ -560,17 +525,6 @@ command = ["bash", "-lc", "echo hi"]
 tl = "{ROLE_TEAM_LEAD}"
 qa = "{TEST_QA}"
 blank = ""
-
-[rmux]
-
-[[rmux.windows]]
-
-[[rmux.windows.panes]]
-name = "team-lead"
-alias = "atm-lead"
-
-[[rmux.windows.panes]]
-name = "arch-ctm"
 "#,
             ),
         )
@@ -616,14 +570,6 @@ name = "arch-ctm"
         );
         assert_eq!(config.aliases.get("qa").map(String::as_str), Some(TEST_QA));
         assert!(!config.aliases.contains_key("blank"));
-        assert_eq!(
-            config
-                .rmux_pane_aliases
-                .get("team-lead")
-                .map(String::as_str),
-            Some("atm-lead")
-        );
-        assert!(!config.rmux_pane_aliases.contains_key("arch-ctm"));
     }
 
     #[test]

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -63,6 +63,7 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         default_team: parse_default_team(parsed.atm.default_team.or(parsed.default_team), &path)?,
         team_members: normalize_team_members(parsed.atm.team_members, &path)?,
         aliases: normalize_aliases(parsed.atm.aliases),
+        rmux_pane_aliases: normalize_rmux_pane_aliases(parsed.rmux),
         post_send_hooks: normalize_post_send_hooks(parsed.atm.post_send_hooks, &config_root)?,
         max_message_bytes: normalize_max_message_bytes(parsed.atm.max_message_bytes, &path)?,
         claude_jsonl_body_export_max_bytes: normalize_claude_jsonl_body_export_max_bytes(
@@ -214,6 +215,28 @@ struct RawConfigFile {
     identity: Option<String>,
     #[serde(default)]
     default_team: Option<String>,
+    #[serde(default)]
+    rmux: RawRmuxSection,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRmuxSection {
+    #[serde(default)]
+    windows: Vec<RawRmuxWindow>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRmuxWindow {
+    #[serde(default)]
+    panes: Vec<RawRmuxPane>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRmuxPane {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    alias: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -371,6 +394,18 @@ fn normalize_aliases(
         .collect()
 }
 
+fn normalize_rmux_pane_aliases(raw: RawRmuxSection) -> std::collections::BTreeMap<String, String> {
+    raw.windows
+        .into_iter()
+        .flat_map(|window| window.panes)
+        .filter_map(|pane| {
+            let alias = pane.alias?.trim().to_string();
+            let name = pane.name.trim().to_string();
+            (!name.is_empty() && !alias.is_empty()).then_some((name, alias))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
     let root: Value = serde_json::from_str(raw).map_err(|error| {
@@ -525,6 +560,17 @@ command = ["bash", "-lc", "echo hi"]
 tl = "{ROLE_TEAM_LEAD}"
 qa = "{TEST_QA}"
 blank = ""
+
+[rmux]
+
+[[rmux.windows]]
+
+[[rmux.windows.panes]]
+name = "team-lead"
+alias = "atm-lead"
+
+[[rmux.windows.panes]]
+name = "arch-ctm"
 "#,
             ),
         )
@@ -570,6 +616,14 @@ blank = ""
         );
         assert_eq!(config.aliases.get("qa").map(String::as_str), Some(TEST_QA));
         assert!(!config.aliases.contains_key("blank"));
+        assert_eq!(
+            config
+                .rmux_pane_aliases
+                .get("team-lead")
+                .map(String::as_str),
+            Some("atm-lead")
+        );
+        assert!(!config.rmux_pane_aliases.contains_key("arch-ctm"));
     }
 
     #[test]

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -75,6 +75,9 @@ pub struct AtmConfig {
     /// Alias destination values are free-form routing strings; no domain constraint is applied at
     /// the config layer, so no newtype wrapper is needed here.
     pub aliases: BTreeMap<String, String>,
+    /// Optional durable roster aliases declared by the repo's rmux pane
+    /// definitions, keyed by the canonical pane/member name.
+    pub rmux_pane_aliases: BTreeMap<String, String>,
     pub post_send_hooks: Vec<PostSendHookRule>,
     /// Bounded message payload policy shared by inline, stdin, and daemon
     /// admission. It deliberately is not a SQLite row-size limit.
@@ -110,6 +113,7 @@ impl Default for AtmConfig {
             default_team: None,
             team_members: Vec::new(),
             aliases: BTreeMap::new(),
+            rmux_pane_aliases: BTreeMap::new(),
             post_send_hooks: Vec::new(),
             max_message_bytes: ByteCount::new(DEFAULT_MAX_MESSAGE_BYTES),
             claude_jsonl_body_export_max_bytes: ByteCount::new(

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -75,9 +75,6 @@ pub struct AtmConfig {
     /// Alias destination values are free-form routing strings; no domain constraint is applied at
     /// the config layer, so no newtype wrapper is needed here.
     pub aliases: BTreeMap<String, String>,
-    /// Optional durable roster aliases declared by the repo's rmux pane
-    /// definitions, keyed by the canonical pane/member name.
-    pub rmux_pane_aliases: BTreeMap<String, String>,
     pub post_send_hooks: Vec<PostSendHookRule>,
     /// Bounded message payload policy shared by inline, stdin, and daemon
     /// admission. It deliberately is not a SQLite row-size limit.
@@ -113,7 +110,6 @@ impl Default for AtmConfig {
             default_team: None,
             team_members: Vec::new(),
             aliases: BTreeMap::new(),
-            rmux_pane_aliases: BTreeMap::new(),
             post_send_hooks: Vec::new(),
             max_message_bytes: ByteCount::new(DEFAULT_MAX_MESSAGE_BYTES),
             claude_jsonl_body_export_max_bytes: ByteCount::new(

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -101,16 +101,38 @@ impl HerdrAgentName {
     }
 }
 
-impl From<&AgentName> for HerdrAgentName {
-    fn from(value: &AgentName) -> Self {
-        Self::new(value.as_str()).expect("AgentName uses Herdr's agent-name grammar")
-    }
-}
-
 impl fmt::Display for HerdrAgentName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
+}
+
+/// Resolves the server-side target for a roster member without allowing a
+/// historical ATM canonical name to panic a Herdr delivery path.
+///
+/// A configured roster alias has already passed Herdr validation. When it is
+/// absent, the canonical ATM name retains the established fallback behavior
+/// only when it also satisfies the Herdr grammar. Otherwise the caller must
+/// skip that best-effort Herdr operation; persisted mailbox state remains
+/// canonical and untouched.
+#[must_use]
+pub fn resolve_herdr_agent_target(
+    member: &AgentName,
+    configured_alias: Option<HerdrAgentName>,
+    warning_site: &'static str,
+) -> Option<HerdrAgentName> {
+    configured_alias.or_else(|| match HerdrAgentName::new(member.as_str()) {
+        Ok(agent) => Some(agent),
+        Err(error) => {
+            tracing::warn!(
+                warning_site,
+                member = %member,
+                %error,
+                "skipping Herdr operation because the canonical member name is not a valid Herdr target"
+            );
+            None
+        }
+    })
 }
 
 /// The first-party local delivery backend a recipient's roster entry
@@ -316,6 +338,26 @@ mod tests {
                 "{invalid} must be rejected"
             );
         }
+    }
+
+    #[test]
+    fn herdr_target_skips_a_nonconforming_canonical_name_without_panicking() {
+        let member = AgentName::from_validated("TeamLead");
+
+        assert_eq!(
+            resolve_herdr_agent_target(&member, None, "delivery_channel test"),
+            None
+        );
+        assert_eq!(
+            resolve_herdr_agent_target(
+                &member,
+                Some(HerdrAgentName::new("team-lead_atm-dev").expect("alias")),
+                "delivery_channel test",
+            )
+            .as_ref()
+            .map(HerdrAgentName::as_str),
+            Some("team-lead_atm-dev")
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -66,7 +66,7 @@ impl fmt::Display for HerdrSession {
 /// One validated live-agent name on a shared Herdr server.
 ///
 /// This is deliberately distinct from an ATM [`AgentName`]: a roster member
-/// keeps its ATM identity while `herdrAgent` selects its unique server-side
+/// keeps its ATM identity while its roster `alias` selects its unique server-side
 /// target.  It lives in atm-core because durable roster metadata and runtime
 /// target selection must not introduce an atm-core -> atm-herdr dependency.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -203,7 +203,7 @@ pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Valu
 /// Derives the local backend from durable roster data. No schema migration:
 /// `recipient_pane_id` selects `Tmux`;
 /// `metadata_json["backendType"] == "herdr"` selects `Herdr`, reading an
-/// optional `metadata_json["herdrSession"]` and `metadata_json["herdrAgent"]`
+/// optional `metadata_json["herdrSession"]` and `metadata_json["alias"]`
 /// string. An unparsable value is treated as absent and logged, not rejected.
 #[must_use]
 pub fn local_message_received_backend(
@@ -241,19 +241,19 @@ pub fn local_message_received_backend(
         });
     let agent = member
         .metadata_json
-        .get("herdrAgent")
+        .get("alias")
         .and_then(Value::as_str)
         .and_then(|raw| match HerdrAgentName::new(raw) {
             Ok(agent) => Some(agent),
             Err(error) => {
                 tracing::warn!(
                     subsystem = "atm_core.delivery_channel",
-                    action = "herdr_agent_parse",
+                    action = "herdr_alias_parse",
                     outcome = "failed",
                     agent = %member.agent_name,
                     team = %member.team_name,
                     %error,
-                    "ignoring invalid herdrAgent roster metadata"
+                    "ignoring invalid Herdr roster alias metadata"
                 );
                 None
             }
@@ -399,14 +399,14 @@ mod tests {
     }
 
     #[test]
-    fn local_message_received_backend_reads_optional_herdr_agent() {
+    fn local_message_received_backend_reads_optional_herdr_alias() {
         let mut member = roster_entry();
         member.metadata_json.insert(
             BACKEND_TYPE_METADATA_KEY.to_owned(),
             Value::String("herdr".to_owned()),
         );
         member.metadata_json.insert(
-            "herdrAgent".to_owned(),
+            "alias".to_owned(),
             Value::String("shared_team_lead".to_owned()),
         );
 
@@ -420,14 +420,14 @@ mod tests {
     }
 
     #[test]
-    fn local_message_received_backend_treats_invalid_herdr_agent_as_absent() {
+    fn local_message_received_backend_treats_invalid_herdr_alias_as_absent() {
         let mut member = roster_entry();
         member.metadata_json.insert(
             BACKEND_TYPE_METADATA_KEY.to_owned(),
             Value::String("herdr".to_owned()),
         );
         member.metadata_json.insert(
-            "herdrAgent".to_owned(),
+            "alias".to_owned(),
             Value::String("Not-A-Herdr-Agent".to_owned()),
         );
 

--- a/crates/atm-core/src/delivery_channel.rs
+++ b/crates/atm-core/src/delivery_channel.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::AtmError;
-use crate::types::PaneId;
+use crate::types::{AgentName, PaneId};
 
 pub(crate) const BACKEND_TYPE_METADATA_KEY: &str = "backendType";
 
@@ -63,6 +63,56 @@ impl fmt::Display for HerdrSession {
     }
 }
 
+/// One validated live-agent name on a shared Herdr server.
+///
+/// This is deliberately distinct from an ATM [`AgentName`]: a roster member
+/// keeps its ATM identity while `herdrAgent` selects its unique server-side
+/// target.  It lives in atm-core because durable roster metadata and runtime
+/// target selection must not introduce an atm-core -> atm-herdr dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HerdrAgentName(String);
+
+impl HerdrAgentName {
+    /// Constructs a Herdr-side agent name using Herdr's live-agent grammar.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when the name is not `[a-z][a-z0-9_-]{0,31}`.
+    pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
+        let value = value.into();
+        let valid = (1..=32).contains(&value.len())
+            && value.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+            && value.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+            });
+        if !valid {
+            return Err(AtmError::validation(
+                "Herdr agent name must match ^[a-z][a-z0-9_-]{0,31}$",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the validated server-side name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&AgentName> for HerdrAgentName {
+    fn from(value: &AgentName) -> Self {
+        Self::new(value.as_str()).expect("AgentName uses Herdr's agent-name grammar")
+    }
+}
+
+impl fmt::Display for HerdrAgentName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// The first-party local delivery backend a recipient's roster entry
 /// resolves to, if any.
 ///
@@ -72,8 +122,13 @@ impl fmt::Display for HerdrSession {
 /// launches sessions and its own env is irrelevant (Rand, 2026-08-26).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LocalMessageReceivedBackend {
-    Tmux { pane_id: PaneId },
-    Herdr { session: Option<HerdrSession> },
+    Tmux {
+        pane_id: PaneId,
+    },
+    Herdr {
+        session: Option<HerdrSession>,
+        agent: Option<HerdrAgentName>,
+    },
 }
 
 /// Whether the recipient's process currently holds an active Graft receiver
@@ -148,8 +203,8 @@ pub fn test_backend_type_metadata(backend: &str) -> serde_json::Map<String, Valu
 /// Derives the local backend from durable roster data. No schema migration:
 /// `recipient_pane_id` selects `Tmux`;
 /// `metadata_json["backendType"] == "herdr"` selects `Herdr`, reading an
-/// optional `metadata_json["herdrSession"]` string. An unparsable
-/// `herdrSession` value is treated as absent and logged, not rejected.
+/// optional `metadata_json["herdrSession"]` and `metadata_json["herdrAgent"]`
+/// string. An unparsable value is treated as absent and logged, not rejected.
 #[must_use]
 pub fn local_message_received_backend(
     member: &crate::boundary::RosterEntry,
@@ -184,7 +239,26 @@ pub fn local_message_received_backend(
                 None
             }
         });
-    Some(LocalMessageReceivedBackend::Herdr { session })
+    let agent = member
+        .metadata_json
+        .get("herdrAgent")
+        .and_then(Value::as_str)
+        .and_then(|raw| match HerdrAgentName::new(raw) {
+            Ok(agent) => Some(agent),
+            Err(error) => {
+                tracing::warn!(
+                    subsystem = "atm_core.delivery_channel",
+                    action = "herdr_agent_parse",
+                    outcome = "failed",
+                    agent = %member.agent_name,
+                    team = %member.team_name,
+                    %error,
+                    "ignoring invalid herdrAgent roster metadata"
+                );
+                None
+            }
+        });
+    Some(LocalMessageReceivedBackend::Herdr { session, agent })
 }
 
 #[cfg(test)]
@@ -224,11 +298,35 @@ mod tests {
     }
 
     #[test]
+    fn herdr_agent_name_uses_the_live_agent_grammar() {
+        let name = HerdrAgentName::new("team_lead-1").expect("valid Herdr agent");
+        assert_eq!(name.as_str(), "team_lead-1");
+        assert_eq!(name.to_string(), "team_lead-1");
+
+        for invalid in [
+            "",
+            "TeamLead",
+            "team lead",
+            "team.lead",
+            "1team",
+            "a".repeat(33).as_str(),
+        ] {
+            assert!(
+                HerdrAgentName::new(invalid).is_err(),
+                "{invalid} must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn classify_delivery_channel_covers_all_four_rows() {
         let tmux = LocalMessageReceivedBackend::Tmux {
             pane_id: PaneId::from_cli("%1").expect("pane"),
         };
-        let herdr = LocalMessageReceivedBackend::Herdr { session: None };
+        let herdr = LocalMessageReceivedBackend::Herdr {
+            session: None,
+            agent: None,
+        };
         assert_eq!(
             classify_delivery_channel(Some(&tmux), GraftLeaseState::Absent),
             DeliveryChannel::TmuxSteer
@@ -293,9 +391,49 @@ mod tests {
 
         let backend = local_message_received_backend(&member).expect("backend");
         match backend {
-            LocalMessageReceivedBackend::Herdr { session } => {
+            LocalMessageReceivedBackend::Herdr { session, .. } => {
                 assert_eq!(session.expect("session").as_str(), "session-7");
             }
+            LocalMessageReceivedBackend::Tmux { .. } => panic!("expected herdr backend"),
+        }
+    }
+
+    #[test]
+    fn local_message_received_backend_reads_optional_herdr_agent() {
+        let mut member = roster_entry();
+        member.metadata_json.insert(
+            BACKEND_TYPE_METADATA_KEY.to_owned(),
+            Value::String("herdr".to_owned()),
+        );
+        member.metadata_json.insert(
+            "herdrAgent".to_owned(),
+            Value::String("shared_team_lead".to_owned()),
+        );
+
+        let backend = local_message_received_backend(&member).expect("backend");
+        match backend {
+            LocalMessageReceivedBackend::Herdr { agent, .. } => {
+                assert_eq!(agent.expect("agent").as_str(), "shared_team_lead");
+            }
+            LocalMessageReceivedBackend::Tmux { .. } => panic!("expected herdr backend"),
+        }
+    }
+
+    #[test]
+    fn local_message_received_backend_treats_invalid_herdr_agent_as_absent() {
+        let mut member = roster_entry();
+        member.metadata_json.insert(
+            BACKEND_TYPE_METADATA_KEY.to_owned(),
+            Value::String("herdr".to_owned()),
+        );
+        member.metadata_json.insert(
+            "herdrAgent".to_owned(),
+            Value::String("Not-A-Herdr-Agent".to_owned()),
+        );
+
+        let backend = local_message_received_backend(&member).expect("backend");
+        match backend {
+            LocalMessageReceivedBackend::Herdr { agent, .. } => assert!(agent.is_none()),
             LocalMessageReceivedBackend::Tmux { .. } => panic!("expected herdr backend"),
         }
     }
@@ -314,7 +452,7 @@ mod tests {
 
         let backend = local_message_received_backend(&member).expect("backend");
         match backend {
-            LocalMessageReceivedBackend::Herdr { session } => assert!(session.is_none()),
+            LocalMessageReceivedBackend::Herdr { session, .. } => assert!(session.is_none()),
             LocalMessageReceivedBackend::Tmux { .. } => panic!("expected herdr backend"),
         }
     }

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -223,6 +223,7 @@ mod tests {
             recipient_pane_id: None,
             local_tmux_post_send: false,
             local_herdr_post_send: false,
+            herdr_agent: None,
             herdr_session: None,
             graft_post_send: false,
             bare_cli_post_send: false,

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -93,9 +93,9 @@ impl DeliveryRecipientSnapshot {
         let local_tmux_post_send = delivery_channel == DeliveryChannel::TmuxSteer;
         let local_herdr_post_send = delivery_channel == DeliveryChannel::HerdrSteer;
         let herdr_session = match local_backend.as_ref() {
-            Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { session }) => {
-                session.clone()
-            }
+            Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr {
+                session, ..
+            }) => session.clone(),
             _ => None,
         };
         let graft_post_send = delivery_channel == DeliveryChannel::Graft;

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -1,4 +1,3 @@
-use crate::HerdrSession;
 use crate::boundary::{RosterEntry, RosterHarness};
 use crate::delivery_channel::{
     DeliveryChannel, GraftLeaseState, classify_delivery_channel, graft_lease_state,
@@ -9,6 +8,7 @@ use crate::provenance::ValidatedWriteProvenance;
 use crate::schema::{AtmMessageId, ThreadMode};
 use crate::service_runtime::{GRAFT_RECEIVER_LEASE_LOOKUP_DEADLINE, RetainedServiceRuntime};
 use crate::types::{AgentName, PaneId, TeamName};
+use crate::{HerdrAgentName, HerdrSession};
 
 #[expect(
     dead_code,
@@ -62,6 +62,7 @@ pub(crate) struct DeliveryRecipientSnapshot {
     pub(crate) recipient_pane_id: Option<PaneId>,
     pub(crate) local_tmux_post_send: bool,
     pub(crate) local_herdr_post_send: bool,
+    pub(crate) herdr_agent: Option<HerdrAgentName>,
     pub(crate) herdr_session: Option<HerdrSession>,
     pub(crate) graft_post_send: bool,
     pub(crate) bare_cli_post_send: bool,
@@ -77,6 +78,7 @@ impl DeliveryRecipientSnapshot {
             recipient_pane_id: None,
             local_tmux_post_send: false,
             local_herdr_post_send: false,
+            herdr_agent: None,
             herdr_session: None,
             graft_post_send: false,
             bare_cli_post_send: false,
@@ -92,11 +94,12 @@ impl DeliveryRecipientSnapshot {
         let delivery_channel = classify_delivery_channel(local_backend.as_ref(), graft_lease);
         let local_tmux_post_send = delivery_channel == DeliveryChannel::TmuxSteer;
         let local_herdr_post_send = delivery_channel == DeliveryChannel::HerdrSteer;
-        let herdr_session = match local_backend.as_ref() {
+        let (herdr_agent, herdr_session) = match local_backend.as_ref() {
             Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr {
-                session, ..
-            }) => session.clone(),
-            _ => None,
+                agent,
+                session,
+            }) => (agent.clone(), session.clone()),
+            _ => (None, None),
         };
         let graft_post_send = delivery_channel == DeliveryChannel::Graft;
         let bare_cli_post_send = delivery_channel == DeliveryChannel::BareCli;
@@ -107,6 +110,7 @@ impl DeliveryRecipientSnapshot {
             recipient_pane_id: member.recipient_pane_id,
             local_tmux_post_send,
             local_herdr_post_send,
+            herdr_agent,
             herdr_session,
             graft_post_send,
             bare_cli_post_send,

--- a/crates/atm-core/src/doctor/herdr_state.rs
+++ b/crates/atm-core/src/doctor/herdr_state.rs
@@ -205,6 +205,7 @@ impl fmt::Display for HerdrVersion {
 pub struct HerdrRosterMember {
     pub ordinal: usize,
     pub name: AgentName,
+    pub herdr_agent: crate::HerdrAgentName,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1036,6 +1036,7 @@ fn member_summary(
         tmux_pane_id: member.tmux_pane_id.clone(),
         backend: None,
         herdr_session: None,
+        herdr_agent: None,
         local_backend: None,
         home_dir: member.home_dir.clone(),
         live_cwd: match (caller_identity, live_cwd) {
@@ -1610,6 +1611,7 @@ mod tests {
                 tmux_pane_id: None,
                 backend: None,
                 herdr_session: None,
+                herdr_agent: None,
                 local_backend: None,
                 home_dir: PathBuf::from("/workspace").into(),
                 live_cwd: None,

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -39,7 +39,7 @@ pub use herdr_state::{
 };
 pub use report::{
     BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
-    BootstrapTraceReport, ClosedHerdrBreakerDoctor, DaemonRuntimeDoctorReport,
+    BootstrapTraceReport, ClosedHerdrBreakerDoctor, DaemonRuntimeDoctorReport, DoctorAliasMismatch,
     DoctorEnvironmentVisibility, DoctorExecutionContext, DoctorFinding, DoctorReport,
     DoctorSeverity, DoctorStatus, DoctorSummary, EscalationRecipientSource,
     EscalationRecipientsDoctorReport, GraftReceiverLeaseDoctorReport, GraftReceiversDoctorReport,
@@ -526,6 +526,7 @@ fn build_doctor_report(
         resolved_team_scope: team_scope,
         member_roster,
         team_rosters,
+        alias_mismatches: Vec::new(),
         graft_receivers,
         observability: observability_health,
         herdr_queue_pump: HerdrQueuePumpDoctorReport {

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1036,7 +1036,7 @@ fn member_summary(
         tmux_pane_id: member.tmux_pane_id.clone(),
         backend: None,
         herdr_session: None,
-        herdr_agent: None,
+        alias: None,
         local_backend: None,
         home_dir: member.home_dir.clone(),
         live_cwd: match (caller_identity, live_cwd) {
@@ -1611,7 +1611,7 @@ mod tests {
                 tmux_pane_id: None,
                 backend: None,
                 herdr_session: None,
-                herdr_agent: None,
+                alias: None,
                 local_backend: None,
                 home_dir: PathBuf::from("/workspace").into(),
                 live_cwd: None,

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -404,6 +404,19 @@ pub struct ReaderPoolDoctorReport {
     pub metrics: Option<ReaderPoolMetricsDoctorReport>,
 }
 
+/// A difference between a local rmux pane alias and durable roster metadata.
+///
+/// This is diagnostic-only. The configuration alias is never used to resolve
+/// an ATM recipient or identity, and it is never persisted outside the roster.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DoctorAliasMismatch {
+    pub team: TeamName,
+    pub member: AgentName,
+    pub config_alias: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub roster_alias: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DoctorReport {
     pub summary: DoctorSummary,
@@ -428,6 +441,9 @@ pub struct DoctorReport {
     /// One roster block for every team when the effective scope is all teams.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub team_rosters: Vec<MembersList>,
+    /// Local rmux aliases that differ from the durable roster alias.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub alias_mismatches: Vec<DoctorAliasMismatch>,
     #[serde(default)]
     pub graft_receivers: GraftReceiversDoctorReport,
     pub observability: AtmObservabilityHealth,

--- a/crates/atm-core/src/herdr_configured.rs
+++ b/crates/atm-core/src/herdr_configured.rs
@@ -40,6 +40,7 @@ mod tests {
             tmux_pane_id: None,
             backend: None,
             herdr_session: None,
+            herdr_agent: None,
             local_backend,
             home_dir: HomeDirPath::default(),
             live_cwd: None,
@@ -64,6 +65,7 @@ mod tests {
                     "herdr-agent",
                     Some(LocalMessageReceivedBackend::Herdr {
                         session: Some(session),
+                        agent: None,
                     }),
                 ),
             ],

--- a/crates/atm-core/src/herdr_configured.rs
+++ b/crates/atm-core/src/herdr_configured.rs
@@ -40,7 +40,7 @@ mod tests {
             tmux_pane_id: None,
             backend: None,
             herdr_session: None,
-            herdr_agent: None,
+            alias: None,
             local_backend,
             home_dir: HomeDirPath::default(),
             live_cwd: None,

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -169,7 +169,7 @@ pub use config::AtmConfig;
 pub use config::load_config as load_atm_config;
 pub use config::types::GraftConfig;
 pub use delivery_channel::{
-    DeliveryChannel, GraftLeaseState, HerdrSession, LocalMessageReceivedBackend,
+    DeliveryChannel, GraftLeaseState, HerdrAgentName, HerdrSession, LocalMessageReceivedBackend,
     classify_delivery_channel, local_message_received_backend,
 };
 /// Canonical stable import path for the retained thin graft-facing client

--- a/crates/atm-core/src/picker_projection.rs
+++ b/crates/atm-core/src/picker_projection.rs
@@ -122,7 +122,7 @@ mod tests {
             tmux_pane_id: None,
             backend: None,
             herdr_session: None,
-            herdr_agent: None,
+            alias: None,
             local_backend: None,
             home_dir: HomeDirPath::from(std::path::PathBuf::from("/home/worker")),
             live_cwd: cwd.map(str::to_string),

--- a/crates/atm-core/src/picker_projection.rs
+++ b/crates/atm-core/src/picker_projection.rs
@@ -122,6 +122,7 @@ mod tests {
             tmux_pane_id: None,
             backend: None,
             herdr_session: None,
+            herdr_agent: None,
             local_backend: None,
             home_dir: HomeDirPath::from(std::path::PathBuf::from("/home/worker")),
             live_cwd: cwd.map(str::to_string),

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::boundary;
+use crate::address::AgentAddress;
+use crate::boundary::{self, RosterEntry};
+use crate::caller_context::{CallerContext, canonicalize_caller_context, resolve_roster_alias};
 use crate::error::AtmError;
 use crate::mailbox::source::resolve_target;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
@@ -33,6 +35,75 @@ pub use request::{
     MAX_CONTAINS_FILTER_LEN, MAX_TIMEOUT_SECS, MailboxQueryFields, MailboxQueryFilters, PeekQuery,
     ReadQuery,
 };
+
+/// Canonicalizes every roster alias carried by a mailbox request before the
+/// request reaches either reader implementation. This covers the caller,
+/// owner target, and sender filter, leaving durable mailbox keys and audit
+/// records in canonical ATM identity form.
+pub fn canonicalize_roster_aliases<F>(query: &mut ReadQuery, roster_for_team: F)
+where
+    F: Fn(&TeamName) -> Vec<RosterEntry>,
+{
+    let original_caller = query.caller_identity.clone();
+    let caller_roster = roster_for_team(&query.caller_team);
+    let caller = canonicalize_caller_context(
+        CallerContext {
+            caller_identity: query.caller_identity.clone(),
+            caller_chat_id: query.caller_chat_id.clone(),
+            caller_team: query.caller_team.clone(),
+            activity_observation: query.activity_observation.clone(),
+        },
+        &caller_roster,
+    );
+    query.caller_identity = caller.caller_identity;
+    query.caller_chat_id = caller.caller_chat_id;
+    query.activity_observation = caller.activity_observation;
+    if let Some(participant) = query.mailbox.participant_filter.as_mut()
+        && participant.agent == original_caller
+    {
+        participant.agent = query.caller_identity.clone();
+    }
+
+    let target_team = query
+        .mailbox
+        .target_address
+        .as_ref()
+        .and_then(|address| address.team().cloned())
+        .unwrap_or_else(|| query.caller_team.clone());
+    let target_roster = roster_for_team(&target_team);
+    if let Some(target) = query.mailbox.target_address.as_ref() {
+        let canonical_target = resolve_roster_alias(target.agent(), &target_team, &target_roster);
+        if let Ok(canonical_address) = AgentAddress::new(
+            canonical_target,
+            target.chat_id().cloned(),
+            target.team().cloned(),
+            target.host().cloned(),
+        ) {
+            query.mailbox.target_address = Some(canonical_address);
+        }
+    }
+    if let Some(sender) = query.mailbox.sender_filter.as_mut() {
+        *sender = resolve_roster_alias(sender, &target_team, &target_roster);
+    }
+}
+
+/// Canonicalizes a read-only peek request through the same ingress resolver.
+pub fn canonicalize_peek_roster_aliases<F>(query: &mut PeekQuery, roster_for_team: F)
+where
+    F: Fn(&TeamName) -> Vec<RosterEntry>,
+{
+    let mut read = ReadQuery {
+        mailbox: query.mailbox.clone(),
+        caller_identity: query.caller_identity.clone(),
+        caller_chat_id: query.caller_chat_id.clone(),
+        caller_team: query.caller_team.clone(),
+        seen_state_update: false,
+        activity_observation: None,
+    };
+    canonicalize_roster_aliases(&mut read, roster_for_team);
+    query.mailbox = read.mailbox;
+    query.caller_identity = read.caller_identity;
+}
 
 /// Bucket counts for one classified mailbox surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,10 +194,11 @@ pub fn peek_mail_with_runtime(
 }
 
 fn peek_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
-    query: PeekQuery,
+    mut query: PeekQuery,
     observability: &dyn ObservabilityPort,
     runtime: &R,
 ) -> Result<ReadOutcome, AtmError> {
+    canonicalize_peek_roster_aliases(&mut query, |team| runtime.load_team_roster(team));
     let synthesized = ReadQuery {
         mailbox: query.mailbox,
         caller_identity: query.caller_identity,
@@ -188,10 +260,11 @@ fn peek_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
 }
 
 fn read_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
-    query: ReadQuery,
+    mut query: ReadQuery,
     observability: &dyn ObservabilityPort,
     runtime: &R,
 ) -> Result<ReadOutcome, AtmError> {
+    canonicalize_roster_aliases(&mut query, |team| runtime.load_team_roster(team));
     let ReadRuntimeContext {
         actor,
         actor_team,
@@ -735,10 +808,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        BucketCounts, ClassifiedMessage, PeekQuery, ReadQuery, metadata_selection,
-        peek_mail_with_runtime_impl, read_mail_with_runtime_impl, state,
+        BucketCounts, ClassifiedMessage, PeekQuery, ReadQuery, canonicalize_roster_aliases,
+        metadata_selection, peek_mail_with_runtime_impl, read_mail_with_runtime_impl, state,
     };
-    use crate::boundary::{self, MessageKey, RosterHarness, RosterMemberKind};
+    use crate::boundary::{self, MessageKey, RosterEntry, RosterHarness, RosterMemberKind};
     use crate::error::AtmError;
     use crate::mailbox::source::SourceFile;
     use crate::mailbox::source::SourcedMessage;
@@ -755,6 +828,57 @@ mod tests {
         AgentName, ChatId, CommandAction, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
         TaskId, TeamName,
     };
+
+    #[test]
+    fn read_ingress_canonicalizes_alias_caller_target_and_from_filter() {
+        let root = tempdir().expect("root");
+        let team = TeamName::from_validated(TEST_TEAM);
+        let mut metadata_json = Map::new();
+        metadata_json.insert("alias".to_owned(), Value::String("atm-lead".to_owned()));
+        let roster = vec![RosterEntry {
+            team_name: team.clone(),
+            agent_name: AgentName::from_validated(ROLE_TEAM_LEAD),
+            member_kind: RosterMemberKind::Permanent,
+            harness: RosterHarness::ClaudeCode,
+            agent_type: crate::schema::AgentType::Lead,
+            model: crate::types::ModelName::default(),
+            recipient_pane_id: None,
+            metadata_json,
+        }];
+        let mut query = ReadQuery::new(
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            AgentName::from_validated("atm-lead"),
+            Some("atm-lead"),
+            team,
+            ReadSelection::All,
+            false,
+            false,
+            None,
+            Some("atm-lead"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("query");
+
+        canonicalize_roster_aliases(&mut query, |_| roster.clone());
+
+        assert_eq!(query.caller_identity.as_str(), ROLE_TEAM_LEAD);
+        assert_eq!(
+            query
+                .mailbox
+                .target_address
+                .as_ref()
+                .map(|target| target.agent().as_str()),
+            Some(ROLE_TEAM_LEAD)
+        );
+        assert_eq!(
+            query.mailbox.sender_filter.as_ref().map(AgentName::as_str),
+            Some(ROLE_TEAM_LEAD)
+        );
+    }
 
     fn selection_state_for_source_files(
         source_files: &[SourceFile],

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1,6 +1,7 @@
 use tracing::warn;
 
 use super::{ResolvedRecipient, nudge_template};
+use crate::HerdrAgentName;
 use crate::boundary::{
     BuiltInPostSendDispatch, GraftNudgeTarget, HerdrNudgeTarget, LocalSteerTarget,
     LocalTmuxNudgeTarget, NudgeKind, PostSendBuiltInTarget, PostSendHookEvent, QueuePullTarget,
@@ -55,6 +56,10 @@ where
         return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
+                agent: delivery_snapshot
+                    .herdr_agent
+                    .clone()
+                    .unwrap_or_else(|| HerdrAgentName::from(&event.recipient)),
                 session: delivery_snapshot.herdr_session.clone(),
                 rendered_nudge,
             })),

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -28,10 +28,7 @@ where
 {
     let kind = nudge_kind_for_mode(nudge_mode);
     if delivery_snapshot.local_tmux_post_send {
-        let pane_id = event
-            .recipient_pane_id
-            .clone()
-            .or_else(|| delivery_snapshot.recipient_pane_id.as_ref().cloned());
+        let pane_id = tmux_pane_id(event, delivery_snapshot);
         let Some(pane_id) = pane_id else {
             return Ok(None);
         };
@@ -97,6 +94,16 @@ where
         }));
     }
     Ok(None)
+}
+
+fn tmux_pane_id(
+    event: &PostSendHookEvent,
+    delivery_snapshot: &DeliveryRecipientSnapshot,
+) -> Option<crate::types::PaneId> {
+    event
+        .recipient_pane_id
+        .clone()
+        .or_else(|| delivery_snapshot.recipient_pane_id.as_ref().cloned())
 }
 
 /// Maps the write-time delivery mode to the dispatch's `NudgeKind`.

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1,7 +1,6 @@
 use tracing::warn;
 
 use super::{ResolvedRecipient, nudge_template};
-use crate::HerdrAgentName;
 use crate::boundary::{
     BuiltInPostSendDispatch, GraftNudgeTarget, HerdrNudgeTarget, LocalSteerTarget,
     LocalTmuxNudgeTarget, NudgeKind, PostSendBuiltInTarget, PostSendHookEvent, QueuePullTarget,
@@ -47,16 +46,20 @@ where
         }));
     }
     if delivery_snapshot.local_herdr_post_send {
+        let Some(agent) = crate::delivery_channel::resolve_herdr_agent_target(
+            &event.recipient,
+            delivery_snapshot.herdr_agent.clone(),
+            "post_send_herdr_dispatch",
+        ) else {
+            return Ok(None);
+        };
         let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
             return Ok(None);
         };
         return Ok(Some(BuiltInPostSendDispatch {
             event: event.clone(),
             target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
-                agent: delivery_snapshot
-                    .herdr_agent
-                    .clone()
-                    .unwrap_or_else(|| HerdrAgentName::from(&event.recipient)),
+                agent,
                 session: delivery_snapshot.herdr_session.clone(),
                 rendered_nudge,
             })),

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -46,25 +46,7 @@ where
         }));
     }
     if delivery_snapshot.local_herdr_post_send {
-        let Some(agent) = crate::delivery_channel::resolve_herdr_agent_target(
-            &event.recipient,
-            delivery_snapshot.herdr_agent.clone(),
-            "post_send_herdr_dispatch",
-        ) else {
-            return Ok(None);
-        };
-        let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
-            return Ok(None);
-        };
-        return Ok(Some(BuiltInPostSendDispatch {
-            event: event.clone(),
-            target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
-                agent,
-                session: delivery_snapshot.herdr_session.clone(),
-                rendered_nudge,
-            })),
-            kind,
-        }));
+        return build_herdr_dispatch(runtime, delivery_snapshot, event, kind);
     }
     if delivery_snapshot.graft_post_send {
         let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
@@ -97,6 +79,36 @@ where
         }));
     }
     Ok(None)
+}
+
+fn build_herdr_dispatch<R>(
+    runtime: &R,
+    delivery_snapshot: &DeliveryRecipientSnapshot,
+    event: &PostSendHookEvent,
+    kind: NudgeKind,
+) -> Result<Option<BuiltInPostSendDispatch>, AtmError>
+where
+    R: RetainedServiceRuntime + ?Sized,
+{
+    let Some(agent) = crate::delivery_channel::resolve_herdr_agent_target(
+        &event.recipient,
+        delivery_snapshot.herdr_agent.clone(),
+        "post_send_herdr_dispatch",
+    ) else {
+        return Ok(None);
+    };
+    let Some(rendered_nudge) = render_built_in_nudge_for_dispatch(runtime, event, kind)? else {
+        return Ok(None);
+    };
+    Ok(Some(BuiltInPostSendDispatch {
+        event: event.clone(),
+        target: PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
+            agent,
+            session: delivery_snapshot.herdr_session.clone(),
+            rendered_nudge,
+        })),
+        kind,
+    }))
 }
 
 fn tmux_pane_id(

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -53,9 +53,7 @@ pub(crate) use peer_routing::direct_peer_destination;
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
 pub(crate) use received_hook::{PreparedReceivedHook, prepare_received_hook};
-pub(crate) use recipient::{
-    ResolvedRecipient, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
-};
+pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 use request::prepare_threaded_message;
 pub(crate) use request::resolve_message_body;
 use template::{requires_plain_template_fallback, verify_template_send};

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -53,7 +53,9 @@ pub(crate) use peer_routing::direct_peer_destination;
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
 pub(crate) use received_hook::{PreparedReceivedHook, prepare_received_hook};
-pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
+pub(crate) use recipient::{
+    ResolvedRecipient, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
+};
 use request::prepare_threaded_message;
 pub(crate) use request::resolve_message_body;
 use template::{requires_plain_template_fallback, verify_template_send};

--- a/crates/atm-core/src/send/recipient.rs
+++ b/crates/atm-core/src/send/recipient.rs
@@ -1,5 +1,4 @@
 use crate::address::AgentAddress;
-use crate::boundary::RosterEntry;
 use crate::config;
 use crate::error::AtmError;
 use crate::provenance::ValidatedWriteProvenance;
@@ -50,41 +49,12 @@ pub(crate) fn resolve_recipient(
     })
 }
 
-/// Resolves a roster-scoped alias after workspace aliases have already been
-/// considered. Canonical roster names always win, which keeps malformed
-/// historical metadata from shadowing a real member.
-pub(crate) fn resolve_roster_alias(
-    candidate: &AgentName,
-    team: &TeamName,
-    roster: &[RosterEntry],
-) -> AgentName {
-    if roster
-        .iter()
-        .any(|member| member.team_name == *team && member.agent_name == *candidate)
-    {
-        return candidate.clone();
-    }
-
-    roster
-        .iter()
-        .find(|member| {
-            member.team_name == *team
-                && member
-                    .metadata_json
-                    .get("alias")
-                    .and_then(serde_json::Value::as_str)
-                    == Some(candidate.as_str())
-        })
-        .map_or_else(|| candidate.clone(), |member| member.agent_name.clone())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        ResolvedRecipient, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
-    };
+    use super::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
     use crate::address::AgentAddress;
     use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind};
+    use crate::caller_context::resolve_roster_alias;
     use crate::error_codes::AtmErrorCode;
     use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
     use crate::roles::ROLE_TEAM_LEAD;

--- a/crates/atm-core/src/send/recipient.rs
+++ b/crates/atm-core/src/send/recipient.rs
@@ -1,4 +1,5 @@
 use crate::address::AgentAddress;
+use crate::boundary::RosterEntry;
 use crate::config;
 use crate::error::AtmError;
 use crate::provenance::ValidatedWriteProvenance;
@@ -49,13 +50,121 @@ pub(crate) fn resolve_recipient(
     })
 }
 
+/// Resolves a roster-scoped alias after workspace aliases have already been
+/// considered. Canonical roster names always win, which keeps malformed
+/// historical metadata from shadowing a real member.
+pub(crate) fn resolve_roster_alias(
+    candidate: &AgentName,
+    team: &TeamName,
+    roster: &[RosterEntry],
+) -> AgentName {
+    if roster
+        .iter()
+        .any(|member| member.team_name == *team && member.agent_name == *candidate)
+    {
+        return candidate.clone();
+    }
+
+    roster
+        .iter()
+        .find(|member| {
+            member.team_name == *team
+                && member
+                    .metadata_json
+                    .get("alias")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(candidate.as_str())
+        })
+        .map_or_else(|| candidate.clone(), |member| member.agent_name.clone())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ResolvedRecipient, validate_non_self_recipient};
+    use super::{
+        ResolvedRecipient, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
+    };
     use crate::address::AgentAddress;
+    use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind};
     use crate::error_codes::AtmErrorCode;
     use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
     use crate::types::{AgentName, TeamName};
+
+    fn member(team: &TeamName, name: &str, alias: Option<&str>) -> RosterEntry {
+        let mut metadata_json = serde_json::Map::new();
+        if let Some(alias) = alias {
+            metadata_json.insert("alias".to_string(), serde_json::json!(alias));
+        }
+        RosterEntry {
+            team_name: team.clone(),
+            agent_name: AgentName::from_validated(name),
+            member_kind: RosterMemberKind::Permanent,
+            harness: RosterHarness::ClaudeCode,
+            agent_type: crate::schema::AgentType::from("worker".to_string()),
+            model: crate::types::ModelName::new("gpt-5").expect("model"),
+            recipient_pane_id: None,
+            metadata_json,
+        }
+    }
+
+    #[test]
+    fn roster_alias_resolves_to_canonical_member() {
+        let team = TeamName::from_validated("test-team");
+        let roster = vec![member(&team, "team-lead", Some("team-lead_atm-dev"))];
+
+        assert_eq!(
+            resolve_roster_alias(
+                &AgentName::from_validated("team-lead_atm-dev"),
+                &team,
+                &roster,
+            ),
+            AgentName::from_validated("team-lead")
+        );
+    }
+
+    #[test]
+    fn roster_alias_resolves_for_implicit_and_explicit_team_targets() {
+        let team = TeamName::from_validated("test-team");
+        let roster = vec![member(&team, "team-lead", Some("team-lead_atm-dev"))];
+
+        for raw_target in ["team-lead_atm-dev", "team-lead_atm-dev@test-team"] {
+            let target = raw_target.parse::<AgentAddress>().expect("target");
+            let resolved = resolve_recipient(&target, &team, None).expect("parse recipient");
+            assert_eq!(resolved.team, team);
+            assert_eq!(
+                resolve_roster_alias(&resolved.agent, &resolved.team, &roster),
+                AgentName::from_validated("team-lead"),
+                "{raw_target} must resolve through roster alias"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_roster_alias_preserves_the_canonical_parse_result() {
+        let team = TeamName::from_validated("test-team");
+        let target = "unknown-alias@test-team"
+            .parse::<AgentAddress>()
+            .expect("target");
+        let resolved = resolve_recipient(&target, &team, None).expect("parse recipient");
+
+        assert_eq!(
+            resolve_roster_alias(&resolved.agent, &resolved.team, &[]),
+            AgentName::from_validated("unknown-alias")
+        );
+    }
+
+    #[test]
+    fn canonical_name_wins_over_historical_alias_collision() {
+        let team = TeamName::from_validated("test-team");
+        let roster = vec![
+            member(&team, "team-lead", Some("worker")),
+            member(&team, "worker", None),
+        ];
+
+        assert_eq!(
+            resolve_roster_alias(&AgentName::from_validated("worker"), &team, &roster),
+            AgentName::from_validated("worker")
+        );
+    }
 
     #[test]
     fn rejects_case_variant_self_target() {

--- a/crates/atm-core/src/send/recipient.rs
+++ b/crates/atm-core/src/send/recipient.rs
@@ -87,6 +87,7 @@ mod tests {
     use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind};
     use crate::error_codes::AtmErrorCode;
     use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::types::{AgentName, TeamName};
 
     fn member(team: &TeamName, name: &str, alias: Option<&str>) -> RosterEntry {
@@ -109,7 +110,7 @@ mod tests {
     #[test]
     fn roster_alias_resolves_to_canonical_member() {
         let team = TeamName::from_validated("test-team");
-        let roster = vec![member(&team, "team-lead", Some("team-lead_atm-dev"))];
+        let roster = vec![member(&team, ROLE_TEAM_LEAD, Some("team-lead_atm-dev"))];
 
         assert_eq!(
             resolve_roster_alias(
@@ -117,14 +118,14 @@ mod tests {
                 &team,
                 &roster,
             ),
-            AgentName::from_validated("team-lead")
+            AgentName::from_validated(ROLE_TEAM_LEAD)
         );
     }
 
     #[test]
     fn roster_alias_resolves_for_implicit_and_explicit_team_targets() {
         let team = TeamName::from_validated("test-team");
-        let roster = vec![member(&team, "team-lead", Some("team-lead_atm-dev"))];
+        let roster = vec![member(&team, ROLE_TEAM_LEAD, Some("team-lead_atm-dev"))];
 
         for raw_target in ["team-lead_atm-dev", "team-lead_atm-dev@test-team"] {
             let target = raw_target.parse::<AgentAddress>().expect("target");
@@ -132,7 +133,7 @@ mod tests {
             assert_eq!(resolved.team, team);
             assert_eq!(
                 resolve_roster_alias(&resolved.agent, &resolved.team, &roster),
-                AgentName::from_validated("team-lead"),
+                AgentName::from_validated(ROLE_TEAM_LEAD),
                 "{raw_target} must resolve through roster alias"
             );
         }
@@ -156,7 +157,7 @@ mod tests {
     fn canonical_name_wins_over_historical_alias_collision() {
         let team = TeamName::from_validated("test-team");
         let roster = vec![
-            member(&team, "team-lead", Some("worker")),
+            member(&team, ROLE_TEAM_LEAD, Some("worker")),
             member(&team, "worker", None),
         ];
 

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -427,6 +427,37 @@ fn tmux_and_herdr_dispatches_share_the_rendered_template() {
     assert_eq!(tmux_text, herdr_text);
 }
 
+#[test]
+fn post_send_herdr_skips_a_nonconforming_canonical_recipient_without_panicking() {
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
+    let event = PostSendHookEvent {
+        sender: AgentName::from_validated(TEST_SENDER),
+        sender_chat_id: None,
+        sender_team: TeamName::from_validated(TEST_TEAM),
+        sender_host: None,
+        recipient: AgentName::from_validated("TeamLead"),
+        recipient_team: TeamName::from_validated(TEST_TEAM),
+        message_id: "01KZ0000000000000000000000".parse().expect("message"),
+        description: "invalid herdr canonical name".to_owned(),
+        requires_ack: false,
+        is_ack: false,
+        task_id: None,
+        recipient_pane_id: None,
+    };
+    let mut snapshot = delivery_snapshot(DeliveryHarnessPath::NonClaude);
+    snapshot.local_herdr_post_send = true;
+
+    let dispatch = super::hook::build_built_in_dispatch(
+        &runtime,
+        &snapshot,
+        &event,
+        crate::send::NudgeMode::Immediate,
+    )
+    .expect("invalid fallback is advisory, not an error");
+
+    assert!(dispatch.is_none(), "invalid Herdr fallback must be skipped");
+}
+
 pub(super) fn outbound_message() -> InboxMessage {
     let ack_intent = AckIntentFields::not_required();
     InboxMessage {

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -94,6 +94,7 @@ pub(crate) struct TestRuntime {
     commit_error_message: Option<&'static str>,
     recipient_harness: DeliveryHarnessPath,
     claude_roster_members: Vec<AgentName>,
+    team_roster_override: Option<Vec<RosterEntry>>,
     pub(crate) roster_member_missing: bool,
     pub(super) appended_messages: Mutex<Vec<InboxMessage>>,
     pub(super) non_claude_deliveries: Mutex<Vec<NonClaudeOutboundDeliveryRequest>>,
@@ -112,6 +113,7 @@ impl TestRuntime {
             commit_error_message,
             recipient_harness,
             claude_roster_members: vec![AgentName::from_validated("recipient")],
+            team_roster_override: None,
             roster_member_missing: false,
             appended_messages: Mutex::new(Vec::new()),
             non_claude_deliveries: Mutex::new(Vec::new()),
@@ -178,6 +180,12 @@ impl RetainedServiceRuntime for TestRuntime {
         if self.roster_member_missing {
             return None;
         }
+        if let Some(roster) = &self.team_roster_override {
+            return roster
+                .iter()
+                .find(|entry| entry.team_name == *team && entry.agent_name == *agent)
+                .cloned();
+        }
         Some(RosterEntry {
             team_name: team.clone(),
             agent_name: agent.clone(),
@@ -197,19 +205,33 @@ impl RetainedServiceRuntime for TestRuntime {
         if self.roster_member_missing {
             return Vec::new();
         }
-        vec![RosterEntry {
-            team_name: team.clone(),
-            agent_name: AgentName::from_validated("recipient"),
-            member_kind: RosterMemberKind::Permanent,
-            harness: match self.recipient_harness {
-                DeliveryHarnessPath::ClaudeCode => RosterHarness::ClaudeCode,
-                DeliveryHarnessPath::NonClaude => RosterHarness::CodexCli,
-            },
-            agent_type: crate::schema::AgentType::default(),
-            model: crate::types::ModelName::default(),
-            recipient_pane_id: None,
-            metadata_json: Map::new(),
-        }]
+        if let Some(roster) = &self.team_roster_override {
+            return roster
+                .iter()
+                .filter(|entry| entry.team_name == *team)
+                .cloned()
+                .collect();
+        }
+        vec![roster_entry(
+            AgentName::from_validated("recipient"),
+            self.recipient_harness,
+        )]
+    }
+}
+
+fn roster_entry(agent_name: AgentName, harness: DeliveryHarnessPath) -> RosterEntry {
+    RosterEntry {
+        team_name: TeamName::from_validated(TEST_TEAM),
+        agent_name,
+        member_kind: RosterMemberKind::Permanent,
+        harness: match harness {
+            DeliveryHarnessPath::ClaudeCode => RosterHarness::ClaudeCode,
+            DeliveryHarnessPath::NonClaude => RosterHarness::CodexCli,
+        },
+        agent_type: crate::schema::AgentType::default(),
+        model: crate::types::ModelName::default(),
+        recipient_pane_id: None,
+        metadata_json: Map::new(),
     }
 }
 
@@ -326,6 +348,7 @@ pub(super) fn delivery_snapshot(harness: DeliveryHarnessPath) -> DeliveryRecipie
         recipient_pane_id: None,
         local_tmux_post_send: false,
         local_herdr_post_send: false,
+        herdr_agent: None,
         herdr_session: None,
         graft_post_send: false,
         bare_cli_post_send: false,
@@ -747,6 +770,47 @@ fn send_sqlite_failure_is_an_error_without_outbound_delivery_or_hook() {
             .is_empty(),
         "a failed SQLite admission must not leave a persisted record"
     );
+}
+
+#[test]
+fn send_aliases_are_resolved_before_any_message_is_persisted() {
+    let mut runtime = TestRuntime::new(None, DeliveryHarnessPath::ClaudeCode);
+    let mut sender = roster_entry(
+        AgentName::from_validated("canonical-sender"),
+        DeliveryHarnessPath::ClaudeCode,
+    );
+    sender
+        .metadata_json
+        .insert("alias".to_string(), serde_json::json!("sender_atm-dev"));
+    let mut recipient = roster_entry(
+        AgentName::from_validated("canonical-recipient"),
+        DeliveryHarnessPath::ClaudeCode,
+    );
+    recipient
+        .metadata_json
+        .insert("alias".to_string(), serde_json::json!("recipient_atm-dev"));
+    runtime.team_roster_override = Some(vec![sender, recipient]);
+    let observability = RecordingObservability::default();
+    let tempdir = tempdir().expect("tempdir");
+    let mut request = send_request(tempdir.path());
+    request.caller_identity = AgentName::from_validated("sender_atm-dev");
+    request.to = Some(
+        format!("recipient_atm-dev@{TEST_TEAM}")
+            .parse()
+            .expect("alias recipient"),
+    );
+
+    let outcome = super::send_mail_with_runtime_impl(request, &observability, &runtime, None)
+        .expect("alias send succeeds");
+    assert_eq!(outcome.sender.as_str(), "canonical-sender");
+    assert_eq!(outcome.agent.as_str(), "canonical-recipient");
+    let records = runtime.persisted_records.lock().expect("records lock");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].agent.as_str(), "canonical-recipient");
+    assert_eq!(records[0].envelope.from.as_str(), "canonical-sender");
+    let serialized = serde_json::to_string(&records[0]).expect("serialize message");
+    assert!(!serialized.contains("sender_atm-dev"));
+    assert!(!serialized.contains("recipient_atm-dev"));
 }
 
 #[test]

--- a/crates/atm-core/src/send/write_context.rs
+++ b/crates/atm-core/src/send/write_context.rs
@@ -16,7 +16,7 @@ use crate::types::{AgentName, CommandAction, TaskId};
 
 use super::{
     DeliveryPersistenceResult, ResolvedRecipient, SendCommandOutcome, SendOutcome, SendRequest,
-    WarningEntry, resolve_recipient, validate_non_self_recipient,
+    WarningEntry, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
 };
 
 #[expect(
@@ -93,7 +93,12 @@ pub(crate) fn prepare_send_context<
     // This is the durable-admission half of the pipeline. A daemon must not
     // inspect caller workspace or hook configuration before a durable reply.
     let warnings = Vec::new();
-    let canonical_sender = request.caller_identity.clone();
+    let sender_roster = runtime.load_team_roster(&request.caller_team);
+    let canonical_sender = resolve_roster_alias(
+        &request.caller_identity,
+        &request.caller_team,
+        &sender_roster,
+    );
     let target = request.to.as_ref().ok_or_else(|| {
         AtmError::validation("write request destination must be resolved before persistence")
     })?;
@@ -106,7 +111,14 @@ pub(crate) fn prepare_send_context<
             origin_timestamp: request.origin_timestamp.is_some(),
         },
     )?;
-    let recipient = resolve_recipient(target, &request.caller_team, None)?;
+    let config = runtime.load_config(&request.current_dir)?;
+    let mut recipient = resolve_recipient(target, &request.caller_team, config.as_ref())?;
+    let recipient_roster = if recipient.team == request.caller_team {
+        sender_roster
+    } else {
+        runtime.load_team_roster(&recipient.team)
+    };
+    recipient.agent = resolve_roster_alias(&recipient.agent, &recipient.team, &recipient_roster);
     validate_non_self_recipient(
         &canonical_sender,
         &request.caller_team,

--- a/crates/atm-core/src/send/write_context.rs
+++ b/crates/atm-core/src/send/write_context.rs
@@ -16,8 +16,9 @@ use crate::types::{AgentName, CommandAction, TaskId};
 
 use super::{
     DeliveryPersistenceResult, ResolvedRecipient, SendCommandOutcome, SendOutcome, SendRequest,
-    WarningEntry, resolve_recipient, resolve_roster_alias, validate_non_self_recipient,
+    WarningEntry, resolve_recipient, validate_non_self_recipient,
 };
+use crate::caller_context::resolve_roster_alias;
 
 #[expect(
     clippy::too_many_arguments,

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -65,12 +65,8 @@ pub struct MemberSummary {
         skip_serializing_if = "Option::is_none"
     )]
     pub herdr_session: Option<String>,
-    #[serde(
-        rename = "herdrAgent",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub herdr_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
     /// Canonical typed backend projection used by runtime doctor consumers.
     /// This is an internal transport detail and never changes the JSON shape.
     #[serde(skip)]
@@ -826,6 +822,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: None,
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -860,6 +857,8 @@ mod tests {
                 backend: Some("herdr"),
                 target: None,
                 session: Some("team-a"),
+                alias: None,
+                clear_alias: false,
             },
         )
         .expect("Herdr request");
@@ -880,6 +879,8 @@ mod tests {
                 backend: Some("herdr"),
                 target: None,
                 session: None,
+                alias: None,
+                clear_alias: false,
             },
         )
         .expect_err("Herdr grammar must be strict");
@@ -901,6 +902,8 @@ mod tests {
                 backend: Some("herdr"),
                 target: None,
                 session: Some("team-a"),
+                alias: None,
+                clear_alias: false,
             },
         )
         .expect("Herdr request");
@@ -959,6 +962,7 @@ mod tests {
                 member_home_dir: tempdir.path().to_path_buf().into(),
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("7").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -999,6 +1003,7 @@ mod tests {
                 member_home_dir: tempdir.path().to_path_buf().into(),
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("session:1.2").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1127,6 +1132,7 @@ mod tests {
                 member_home_dir: tempdir.path().to_path_buf().into(),
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("%12").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1326,6 +1332,7 @@ mod tests {
                 model: Some(crate::types::ModelName::new("gpt-5").expect("model")),
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("22").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1389,6 +1396,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("%0").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1409,6 +1417,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: Some(crate::types::PaneId::from_cli("%1").expect("pane")),
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1458,6 +1467,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: None,
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1489,6 +1499,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: None,
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },
@@ -1520,6 +1531,7 @@ mod tests {
                 model: None,
                 tmux_pane_id: None,
                 local_backend: None,
+                alias: None,
                 backend_warning: None,
                 host: None,
             },

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -65,6 +65,12 @@ pub struct MemberSummary {
         skip_serializing_if = "Option::is_none"
     )]
     pub herdr_session: Option<String>,
+    #[serde(
+        rename = "herdrAgent",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub herdr_agent: Option<String>,
     /// Canonical typed backend projection used by runtime doctor consumers.
     /// This is an internal transport detail and never changes the JSON shape.
     #[serde(skip)]

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind, RosterStore};
-use crate::delivery_channel::{HerdrSession, LocalMessageReceivedBackend};
+use crate::delivery_channel::{HerdrAgentName, HerdrSession, LocalMessageReceivedBackend};
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::home;
@@ -24,6 +24,8 @@ pub struct BackendOptions<'a> {
     pub backend: Option<&'a str>,
     pub target: Option<&'a str>,
     pub session: Option<&'a str>,
+    pub alias: Option<&'a str>,
+    pub clear_alias: bool,
 }
 
 /// Parameters for adding one member to a team roster.
@@ -37,6 +39,7 @@ pub struct AddMemberRequest {
     pub member_home_dir: HomeDirPath,
     pub tmux_pane_id: Option<PaneId>,
     pub local_backend: Option<LocalMessageReceivedBackend>,
+    pub alias: Option<String>,
     pub backend_warning: Option<String>,
     /// This member's registered host (ADR-055 decision (e)), or `None` when
     /// unset. Set via [`AddMemberRequest::with_host`].
@@ -64,6 +67,7 @@ impl AddMemberRequest {
             tmux_pane_id: tmux_pane_id.clone(),
             local_backend: tmux_pane_id
                 .map(|pane_id| LocalMessageReceivedBackend::Tmux { pane_id }),
+            alias: None,
             backend_warning: None,
             host: None,
         })
@@ -80,11 +84,13 @@ impl AddMemberRequest {
         options: BackendOptions<'_>,
     ) -> Result<Self, AtmError> {
         let member_name: AgentName = member.parse()?;
+        let alias = parse_alias(options.alias, options.clear_alias, false)?.flatten();
         let local_backend = parse_backend(
             &member_name,
             options.backend,
             options.target,
             options.session,
+            alias.as_deref(),
         )?;
         let backend_warning =
             nonstandard_tmux_warning(&member_name, options.backend, options.target)?;
@@ -101,6 +107,7 @@ impl AddMemberRequest {
             member_home_dir: member_home_dir.into(),
             tmux_pane_id,
             local_backend,
+            alias,
             backend_warning,
             host: None,
         })
@@ -142,6 +149,8 @@ pub struct UpdateMemberRequest {
     pub model: Option<ModelName>,
     pub tmux_pane_id: Option<PaneId>,
     pub local_backend: Option<LocalMessageReceivedBackend>,
+    /// `None` leaves the roster alias unchanged; `Some(None)` clears it.
+    pub alias: Option<Option<String>>,
     pub backend_warning: Option<String>,
     /// This member's registered host (ADR-055 decision (e)); `None` means
     /// "leave unchanged" (the same convention as `harness`/`agent_type`/
@@ -181,6 +190,7 @@ impl UpdateMemberRequest {
                 .clone()
                 .map(|pane_id| LocalMessageReceivedBackend::Tmux { pane_id }),
             tmux_pane_id,
+            alias: None,
             backend_warning: None,
             host: None,
         })
@@ -204,11 +214,13 @@ impl UpdateMemberRequest {
         options: BackendOptions<'_>,
     ) -> Result<Self, AtmError> {
         let member_name: AgentName = member.parse()?;
+        let alias = parse_alias(options.alias, options.clear_alias, true)?;
         let local_backend = parse_backend(
             &member_name,
             options.backend,
             options.target,
             options.session,
+            alias.as_ref().and_then(|value| value.as_deref()),
         )?;
         let backend_warning =
             nonstandard_tmux_warning(&member_name, options.backend, options.target)?;
@@ -228,6 +240,7 @@ impl UpdateMemberRequest {
             model: model.map(ModelName::new).transpose()?,
             tmux_pane_id,
             local_backend,
+            alias,
             backend_warning,
             host: None,
         })
@@ -346,6 +359,13 @@ pub fn update_member_with_roster_store(
         .find(|existing_member| existing_member.agent_name == member_name)
         .ok_or_else(|| AtmError::member_not_found(member_name.as_str(), request.team.as_str()))?;
 
+    if request.alias == Some(None) {
+        ensure_canonical_member_name_available(roster_store, &request.team, &member_name)?;
+    }
+    validate_effective_herdr_agent_name(member, &request)?;
+    if let Some(alias) = request.alias.as_ref().and_then(|value| value.as_deref()) {
+        ensure_alias_available(roster_store, alias)?;
+    }
     apply_member_metadata_update(member, &request);
     roster_store.replace_roster(&request.team, &existing_roster)?;
 
@@ -389,6 +409,12 @@ fn load_member_add_context(
 ) -> Result<MemberAddContext, AtmError> {
     let existing_roster = projection::load_team_roster(roster_store, &request.team)?;
     ensure_member_absent(&existing_roster, &request.team, &request.member)?;
+    if request.alias.is_none() {
+        ensure_canonical_member_name_available(roster_store, &request.team, &request.member)?;
+    }
+    if let Some(alias) = request.alias.as_deref() {
+        ensure_alias_available(roster_store, alias)?;
+    }
     Ok(MemberAddContext { existing_roster })
 }
 
@@ -408,6 +434,78 @@ fn ensure_member_absent(
         ));
     }
     Ok(())
+}
+
+fn ensure_alias_available(roster_store: &dyn RosterStore, alias: &str) -> Result<(), AtmError> {
+    for conflicting_team in roster_store.list_teams()? {
+        for entry in roster_store.load_roster(&conflicting_team)? {
+            if entry.agent_name.as_str() == alias
+                || entry
+                    .metadata_json
+                    .get("alias")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(alias)
+            {
+                return Err(AtmError::validation(format!(
+                    "alias '{alias}' is already assigned in team '{conflicting_team}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_canonical_member_name_available(
+    roster_store: &dyn RosterStore,
+    team: &TeamName,
+    member: &AgentName,
+) -> Result<(), AtmError> {
+    for conflicting_team in roster_store.list_teams()? {
+        if conflicting_team == *team {
+            continue;
+        }
+        if roster_store
+            .load_roster(&conflicting_team)?
+            .iter()
+            .any(|entry| entry.agent_name == *member)
+        {
+            return Err(AtmError::validation(format!(
+                "member '{}' already exists in team '{conflicting_team}'; add it with a unique --alias",
+                member
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_effective_herdr_agent_name(
+    member: &RosterEntry,
+    request: &UpdateMemberRequest,
+) -> Result<(), AtmError> {
+    let requested_herdr = matches!(
+        request.local_backend,
+        Some(LocalMessageReceivedBackend::Herdr { .. })
+    );
+    let retained_herdr = request.local_backend.is_none()
+        && member
+            .metadata_json
+            .get("backendType")
+            .and_then(serde_json::Value::as_str)
+            == Some("herdr");
+    if !(requested_herdr || retained_herdr) {
+        return Ok(());
+    }
+    let alias = request
+        .alias
+        .as_ref()
+        .and_then(|value| value.as_deref())
+        .or_else(|| {
+            member
+                .metadata_json
+                .get("alias")
+                .and_then(serde_json::Value::as_str)
+        });
+    HerdrAgentName::new(alias.unwrap_or(member.agent_name.as_str())).map(|_| ())
 }
 
 fn ensure_member_name_available(member: &AgentName) -> Result<(), AtmError> {
@@ -497,13 +595,10 @@ fn build_member_add_roster_record(request: &AddMemberRequest) -> RosterEntry {
             extra.insert("backendType".to_string(), json!("tmux"));
             extra.insert("isActive".to_string(), json!(true));
         }
-        Some(LocalMessageReceivedBackend::Herdr { session, agent }) => {
+        Some(LocalMessageReceivedBackend::Herdr { session, .. }) => {
             extra.insert("backendType".to_string(), json!("herdr"));
             if let Some(session) = session {
                 extra.insert("herdrSession".to_string(), json!(session.as_str()));
-            }
-            if let Some(agent) = agent {
-                extra.insert("herdrAgent".to_string(), json!(agent.as_str()));
             }
         }
         None if normalized_tmux_pane_id.is_some() => {
@@ -523,6 +618,9 @@ fn build_member_add_roster_record(request: &AddMemberRequest) -> RosterEntry {
         "agentId".to_string(),
         json!(format!("{}@{}", request.member, request.team)),
     );
+    if let Some(alias) = &request.alias {
+        extra.insert("alias".to_string(), json!(alias));
+    }
     extra.insert(
         "joinedAt".to_string(),
         json!(Utc::now().timestamp_millis() as u64),
@@ -586,6 +684,18 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
             json!(host.as_str()),
         );
     }
+    if let Some(alias) = &request.alias {
+        match alias {
+            Some(alias) => {
+                member
+                    .metadata_json
+                    .insert("alias".to_string(), json!(alias));
+            }
+            None => {
+                member.metadata_json.remove("alias");
+            }
+        }
+    }
     match request.local_backend.as_ref() {
         Some(LocalMessageReceivedBackend::Tmux { pane_id }) => {
             member.recipient_pane_id = Some(pane_id.clone());
@@ -597,7 +707,7 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
                 .insert("isActive".to_string(), json!(true));
             member.metadata_json.remove("herdrSession");
         }
-        Some(LocalMessageReceivedBackend::Herdr { session, agent }) => {
+        Some(LocalMessageReceivedBackend::Herdr { session, .. }) => {
             member.recipient_pane_id = None;
             member
                 .metadata_json
@@ -611,16 +721,6 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
                 }
                 None => {
                     member.metadata_json.remove("herdrSession");
-                }
-            }
-            match agent {
-                Some(agent) => {
-                    member
-                        .metadata_json
-                        .insert("herdrAgent".to_string(), json!(agent.as_str()));
-                }
-                None => {
-                    member.metadata_json.remove("herdrAgent");
                 }
             }
         }
@@ -700,6 +800,7 @@ fn parse_backend(
     backend: Option<&str>,
     target: Option<&str>,
     session: Option<&str>,
+    alias: Option<&str>,
 ) -> Result<Option<LocalMessageReceivedBackend>, AtmError> {
     match backend {
         None => {
@@ -733,10 +834,9 @@ fn parse_backend(
                     "--backend herdr does not accept --target",
                 ));
             }
-            if !is_herdr_agent_name(member.as_str()) {
-                return Err(AtmError::validation(format!(
-                    "Herdr agent name must match ^[a-z][a-z0-9_-]{{0,31}}$: {member}"
-                )));
+            if alias.is_none() {
+                // A member without an alias retains its canonical Herdr name.
+                HerdrAgentName::new(member.as_str())?;
             }
             let session = session
                 .map(|value| {
@@ -746,7 +846,7 @@ fn parse_backend(
                 .transpose()?;
             Ok(Some(LocalMessageReceivedBackend::Herdr {
                 session,
-                agent: None,
+                agent: alias.map(HerdrAgentName::new).transpose()?,
             }))
         }
         Some(other) => Err(AtmError::validation(format!(
@@ -755,14 +855,28 @@ fn parse_backend(
     }
 }
 
-fn is_herdr_agent_name(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
+fn parse_alias(
+    alias: Option<&str>,
+    clear_alias: bool,
+    allow_clear: bool,
+) -> Result<Option<Option<String>>, AtmError> {
+    if clear_alias && alias.is_some_and(|value| !value.trim().is_empty()) {
+        return Err(AtmError::validation(
+            "--alias and --clear-alias cannot be combined",
+        ));
+    }
+    if clear_alias || alias.is_some_and(|value| value.trim().is_empty()) {
+        return if allow_clear {
+            Ok(Some(None))
+        } else {
+            Err(AtmError::validation("add-member --alias must not be blank"))
+        };
+    }
+    let Some(alias) = alias else {
+        return Ok(None);
     };
-    value.len() <= 32
-        && first.is_ascii_lowercase()
-        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_' || ch == '-')
+    crate::address::validate_path_segment(alias, "alias")?;
+    Ok(Some(Some(alias.to_owned())))
 }
 
 fn nonstandard_tmux_warning(
@@ -979,5 +1093,217 @@ mod tests {
                 .get(crate::send_to::ROSTER_HOST_METADATA_KEY),
             Some(&json!("m5.local"))
         );
+    }
+
+    #[test]
+    fn add_member_persists_alias_without_a_herdr_backend() {
+        let store = TestRosterStore::default();
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        store.seed(&team, vec![lead_member(TEST_TEAM, ROLE_TEAM_LEAD)]);
+        let root = tempfile::tempdir().expect("tempdir");
+        let request = AddMemberRequest::new_with_backend(
+            root.path().to_path_buf(),
+            TEST_TEAM,
+            "worker",
+            "worker".to_owned(),
+            "gpt-5".to_owned(),
+            root.path().join("worker-home"),
+            BackendOptions {
+                backend: None,
+                target: None,
+                session: None,
+                alias: Some("team-lead_atm-dev"),
+                clear_alias: false,
+            },
+        )
+        .expect("alias-only request");
+
+        add_member_with_roster_store(&store, request).expect("add member");
+
+        let worker = store
+            .members(&team)
+            .into_iter()
+            .find(|member| member.agent_name.as_str() == "worker")
+            .expect("worker record");
+        assert_eq!(
+            worker.metadata_json.get("alias"),
+            Some(&json!("team-lead_atm-dev"))
+        );
+    }
+
+    #[test]
+    fn herdr_alias_uses_herdr_agent_name_validation() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let error = AddMemberRequest::new_with_backend(
+            root.path().to_path_buf(),
+            TEST_TEAM,
+            "worker",
+            "worker".to_owned(),
+            "gpt-5".to_owned(),
+            root.path().join("worker-home"),
+            BackendOptions {
+                backend: Some("herdr"),
+                target: None,
+                session: None,
+                alias: Some("TeamLead"),
+                clear_alias: false,
+            },
+        )
+        .expect_err("uppercase Herdr aliases are rejected");
+
+        assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
+    }
+
+    #[test]
+    fn alias_must_not_collide_with_member_name_or_team_alias() {
+        let store = TestRosterStore::default();
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let mut worker = roster_member(TEST_TEAM, "worker");
+        worker
+            .metadata_json
+            .insert("alias".to_string(), json!("worker_atm-dev"));
+        store.seed(&team, vec![lead_member(TEST_TEAM, ROLE_TEAM_LEAD), worker]);
+        let root = tempfile::tempdir().expect("tempdir");
+
+        for alias in ["worker", "worker_atm-dev"] {
+            let request = AddMemberRequest::new_with_backend(
+                root.path().to_path_buf(),
+                TEST_TEAM,
+                "other",
+                "worker".to_owned(),
+                "gpt-5".to_owned(),
+                root.path().join("other-home"),
+                BackendOptions {
+                    backend: None,
+                    target: None,
+                    session: None,
+                    alias: Some(alias),
+                    clear_alias: false,
+                },
+            )
+            .expect("request");
+
+            let error = add_member_with_roster_store(&store, request).expect_err("alias collision");
+            assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
+        }
+    }
+
+    #[test]
+    fn cross_team_member_names_require_alias_but_first_occurrence_does_not() {
+        let store = TestRosterStore::default();
+        let first_team: TeamName = "other-team".parse().expect("team");
+        store.seed(&first_team, vec![lead_member("other-team", "team-lead")]);
+        let root = tempfile::tempdir().expect("tempdir");
+        let no_alias = AddMemberRequest::new_with_backend(
+            root.path().to_path_buf(),
+            TEST_TEAM,
+            "team-lead",
+            "lead".to_owned(),
+            "gpt-5".to_owned(),
+            root.path().join("duplicate-home"),
+            BackendOptions {
+                backend: None,
+                target: None,
+                session: None,
+                alias: None,
+                clear_alias: false,
+            },
+        )
+        .expect("request");
+        let error = add_member_with_roster_store(&store, no_alias).expect_err("duplicate name");
+        assert!(error.message().contains("other-team"));
+        assert!(error.message().contains("--alias"));
+
+        let with_alias = AddMemberRequest::new_with_backend(
+            root.path().to_path_buf(),
+            TEST_TEAM,
+            "team-lead",
+            "lead".to_owned(),
+            "gpt-5".to_owned(),
+            root.path().join("aliased-home"),
+            BackendOptions {
+                backend: None,
+                target: None,
+                session: None,
+                alias: Some("team-lead_atm-dev"),
+                clear_alias: false,
+            },
+        )
+        .expect("aliased request");
+        add_member_with_roster_store(&store, with_alias).expect("alias resolves duplicate name");
+    }
+
+    #[test]
+    fn clearing_alias_is_rejected_when_the_canonical_name_is_cross_team_duplicate() {
+        let store = TestRosterStore::default();
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let other: TeamName = "other-team".parse().expect("team");
+        let mut local = lead_member(TEST_TEAM, "team-lead");
+        local
+            .metadata_json
+            .insert("alias".to_string(), json!("team-lead_atm-dev"));
+        store.seed(&team, vec![local]);
+        store.seed(&other, vec![lead_member("other-team", "team-lead")]);
+        let request = UpdateMemberRequest::new_with_backend(
+            "team-lead".parse().expect("caller"),
+            team.clone(),
+            TEST_TEAM,
+            "team-lead",
+            None,
+            None,
+            None,
+            None,
+            None,
+            BackendOptions {
+                backend: None,
+                target: None,
+                session: None,
+                alias: None,
+                clear_alias: true,
+            },
+        )
+        .expect("clear request");
+        let error = update_member_with_roster_store(&store, request).expect_err("duplicate name");
+        assert!(error.message().contains("other-team"));
+        assert!(error.message().contains("--alias"));
+    }
+
+    #[test]
+    fn update_member_can_clear_an_existing_alias() {
+        let store = TestRosterStore::default();
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let mut worker = roster_member(TEST_TEAM, "worker");
+        worker
+            .metadata_json
+            .insert("alias".to_string(), json!("worker_atm-dev"));
+        store.seed(&team, vec![lead_member(TEST_TEAM, ROLE_TEAM_LEAD), worker]);
+        let request = UpdateMemberRequest::new_with_backend(
+            ROLE_TEAM_LEAD.parse().expect("caller"),
+            team.clone(),
+            TEST_TEAM,
+            "worker",
+            None,
+            None,
+            None,
+            None,
+            None,
+            BackendOptions {
+                backend: None,
+                target: None,
+                session: None,
+                alias: None,
+                clear_alias: true,
+            },
+        )
+        .expect("clear-alias request");
+
+        update_member_with_roster_store(&store, request).expect("update member");
+
+        let worker = store
+            .members(&team)
+            .into_iter()
+            .find(|member| member.agent_name.as_str() == "worker")
+            .expect("worker record");
+        assert!(!worker.metadata_json.contains_key("alias"));
     }
 }

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -696,6 +696,10 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
             }
         }
     }
+    update_member_local_backend(member, request);
+}
+
+fn update_member_local_backend(member: &mut RosterEntry, request: &UpdateMemberRequest) {
     match request.local_backend.as_ref() {
         Some(LocalMessageReceivedBackend::Tmux { pane_id }) => {
             member.recipient_pane_id = Some(pane_id.clone());

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -1196,12 +1196,12 @@ mod tests {
     fn cross_team_member_names_require_alias_but_first_occurrence_does_not() {
         let store = TestRosterStore::default();
         let first_team: TeamName = "other-team".parse().expect("team");
-        store.seed(&first_team, vec![lead_member("other-team", "team-lead")]);
+        store.seed(&first_team, vec![lead_member("other-team", ROLE_TEAM_LEAD)]);
         let root = tempfile::tempdir().expect("tempdir");
         let no_alias = AddMemberRequest::new_with_backend(
             root.path().to_path_buf(),
             TEST_TEAM,
-            "team-lead",
+            ROLE_TEAM_LEAD,
             "lead".to_owned(),
             "gpt-5".to_owned(),
             root.path().join("duplicate-home"),
@@ -1221,7 +1221,7 @@ mod tests {
         let with_alias = AddMemberRequest::new_with_backend(
             root.path().to_path_buf(),
             TEST_TEAM,
-            "team-lead",
+            ROLE_TEAM_LEAD,
             "lead".to_owned(),
             "gpt-5".to_owned(),
             root.path().join("aliased-home"),
@@ -1242,17 +1242,17 @@ mod tests {
         let store = TestRosterStore::default();
         let team: TeamName = TEST_TEAM.parse().expect("team");
         let other: TeamName = "other-team".parse().expect("team");
-        let mut local = lead_member(TEST_TEAM, "team-lead");
+        let mut local = lead_member(TEST_TEAM, ROLE_TEAM_LEAD);
         local
             .metadata_json
             .insert("alias".to_string(), json!("team-lead_atm-dev"));
         store.seed(&team, vec![local]);
-        store.seed(&other, vec![lead_member("other-team", "team-lead")]);
+        store.seed(&other, vec![lead_member("other-team", ROLE_TEAM_LEAD)]);
         let request = UpdateMemberRequest::new_with_backend(
-            "team-lead".parse().expect("caller"),
+            ROLE_TEAM_LEAD.parse().expect("caller"),
             team.clone(),
             TEST_TEAM,
-            "team-lead",
+            ROLE_TEAM_LEAD,
             None,
             None,
             None,

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -497,10 +497,13 @@ fn build_member_add_roster_record(request: &AddMemberRequest) -> RosterEntry {
             extra.insert("backendType".to_string(), json!("tmux"));
             extra.insert("isActive".to_string(), json!(true));
         }
-        Some(LocalMessageReceivedBackend::Herdr { session }) => {
+        Some(LocalMessageReceivedBackend::Herdr { session, agent }) => {
             extra.insert("backendType".to_string(), json!("herdr"));
             if let Some(session) = session {
                 extra.insert("herdrSession".to_string(), json!(session.as_str()));
+            }
+            if let Some(agent) = agent {
+                extra.insert("herdrAgent".to_string(), json!(agent.as_str()));
             }
         }
         None if normalized_tmux_pane_id.is_some() => {
@@ -594,7 +597,7 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
                 .insert("isActive".to_string(), json!(true));
             member.metadata_json.remove("herdrSession");
         }
-        Some(LocalMessageReceivedBackend::Herdr { session }) => {
+        Some(LocalMessageReceivedBackend::Herdr { session, agent }) => {
             member.recipient_pane_id = None;
             member
                 .metadata_json
@@ -608,6 +611,16 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
                 }
                 None => {
                     member.metadata_json.remove("herdrSession");
+                }
+            }
+            match agent {
+                Some(agent) => {
+                    member
+                        .metadata_json
+                        .insert("herdrAgent".to_string(), json!(agent.as_str()));
+                }
+                None => {
+                    member.metadata_json.remove("herdrAgent");
                 }
             }
         }
@@ -731,7 +744,10 @@ fn parse_backend(
                     HerdrSession::new(value)
                 })
                 .transpose()?;
-            Ok(Some(LocalMessageReceivedBackend::Herdr { session }))
+            Ok(Some(LocalMessageReceivedBackend::Herdr {
+                session,
+                agent: None,
+            }))
         }
         Some(other) => Err(AtmError::validation(format!(
             "unsupported local backend '{other}'; expected tmux or herdr"

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind, RosterStore};
+use crate::caller_context::resolve_roster_alias;
 use crate::delivery_channel::{HerdrAgentName, HerdrSession, LocalMessageReceivedBackend};
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
@@ -350,8 +351,10 @@ pub fn update_member_with_roster_store(
     roster_store: &(dyn RosterStore + Send + Sync),
     request: UpdateMemberRequest,
 ) -> Result<UpdateMemberOutcome, AtmError> {
-    validate_update_member_caller(roster_store, &request)?;
+    let mut request = request;
     let mut existing_roster = projection::load_team_roster(roster_store, &request.team)?;
+    canonicalize_member_mutation_aliases(&mut request, &existing_roster);
+    validate_update_member_caller(roster_store, &request)?;
     let member_name = request.member.0.clone();
     ensure_member_name_available(&member_name)?;
     let member = existing_roster
@@ -388,8 +391,10 @@ pub fn remove_member_with_roster_store(
     roster_store: &(dyn RosterStore + Send + Sync),
     request: RemoveMemberRequest,
 ) -> Result<RemoveMemberOutcome, AtmError> {
-    validate_remove_member_caller(roster_store, &request)?;
+    let mut request = request;
     let mut existing_roster = projection::load_team_roster(roster_store, &request.team)?;
+    canonicalize_remove_member_aliases(&mut request, &existing_roster);
+    validate_remove_member_caller(roster_store, &request)?;
     ensure_member_present(&existing_roster, &request.team, &request.member)?;
     existing_roster.retain(|entry| entry.agent_name != request.member);
     roster_store.replace_roster(&request.team, &existing_roster)?;
@@ -399,6 +404,20 @@ pub fn remove_member_with_roster_store(
         team: request.team,
         member: request.member,
     })
+}
+
+/// Canonicalize every agent-name input before membership validation or roster
+/// persistence so an alias cannot become a durable target or audit identity.
+fn canonicalize_member_mutation_aliases(request: &mut UpdateMemberRequest, roster: &[RosterEntry]) {
+    request.caller_identity =
+        resolve_roster_alias(&request.caller_identity, &request.caller_team, roster);
+    request.member.0 = resolve_roster_alias(&request.member.0, &request.team, roster);
+}
+
+fn canonicalize_remove_member_aliases(request: &mut RemoveMemberRequest, roster: &[RosterEntry]) {
+    request.caller_identity =
+        resolve_roster_alias(&request.caller_identity, &request.caller_team, roster);
+    request.member = resolve_roster_alias(&request.member, &request.team, roster);
 }
 
 pub(crate) const MAX_MEMBER_METADATA_FIELD_LEN: usize = 256;
@@ -1309,5 +1328,53 @@ mod tests {
             .find(|member| member.agent_name.as_str() == "worker")
             .expect("worker record");
         assert!(!worker.metadata_json.contains_key("alias"));
+    }
+
+    #[test]
+    fn update_and_remove_member_canonicalize_alias_arguments_before_persistence() {
+        let store = TestRosterStore::default();
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let mut lead = lead_member(TEST_TEAM, ROLE_TEAM_LEAD);
+        lead.metadata_json
+            .insert("alias".to_owned(), json!("atm-lead"));
+        let mut worker = roster_member(TEST_TEAM, "worker");
+        worker
+            .metadata_json
+            .insert("alias".to_owned(), json!("atm-worker"));
+        store.seed(&team, vec![lead, worker]);
+
+        let update = UpdateMemberRequest::new(
+            "atm-lead".parse().expect("alias caller"),
+            team.clone(),
+            TEST_TEAM,
+            "atm-worker",
+            None,
+            None,
+            None,
+            Some("lead".to_owned()),
+            None,
+            None,
+        )
+        .expect("update request");
+        let outcome =
+            update_member_with_roster_store(&store, update).expect("update through alias");
+        assert_eq!(outcome.member.as_str(), "worker");
+
+        let remove = RemoveMemberRequest::new(
+            "atm-lead".parse().expect("alias caller"),
+            team.clone(),
+            TEST_TEAM,
+            "atm-worker",
+        )
+        .expect("remove request");
+        let outcome =
+            remove_member_with_roster_store(&store, remove).expect("remove through alias");
+        assert_eq!(outcome.member.as_str(), "worker");
+        assert!(
+            store
+                .members(&team)
+                .iter()
+                .all(|member| member.agent_name.as_str() != "worker")
+        );
     }
 }

--- a/crates/atm-core/src/team_admin/projection.rs
+++ b/crates/atm-core/src/team_admin/projection.rs
@@ -98,13 +98,12 @@ fn member_summary_from_roster(
     live_cwd: Option<&Path>,
 ) -> MemberSummary {
     let local_backend = local_message_received_backend(record);
-    let (backend, herdr_session, herdr_agent) = match local_backend.as_ref() {
-        Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { session, agent }) => (
+    let (backend, herdr_session) = match local_backend.as_ref() {
+        Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { session, .. }) => (
             Some("herdr".to_string()),
             session.as_ref().map(ToString::to_string),
-            agent.as_ref().map(ToString::to_string),
         ),
-        _ => (None, None, None),
+        _ => (None, None),
     };
     MemberSummary {
         name: record.agent_name.clone(),
@@ -117,7 +116,7 @@ fn member_summary_from_roster(
         tmux_pane_id: record.recipient_pane_id.clone(),
         backend,
         herdr_session,
-        herdr_agent,
+        alias: metadata_string(&record.metadata_json, "alias"),
         local_backend,
         home_dir: canonical_home_dir(&record.metadata_json).unwrap_or_default(),
         live_cwd: runtime_live_cwd(record, caller_identity, live_cwd),

--- a/crates/atm-core/src/team_admin/projection.rs
+++ b/crates/atm-core/src/team_admin/projection.rs
@@ -98,12 +98,13 @@ fn member_summary_from_roster(
     live_cwd: Option<&Path>,
 ) -> MemberSummary {
     let local_backend = local_message_received_backend(record);
-    let (backend, herdr_session) = match local_backend.as_ref() {
-        Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { session }) => (
+    let (backend, herdr_session, herdr_agent) = match local_backend.as_ref() {
+        Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { session, agent }) => (
             Some("herdr".to_string()),
             session.as_ref().map(ToString::to_string),
+            agent.as_ref().map(ToString::to_string),
         ),
-        _ => (None, None),
+        _ => (None, None, None),
     };
     MemberSummary {
         name: record.agent_name.clone(),
@@ -116,6 +117,7 @@ fn member_summary_from_roster(
         tmux_pane_id: record.recipient_pane_id.clone(),
         backend,
         herdr_session,
+        herdr_agent,
         local_backend,
         home_dir: canonical_home_dir(&record.metadata_json).unwrap_or_default(),
         live_cwd: runtime_live_cwd(record, caller_identity, live_cwd),

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -430,7 +430,7 @@ impl AsyncMessageReceivedHookEmitter for HerdrReceivedHook {
             };
             let result = process
                 .prompt(
-                    &dispatch.event.recipient,
+                    &target.agent,
                     target.session.as_ref(),
                     &target.rendered_nudge,
                     deadline,
@@ -793,6 +793,7 @@ mod tests {
         dispatch.kind = kind;
         dispatch.target =
             PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
+                agent: atm_core::HerdrAgentName::new("team-lead").expect("agent"),
                 session: Some(atm_core::HerdrSession::new("team-a").expect("session")),
                 rendered_nudge: "test".to_owned(),
             }));

--- a/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
+++ b/crates/atm-daemon-bootstrap/src/received_hook_selector.rs
@@ -160,7 +160,7 @@ pub struct BenchmarkNoopHerdrProcessAdapter;
 impl HerdrProcessAdapter for BenchmarkNoopHerdrProcessAdapter {
     fn prompt<'a>(
         &'a self,
-        agent: &'a atm_core::types::AgentName,
+        agent: &'a atm_core::HerdrAgentName,
         _session: Option<&'a HerdrSession>,
         _text: &'a str,
         _deadline: RequestDeadline,
@@ -175,7 +175,7 @@ impl HerdrProcessAdapter for BenchmarkNoopHerdrProcessAdapter {
 
     fn wait<'a>(
         &'a self,
-        agent: &'a atm_core::types::AgentName,
+        agent: &'a atm_core::HerdrAgentName,
         _session: Option<&'a HerdrSession>,
         _until: &'a [HerdrAgentStatus],
         _timeout: std::time::Duration,
@@ -192,7 +192,7 @@ impl HerdrProcessAdapter for BenchmarkNoopHerdrProcessAdapter {
 
     fn get<'a>(
         &'a self,
-        agent: &'a atm_core::types::AgentName,
+        agent: &'a atm_core::HerdrAgentName,
         _session: Option<&'a HerdrSession>,
         _deadline: RequestDeadline,
         _breaker_policy: atm_herdr::BreakerPolicy,
@@ -793,7 +793,8 @@ mod tests {
         dispatch.kind = kind;
         dispatch.target =
             PostSendBuiltInTarget::LocalSteer(LocalSteerTarget::Herdr(HerdrNudgeTarget {
-                agent: atm_core::HerdrAgentName::new("team-lead").expect("agent"),
+                agent: atm_core::HerdrAgentName::new(atm_core::roles::ROLE_TEAM_LEAD)
+                    .expect("agent"),
                 session: Some(atm_core::HerdrSession::new("team-a").expect("session")),
                 rendered_nudge: "test".to_owned(),
             }));

--- a/crates/atm-daemon-bootstrap/src/replacement_handler.rs
+++ b/crates/atm-daemon-bootstrap/src/replacement_handler.rs
@@ -127,7 +127,9 @@ fn herdr_roster_groups(
         .members
         .iter()
         .filter_map(|member| match member.local_message_received_backend() {
-            Some(atm_core::LocalMessageReceivedBackend::Herdr { session }) => Some(session.clone()),
+            Some(atm_core::LocalMessageReceivedBackend::Herdr { session, .. }) => {
+                Some(session.clone())
+            }
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -149,9 +151,13 @@ fn herdr_roster_groups(
                     |(ordinal, member)| match member.local_message_received_backend() {
                         Some(atm_core::LocalMessageReceivedBackend::Herdr {
                             session: member_session,
+                            agent,
                         }) if *member_session == session => Some(HerdrRosterMember {
                             ordinal,
                             name: member.name.clone(),
+                            herdr_agent: agent
+                                .clone()
+                                .unwrap_or_else(|| atm_core::HerdrAgentName::from(&member.name)),
                         }),
                         _ => None,
                     },
@@ -382,8 +388,10 @@ mod tests {
             tmux_pane_id: None,
             backend: None,
             herdr_session: None,
+            alias: None,
             local_backend: Some(LocalMessageReceivedBackend::Herdr {
                 session: session.map(|value| HerdrSession::new(value).expect("valid test session")),
+                agent: None,
             }),
             home_dir: HomeDirPath::default(),
             live_cwd: None,

--- a/crates/atm-daemon-bootstrap/src/replacement_handler.rs
+++ b/crates/atm-daemon-bootstrap/src/replacement_handler.rs
@@ -152,13 +152,18 @@ fn herdr_roster_groups(
                         Some(atm_core::LocalMessageReceivedBackend::Herdr {
                             session: member_session,
                             agent,
-                        }) if *member_session == session => Some(HerdrRosterMember {
-                            ordinal,
-                            name: member.name.clone(),
-                            herdr_agent: agent
-                                .clone()
-                                .unwrap_or_else(|| atm_core::HerdrAgentName::from(&member.name)),
-                        }),
+                        }) if *member_session == session => {
+                            atm_core::delivery_channel::resolve_herdr_agent_target(
+                                &member.name,
+                                agent.clone(),
+                                "herdr_endpoint_doctor",
+                            )
+                            .map(|herdr_agent| HerdrRosterMember {
+                                ordinal,
+                                name: member.name.clone(),
+                                herdr_agent,
+                            })
+                        }
                         _ => None,
                     },
                 )
@@ -438,6 +443,21 @@ mod tests {
                 .map(|member| member.ordinal)
                 .collect::<Vec<_>>(),
             vec![1, 4]
+        );
+    }
+
+    #[test]
+    fn herdr_endpoint_doctor_skips_a_nonconforming_canonical_name_without_panicking() {
+        let roster = atm_core::team_admin::MembersList {
+            team: TeamName::from_validated("test-team"),
+            members: vec![herdr_member("TeamLead", None)],
+        };
+
+        let groups = herdr_roster_groups(&roster);
+        assert_eq!(groups.len(), 1, "the endpoint partition is retained");
+        assert!(
+            groups[0].1.is_empty(),
+            "an invalid fallback target must not reach the Herdr doctor probe"
         );
     }
 }

--- a/crates/atm-herdr/src/doctor_probe.rs
+++ b/crates/atm-herdr/src/doctor_probe.rs
@@ -96,7 +96,7 @@ impl HerdrDoctorProbe {
                 .io
                 .call(
                     HerdrOp::Get {
-                        agent: &member.name,
+                        agent: &member.herdr_agent,
                     },
                     session,
                     member_deadline,

--- a/crates/atm-herdr/src/lib.rs
+++ b/crates/atm-herdr/src/lib.rs
@@ -5,8 +5,8 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+pub use atm_core::HerdrAgentName;
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::types::AgentName;
 use atm_core::{HerdrSession, RequestDeadline};
 
 mod doctor_probe;
@@ -247,7 +247,7 @@ impl HerdrError {
 pub trait HerdrProcessAdapter: Send + Sync {
     fn prompt<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         text: &'a str,
         deadline: RequestDeadline,
@@ -255,7 +255,7 @@ pub trait HerdrProcessAdapter: Send + Sync {
 
     fn wait<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         until: &'a [HerdrAgentStatus],
         timeout: Duration,
@@ -264,7 +264,7 @@ pub trait HerdrProcessAdapter: Send + Sync {
 
     fn get<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         deadline: RequestDeadline,
         breaker_policy: BreakerPolicy,
@@ -494,7 +494,7 @@ fn validate_prompt_text(text: &str) -> Result<(), HerdrError> {
 impl HerdrProcessAdapter for HerdrProcessInvoker {
     fn prompt<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         text: &'a str,
         deadline: RequestDeadline,
@@ -519,7 +519,7 @@ impl HerdrProcessAdapter for HerdrProcessInvoker {
 
     fn wait<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         until: &'a [HerdrAgentStatus],
         timeout: Duration,
@@ -546,7 +546,7 @@ impl HerdrProcessAdapter for HerdrProcessInvoker {
 
     fn get<'a>(
         &'a self,
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         session: Option<&'a HerdrSession>,
         deadline: RequestDeadline,
         breaker_policy: BreakerPolicy,
@@ -698,7 +698,7 @@ pub mod testing {
     /// a direct prompt call site to an integration fixture.
     pub async fn socket_prompt(
         invoker: &HerdrProcessInvoker,
-        agent: &AgentName,
+        agent: &HerdrAgentName,
         text: &str,
         deadline: RequestDeadline,
     ) -> Result<HerdrPromptOutcome, HerdrError> {
@@ -781,7 +781,7 @@ pub mod testing {
         }
     }
 
-    fn default_snapshot(agent: &AgentName) -> AgentSnapshot {
+    fn default_snapshot(agent: &HerdrAgentName) -> AgentSnapshot {
         AgentSnapshot {
             name: Some(agent.to_string()),
             status: HerdrAgentStatus::Idle,
@@ -792,7 +792,7 @@ pub mod testing {
     impl HerdrProcessAdapter for FakeHerdrProcessAdapter {
         fn prompt<'a>(
             &'a self,
-            agent: &'a AgentName,
+            agent: &'a HerdrAgentName,
             session: Option<&'a HerdrSession>,
             text: &'a str,
             _deadline: RequestDeadline,
@@ -823,7 +823,7 @@ pub mod testing {
 
         fn wait<'a>(
             &'a self,
-            agent: &'a AgentName,
+            agent: &'a HerdrAgentName,
             session: Option<&'a HerdrSession>,
             until: &'a [HerdrAgentStatus],
             timeout: Duration,
@@ -854,7 +854,7 @@ pub mod testing {
 
         fn get<'a>(
             &'a self,
-            agent: &'a AgentName,
+            agent: &'a HerdrAgentName,
             session: Option<&'a HerdrSession>,
             _deadline: RequestDeadline,
             breaker_policy: BreakerPolicy,
@@ -1084,7 +1084,7 @@ mod tests {
 
     #[test]
     fn every_adapter_argv_matches_the_herdr_contract() {
-        let agent: AgentName = "alice".parse().expect("agent");
+        let agent = HerdrAgentName::new("alice").expect("agent");
         let text = "line one\nline two\nline three\nline four\nline five\nline six";
         let args = transport_cli::command_args(HerdrOp::Prompt {
             agent: &agent,
@@ -1149,7 +1149,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_prompt_is_rejected_before_process_spawn() {
-        let agent: AgentName = "alice".parse().expect("agent");
+        let agent = HerdrAgentName::new("alice").expect("agent");
         let invoker = HerdrProcessInvoker {
             breaker: Arc::new(HerdrSpawnBreaker::default()),
             io: HerdrIo::default(),

--- a/crates/atm-herdr/src/transport.rs
+++ b/crates/atm-herdr/src/transport.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use atm_core::doctor::{
     HerdrEndpointDisplay, HerdrEndpointDisplayRoot, HerdrTransportKind, HerdrVersion,
 };
+use atm_core::HerdrAgentName;
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::types::AgentName;
 use atm_core::{HerdrSession, RequestDeadline};
 use serde_json::Value;
 
@@ -85,16 +85,16 @@ impl HerdrClientConfig {
 /// One request the private Herdr transport can carry.
 pub(crate) enum HerdrOp<'a> {
     Prompt {
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         text: &'a str,
     },
     Wait {
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
         until: &'a [HerdrAgentStatus],
         timeout: Duration,
     },
     Get {
-        agent: &'a AgentName,
+        agent: &'a HerdrAgentName,
     },
     List,
     StatusServer,

--- a/crates/atm-herdr/src/transport.rs
+++ b/crates/atm-herdr/src/transport.rs
@@ -3,10 +3,10 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use atm_core::HerdrAgentName;
 use atm_core::doctor::{
     HerdrEndpointDisplay, HerdrEndpointDisplayRoot, HerdrTransportKind, HerdrVersion,
 };
-use atm_core::HerdrAgentName;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::{HerdrSession, RequestDeadline};
 use serde_json::Value;

--- a/crates/atm-herdr/src/transport_socket.rs
+++ b/crates/atm-herdr/src/transport_socket.rs
@@ -429,7 +429,7 @@ fn decode_envelope(bytes: &[u8]) -> Result<HerdrEnvelope, HerdrError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use atm_core::types::AgentName;
+    use atm_core::HerdrAgentName;
 
     fn env(platform: Platform) -> HerdrHostEnv {
         HerdrHostEnv {
@@ -526,7 +526,7 @@ mod tests {
 
     #[test]
     fn request_ids_and_ndjson_framing_are_stable() {
-        let agent: AgentName = "alice".parse().expect("agent");
+        let agent = HerdrAgentName::new("alice").expect("agent");
         let request = encode_request(HerdrOp::Get { agent: &agent }).expect("request");
         assert_eq!(request.last(), Some(&b'\n'));
         let value: Value = serde_json::from_slice(&request).expect("request JSON");
@@ -595,7 +595,7 @@ mod tests {
             in_flight: Arc::new(Semaphore::new(SOCKET_PERMITS)),
             pipe_busy_retry_delay: PIPE_BUSY_RETRY_DELAY,
         };
-        let agent: AgentName = "alice".parse().expect("agent");
+        let agent = HerdrAgentName::new("alice").expect("agent");
         let envelope = io
             .call(
                 HerdrOp::Get { agent: &agent },

--- a/crates/atm-herdr/tests/transport_fixture.rs
+++ b/crates/atm-herdr/tests/transport_fixture.rs
@@ -4,8 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use atm_core::types::AgentName;
-use atm_core::{HerdrSession, RequestDeadline};
+use atm_core::{HerdrAgentName, HerdrSession, RequestDeadline};
 use atm_herdr::testing::production_invoker_with_test_binary_and_environment;
 use atm_herdr::{HerdrError, HerdrProcessAdapter};
 
@@ -94,7 +93,7 @@ async fn get_with_deadline(
     session: Option<&HerdrSession>,
     deadline: RequestDeadline,
 ) -> Result<atm_herdr::HerdrGetOutcome, HerdrError> {
-    let agent: AgentName = "fixture-agent".parse().expect("agent name");
+    let agent = HerdrAgentName::new("fixture-agent").expect("agent name");
     invoker
         .get(&agent, session, deadline, atm_herdr::BreakerPolicy::Shared)
         .await
@@ -344,7 +343,7 @@ async fn socket_fixture_matrix_covers_stalled_write_and_cancellation() {
     let server = fake_herdr_socket::FakeHerdrSocket::bind(&stalled_write).expect("bind");
     let task = tokio::spawn(server.stall_before_read());
     let invoker = atm_herdr::testing::production_invoker_with_test_socket(stalled_write);
-    let agent: AgentName = "fixture-agent".parse().expect("agent name");
+    let agent = HerdrAgentName::new("fixture-agent").expect("agent name");
     let prompt = "synthetic stalled-write fixture\n".repeat(512 * 1024);
     let result = atm_herdr::testing::socket_prompt(
         &invoker,

--- a/crates/atm-herdr/tests/windows_transport_cli.rs
+++ b/crates/atm-herdr/tests/windows_transport_cli.rs
@@ -4,8 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use atm_core::RequestDeadline;
-use atm_core::types::AgentName;
+use atm_core::{HerdrAgentName, RequestDeadline};
 use atm_herdr::testing::production_invoker_with_test_binary_and_environment;
 use atm_herdr::{HerdrAgentStatus, HerdrError, HerdrProcessAdapter};
 use serde_json::json;
@@ -21,7 +20,7 @@ async fn get(
     invoker: &atm_herdr::HerdrProcessInvoker,
     deadline: RequestDeadline,
 ) -> Result<atm_herdr::HerdrGetOutcome, HerdrError> {
-    let agent: AgentName = "windows-fixture".parse().expect("agent name");
+    let agent = HerdrAgentName::new("windows-fixture").expect("agent name");
     invoker
         .get(&agent, None, deadline, atm_herdr::BreakerPolicy::Shared)
         .await

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -1323,7 +1323,7 @@ mod tests {
                 team_name: team_a.clone(),
                 members: vec![herdr_member_with_alias(
                     &team_a,
-                    "team-lead",
+                    atm_core::roles::ROLE_TEAM_LEAD,
                     "team-lead_a-team",
                 )],
                 refreshed_at: None,
@@ -1336,14 +1336,24 @@ mod tests {
                 team_name: team_b.clone(),
                 members: vec![herdr_member_with_alias(
                     &team_b,
-                    "team-lead",
+                    atm_core::roles::ROLE_TEAM_LEAD,
                     "team-lead_b-team",
                 )],
                 refreshed_at: None,
             })
             .expect("team b roster");
-        queue_message(root.path(), &assembly.service_runtime, &team_a, "team-lead");
-        queue_message(root.path(), &assembly.service_runtime, &team_b, "team-lead");
+        queue_message(
+            root.path(),
+            &assembly.service_runtime,
+            &team_a,
+            atm_core::roles::ROLE_TEAM_LEAD,
+        );
+        queue_message(
+            root.path(),
+            &assembly.service_runtime,
+            &team_b,
+            atm_core::roles::ROLE_TEAM_LEAD,
+        );
 
         let fake = Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default());
         fake.queue_list_result(Ok(HerdrListOutcome {

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -15,7 +15,7 @@ use atm_core::boundary::{
     TaskRow, TaskState,
 };
 use atm_core::delivery_channel::{
-    DeliveryChannel, GraftLeaseState, HerdrSession, classify_delivery_channel,
+    DeliveryChannel, GraftLeaseState, HerdrAgentName, HerdrSession, classify_delivery_channel,
     local_message_received_backend,
 };
 use atm_core::error::{AtmError, AtmErrorCode};
@@ -395,12 +395,13 @@ impl HerdrQueueWakePump {
             .filter_map(|snapshot| snapshot.name.as_deref().map(|name| (name, snapshot)))
             .collect();
         for member in members {
-            let Some(snapshot) = snapshots.get(member.key.agent().as_str()) else {
+            let Some(snapshot) = snapshots.get(member.herdr_agent.as_str()) else {
                 if member.pending {
                     stats.not_present += 1;
                     tracing::info!(
                         event = "herdr_queue_poll_outcome",
                         member = %member.key,
+                        herdr_agent = %member.herdr_agent,
                         queue_kind = NudgeKind::Queue.as_str(),
                         outcome = "held_target_not_present",
                         "Herdr queue target was absent from the poll result"
@@ -723,6 +724,7 @@ impl crate::RuntimeMaintenance for HerdrQueueWakePump {
 #[derive(Clone)]
 struct HerdrCandidate {
     key: MemberKey,
+    herdr_agent: HerdrAgentName,
     session: Option<HerdrSession>,
     pending: bool,
 }
@@ -765,15 +767,20 @@ fn herdr_candidates(
             {
                 continue;
             }
-            let session = match backend {
-                atm_core::delivery_channel::LocalMessageReceivedBackend::Herdr { session } => {
-                    session
-                }
+            let (herdr_agent, session) = match backend {
+                atm_core::delivery_channel::LocalMessageReceivedBackend::Herdr {
+                    session,
+                    agent,
+                } => (
+                    agent.unwrap_or_else(|| HerdrAgentName::from(key.agent())),
+                    session,
+                ),
                 atm_core::delivery_channel::LocalMessageReceivedBackend::Tmux { .. } => continue,
             };
             candidates.push(HerdrCandidate {
                 pending: pending.contains(&key),
                 key,
+                herdr_agent,
                 session,
             });
         }
@@ -1003,7 +1010,7 @@ mod tests {
                 };
                 process
                     .prompt(
-                        &dispatch.event.recipient,
+                        &target.agent,
                         target.session.as_ref(),
                         &target.rendered_nudge,
                         deadline,
@@ -1034,6 +1041,14 @@ mod tests {
 
     fn herdr_member(team: &TeamName, agent: &str) -> RosterEntry {
         herdr_member_with_session(team, agent, "aq27-test")
+    }
+
+    fn herdr_member_with_alias(team: &TeamName, agent: &str, alias: &str) -> RosterEntry {
+        let mut member = herdr_member(team, agent);
+        member
+            .metadata_json
+            .insert("alias".to_string(), json!(alias));
+        member
     }
 
     fn queue_message(
@@ -1293,6 +1308,84 @@ mod tests {
             status: HerdrAgentStatus::Idle,
             workspace_id: None,
         }])
+    }
+
+    #[tokio::test]
+    async fn shared_herdr_server_prompts_each_team_by_its_roster_alias() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let assembly = open_isolated_sqlite_boundary(root.path()).expect("runtime");
+        let team_a: TeamName = "a-team".parse().expect("team");
+        let team_b: TeamName = "b-team".parse().expect("team");
+        assembly
+            .service_runtime
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team_a.clone(),
+                members: vec![herdr_member_with_alias(
+                    &team_a,
+                    "team-lead",
+                    "team-lead_a-team",
+                )],
+                refreshed_at: None,
+            })
+            .expect("team a roster");
+        assembly
+            .service_runtime
+            .shared_roster_store_arc()
+            .save_roster(&RosterSnapshot {
+                team_name: team_b.clone(),
+                members: vec![herdr_member_with_alias(
+                    &team_b,
+                    "team-lead",
+                    "team-lead_b-team",
+                )],
+                refreshed_at: None,
+            })
+            .expect("team b roster");
+        queue_message(root.path(), &assembly.service_runtime, &team_a, "team-lead");
+        queue_message(root.path(), &assembly.service_runtime, &team_b, "team-lead");
+
+        let fake = Arc::new(atm_herdr::testing::FakeHerdrProcessAdapter::default());
+        fake.queue_list_result(Ok(HerdrListOutcome {
+            agents: vec![
+                AgentSnapshot {
+                    name: Some("team-lead_a-team".to_owned()),
+                    status: HerdrAgentStatus::Idle,
+                    workspace_id: None,
+                },
+                AgentSnapshot {
+                    name: Some("team-lead_b-team".to_owned()),
+                    status: HerdrAgentStatus::Idle,
+                    workspace_id: None,
+                },
+            ],
+        }));
+        let selector = Arc::new(FakeSelector {
+            emitter: FakeEmitter {
+                process: Arc::clone(&fake),
+            },
+        });
+        let process: Arc<dyn HerdrProcessAdapter> = fake.clone();
+        let pump = HerdrQueueWakePump::new(
+            assembly.service_runtime,
+            selector,
+            super::RuntimeHealth::default(),
+            process,
+        );
+
+        pump.tick_once().await;
+
+        let prompted: Vec<String> = fake
+            .calls()
+            .into_iter()
+            .filter_map(|call| match call {
+                atm_herdr::testing::FakeHerdrCall::Prompt { agent, .. } => Some(agent),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(prompted.len(), 2);
+        assert!(prompted.contains(&"team-lead_a-team".to_owned()));
+        assert!(prompted.contains(&"team-lead_b-team".to_owned()));
     }
 
     type TaskOnlyPumpFixture = (

--- a/crates/atm-http-runtime/src/herdr_queue_wake.rs
+++ b/crates/atm-http-runtime/src/herdr_queue_wake.rs
@@ -767,15 +767,19 @@ fn herdr_candidates(
             {
                 continue;
             }
-            let (herdr_agent, session) = match backend {
+            let (configured_agent, session) = match backend {
                 atm_core::delivery_channel::LocalMessageReceivedBackend::Herdr {
                     session,
                     agent,
-                } => (
-                    agent.unwrap_or_else(|| HerdrAgentName::from(key.agent())),
-                    session,
-                ),
+                } => (agent, session),
                 atm_core::delivery_channel::LocalMessageReceivedBackend::Tmux { .. } => continue,
+            };
+            let Some(herdr_agent) = atm_core::delivery_channel::resolve_herdr_agent_target(
+                key.agent(),
+                configured_agent,
+                "herdr_queue_wake",
+            ) else {
+                continue;
             };
             candidates.push(HerdrCandidate {
                 pending: pending.contains(&key),
@@ -3587,5 +3591,37 @@ mod tests {
             1,
             "herdr_candidates must not call load_roster on the durable store"
         );
+    }
+
+    #[test]
+    fn herdr_queue_wake_skips_a_nonconforming_canonical_name_without_panicking() {
+        let team: TeamName = "aq27-invalid-herdr-name".parse().expect("team");
+        let member = herdr_member(&team, "TeamLead");
+        let durable = std::sync::Arc::new(CountingRosterStore {
+            roster: RosterSnapshot {
+                team_name: team,
+                members: vec![member],
+                refreshed_at: None,
+            },
+            load_roster_calls: std::sync::atomic::AtomicUsize::new(0),
+            list_teams_calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let (roster_store, roster_runtime_mirror) =
+            atm_runtime_test_support::build_write_through_roster_for_test(durable)
+                .expect("write-through roster fixture hydrates");
+        let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
+            std::sync::Arc::new(UnusedMailStore),
+            roster_store,
+            roster_runtime_mirror,
+            std::sync::Arc::new(NoopNudgeTemplateOverrideStore),
+            std::sync::Arc::new(UnusedNonClaudeOutbound),
+        );
+
+        let pending = std::collections::HashSet::new();
+        let candidates =
+            super::herdr_candidates(runtime.shared_roster_store_arc().as_ref(), &pending)
+                .expect("invalid Herdr fallback is skipped, not surfaced as a failure");
+
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/atm-http-runtime/src/storage_and_nudge_router.rs
+++ b/crates/atm-http-runtime/src/storage_and_nudge_router.rs
@@ -545,7 +545,7 @@ impl StorageAndNudgeRouter {
 
     async fn peek_messages(
         &self,
-        query: PeekQuery,
+        mut query: PeekQuery,
         deadline: RequestDeadline,
     ) -> Result<ApiResponse, AtmError> {
         let runtime = self.async_mailbox_runtime.as_ref().ok_or_else(|| {
@@ -553,6 +553,9 @@ impl StorageAndNudgeRouter {
                 "async mailbox runtime was not installed at daemon startup",
             )
         })?;
+        atm_core::read::canonicalize_peek_roster_aliases(&mut query, |team| {
+            self.service_runtime.load_team_roster(team)
+        });
         let command = atm_core::read::async_projection::prepare_async_peek(&query)?;
         runtime
             .peek_command(command, deadline)
@@ -564,7 +567,7 @@ impl StorageAndNudgeRouter {
 
     async fn receive_messages(
         &self,
-        query: ReadQuery,
+        mut query: ReadQuery,
         deadline: RequestDeadline,
     ) -> Result<ApiResponse, AtmError> {
         let runtime = self.async_mailbox_runtime.as_ref().ok_or_else(|| {
@@ -572,6 +575,9 @@ impl StorageAndNudgeRouter {
                 "async mailbox runtime was not installed at daemon startup",
             )
         })?;
+        atm_core::read::canonicalize_roster_aliases(&mut query, |team| {
+            self.service_runtime.load_team_roster(team)
+        });
         let command = atm_core::read::async_projection::prepare_async_read(&query)?;
         runtime
             .read_command(command, deadline)

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -1036,7 +1036,7 @@ mod tests {
     use chrono::Utc;
     use rusqlite::{Connection, OptionalExtension, params};
     use serde_json::Map;
-    use std::sync::Arc;
+    use std::sync::{Arc, Barrier};
 
     type OrdinaryMessageColumns = (
         Option<String>,
@@ -3881,6 +3881,65 @@ mod tests {
         let loaded = store.load_roster(&team).expect("load roster");
         assert_eq!(loaded.members.len(), 1);
         assert_eq!(store.list_teams().expect("list teams"), vec![team]);
+    }
+
+    #[test]
+    fn roster_aliases_are_globally_unique_under_the_single_writer_lane() {
+        fn roster(team: &str, agent: &str, alias: Option<&str>) -> RosterSnapshot {
+            let team_name: TeamName = team.parse().expect("team");
+            let mut metadata_json = Map::new();
+            if let Some(alias) = alias {
+                metadata_json.insert("alias".to_string(), serde_json::json!(alias));
+            }
+            RosterSnapshot {
+                team_name: team_name.clone(),
+                members: vec![RosterMember {
+                    team_name,
+                    agent_name: agent.parse().expect("agent"),
+                    member_kind: RosterMemberKind::Permanent,
+                    harness: RosterHarness::ClaudeCode,
+                    agent_type: AgentType::Worker,
+                    model: ModelName::default(),
+                    recipient_pane_id: None,
+                    metadata_json,
+                }],
+                refreshed_at: None,
+            }
+        }
+
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.roster_store();
+        store
+            .save_roster(&roster("team-a", "alpha", Some("shared-alias")))
+            .expect("first alias");
+        let duplicate = store
+            .save_roster(&roster("team-b", "beta", Some("shared-alias")))
+            .expect_err("cross-team duplicate alias");
+        assert!(duplicate.message().contains("team-a"));
+        let canonical = store
+            .save_roster(&roster("team-b", "beta", Some("alpha")))
+            .expect_err("canonical-name collision");
+        assert!(canonical.message().contains("team-a"));
+
+        let concurrent_backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let concurrent_store = concurrent_backend.roster_store();
+        let barrier = Arc::new(Barrier::new(2));
+        let left_store = Arc::clone(&concurrent_store);
+        let left_barrier = Arc::clone(&barrier);
+        let left = std::thread::spawn(move || {
+            left_barrier.wait();
+            left_store.save_roster(&roster("race-a", "alpha", Some("race-alias")))
+        });
+        let right_store = Arc::clone(&concurrent_store);
+        let right = std::thread::spawn(move || {
+            barrier.wait();
+            right_store.save_roster(&roster("race-b", "beta", Some("race-alias")))
+        });
+        let results = [
+            left.join().expect("left writer"),
+            right.join().expect("right writer"),
+        ];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/roster_store.rs
+++ b/crates/atm-storage-rusqlite/src/roster_store.rs
@@ -198,13 +198,7 @@ fn validate_database_wide_aliases(
     let aliases = roster
         .members
         .iter()
-        .filter_map(|member| {
-            member
-                .metadata_json
-                .get("alias")
-                .and_then(Value::as_str)
-                .map(|alias| alias)
-        })
+        .filter_map(|member| member.metadata_json.get("alias").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
     for (index, alias) in aliases.iter().enumerate() {
@@ -215,10 +209,7 @@ fn validate_database_wide_aliases(
         {
             return Err(alias_conflict_error(alias, team));
         }
-        if aliases[..index]
-            .iter()
-            .any(|existing_alias| *existing_alias == *alias)
-        {
+        if aliases[..index].contains(alias) {
             return Err(alias_conflict_error(alias, team));
         }
     }

--- a/crates/atm-storage-rusqlite/src/roster_store.rs
+++ b/crates/atm-storage-rusqlite/src/roster_store.rs
@@ -101,6 +101,7 @@ impl RosterStore for SqliteRosterStore {
 
         let updated_at = chrono::Utc::now().to_rfc3339();
         self.db.with_transaction(|transaction| {
+            validate_database_wide_aliases(transaction, roster)?;
             transaction
                 .execute(
                     "DELETE FROM team_roster WHERE team_name = ?1;",
@@ -181,6 +182,96 @@ impl RosterStore for SqliteRosterStore {
             Ok(teams)
         })
     }
+}
+
+/// Reject aliases that would make the durable roster namespace ambiguous.
+///
+/// This deliberately executes in the same immediate SQLite transaction as
+/// the replacement.  The preflight in the CLI gives a prompt diagnostic, but
+/// this is the authority that prevents two concurrent writers from claiming
+/// the same alias.
+fn validate_database_wide_aliases(
+    transaction: &rusqlite::Transaction<'_>,
+    roster: &RosterSnapshot,
+) -> Result<(), AtmError> {
+    let team = &roster.team_name;
+    let aliases = roster
+        .members
+        .iter()
+        .filter_map(|member| {
+            member
+                .metadata_json
+                .get("alias")
+                .and_then(Value::as_str)
+                .map(|alias| alias)
+        })
+        .collect::<Vec<_>>();
+
+    for (index, alias) in aliases.iter().enumerate() {
+        if roster
+            .members
+            .iter()
+            .any(|candidate| candidate.agent_name.as_str() == *alias)
+        {
+            return Err(alias_conflict_error(alias, team));
+        }
+        if aliases[..index]
+            .iter()
+            .any(|existing_alias| *existing_alias == *alias)
+        {
+            return Err(alias_conflict_error(alias, team));
+        }
+    }
+
+    let mut statement = transaction
+        .prepare(
+            "SELECT team_name, agent_name, metadata_json
+             FROM team_roster
+             WHERE team_name != ?1;",
+        )
+        .map_err(|error| {
+            AtmError::validation(format!(
+                "failed to prepare database-wide roster alias validation: {error}"
+            ))
+        })?;
+    let rows = statement
+        .query_map(params![team.as_str()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|error| {
+            AtmError::validation(format!(
+                "failed to query database-wide roster alias validation: {error}"
+            ))
+        })?;
+    for row in rows {
+        let (conflicting_team, canonical_name, metadata_json) = row.map_err(|error| {
+            AtmError::validation(format!(
+                "failed to decode database-wide roster alias validation: {error}"
+            ))
+        })?;
+        let metadata = deserialize_json::<Map<String, Value>>(
+            &metadata_json,
+            "team-roster metadata during alias validation",
+        )?;
+        for alias in &aliases {
+            if canonical_name == *alias
+                || metadata.get("alias").and_then(Value::as_str) == Some(*alias)
+            {
+                return Err(alias_conflict_error(alias, &conflicting_team));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn alias_conflict_error(alias: &str, conflicting_team: impl std::fmt::Display) -> AtmError {
+    AtmError::validation(format!(
+        "alias '{alias}' is already assigned in team '{conflicting_team}'"
+    ))
 }
 
 fn build_roster_member(

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -48,6 +48,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
 time = "0.3"
+toml = "0.8"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 async-trait.workspace = true

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -1,12 +1,17 @@
 use crate::observability::CliObservability;
 use crate::output;
 use anyhow::Result;
-use atm_core::doctor::{self, DaemonRuntimeDoctorReport, DoctorQuery};
+use atm_core::doctor::{self, DaemonRuntimeDoctorReport, DoctorAliasMismatch, DoctorQuery};
+use atm_core::team_admin::MembersList;
+use atm_core::types::TeamName;
 #[cfg(not(test))]
 use atm_daemon_bootstrap::assemble_default_runtime;
 #[cfg(test)]
 use atm_runtime_test_support::open_sqlite_boundary;
 use clap::Args;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use crate::composition::{
     AtmHomePath, CliComposition, InvocationDir, resolve_command_runtime_context,
@@ -88,15 +93,20 @@ impl DoctorCommand {
             self.execute_direct_local(observability, home_dir.clone(), current_dir.clone())?;
         let query = self.build_query(home_dir.clone(), current_dir)?;
 
-        match CliComposition::bootstrap(
+        let mut report = match CliComposition::bootstrap(
             "doctor",
             observability,
             InvocationDir::new(&query.current_dir),
             AtmHomePath::new(&query.home_dir),
         ) {
-            Ok(composition) => composition.doctor(query).await.map_err(anyhow::Error::from),
+            Ok(composition) => composition
+                .doctor(query.clone())
+                .await
+                .map_err(anyhow::Error::from),
             Err(_) => Ok(local_report),
-        }
+        }?;
+        append_pane_alias_mismatches(&mut report, &query);
+        Ok(report)
     }
 
     fn execute_direct_local(
@@ -126,6 +136,115 @@ impl DoctorCommand {
     }
 }
 
+/// The only Rust reader of rmux pane aliases. The values remain rmux/spawner
+/// data; doctor compares them with durable roster aliases but never uses them
+/// for ATM ingress, resolution, sends, or writes.
+#[derive(Debug, Deserialize)]
+struct PaneAliasConfig {
+    #[serde(default)]
+    rmux: RmuxConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RmuxConfig {
+    #[serde(default)]
+    windows: Vec<RmuxWindow>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RmuxWindow {
+    #[serde(default)]
+    panes: Vec<RmuxPane>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RmuxPane {
+    name: String,
+    #[serde(default)]
+    alias: Option<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+fn append_pane_alias_mismatches(report: &mut atm_core::doctor::DoctorReport, query: &DoctorQuery) {
+    let Some(workspace_team) = caller_workspace_team(query) else {
+        return;
+    };
+    let Some(path) = discover_atm_toml(&query.current_dir) else {
+        return;
+    };
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(config) = toml::from_str::<PaneAliasConfig>(&contents) else {
+        return;
+    };
+    let Some(roster) = roster_for_workspace_team(report, &workspace_team) else {
+        return;
+    };
+
+    let roster_aliases = roster
+        .members
+        .iter()
+        .map(|member| (member.name.as_str().to_owned(), member.alias.clone()))
+        .collect::<BTreeMap<_, _>>();
+    report.alias_mismatches = pane_alias_mismatches(config, &workspace_team, &roster_aliases);
+}
+
+fn caller_workspace_team(query: &DoctorQuery) -> Option<TeamName> {
+    query.caller_team.clone()
+}
+
+fn discover_atm_toml(current_dir: &Path) -> Option<PathBuf> {
+    current_dir
+        .ancestors()
+        .map(|directory| directory.join(".atm.toml"))
+        .find(|path| path.is_file())
+}
+
+fn roster_for_workspace_team<'a>(
+    report: &'a atm_core::doctor::DoctorReport,
+    workspace_team: &TeamName,
+) -> Option<&'a MembersList> {
+    report
+        .member_roster
+        .as_ref()
+        .filter(|roster| roster.team == *workspace_team)
+        .or_else(|| {
+            report
+                .team_rosters
+                .iter()
+                .find(|roster| roster.team == *workspace_team)
+        })
+}
+
+fn pane_alias_mismatches(
+    config: PaneAliasConfig,
+    workspace_team: &TeamName,
+    roster_aliases: &BTreeMap<String, Option<String>>,
+) -> Vec<DoctorAliasMismatch> {
+    config
+        .rmux
+        .windows
+        .into_iter()
+        .flat_map(|window| window.panes)
+        .filter_map(|pane| {
+            let config_alias = pane.alias?;
+            if pane.env.get("ATM_TEAM").map(String::as_str) != Some(workspace_team.as_str()) {
+                return None;
+            }
+            let roster_alias = roster_aliases.get(&pane.name).cloned().flatten();
+            let member = pane.name.parse().ok()?;
+            (roster_alias.as_deref() != Some(config_alias.as_str())).then(|| DoctorAliasMismatch {
+                team: workspace_team.clone(),
+                member,
+                config_alias,
+                roster_alias,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use atm_core::error::AtmError;
@@ -134,7 +253,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::DoctorCommand;
+    use super::{DoctorCommand, PaneAliasConfig, discover_atm_toml, pane_alias_mismatches};
     use crate::observability::CliObservability;
 
     #[derive(Debug, Parser)]
@@ -156,6 +275,101 @@ mod tests {
         let home_dir = tempdir.path().join("home");
         let current_dir = tempdir.path().join("cwd");
         (tempdir, home_dir, current_dir)
+    }
+
+    fn pane_config(panes: &str) -> PaneAliasConfig {
+        toml::from_str(&format!("[rmux]\n[[rmux.windows]]\n{panes}",)).expect("pane config")
+    }
+
+    fn workspace_team() -> atm_core::types::TeamName {
+        "workspace".parse().expect("team")
+    }
+
+    fn alias_map(
+        entries: &[(&str, Option<&str>)],
+    ) -> std::collections::BTreeMap<String, Option<String>> {
+        entries
+            .iter()
+            .map(|(name, alias)| ((*name).to_owned(), alias.map(str::to_owned)))
+            .collect()
+    }
+
+    #[test]
+    fn pane_alias_mismatch_omits_matching_alias() {
+        let config = pane_config(
+            r#"[[rmux.windows.panes]]
+name = "member-a"
+alias = "alias-a"
+env = { ATM_TEAM = "workspace" }
+"#,
+        );
+
+        let mismatches = pane_alias_mismatches(
+            config,
+            &workspace_team(),
+            &alias_map(&[("member-a", Some("alias-a"))]),
+        );
+
+        assert!(mismatches.is_empty());
+    }
+
+    #[test]
+    fn pane_alias_mismatch_reports_differing_and_absent_roster_aliases() {
+        let config = pane_config(
+            r#"[[rmux.windows.panes]]
+name = "member-a"
+alias = "alias-a"
+env = { ATM_TEAM = "workspace" }
+
+[[rmux.windows.panes]]
+name = "member-b"
+alias = "alias-b"
+env = { ATM_TEAM = "workspace" }
+"#,
+        );
+
+        let mismatches = pane_alias_mismatches(
+            config,
+            &workspace_team(),
+            &alias_map(&[("member-a", Some("wrong")), ("member-b", None)]),
+        );
+
+        assert_eq!(mismatches.len(), 2);
+        assert_eq!(mismatches[0].member.as_str(), "member-a");
+        assert_eq!(mismatches[0].config_alias, "alias-a");
+        assert_eq!(mismatches[0].roster_alias.as_deref(), Some("wrong"));
+        assert_eq!(mismatches[1].member.as_str(), "member-b");
+        assert_eq!(mismatches[1].roster_alias, None);
+    }
+
+    #[test]
+    fn pane_alias_mismatch_ignores_panes_without_alias_or_from_other_teams() {
+        let config = pane_config(
+            r#"[[rmux.windows.panes]]
+name = "member-a"
+env = { ATM_TEAM = "workspace" }
+
+[[rmux.windows.panes]]
+name = "member-b"
+alias = "other-alias"
+env = { ATM_TEAM = "other" }
+"#,
+        );
+
+        let mismatches = pane_alias_mismatches(
+            config,
+            &workspace_team(),
+            &alias_map(&[("member-a", None), ("member-b", None)]),
+        );
+
+        assert!(mismatches.is_empty());
+    }
+
+    #[test]
+    fn pane_alias_check_skips_when_no_atm_toml_is_discovered() {
+        let temporary_directory = TempDir::new().expect("temporary directory");
+
+        assert_eq!(discover_atm_toml(temporary_directory.path()), None);
     }
 
     #[test]

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -79,6 +79,12 @@ struct AddMemberCommand {
     session: Option<String>,
 
     #[arg(
+        long,
+        help = "durable roster alias; Herdr members use it as their live-agent target"
+    )]
+    alias: Option<String>,
+
+    #[arg(
         long = "pane-id",
         help = "deprecated compatibility spelling for --backend tmux --target"
     )]
@@ -123,6 +129,15 @@ struct UpdateMemberCommand {
 
     #[arg(long, help = "Herdr session name; only valid with --backend herdr")]
     session: Option<String>,
+
+    #[arg(
+        long,
+        help = "durable roster alias; Herdr members use it as their live-agent target"
+    )]
+    alias: Option<String>,
+
+    #[arg(long, help = "remove the member's durable roster alias")]
+    clear_alias: bool,
 
     #[arg(
         long = "pane-id",
@@ -360,10 +375,14 @@ impl AddMemberCommand {
         member_home_dir: PathBuf,
     ) -> Result<AddMemberRequest> {
         let host = self.host.clone();
-        let request = if self.backend.is_some() || self.target.is_some() || self.session.is_some() {
+        let request = if self.backend.is_some()
+            || self.target.is_some()
+            || self.session.is_some()
+            || self.alias.is_some()
+        {
             if self.pane_id.is_some() {
                 return Err(anyhow::anyhow!(
-                    "--pane-id cannot be combined with --backend, --target, or --session"
+                    "--pane-id cannot be combined with --backend, --target, --session, or --alias"
                 ));
             }
             AddMemberRequest::new_with_backend(
@@ -377,6 +396,8 @@ impl AddMemberCommand {
                     backend: self.backend.as_deref(),
                     target: self.target.as_deref(),
                     session: self.session.as_deref(),
+                    alias: self.alias.as_deref(),
+                    clear_alias: false,
                 },
             )
         } else {
@@ -487,10 +508,15 @@ impl UpdateMemberCommand {
 
     fn build_request(self, caller_context: CallerContext) -> Result<UpdateMemberRequest> {
         let host = self.host.clone();
-        let request = if self.backend.is_some() || self.target.is_some() || self.session.is_some() {
+        let request = if self.backend.is_some()
+            || self.target.is_some()
+            || self.session.is_some()
+            || self.alias.is_some()
+            || self.clear_alias
+        {
             if self.pane_id.is_some() {
                 return Err(anyhow::anyhow!(
-                    "--pane-id cannot be combined with --backend, --target, or --session"
+                    "--pane-id cannot be combined with --backend, --target, --session, or --alias"
                 ));
             }
             UpdateMemberRequest::new_with_backend(
@@ -507,6 +533,8 @@ impl UpdateMemberCommand {
                     backend: self.backend.as_deref(),
                     target: self.target.as_deref(),
                     session: self.session.as_deref(),
+                    alias: self.alias.as_deref(),
+                    clear_alias: self.clear_alias,
                 },
             )
         } else {
@@ -639,6 +667,8 @@ mod tests {
                 backend: None,
                 target: None,
                 session: None,
+                alias: None,
+                clear_alias: false,
                 pane_id: Some("%19".to_string()),
                 host: None,
                 json,
@@ -804,6 +834,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: None,
             host: None,
             json: false,
@@ -828,6 +859,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: None,
             host: None,
             json: false,
@@ -920,6 +952,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: Some("17".to_string()),
             host: None,
             json: false,
@@ -947,6 +980,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: None,
             host: Some("rand-m5.local".to_string()),
             json: false,
@@ -975,6 +1009,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: None,
             host: Some("has a space".to_string()),
             json: false,
@@ -1000,6 +1035,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             pane_id: None,
             host: None,
             json: false,
@@ -1041,6 +1077,8 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
+            clear_alias: false,
             pane_id: Some("17".to_string()),
             host: None,
             json: true,
@@ -1079,6 +1117,8 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
+            clear_alias: false,
             pane_id: None,
             host: Some("fastpc4.local".to_string()),
             json: false,
@@ -1112,6 +1152,8 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
+            clear_alias: false,
             pane_id: None,
             host: Some("has a space".to_string()),
             json: false,
@@ -1290,6 +1332,7 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
             json: true,
         };
 
@@ -1325,6 +1368,8 @@ mod tests {
             backend: None,
             target: None,
             session: None,
+            alias: None,
+            clear_alias: false,
             json: true,
         };
 

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -374,25 +374,11 @@ impl AddMemberCommand {
         atm_home_dir: PathBuf,
         member_home_dir: PathBuf,
     ) -> Result<AddMemberRequest> {
-        let invocation_dir = home::command_invocation_dir()?;
-        let config = atm_core::load_atm_config(&invocation_dir)?;
-        self.build_request_with_config(atm_home_dir, member_home_dir, config.as_ref())
-    }
-
-    fn build_request_with_config(
-        self,
-        atm_home_dir: PathBuf,
-        member_home_dir: PathBuf,
-        config: Option<&atm_core::AtmConfig>,
-    ) -> Result<AddMemberRequest> {
         let host = self.host.clone();
-        let alias = self.alias.clone().or_else(|| {
-            config.and_then(|config| config.rmux_pane_aliases.get(&self.member).cloned())
-        });
         let request = if self.backend.is_some()
             || self.target.is_some()
             || self.session.is_some()
-            || alias.is_some()
+            || self.alias.is_some()
         {
             if self.pane_id.is_some() {
                 return Err(anyhow::anyhow!(
@@ -410,7 +396,7 @@ impl AddMemberCommand {
                     backend: self.backend.as_deref(),
                     target: self.target.as_deref(),
                     session: self.session.as_deref(),
-                    alias: alias.as_deref(),
+                    alias: self.alias.as_deref(),
                     clear_alias: false,
                 },
             )
@@ -666,23 +652,6 @@ mod tests {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join(label);
         (tempdir, path)
-    }
-
-    fn add_member_command(member: &str, alias: Option<&str>) -> AddMemberCommand {
-        AddMemberCommand {
-            team: TEST_TEAM.to_string(),
-            member: member.to_string(),
-            agent_type: "worker".to_string(),
-            model: "gpt-5".to_string(),
-            home_dir: None,
-            backend: None,
-            target: None,
-            session: None,
-            alias: alias.map(str::to_string),
-            pane_id: None,
-            host: None,
-            json: false,
-        }
     }
 
     fn update_member_command(json: bool, home_dir: PathBuf) -> TeamsCommand {
@@ -1027,44 +996,6 @@ mod tests {
             request.host.as_ref().map(|host| host.as_str()),
             Some("rand-m5.local")
         );
-    }
-
-    #[test]
-    #[serial(env)]
-    fn add_member_alias_defaults_from_rmux_config_and_allows_override() {
-        let config_root = TempDir::new().expect("config root");
-        fs::write(
-            config_root.path().join(".atm.toml"),
-            r#"[rmux]
-
-[[rmux.windows]]
-
-[[rmux.windows.panes]]
-name = "team-lead"
-alias = "atm-lead"
-
-[[rmux.windows.panes]]
-name = "arch-ctm"
-"#,
-        )
-        .expect("config");
-        let _cwd = CwdGuard::change_to(config_root.path());
-        let (_atm_home_guard, atm_home_dir) = temp_test_path("atm-home");
-        let (_member_home_guard, member_home_dir) = temp_test_path("member-home");
-
-        let defaulted = add_member_command(ROLE_TEAM_LEAD, None)
-            .build_request(atm_home_dir.clone(), member_home_dir.clone())
-            .expect("default alias request");
-        let explicit = add_member_command(ROLE_TEAM_LEAD, Some("lead-override"))
-            .build_request(atm_home_dir.clone(), member_home_dir.clone())
-            .expect("explicit alias request");
-        let undeclared = add_member_command("arch-ctm", None)
-            .build_request(atm_home_dir, member_home_dir)
-            .expect("no alias request");
-
-        assert_eq!(defaulted.alias.as_deref(), Some("atm-lead"));
-        assert_eq!(explicit.alias.as_deref(), Some("lead-override"));
-        assert_eq!(undeclared.alias, None);
     }
 
     #[test]

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -374,11 +374,25 @@ impl AddMemberCommand {
         atm_home_dir: PathBuf,
         member_home_dir: PathBuf,
     ) -> Result<AddMemberRequest> {
+        let invocation_dir = home::command_invocation_dir()?;
+        let config = atm_core::load_atm_config(&invocation_dir)?;
+        self.build_request_with_config(atm_home_dir, member_home_dir, config.as_ref())
+    }
+
+    fn build_request_with_config(
+        self,
+        atm_home_dir: PathBuf,
+        member_home_dir: PathBuf,
+        config: Option<&atm_core::AtmConfig>,
+    ) -> Result<AddMemberRequest> {
         let host = self.host.clone();
+        let alias = self.alias.clone().or_else(|| {
+            config.and_then(|config| config.rmux_pane_aliases.get(&self.member).cloned())
+        });
         let request = if self.backend.is_some()
             || self.target.is_some()
             || self.session.is_some()
-            || self.alias.is_some()
+            || alias.is_some()
         {
             if self.pane_id.is_some() {
                 return Err(anyhow::anyhow!(
@@ -396,7 +410,7 @@ impl AddMemberCommand {
                     backend: self.backend.as_deref(),
                     target: self.target.as_deref(),
                     session: self.session.as_deref(),
-                    alias: self.alias.as_deref(),
+                    alias: alias.as_deref(),
                     clear_alias: false,
                 },
             )
@@ -652,6 +666,23 @@ mod tests {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join(label);
         (tempdir, path)
+    }
+
+    fn add_member_command(member: &str, alias: Option<&str>) -> AddMemberCommand {
+        AddMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: member.to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            home_dir: None,
+            backend: None,
+            target: None,
+            session: None,
+            alias: alias.map(str::to_string),
+            pane_id: None,
+            host: None,
+            json: false,
+        }
     }
 
     fn update_member_command(json: bool, home_dir: PathBuf) -> TeamsCommand {
@@ -996,6 +1027,44 @@ mod tests {
             request.host.as_ref().map(|host| host.as_str()),
             Some("rand-m5.local")
         );
+    }
+
+    #[test]
+    #[serial(env)]
+    fn add_member_alias_defaults_from_rmux_config_and_allows_override() {
+        let config_root = TempDir::new().expect("config root");
+        fs::write(
+            config_root.path().join(".atm.toml"),
+            r#"[rmux]
+
+[[rmux.windows]]
+
+[[rmux.windows.panes]]
+name = "team-lead"
+alias = "atm-lead"
+
+[[rmux.windows.panes]]
+name = "arch-ctm"
+"#,
+        )
+        .expect("config");
+        let _cwd = CwdGuard::change_to(config_root.path());
+        let (_atm_home_guard, atm_home_dir) = temp_test_path("atm-home");
+        let (_member_home_guard, member_home_dir) = temp_test_path("member-home");
+
+        let defaulted = add_member_command(ROLE_TEAM_LEAD, None)
+            .build_request(atm_home_dir.clone(), member_home_dir.clone())
+            .expect("default alias request");
+        let explicit = add_member_command(ROLE_TEAM_LEAD, Some("lead-override"))
+            .build_request(atm_home_dir.clone(), member_home_dir.clone())
+            .expect("explicit alias request");
+        let undeclared = add_member_command("arch-ctm", None)
+            .build_request(atm_home_dir, member_home_dir)
+            .expect("no alias request");
+
+        assert_eq!(defaulted.alias.as_deref(), Some("atm-lead"));
+        assert_eq!(explicit.alias.as_deref(), Some("lead-override"));
+        assert_eq!(undeclared.alias, None);
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -316,6 +316,7 @@ pub fn print_doctor_result(report: &DoctorReport, json: bool) -> Result<()> {
     print_doctor_environment(report);
     print_doctor_findings(report);
     print_doctor_roster(report);
+    print_doctor_alias_mismatches(report);
     print_doctor_recommendations(report);
 
     Ok(())
@@ -624,6 +625,33 @@ fn print_doctor_roster(report: &DoctorReport) {
         "{}",
         render_doctor_rosters(report.member_roster.as_ref(), &report.team_rosters)
     );
+}
+
+fn print_doctor_alias_mismatches(report: &DoctorReport) {
+    let rendered = render_doctor_alias_mismatches(&report.alias_mismatches);
+    if rendered.is_empty() {
+        return;
+    }
+    print!("{rendered}");
+}
+
+fn render_doctor_alias_mismatches(mismatches: &[atm_core::doctor::DoctorAliasMismatch]) -> String {
+    if mismatches.is_empty() {
+        return String::new();
+    }
+
+    let mut rendered = String::from("\nAlias mismatches:\n");
+    for mismatch in mismatches {
+        let _ = writeln!(
+            rendered,
+            "  team={} member={} config_alias={} roster_alias={}",
+            mismatch.team,
+            mismatch.member,
+            mismatch.config_alias,
+            empty_dash_opt(mismatch.roster_alias.as_deref()),
+        );
+    }
+    rendered
 }
 
 fn render_doctor_rosters(
@@ -1057,7 +1085,7 @@ mod tests {
     use atm_core::ack::AckOutcome;
     use atm_core::doctor::{
         BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
-        BootstrapTraceReport, HerdrDoctorReport, HerdrDoctorState,
+        BootstrapTraceReport, DoctorAliasMismatch, HerdrDoctorReport, HerdrDoctorState,
         HerdrEndpointCapabilitiesDoctorReport, HerdrEndpointDisplay, HerdrEndpointDisplayRoot,
         HerdrEndpointDoctorReport, HerdrEndpointProvenance, HerdrTransportKind, HerdrVersion,
         PeerConfigDoctorReport,
@@ -1070,8 +1098,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        render_bootstrap_trace_section, render_doctor_herdr, render_doctor_peer_config,
-        render_doctor_rosters, render_send_stdout, render_warnings_to_stderr,
+        render_bootstrap_trace_section, render_doctor_alias_mismatches, render_doctor_herdr,
+        render_doctor_peer_config, render_doctor_rosters, render_send_stdout,
+        render_warnings_to_stderr,
     };
 
     #[test]
@@ -1119,6 +1148,21 @@ mod tests {
         assert_eq!(rendered.matches("Members: ").count(), 2);
         assert!(rendered.contains("Members: team-a"));
         assert!(rendered.contains("Members: team-b"));
+    }
+
+    #[test]
+    fn doctor_alias_mismatch_text_includes_both_alias_values() {
+        let rendered = render_doctor_alias_mismatches(&[DoctorAliasMismatch {
+            team: "workspace".parse().expect("team"),
+            member: "member-a".parse().expect("member"),
+            config_alias: "alias-a".to_owned(),
+            roster_alias: Some("stale-alias".to_owned()),
+        }]);
+
+        assert!(rendered.contains("Alias mismatches:"));
+        assert!(rendered.contains("team=workspace member=member-a"));
+        assert!(rendered.contains("config_alias=alias-a"));
+        assert!(rendered.contains("roster_alias=stale-alias"));
     }
 
     #[test]

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -3174,6 +3174,17 @@
             },
             {
               "has_default": false,
+              "id": "alias",
+              "long": "alias",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
               "id": "backend",
               "long": "backend",
               "num_args": {
@@ -3623,11 +3634,33 @@
             },
             {
               "has_default": false,
+              "id": "alias",
+              "long": "alias",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
               "id": "backend",
               "long": "backend",
               "num_args": {
                 "max": 1,
                 "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "clear_alias",
+              "long": "clear-alias",
+              "num_args": {
+                "max": 0,
+                "min": 0
               },
               "required": false,
               "short": null

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -1,5 +1,25 @@
 # ATM agent conventions
 
+## Durable roster aliases for shared Herdr servers
+
+An ATM member's canonical name remains its routing, audit, and persisted
+message identity. A member may additionally have a durable roster `alias` in
+the SQLite-backed `metadata_json`. For a Herdr member, that alias is the
+unique live-agent target on a shared Herdr server; without one, ATM uses the
+canonical member name as before.
+
+Set an alias with `atm teams add-member ... --alias <name>` or `atm teams
+update-member ... --alias <name>`; remove it with `--clear-alias`. Aliases are
+team-scoped, must not collide with a canonical member name or another alias,
+and use normal ATM path-segment validation. A Herdr member's alias must also
+match `[a-z][a-z0-9_-]{0,31}`. Use `<identity>_<team>` when teams share one
+Herdr server, for example `team-lead_atm-dev`.
+
+`atm send <alias>` and `atm send <alias>@<team>` resolve to the canonical
+roster member before self-send validation and mailbox lookup. Workspace
+`.atm.toml` aliases take precedence. `ATM_IDENTITY=<alias>` and `--as <alias>`
+likewise resolve to the canonical sender identity.
+
 ## AQ2 dual-channel delivery
 
 For an `atm-graft` message-received delivery, the agent loop receives the

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -903,6 +903,13 @@ Runtime caller-context rules:
   should always be present in `config.json`
 - `.atm.toml` may define `[atm].aliases` for ATM-owned shorthand addressing of
   canonical member identities
+- `[[rmux.windows.panes]]` may declare an optional `alias` for its canonical
+  pane name; `atm teams add-member` uses that value as its default durable
+  roster alias when invoked from that repository, unless `--alias` explicitly
+  overrides it
+- a durable roster alias is the addressing alias recorded in roster metadata;
+  `[atm].aliases` remains CLI-only shorthand and never supplies durable roster
+  metadata
 - `.atm.toml` may define one or more `[[atm.post_send_hooks]]` rules for
   best-effort recipient-scoped post-send automation
 - retired `[atm].post_send_hook`, `[atm].post_send_hook_senders`,

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -910,7 +910,15 @@ Runtime caller-context rules:
   must be rejected with migration guidance directing operators to
   `[[atm.post_send_hooks]]`
 - config sections outside ATM-owned config, such as `[rmux]` or future
-  `[scmux]`, are not ATM runtime config and must be ignored by `atm-core`
+  `[scmux]`, are not ATM runtime config and must be ignored by `atm-core`,
+  with one diagnostic-only exception: `atm doctor` may read
+  `[[rmux.windows.panes]].alias` from the `.atm.toml` discovered from its
+  caller cwd and compare it with the durable alias of the named pane member
+  for that caller's `ATM_TEAM`
+- that doctor comparison is validation only: it never supplies an alias to
+  member creation, identity or recipient resolution, sends, or writes; it
+  does not widen under `--all-teams`, and a missing or unparsable `.atm.toml`
+  skips the comparison without failing doctor
 
 ### 3.3.1 Config And Schema Recovery
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -903,13 +903,6 @@ Runtime caller-context rules:
   should always be present in `config.json`
 - `.atm.toml` may define `[atm].aliases` for ATM-owned shorthand addressing of
   canonical member identities
-- `[[rmux.windows.panes]]` may declare an optional `alias` for its canonical
-  pane name; `atm teams add-member` uses that value as its default durable
-  roster alias when invoked from that repository, unless `--alias` explicitly
-  overrides it
-- a durable roster alias is the addressing alias recorded in roster metadata;
-  `[atm].aliases` remains CLI-only shorthand and never supplies durable roster
-  metadata
 - `.atm.toml` may define one or more `[[atm.post_send_hooks]]` rules for
   best-effort recipient-scoped post-send automation
 - retired `[atm].post_send_hook`, `[atm].post_send_hook_senders`,


### PR DESCRIPTION
## Scope

- **D8:** resolves Herdr roster aliases through the durable roster mapping.
- **D9:** `atm doctor` reads rmux pane aliases only from the caller workspace `.atm.toml` and compares them to the durable roster for that same `ATM_TEAM`.
- The check is diagnostic-only: it does not widen under `--all-teams`, and `.atm.toml` aliases never participate in ATM ingress, identity resolution, routing, sends, or writes. No Rust `.atm.toml` reader exists outside doctor.

## ADR-061 compatibility note

The `HerdrProcessAdapter` interface uses `HerdrAgentName`; this layer updates the benchmark no-op adapter to the same signature. This is an ADR-061 minor-version compatibility change, with no legacy daemon runtime behavior change.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- targeted core, CLI, HTTP-runtime, and bootstrap test suites
- identity and boundary source gates