### PR TITLE
chore: add TTL validation gate to pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,10 +40,12 @@ zero=0000000000000000000000000000000000000000
 # pre-existing, unrelated validation failures; see docs/triage/ttl-repair.md).
 tooling_pattern='(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.py$|(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.sparql$|(^|/)\.triage/\.graph-orchestration-ignore$|(^|/)\.claude/skills/triaging-findings/triage-record\.ttl\.j2$'
 
+remote_name="${1:-origin}"
+
 needs_rust_gate=0
 ttl_fail=0
-tmp_root=""
-cleanup() { [ -n "$tmp_root" ] && rm -rf "$tmp_root"; }
+tmp_root=$(mktemp -d)
+cleanup() { rm -rf "$tmp_root"; }
 trap cleanup EXIT
 
 while read -r _local_ref local_sha _remote_ref remote_sha; do
@@ -66,11 +68,21 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         if [ "$remote_sha" != "$zero" ]; then
             echo "pre-push: remote head $remote_sha not fetched locally; gating every commit not already on an origin ref" >&2
         fi
-        commits=$(git rev-list "$local_sha" --not --remotes=origin 2>/dev/null)
+        commits=$(git rev-list "$local_sha" --not --remotes="$remote_name" 2>/dev/null)
     fi
     [ -n "$commits" ] || continue
 
-    changed=$(git diff-tree --no-commit-id -r --name-only -m $commits 2>/dev/null | sort -u)
+    # -c (combined diff), not -m: -m against a merge lists the diff against
+    # EVERY parent separately, so a develop->integrate merge push lists that
+    # phase's entire TTL history as "changed" and false-refuses unrelated
+    # pushes on other (pre-existing-broken) phases. -c lists only paths
+    # whose merge result differs from every parent (real conflict
+    # resolutions); each side's own commits are already covered by
+    # `git rev-list` above. Commits are fed on stdin, not as trailing argv,
+    # because `git diff-tree` only accepts up to two tree-ish positional
+    # args -- with 3+ commits the extras are silently treated as pathspecs
+    # that match nothing, un-gating multi-commit pushes.
+    changed=$(printf '%s\n' "$commits" | git diff-tree --stdin --no-commit-id -r --name-only -c 2>/dev/null | sort -u)
     [ -n "$changed" ] || continue
 
     if printf '%s\n' "$changed" | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
@@ -91,8 +103,6 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
             -e 's#^(.*/)?\.sprints/([^/]+)/.*#\2#' \
         | tr '[:lower:]' '[:upper:]' | sort -u)
     [ -n "$touched_phases" ] || continue
-
-    tmp_root=$(mktemp -d)
 
     # Extract the validator from the pushed commit itself, not from disk --
     # it may be the very thing changing in this push.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,17 +5,25 @@
 # `git config core.hooksPath .githooks`; the setting is repo-wide, so one
 # install covers every worktree.
 #
-# Explicit opt-out only: ATM_SKIP_PUSH_GATE=1 skips the gate and says so.
+# Also gates pushes that touch triage TTL data (.triage/ or .sprints/):
+# validate-findings.py must pass before a broken finding/structure record
+# leaves this machine, so /sprint-report and /triage-report never see a
+# structural data gap that was pushable but unvalidated.
+#
+# Explicit opt-out only: ATM_SKIP_PUSH_GATE=1 skips both gates and says so.
 # There is no implicit bypass.
 set -u
 
 if [ "${ATM_SKIP_PUSH_GATE:-}" = "1" ]; then
-    echo "pre-push: ATM_SKIP_PUSH_GATE=1 set; skipping fmt/clippy gate" >&2
+    echo "pre-push: ATM_SKIP_PUSH_GATE=1 set; skipping fmt/clippy/ttl gates" >&2
     exit 0
 fi
 
+repo_root=$(git rev-parse --show-toplevel)
+
 zero=0000000000000000000000000000000000000000
-needs_gate=0
+needs_rust_gate=0
+ttl_phases=""
 while read -r _local_ref local_sha _remote_ref remote_sha; do
     [ "$local_sha" = "$zero" ] && continue   # branch delete: nothing to check
     if [ "$remote_sha" = "$zero" ]; then
@@ -24,30 +32,91 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         range="$remote_sha..$local_sha"
     fi
     if git rev-list "$range" 2>/dev/null | head -n 1 | grep -q .; then
-        if git diff --name-only "$range" 2>/dev/null | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
-            needs_gate=1
+        changed=$(git diff --name-only "$range" 2>/dev/null)
+        if printf '%s\n' "$changed" | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
+            needs_rust_gate=1
+        fi
+        # Only validate phases whose own .triage/.sprints files are actually
+        # touched by this push. Other phases (including already-broken
+        # historical ones) must never block an unrelated push.
+        touched_phases=$(printf '%s\n' "$changed" \
+            | grep -E '(^|/)\.triage/phase-[^/]+/.*\.ttl$|(^|/)\.sprints/[^/]+/.*\.ttl$' \
+            | sed -E \
+                -e 's#^(.*/)?\.triage/phase-([^/]+)/.*#\2#' \
+                -e 's#^(.*/)?\.sprints/([^/]+)/.*#\2#' \
+            | tr '[:lower:]' '[:upper:]' | sort -u)
+        if [ -n "$touched_phases" ]; then
+            ttl_phases="$ttl_phases
+$touched_phases"
         fi
     fi
 done
+ttl_phases=$(printf '%s\n' "$ttl_phases" | grep -v '^$' | sort -u)
 
-if [ "$needs_gate" -eq 0 ]; then
-    exit 0
+if [ "$needs_rust_gate" -eq 1 ]; then
+    echo "pre-push: running cargo fmt --all --check" >&2
+    if ! cargo fmt --all --check; then
+        echo "pre-push: REFUSED. Formatting differs from rustfmt; run 'just fmt write' and amend." >&2
+        exit 1
+    fi
+
+    echo "pre-push: running cargo clippy --workspace --all-targets -- -D warnings" >&2
+    # This is byte-for-byte the gating clippy job in .github/workflows/ci.yml
+    # (job "clippy"): bare cargo, no PYO3_PYTHON, no venv, no `just`. Keeping it
+    # identical to CI is the whole point; do not route it through the Justfile.
+    cargo clippy --workspace --all-targets -- -D warnings
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        echo "pre-push: REFUSED. Clippy reported warnings; fix them before pushing." >&2
+        exit "$status"
+    fi
 fi
 
-echo "pre-push: running cargo fmt --all --check" >&2
-if ! cargo fmt --all --check; then
-    echo "pre-push: REFUSED. Formatting differs from rustfmt; run 'just fmt write' and amend." >&2
-    exit 1
+if [ -n "$ttl_phases" ]; then
+    validator="$repo_root/.claude/skills/graph-orchestration/scripts/validate-findings.py"
+    if [ ! -f "$validator" ]; then
+        echo "pre-push: REFUSED. TTL files changed but validate-findings.py is missing at $validator." >&2
+        exit 1
+    fi
+    fail=0
+    for phase_short in $ttl_phases; do
+        structure_dir=""
+        for candidate in "$repo_root"/.sprints/*/; do
+            [ -d "$candidate" ] || continue
+            candidate_name=$(basename "$candidate")
+            if [ "$(printf '%s' "$candidate_name" | tr '[:lower:]' '[:upper:]')" = "$phase_short" ]; then
+                structure_dir="$candidate"
+                break
+            fi
+        done
+        if [ -z "$structure_dir" ]; then
+            echo "pre-push: REFUSED. Pushed .triage/.sprints changes reference phase $phase_short but no matching .sprints/*/structure.ttl exists." >&2
+            fail=1
+            continue
+        fi
+        structure="${structure_dir}structure.ttl"
+        events="${structure_dir}events.ttl"
+        findings_dir="$repo_root/.triage/phase-$(printf '%s' "$phase_short" | tr '[:upper:]' '[:lower:]')/findings"
+        if [ ! -f "$structure" ] || [ ! -d "$findings_dir" ]; then
+            echo "pre-push: REFUSED. Phase $phase_short is missing structure.ttl or findings dir under $findings_dir." >&2
+            fail=1
+            continue
+        fi
+        echo "pre-push: running validate-findings.py for phase $phase_short (touched by this push)" >&2
+        result=$(python3 "$validator" \
+            --findings-dir "$findings_dir" \
+            --structure "$structure" \
+            --events "$events" --json 2>&1)
+        py_status=$?
+        if [ "$py_status" -ne 0 ]; then
+            echo "$result" >&2
+            echo "pre-push: REFUSED. validate-findings.py failed for phase $phase_short; repair per docs/triage/ttl-repair.md." >&2
+            fail=1
+        fi
+    done
+    if [ "$fail" -ne 0 ]; then
+        exit 1
+    fi
 fi
 
-echo "pre-push: running cargo clippy --workspace --all-targets -- -D warnings" >&2
-# This is byte-for-byte the gating clippy job in .github/workflows/ci.yml
-# (job "clippy"): bare cargo, no PYO3_PYTHON, no venv, no `just`. Keeping it
-# identical to CI is the whole point; do not route it through the Justfile.
-cargo clippy --workspace --all-targets -- -D warnings
-status=$?
-if [ "$status" -ne 0 ]; then
-    echo "pre-push: REFUSED. Clippy reported warnings; fix them before pushing." >&2
-    exit "$status"
-fi
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,17 @@
 # leaves this machine, so /sprint-report and /triage-report never see a
 # structural data gap that was pushable but unvalidated.
 #
+# Both the changed-file detection and the TTL validation itself operate on
+# the actual commits/tree being pushed (via `git rev-list`/`git diff-tree`
+# and `git archive <local_sha>`), never on the working tree on disk. A push
+# can legitimately differ from what's currently checked out (cross-worktree
+# push, `gh stack sync`, pushing an older local branch), so reading paths off
+# disk would validate the wrong content. The Rust fmt/clippy gate below is a
+# known, pre-existing exception: it still runs against the working tree,
+# because running cargo against an arbitrary pushed commit would require
+# building in a throwaway worktree; that gap predates this file's TTL gate
+# and is not addressed here.
+#
 # Explicit opt-out only: ATM_SKIP_PUSH_GATE=1 skips both gates and says so.
 # There is no implicit bypass.
 set -u
@@ -20,38 +31,154 @@ if [ "${ATM_SKIP_PUSH_GATE:-}" = "1" ]; then
 fi
 
 repo_root=$(git rev-parse --show-toplevel)
-
 zero=0000000000000000000000000000000000000000
+
+# Paths to the validator and its supporting tooling. A change to any of
+# these is a change to the gate's own correctness, so it can silently
+# invalidate what every other TTL push relies on -- warn loudly even though
+# we deliberately do not hard-fail every phase over it (most phases have
+# pre-existing, unrelated validation failures; see docs/triage/ttl-repair.md).
+tooling_pattern='(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.py$|(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.sparql$|(^|/)\.triage/\.graph-orchestration-ignore$|(^|/)\.claude/skills/triaging-findings/triage-record\.ttl\.j2$'
+
 needs_rust_gate=0
-ttl_phases=""
+ttl_fail=0
+tmp_root=""
+cleanup() { [ -n "$tmp_root" ] && rm -rf "$tmp_root"; }
+trap cleanup EXIT
+
 while read -r _local_ref local_sha _remote_ref remote_sha; do
     [ "$local_sha" = "$zero" ] && continue   # branch delete: nothing to check
-    if [ "$remote_sha" = "$zero" ]; then
-        range="$local_sha"
+
+    # Derive the pushed commit range from actual commit history, never from
+    # a raw working-tree diff. If the remote tip isn't locally known (the
+    # `gh stack sync` / force-push case where $remote_sha was never fetched),
+    # `rev-list remote..local` would silently resolve as if remote_sha were
+    # an ancestor and often emit nothing -- gate everything not already on
+    # any origin ref instead, and say so, rather than let it collapse to
+    # "nothing to check".
+    remote_known=0
+    if [ "$remote_sha" != "$zero" ] && git cat-file -e "${remote_sha}^{commit}" 2>/dev/null; then
+        remote_known=1
+    fi
+    if [ "$remote_known" -eq 1 ]; then
+        commits=$(git rev-list "${remote_sha}..${local_sha}" 2>/dev/null)
     else
-        range="$remote_sha..$local_sha"
-    fi
-    if git rev-list "$range" 2>/dev/null | head -n 1 | grep -q .; then
-        changed=$(git diff --name-only "$range" 2>/dev/null)
-        if printf '%s\n' "$changed" | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
-            needs_rust_gate=1
+        if [ "$remote_sha" != "$zero" ]; then
+            echo "pre-push: remote head $remote_sha not fetched locally; gating every commit not already on an origin ref" >&2
         fi
-        # Only validate phases whose own .triage/.sprints files are actually
-        # touched by this push. Other phases (including already-broken
-        # historical ones) must never block an unrelated push.
-        touched_phases=$(printf '%s\n' "$changed" \
-            | grep -E '(^|/)\.triage/phase-[^/]+/.*\.ttl$|(^|/)\.sprints/[^/]+/.*\.ttl$' \
-            | sed -E \
-                -e 's#^(.*/)?\.triage/phase-([^/]+)/.*#\2#' \
-                -e 's#^(.*/)?\.sprints/([^/]+)/.*#\2#' \
-            | tr '[:lower:]' '[:upper:]' | sort -u)
-        if [ -n "$touched_phases" ]; then
-            ttl_phases="$ttl_phases
-$touched_phases"
-        fi
+        commits=$(git rev-list "$local_sha" --not --remotes=origin 2>/dev/null)
     fi
+    [ -n "$commits" ] || continue
+
+    changed=$(git diff-tree --no-commit-id -r --name-only -m $commits 2>/dev/null | sort -u)
+    [ -n "$changed" ] || continue
+
+    if printf '%s\n' "$changed" | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
+        needs_rust_gate=1
+    fi
+
+    if printf '%s\n' "$changed" | grep -Eq "$tooling_pattern"; then
+        echo "pre-push: WARNING: validate-findings.py/.sparql, .graph-orchestration-ignore, or triage-record.ttl.j2 changed in this push. Only phases whose own TTL files are touched are gated below -- a tooling regression affecting other phases will NOT be caught by this hook. Run validate-findings.py manually against every phase before relying on this change." >&2
+    fi
+
+    # Only validate phases whose own .triage/.sprints files are actually
+    # touched by this push. Other phases (including already-broken
+    # historical ones) must never block an unrelated push.
+    touched_phases=$(printf '%s\n' "$changed" \
+        | grep -E '(^|/)\.triage/phase-[^/]+/.*\.ttl$|(^|/)\.sprints/[^/]+/.*\.ttl$' \
+        | sed -E \
+            -e 's#^(.*/)?\.triage/phase-([^/]+)/.*#\2#' \
+            -e 's#^(.*/)?\.sprints/([^/]+)/.*#\2#' \
+        | tr '[:lower:]' '[:upper:]' | sort -u)
+    [ -n "$touched_phases" ] || continue
+
+    tmp_root=$(mktemp -d)
+
+    # Extract the validator from the pushed commit itself, not from disk --
+    # it may be the very thing changing in this push.
+    script_rel=".claude/skills/graph-orchestration/scripts"
+    if ! git archive "$local_sha" -- "$script_rel" 2>/dev/null | tar -x -C "$tmp_root" 2>/dev/null; then
+        echo "pre-push: REFUSED. Could not extract $script_rel from pushed commit $local_sha." >&2
+        ttl_fail=1
+        continue
+    fi
+    validator="$tmp_root/$script_rel/validate-findings.py"
+    if [ ! -f "$validator" ]; then
+        echo "pre-push: REFUSED. TTL files changed but validate-findings.py is not present at pushed commit $local_sha ($script_rel)." >&2
+        ttl_fail=1
+        continue
+    fi
+
+    for phase_short in $touched_phases; do
+        # Case-insensitively resolve the declared phase dir name from the
+        # pushed tree, not from whatever happens to be checked out.
+        sprints_listing=$(git ls-tree --name-only "$local_sha" -- .sprints/ 2>/dev/null)
+        real_phase_name=""
+        for candidate in $sprints_listing; do
+            cname=$(basename "$candidate")
+            if [ "$(printf '%s' "$cname" | tr '[:lower:]' '[:upper:]')" = "$phase_short" ]; then
+                real_phase_name="$cname"
+                break
+            fi
+        done
+        if [ -z "$real_phase_name" ]; then
+            echo "pre-push: REFUSED. Pushed .triage/.sprints changes reference phase $phase_short but no matching .sprints/* directory exists at pushed commit $local_sha." >&2
+            ttl_fail=1
+            continue
+        fi
+
+        triage_listing=$(git ls-tree --name-only "$local_sha" -- .triage/ 2>/dev/null)
+        real_triage_dir=""
+        for candidate in $triage_listing; do
+            cname=$(basename "$candidate")   # phase-xx
+            cshort=${cname#phase-}
+            if [ "$(printf '%s' "$cshort" | tr '[:lower:]' '[:upper:]')" = "$phase_short" ]; then
+                real_triage_dir="$cname"
+                break
+            fi
+        done
+        if [ -z "$real_triage_dir" ]; then
+            echo "pre-push: REFUSED. Phase $real_phase_name has no matching .triage/phase-* directory at pushed commit $local_sha." >&2
+            ttl_fail=1
+            continue
+        fi
+
+        sprints_rel=".sprints/$real_phase_name"
+        triage_rel=".triage/$real_triage_dir"
+
+        if ! git archive "$local_sha" -- "$sprints_rel" "$triage_rel" 2>/dev/null | tar -x -C "$tmp_root" 2>/dev/null; then
+            echo "pre-push: REFUSED. Could not extract $sprints_rel / $triage_rel from pushed commit $local_sha." >&2
+            ttl_fail=1
+            continue
+        fi
+
+        structure="$tmp_root/$sprints_rel/structure.ttl"
+        events="$tmp_root/$sprints_rel/events.ttl"
+        findings_dir="$tmp_root/$triage_rel/findings"
+        if [ ! -f "$structure" ]; then
+            echo "pre-push: REFUSED. $sprints_rel/structure.ttl missing at pushed commit $local_sha." >&2
+            ttl_fail=1
+            continue
+        fi
+        if [ ! -d "$findings_dir" ]; then
+            echo "pre-push: REFUSED. $triage_rel/findings missing at pushed commit $local_sha." >&2
+            ttl_fail=1
+            continue
+        fi
+
+        set -- --findings-dir "$findings_dir" --structure "$structure"
+        [ -f "$events" ] && set -- "$@" --events "$events"
+
+        echo "pre-push: running validate-findings.py for phase $real_phase_name against pushed commit $local_sha" >&2
+        result=$(python3 "$validator" "$@" --json 2>&1)
+        py_status=$?
+        if [ "$py_status" -ne 0 ]; then
+            echo "$result" >&2
+            echo "pre-push: REFUSED. validate-findings.py failed for phase $real_phase_name at pushed commit $local_sha; repair per docs/triage/ttl-repair.md." >&2
+            ttl_fail=1
+        fi
+    done
 done
-ttl_phases=$(printf '%s\n' "$ttl_phases" | grep -v '^$' | sort -u)
 
 if [ "$needs_rust_gate" -eq 1 ]; then
     echo "pre-push: running cargo fmt --all --check" >&2
@@ -72,51 +199,8 @@ if [ "$needs_rust_gate" -eq 1 ]; then
     fi
 fi
 
-if [ -n "$ttl_phases" ]; then
-    validator="$repo_root/.claude/skills/graph-orchestration/scripts/validate-findings.py"
-    if [ ! -f "$validator" ]; then
-        echo "pre-push: REFUSED. TTL files changed but validate-findings.py is missing at $validator." >&2
-        exit 1
-    fi
-    fail=0
-    for phase_short in $ttl_phases; do
-        structure_dir=""
-        for candidate in "$repo_root"/.sprints/*/; do
-            [ -d "$candidate" ] || continue
-            candidate_name=$(basename "$candidate")
-            if [ "$(printf '%s' "$candidate_name" | tr '[:lower:]' '[:upper:]')" = "$phase_short" ]; then
-                structure_dir="$candidate"
-                break
-            fi
-        done
-        if [ -z "$structure_dir" ]; then
-            echo "pre-push: REFUSED. Pushed .triage/.sprints changes reference phase $phase_short but no matching .sprints/*/structure.ttl exists." >&2
-            fail=1
-            continue
-        fi
-        structure="${structure_dir}structure.ttl"
-        events="${structure_dir}events.ttl"
-        findings_dir="$repo_root/.triage/phase-$(printf '%s' "$phase_short" | tr '[:upper:]' '[:lower:]')/findings"
-        if [ ! -f "$structure" ] || [ ! -d "$findings_dir" ]; then
-            echo "pre-push: REFUSED. Phase $phase_short is missing structure.ttl or findings dir under $findings_dir." >&2
-            fail=1
-            continue
-        fi
-        echo "pre-push: running validate-findings.py for phase $phase_short (touched by this push)" >&2
-        result=$(python3 "$validator" \
-            --findings-dir "$findings_dir" \
-            --structure "$structure" \
-            --events "$events" --json 2>&1)
-        py_status=$?
-        if [ "$py_status" -ne 0 ]; then
-            echo "$result" >&2
-            echo "pre-push: REFUSED. validate-findings.py failed for phase $phase_short; repair per docs/triage/ttl-repair.md." >&2
-            fail=1
-        fi
-    done
-    if [ "$fail" -ne 0 ]; then
-        exit 1
-    fi
+if [ "$ttl_fail" -ne 0 ]; then
+    exit 1
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,8 +40,6 @@ zero=0000000000000000000000000000000000000000
 # pre-existing, unrelated validation failures; see docs/triage/ttl-repair.md).
 tooling_pattern='(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.py$|(^|/)\.claude/skills/graph-orchestration/scripts/validate-findings\.sparql$|(^|/)\.triage/\.graph-orchestration-ignore$|(^|/)\.claude/skills/triaging-findings/triage-record\.ttl\.j2$'
 
-remote_name="${1:-origin}"
-
 needs_rust_gate=0
 ttl_fail=0
 tmp_root=$(mktemp -d)
@@ -66,9 +64,16 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         commits=$(git rev-list "${remote_sha}..${local_sha}" 2>/dev/null)
     else
         if [ "$remote_sha" != "$zero" ]; then
-            echo "pre-push: remote head $remote_sha not fetched locally; gating every commit not already on an origin ref" >&2
+            echo "pre-push: remote head $remote_sha not fetched locally; gating every commit not already on any remote-tracking ref" >&2
         fi
-        commits=$(git rev-list "$local_sha" --not --remotes="$remote_name" 2>/dev/null)
+        # No --remotes=<name> filter: $1 is the destination as given on the
+        # command line (a nickname, a bare URL, anything), not necessarily a
+        # configured remote with up-to-date tracking refs. An unrelated or
+        # stale remote name here silently gates the entire repo history
+        # instead of just this push. Bare `--remotes` (no argument) excludes
+        # anything reachable from ANY remote-tracking ref, which is what
+        # "not already known to be published" actually means.
+        commits=$(git rev-list "$local_sha" --not --remotes 2>/dev/null)
     fi
     [ -n "$commits" ] || continue
 
@@ -85,11 +90,11 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     changed=$(printf '%s\n' "$commits" | git diff-tree --stdin --no-commit-id -r --name-only -c 2>/dev/null | sort -u)
     [ -n "$changed" ] || continue
 
-    if printf '%s\n' "$changed" | grep -Eq '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$'; then
+    if printf '%s\n' "$changed" | grep -E '\.rs$|^Cargo\.(toml|lock)$|/Cargo\.toml$' >/dev/null 2>&1; then
         needs_rust_gate=1
     fi
 
-    if printf '%s\n' "$changed" | grep -Eq "$tooling_pattern"; then
+    if printf '%s\n' "$changed" | grep -E "$tooling_pattern" >/dev/null 2>&1; then
         echo "pre-push: WARNING: validate-findings.py/.sparql, .graph-orchestration-ignore, or triage-record.ttl.j2 changed in this push. Only phases whose own TTL files are touched are gated below -- a tooling regression affecting other phases will NOT be caught by this hook. Run validate-findings.py manually against every phase before relying on this change." >&2
     fi
 
@@ -104,15 +109,23 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         | tr '[:lower:]' '[:upper:]' | sort -u)
     [ -n "$touched_phases" ] || continue
 
+    # Extract into a fresh subdirectory per ref, not the shared tmp_root: a
+    # multi-ref push where an earlier ref carries a TTL file a later ref
+    # lacks would otherwise leave it behind after tar's overwrite-only
+    # extraction, making the later ref validate against a mix of both refs'
+    # trees. tmp_root itself is still created once (for the single EXIT
+    # trap) and only its per-ref children are used for content.
+    ref_root=$(mktemp -d "$tmp_root/ref.XXXXXX")
+
     # Extract the validator from the pushed commit itself, not from disk --
     # it may be the very thing changing in this push.
     script_rel=".claude/skills/graph-orchestration/scripts"
-    if ! git archive "$local_sha" -- "$script_rel" 2>/dev/null | tar -x -C "$tmp_root" 2>/dev/null; then
+    if ! git archive "$local_sha" -- "$script_rel" 2>/dev/null | tar -x -C "$ref_root" 2>/dev/null; then
         echo "pre-push: REFUSED. Could not extract $script_rel from pushed commit $local_sha." >&2
         ttl_fail=1
         continue
     fi
-    validator="$tmp_root/$script_rel/validate-findings.py"
+    validator="$ref_root/$script_rel/validate-findings.py"
     if [ ! -f "$validator" ]; then
         echo "pre-push: REFUSED. TTL files changed but validate-findings.py is not present at pushed commit $local_sha ($script_rel)." >&2
         ttl_fail=1
@@ -156,15 +169,15 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         sprints_rel=".sprints/$real_phase_name"
         triage_rel=".triage/$real_triage_dir"
 
-        if ! git archive "$local_sha" -- "$sprints_rel" "$triage_rel" 2>/dev/null | tar -x -C "$tmp_root" 2>/dev/null; then
+        if ! git archive "$local_sha" -- "$sprints_rel" "$triage_rel" 2>/dev/null | tar -x -C "$ref_root" 2>/dev/null; then
             echo "pre-push: REFUSED. Could not extract $sprints_rel / $triage_rel from pushed commit $local_sha." >&2
             ttl_fail=1
             continue
         fi
 
-        structure="$tmp_root/$sprints_rel/structure.ttl"
-        events="$tmp_root/$sprints_rel/events.ttl"
-        findings_dir="$tmp_root/$triage_rel/findings"
+        structure="$ref_root/$sprints_rel/structure.ttl"
+        events="$ref_root/$sprints_rel/events.ttl"
+        findings_dir="$ref_root/$triage_rel/findings"
         if [ ! -f "$structure" ]; then
             echo "pre-push: REFUSED. $sprints_rel/structure.ttl missing at pushed commit $local_sha." >&2
             ttl_fail=1


### PR DESCRIPTION
## Summary
- Extends the existing repo-wide `.githooks/pre-push` fmt/clippy gate with a TTL validation gate: pushes that touch `.triage/*/findings/*.ttl` or `.sprints/*/*.ttl` now run `validate-findings.py` before the push leaves the machine.
- Scoped strictly to the phase(s) actually touched by the push — several historical phases (AL, AM, AQ, AT, AW) currently fail validation for pre-existing reasons unrelated to any given push, so a blanket all-phase scan would have blocked nearly every future push. Verified against real diffs (e.g. 943b4a64f on integrate/phase-ay) that phase extraction resolves correctly.
- Same explicit-opt-out convention as the existing gate: `ATM_SKIP_PUSH_GATE=1`.

## Test plan
- [x] `sh -n .githooks/pre-push` syntax check
- [x] Dry-ran `validate-findings.py` against all 12 currently-declared phases directly to confirm which already fail (AL/AM/AQ/AT/AW) vs pass (AJ/AN/AO2/AU/AV/AX/AY) — confirms scoping to touched-phase-only is required, not optional
- [x] Verified the changed-path → phase-short-code extraction against a real commit's diff (943b4a64f, integrate/phase-ay) resolves to `AY`
- [ ] Live end-to-end push exercising a deliberately broken finding record, to confirm the gate actually refuses (recommend as part of review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)