### PR TITLE
fix(boundary): authorize benchmark HerdrProcessAdapter double under RULE-012 (ARCH-AY-R2-001)

### DIFF
--- a/boundaries/atm-herdr/herdr-process-adapter.toml
+++ b/boundaries/atm-herdr/herdr-process-adapter.toml
@@ -63,7 +63,7 @@ notes = [
 ]
 
 [testing]
-allowed_test_double_paths = ["atm_herdr::testing::FakeHerdrProcessAdapter"]
+allowed_test_double_paths = ["atm_herdr::testing::FakeHerdrProcessAdapter", "atm_daemon_bootstrap::received_hook_selector::BenchmarkNoopHerdrProcessAdapter"]
 forbidden_test_bypasses = ["std::process::Command", "tokio::process::Command"]
 
 [enforcement]
@@ -77,6 +77,7 @@ review_gates = [
 [status]
 state = "active"
 notes = [
+  "The benchmark-harness-only BenchmarkNoop adapter accepts active-hook wakes locally so capacity runs neither invoke Herdr nor construct its real process invoker.",
   "AQ2.6 owns the immediate steer adapter contract; AQ2.7 reuses the same adapter for wait/get queue wake behavior",
   "HerdrSession remains owned by AQ1 delivery_channel.rs; this crate consumes the session string only for child HERDR_SESSION",
   "Phase AX.2: prompt text is caller-supplied rendered built-in nudge template text; the adapter never composes or alters it (2026-09-05)",


### PR DESCRIPTION
Phase-ay gate round 2 (PR #1308) blocking finding ARCH-AY-R2-001: `BenchmarkNoopHerdrProcessAdapter` in `crates/atm-daemon-bootstrap/src/received_hook_selector.rs` is a second `HerdrProcessAdapter` impl site outside the RULE-012 allowlist (`boundaries/atm-herdr/herdr-process-adapter.toml`).

Scope: blocking finding only (assignee arch-ctm). Non-blocking gate r2 findings ride the stacked layer above.

Triage record: `.triage/phase-ay/findings/ARCH-AY-R2-001.ttl` on integrate/phase-ay at 5c62c1d15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
