### PR TITLE
fix(phase-ay): gate round-3 architecture findings (ARCH-AY-R2-002/003/004)

### DIFF
--- a/boundaries/atm-core/herdr-endpoint-doctor.toml
+++ b/boundaries/atm-core/herdr-endpoint-doctor.toml
@@ -60,7 +60,10 @@ notes = [
 ]
 
 [testing]
-allowed_test_double_paths = []
+allowed_test_double_paths = [
+  "crate::doctor::ClosedHerdrEndpointDoctor",
+  "atm_runtime::doctor_projection::tests::CountingEndpoint",
+]
 forbidden_test_bypasses = ["std::process::Command", "tokio::process::Command"]
 
 [enforcement]

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1834,6 +1834,43 @@ mod tests {
     }
 
     #[test]
+    fn all_teams_duplicate_name_warnings_preserve_team_context() {
+        let paths = TestPaths::new();
+        let mut store =
+            roster_store_for_teams(&[("team-a", "local-member"), ("team-b", "remote-member")]);
+        for member in &mut store.members {
+            member.metadata_json.insert(
+                "alias".to_owned(),
+                serde_json::Value::String("shared-herdr-name".to_owned()),
+            );
+        }
+        let runtime = test_runtime_from_store(store);
+        let query = DoctorQuery {
+            home_dir: paths.home_dir.clone(),
+            current_dir: paths.current_dir.clone(),
+            all_teams: true,
+            ..DoctorQuery::default()
+        };
+
+        let report = run_doctor_with_runtime(query, &healthy_observability(&paths), &runtime)
+            .expect("all-team doctor report");
+        let warnings = report
+            .findings
+            .iter()
+            .filter(|finding| finding.code == AtmErrorCode::WarningRosterDrift)
+            .map(|finding| finding.message.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().any(|message| {
+            message.starts_with("team team-a:") && message.contains("remote-member@team-b")
+        }));
+        assert!(warnings.iter().any(|message| {
+            message.starts_with("team team-b:") && message.contains("local-member@team-a")
+        }));
+    }
+
+    #[test]
     #[serial_test::serial(env)]
     fn run_doctor_without_team_falls_back_to_all_with_info_finding() {
         let paths = TestPaths::new();

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -8,13 +8,14 @@ mod team_scope;
 #[cfg(test)]
 use std::collections::BTreeSet;
 use std::future::Future;
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::pin::Pin;
 
 use crate::api::RequestDeadline;
 use crate::boundary::{ConfigDoctor, MailStoreDoctor, RosterStoreDoctor};
 use crate::config;
-use crate::delivery_channel::local_message_received_backend;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::ObservabilityPort;
 #[cfg(test)]
@@ -23,7 +24,7 @@ use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::AgentMember;
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::default_runtime;
-use crate::team_admin::{MembersList, ordered_roster_member_summaries};
+use crate::team_admin::MembersList;
 use crate::types::{AgentName, TeamName};
 use atm_storage::PeerConfigStore;
 use std::sync::Arc;
@@ -903,74 +904,6 @@ fn summarize_doctor_findings(findings: &[DoctorFinding]) -> DoctorSummary {
         warning_count,
         error_count,
     }
-}
-
-fn load_member_roster(
-    runtime: &LocalServiceRuntime,
-    team: &TeamName,
-    caller_identity: Option<&AgentName>,
-    live_cwd: Option<&Path>,
-    team_context: bool,
-    findings: &mut Vec<DoctorFinding>,
-) -> Option<MembersList> {
-    if let Err(error) = crate::address::validate_path_segment(team.as_str(), "team") {
-        push_doctor_error_for_team(
-            findings,
-            DoctorSeverity::Error,
-            error,
-            team_context.then_some(team),
-        );
-        return None;
-    }
-    let roster = runtime.load_team_roster(team);
-    push_mixed_local_backend_warning(team, &roster, findings);
-    roster_names::push_duplicate_effective_name_warnings(
-        runtime,
-        team,
-        &roster,
-        team_context,
-        findings,
-    );
-    let members = ordered_roster_member_summaries(&roster, caller_identity, live_cwd);
-
-    Some(MembersList {
-        team: team.clone(),
-        members,
-    })
-}
-
-fn push_mixed_local_backend_warning(
-    team: &TeamName,
-    roster: &[crate::boundary::RosterEntry],
-    findings: &mut Vec<DoctorFinding>,
-) {
-    let mut tmux = Vec::new();
-    let mut herdr = Vec::new();
-    for member in roster {
-        match local_message_received_backend(member) {
-            Some(crate::delivery_channel::LocalMessageReceivedBackend::Tmux { .. }) => {
-                tmux.push(member.agent_name.to_string())
-            }
-            Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { .. }) => {
-                herdr.push(member.agent_name.to_string())
-            }
-            None => {}
-        }
-    }
-    if tmux.is_empty() || herdr.is_empty() {
-        return;
-    }
-    findings.push(DoctorFinding {
-        severity: DoctorSeverity::Warning,
-        code: AtmErrorCode::RosterMixedLocalBackend,
-        message: format!(
-            "team {team} has mixed local backends; tmux members: [{}]; Herdr members: [{}]",
-            tmux.join(", "), herdr.join(", ")
-        ),
-        remediation: Some(format!(
-            "Use `atm teams update-member {team} <member> --backend herdr` or `atm teams update-member {team} <member> --backend tmux --target %N` to select the intended backend."
-        )),
-    });
 }
 
 fn push_doctor_error(

--- a/crates/atm-core/src/doctor/roster_names.rs
+++ b/crates/atm-core/src/doctor/roster_names.rs
@@ -1,22 +1,18 @@
 use super::{DoctorFinding, DoctorSeverity, team_scope};
+use crate::boundary::RosterEntry;
 use crate::error_codes::AtmErrorCode;
-use crate::service_runtime::LocalServiceRuntime;
 use crate::types::TeamName;
 
 pub(super) fn push_duplicate_effective_name_warnings(
-    runtime: &LocalServiceRuntime,
     team: &TeamName,
-    roster: &[crate::boundary::RosterEntry],
+    roster: &[RosterEntry],
+    all_rosters: &[(TeamName, Vec<RosterEntry>)],
     team_context: bool,
     findings: &mut Vec<DoctorFinding>,
 ) {
-    let all_members = runtime
-        .list_roster_teams()
-        .into_iter()
-        .flat_map(|other_team| runtime.load_team_roster(&other_team))
-        .collect::<Vec<_>>();
-    let all_names = all_members
+    let all_names = all_rosters
         .iter()
+        .flat_map(|(_, roster)| roster.iter())
         .map(atm_storage::RosterUniqueName::from_member)
         .collect::<Vec<_>>();
     let collisions = atm_storage::roster_unique_name_collisions(&all_names);

--- a/crates/atm-core/src/doctor/team_scope.rs
+++ b/crates/atm-core/src/doctor/team_scope.rs
@@ -7,6 +7,8 @@ use crate::team_admin::{MembersList, ordered_roster_member_summaries};
 use crate::types::{AgentName, TeamName};
 use std::path::Path;
 
+type LoadedRosters = Vec<(TeamName, Vec<RosterEntry>)>;
+
 /// The effective team scope for one doctor run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DoctorTeamScope {
@@ -73,6 +75,14 @@ pub(super) fn load_scoped_rosters(
     findings: &mut Vec<DoctorFinding>,
 ) -> (Option<MembersList>, Vec<MembersList>) {
     let team_context = scope.is_all_teams();
+    let mut all_rosters = runtime
+        .list_roster_teams()
+        .into_iter()
+        .map(|team| {
+            let roster = runtime.load_team_roster(&team);
+            (team, roster)
+        })
+        .collect::<LoadedRosters>();
     let rosters = teams
         .iter()
         .filter_map(|team| {
@@ -82,6 +92,7 @@ pub(super) fn load_scoped_rosters(
                 caller_identity,
                 live_cwd,
                 team_context,
+                &mut all_rosters,
                 findings,
             )
         })
@@ -99,6 +110,7 @@ fn load_member_roster(
     caller_identity: Option<&AgentName>,
     live_cwd: Option<&Path>,
     team_context: bool,
+    all_rosters: &mut LoadedRosters,
     findings: &mut Vec<DoctorFinding>,
 ) -> Option<MembersList> {
     if let Err(error) = crate::address::validate_path_segment(team.as_str(), "team") {
@@ -110,12 +122,20 @@ fn load_member_roster(
         );
         return None;
     }
-    let roster = runtime.load_team_roster(team);
+    let roster = all_rosters
+        .iter()
+        .find(|(loaded_team, _)| loaded_team == team)
+        .map(|(_, roster)| roster.clone())
+        .unwrap_or_else(|| {
+            let roster = runtime.load_team_roster(team);
+            all_rosters.push((team.clone(), roster.clone()));
+            roster
+        });
     push_mixed_local_backend_warning(team, &roster, findings);
     roster_names::push_duplicate_effective_name_warnings(
-        runtime,
         team,
         &roster,
+        all_rosters,
         team_context,
         findings,
     );

--- a/crates/atm-core/src/doctor/team_scope.rs
+++ b/crates/atm-core/src/doctor/team_scope.rs
@@ -1,7 +1,9 @@
-use super::{DoctorFinding, DoctorSeverity, load_member_roster, push_doctor_error};
+use super::{DoctorFinding, DoctorSeverity, push_doctor_error, roster_names};
+use crate::boundary::RosterEntry;
+use crate::delivery_channel::local_message_received_backend;
 use crate::error_codes::AtmErrorCode;
 use crate::service_runtime::LocalServiceRuntime;
-use crate::team_admin::MembersList;
+use crate::team_admin::{MembersList, ordered_roster_member_summaries};
 use crate::types::{AgentName, TeamName};
 use std::path::Path;
 
@@ -89,6 +91,74 @@ pub(super) fn load_scoped_rosters(
     } else {
         (rosters.into_iter().next(), Vec::new())
     }
+}
+
+fn load_member_roster(
+    runtime: &LocalServiceRuntime,
+    team: &TeamName,
+    caller_identity: Option<&AgentName>,
+    live_cwd: Option<&Path>,
+    team_context: bool,
+    findings: &mut Vec<DoctorFinding>,
+) -> Option<MembersList> {
+    if let Err(error) = crate::address::validate_path_segment(team.as_str(), "team") {
+        push_doctor_error_for_team(
+            findings,
+            DoctorSeverity::Error,
+            error,
+            team_context.then_some(team),
+        );
+        return None;
+    }
+    let roster = runtime.load_team_roster(team);
+    push_mixed_local_backend_warning(team, &roster, findings);
+    roster_names::push_duplicate_effective_name_warnings(
+        runtime,
+        team,
+        &roster,
+        team_context,
+        findings,
+    );
+    let members = ordered_roster_member_summaries(&roster, caller_identity, live_cwd);
+
+    Some(MembersList {
+        team: team.clone(),
+        members,
+    })
+}
+
+fn push_mixed_local_backend_warning(
+    team: &TeamName,
+    roster: &[RosterEntry],
+    findings: &mut Vec<DoctorFinding>,
+) {
+    let mut tmux = Vec::new();
+    let mut herdr = Vec::new();
+    for member in roster {
+        match local_message_received_backend(member) {
+            Some(crate::delivery_channel::LocalMessageReceivedBackend::Tmux { .. }) => {
+                tmux.push(member.agent_name.to_string())
+            }
+            Some(crate::delivery_channel::LocalMessageReceivedBackend::Herdr { .. }) => {
+                herdr.push(member.agent_name.to_string())
+            }
+            None => {}
+        }
+    }
+    if tmux.is_empty() || herdr.is_empty() {
+        return;
+    }
+    findings.push(DoctorFinding {
+        severity: DoctorSeverity::Warning,
+        code: AtmErrorCode::RosterMixedLocalBackend,
+        message: format!(
+            "team {team} has mixed local backends; tmux members: [{}]; Herdr members: [{}]",
+            tmux.join(", "), herdr.join(", ")
+        ),
+        remediation: Some(format!(
+            "Use `atm teams update-member {team} <member> --backend herdr` or `atm teams update-member {team} <member> --backend tmux --target %N` to select the intended backend."
+        )),
+    });
 }
 
 pub(super) fn graft_receivers_for_teams(


### PR DESCRIPTION
Top layer of the phase-ay stack, on top of PR #1318.

PR #1318 represents integrate/phase-ay today, so remaining phase-ay changes
land here as a new stack layer rather than on #1318 itself.

## Scope — gate round 3 findings (quality-mgr, arch-qa, at ef79745ae)

- **ARCH-AY-R2-002** (blocking) — `crates/atm-core/src/doctor/mod.rs` has 1061
  non-test lines, over RULE-003's 1000-line cap (develop baseline: 931). Split
  non-test code into a child module.
- **ARCH-AY-R2-003** (important) — `CountingEndpoint` at
  `crates/atm-runtime/src/doctor_projection.rs:384` implements
  `HerdrEndpointDoctor` but is absent from
  `boundaries/atm-core/herdr-endpoint-doctor.toml` `[testing].allowed_test_double_paths`
  (currently `[]`). Document the legitimate test double.
- **ARCH-AY-R2-004** (important) — O(N^2) `doctor --all-teams` roster reload
  from the AY.13 x AY.15 composition: `load_scoped_rosters` iterates teams and
  `push_duplicate_effective_name_warnings` reloads every team's full roster on
  each call. Hoist to a single load.

Triage records: `.triage/phase-ay/findings/ARCH-AY-R2-00{2,3,4}.ttl` on
integrate/phase-ay @ a44758d1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK