### PR TITLE
docs(phase-ay): set sprint-doc status complete for merged sprints (DOCS-AY-R4-001)

### DIFF
--- a/docs/plans/phase-ay/sprint-AY.1-herdr-audit-docs.md
+++ b/docs/plans/phase-ay/sprint-AY.1-herdr-audit-docs.md
@@ -6,7 +6,7 @@ title: Herdr audit, version table, requirements, and ADR text
 branch: feature/ay1-herdr-audit-docs
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay1-herdr-audit-docs
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_track: docs

--- a/docs/plans/phase-ay/sprint-AY.13-doctor-team-scope.md
+++ b/docs/plans/phase-ay/sprint-AY.13-doctor-team-scope.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: none
 pr_target: integrate/phase-ay
 target: integrate/phase-ay
-status: dispatched
+status: complete
 recommended_agent: cipher
 recommended_model: implementation
 execution_track: parallel

--- a/docs/plans/phase-ay/sprint-AY.14-herdr-agent-name-mapping.md
+++ b/docs/plans/phase-ay/sprint-AY.14-herdr-agent-name-mapping.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: none
 pr_target: integrate/phase-ay
 target: integrate/phase-ay
-status: dispatched
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: parallel

--- a/docs/plans/phase-ay/sprint-AY.2-herdr-transport-seam.md
+++ b/docs/plans/phase-ay/sprint-AY.2-herdr-transport-seam.md
@@ -6,7 +6,7 @@ title: Private transport foundation, CLI pure motion, and portable fake Herdr
 branch: feature/ay2-herdr-transport-seam
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay2-herdr-transport-seam
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core

--- a/docs/plans/phase-ay/sprint-AY.3-herdr-endpoint-doctor-config.md
+++ b/docs/plans/phase-ay/sprint-AY.3-herdr-endpoint-doctor-config.md
@@ -6,7 +6,7 @@ title: Herdr endpoint doctor and daemon configuration
 branch: feature/ay3-herdr-endpoint-doctor-config
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay3-herdr-endpoint-doctor-config
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core

--- a/docs/plans/phase-ay/sprint-AY.4-herdr-breaker-lifecycle.md
+++ b/docs/plans/phase-ay/sprint-AY.4-herdr-breaker-lifecycle.md
@@ -6,7 +6,7 @@ title: Herdr breaker escalation and failure lifecycle
 branch: feature/ay4-herdr-breaker-lifecycle
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay4-herdr-breaker-lifecycle
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core

--- a/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
+++ b/docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md
@@ -6,7 +6,7 @@ title: Transactional Herdr entry control plane
 branch: feature/ay5-herdr-entry-control-plane
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay5-herdr-entry-control-plane
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core

--- a/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
+++ b/docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md
@@ -6,7 +6,7 @@ title: Coordinated Herdr endpoint restart
 branch: feature/ay6-herdr-restart-coordination
 worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ay6-herdr-restart-coordination
 integration_branch: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: core

--- a/docs/plans/phase-ay/sprint-AY.7-windows-herdr-process-installer.md
+++ b/docs/plans/phase-ay/sprint-AY.7-windows-herdr-process-installer.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: feature/ay6-herdr-restart-coordination
 pr_target: feature/ay6-herdr-restart-coordination
 target: feature/ay6-herdr-restart-coordination
-status: draft
+status: complete
 recommended_agent: arch-ctm (no Windows machine required; the Windows CI lane is the gate)
 recommended_model: n/a
 execution_track: windows

--- a/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
+++ b/docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: none
 pr_target: integrate/phase-ay
 target: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: cipher
 recommended_model: fast
 rework: 2026-09-06 (transport isolation ruling; see phase-ay-plan.md "Rework record")

--- a/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
+++ b/docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md
@@ -9,7 +9,7 @@ integration_branch: integrate/phase-ay
 stack_parent: none
 pr_target: integrate/phase-ay
 target: integrate/phase-ay
-status: draft
+status: complete
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 execution_track: join


### PR DESCRIPTION
## Summary

Round-4 phase-gate non-blocking minor. `docs/project-plan.md` records phase-AY sprints AY.1–AY.9, AY.13 and AY.14 as `merged` (with PR numbers and SHAs), but their sprint-doc frontmatter still read `draft` / `dispatched`. This reconciles the eleven docs to `status: complete`.

quality-mgr reported two files (AY.9, AY.13); the workspace-wide repeatable-pattern sweep widened the true scope to eleven.

Left unchanged, deliberately:

- **AY.10, AY.12** — `gated`, correctly undispatched behind a recorded decision.
- **AY.11** — never executed; absent from the project-plan sprint status table.
- **AY.15** — already `complete`.

Docs-only: eleven single-line frontmatter changes, no code touched.

Triage record: `.triage/phase-ay/findings/DOCS-AY-R4-001.ttl` (on `integrate/phase-ay` @ `87c365563`).

New top layer (L4) of stack #1319, per the standing direction that any remaining phase-ay change lands as a new stacked layer rather than a push to an in-flight one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
