### PR TITLE
fix(hermes-atm): nudge injection platform from hook config (#1307)

### DIFF
--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -68,6 +68,7 @@ the nudge will fail closed because it cannot find or contact the receiver.
      --chat-id "$ATM_CHAT_ID" \
      --atm-home "$ATM_HOME" \
      --workspace-root "$ATM_WORKSPACE_ROOT" \
+     --platform <telegram|api_server> \
      --launch-agent-plist <gateway-launch-agent.plist>
    ```
 

--- a/crates/hermes-atm/README.md
+++ b/crates/hermes-atm/README.md
@@ -22,6 +22,7 @@ or shared install notes.
 | `chat_id` | Hermes session chat binding | Gateway's configured session |
 | `atm_home` | ATM durable home | `ATM_HOME` for the profile |
 | `workspace_root` | Canonical graft endpoint root | ATM roster `workspace_root` exactly |
+| `platform` | Hermes gateway platform | `telegram` by default; `api_server` for headless gateways |
 | `launch_agent_plist` | Gateway LaunchAgent plist | Its first `ProgramArguments` entry must be the Python running this installer |
 
 The `workspace_root` equality is mandatory. ATM post-send delivery resolves a

--- a/crates/hermes-atm/src/hermes_atm/hook.py
+++ b/crates/hermes-atm/src/hermes_atm/hook.py
@@ -37,7 +37,10 @@ def _configuration(path: Path) -> Mapping[str, str]:
         for name in required
     ):
         raise HermesAtmRuntimeError("invalid Hermes ATM hook configuration")
-    return {name: value[name] for name in required}
+    platform = value.get("platform", "telegram")
+    if not isinstance(platform, str) or not platform.strip():
+        raise HermesAtmRuntimeError("invalid Hermes ATM hook configuration")
+    return {**{name: value[name] for name in required}, "platform": platform}
 
 
 def _gateway_runner(context: Any) -> Any:
@@ -75,6 +78,7 @@ async def handle(event_type: str, context: Any, config_path: Path) -> None:
     runtime = HermesAtmRuntime.from_gateway_runner(
         runner,
         profile=configuration["profile"],
+        platform=configuration["platform"],
         environment=environment,
     )
     _runtime = runtime

--- a/crates/hermes-atm/src/hermes_atm/installer.py
+++ b/crates/hermes-atm/src/hermes_atm/installer.py
@@ -96,6 +96,18 @@ def _required(value: str | None, name: str) -> str:
     return normalized
 
 
+def _platform_name(value: str) -> str:
+    """Validate a public Hermes platform name before writing hook config."""
+
+    name = _required(value, "platform").upper()
+    platform = _require_public_capability(
+        "gateway.config", "Platform", "TELEGRAM", member_must_be_callable=False
+    )
+    if getattr(platform, name, None) is None:
+        raise HermesAtmInstallError(f"unsupported Hermes injection platform {value!r}")
+    return name.lower()
+
+
 def _read_launch_agent_python(path: Path) -> str:
     try:
         with path.open("rb") as source:
@@ -258,11 +270,13 @@ def install_profile(
     chat_id: str,
     atm_home: str,
     workspace_root: str,
+    platform: str = "telegram",
     launch_agent_plist: Path | None = None,
 ) -> Mapping[str, Any]:
     """Validate the host then materialize the standard declarative profile hook."""
 
     profile = _required(profile, "profile")
+    platform = _platform_name(platform)
     config = {
         "schema_version": 1,
         "profile": profile,
@@ -271,6 +285,7 @@ def install_profile(
         "team": _required(team, "ATM_TEAM"),
         "chat_id": _required(chat_id, "ATM_CHAT_ID"),
         "workspace_root": _required(workspace_root, "ATM_WORKSPACE_ROOT"),
+        "platform": platform,
     }
     validate_host_capability(launch_agent_plist=launch_agent_plist)
     hook_dir = profile_home / "hooks" / HOOK_NAME
@@ -330,6 +345,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("ATM_WORKSPACE_ROOT", ""),
         help="canonical graft root; must equal the roster workspace_root",
     )
+    install.add_argument(
+        "--platform",
+        default="telegram",
+        help="Hermes injection platform (for example telegram or api_server)",
+    )
     install.add_argument("--launch-agent-plist", type=Path)
     return parser
 
@@ -345,6 +365,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             chat_id=args.chat_id,
             atm_home=args.atm_home,
             workspace_root=args.workspace_root,
+            platform=args.platform,
             launch_agent_plist=args.launch_agent_plist,
         )
     except HermesAtmInstallError as error:

--- a/crates/hermes-atm/src/hermes_atm/runtime.py
+++ b/crates/hermes-atm/src/hermes_atm/runtime.py
@@ -16,7 +16,7 @@ class HermesAtmRuntimeError(RuntimeError):
 
 @dataclass
 class HermesAtmRuntime:
-    """One profile-owned graft receiver and Telegram delivery callback."""
+    """One profile-owned graft receiver and configured delivery callback."""
 
     session: Any
     chat_id: str
@@ -33,6 +33,7 @@ class HermesAtmRuntime:
         gateway_runner: Any,
         *,
         profile: str,
+        platform: str = "telegram",
         environment: Mapping[str, str] | None = None,
         notice_text: str | None = None,
     ) -> "HermesAtmRuntime":
@@ -50,10 +51,17 @@ class HermesAtmRuntime:
         # Use that active loop as the portable fallback so receiver
         # publication does not fail solely on optional host bookkeeping.
         loop = getattr(gateway_runner, "gateway_loop", None) or asyncio.get_running_loop()
+        platform_name = platform.strip().upper()
+        try:
+            resolved_platform = Platform[platform_name]
+        except KeyError as error:
+            raise HermesAtmRuntimeError(
+                f"Hermes platform {platform!r} is not available for ATM injection"
+            ) from error
         return cls.from_components(
             inject_internal_message=injector,
             loop=loop,
-            platform=Platform.TELEGRAM,
+            platform=resolved_platform,
             profile=profile,
             environment=environment,
             notice_text=notice_text,

--- a/crates/hermes-atm/tests/test_hook.py
+++ b/crates/hermes-atm/tests/test_hook.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+
+# Hook configuration validation does not use the compiled graft extension.
+# Keep this module runnable with the documented source-only test command.
+sys.modules.setdefault("atm_graft", types.ModuleType("atm_graft"))
+
+from hermes_atm.hook import _configuration
+from hermes_atm import HermesAtmRuntimeError
+
+
+BASE_CONFIGURATION = {
+    "schema_version": 1,
+    "profile": "test-profile",
+    "atm_home": "/tmp/atm",
+    "identity": "test-agent",
+    "team": "test-team",
+    "chat_id": "100000001",
+    "workspace_root": "/tmp/workspace",
+}
+
+
+class HookConfigurationTests(unittest.TestCase):
+    def write_configuration(self, value: dict) -> Path:
+        directory = Path(self.temporary.name)
+        path = directory / "config.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_missing_platform_defaults_to_telegram(self) -> None:
+        configuration = _configuration(self.write_configuration(BASE_CONFIGURATION))
+
+        self.assertEqual(configuration["platform"], "telegram")
+
+    def test_invalid_platform_values_raise_runtime_error(self) -> None:
+        for value in ("", "  ", None, 42):
+            with self.subTest(platform=value):
+                configuration = {**BASE_CONFIGURATION, "platform": value}
+                with self.assertRaises(HermesAtmRuntimeError):
+                    _configuration(self.write_configuration(configuration))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/hermes-atm/tests/test_installer.py
+++ b/crates/hermes-atm/tests/test_installer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import redirect_stdout
+from enum import Enum
 from io import StringIO
 import json
 import os
@@ -73,8 +74,9 @@ class GatewayModules:
         self.original_hermes_config = sys.modules.get("hermes_cli.config")
         self.original_plugins = sys.modules.get("hermes_cli.plugins")
 
-        class Platform:
-            TELEGRAM = object()
+        class Platform(Enum):
+            TELEGRAM = "telegram"
+            API_SERVER = "api_server"
 
         class GatewayRunner:
             gateway_loop = None
@@ -141,7 +143,7 @@ class GatewayModules:
 
 
 class InstallerTests(unittest.TestCase):
-    def test_install_writes_standard_hook_and_is_idempotent(self):
+    def test_install_writes_standard_hook_and_defaults_to_telegram(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():
             profile_home = Path(temporary) / TEST_PROFILE
             result = install_profile(
@@ -165,6 +167,7 @@ class InstallerTests(unittest.TestCase):
                     "team": TEST_TEAM,
                     "chat_id": TEST_CHAT_ID,
                     "workspace_root": "/tmp/workspace",
+                    "platform": "telegram",
                 },
             )
             self.assertIn("gateway:startup", (hook / "HOOK.yaml").read_text())
@@ -194,6 +197,38 @@ class InstallerTests(unittest.TestCase):
                     workspace_root="/tmp/workspace",
                 )["changed"]
             )
+
+    def test_install_writes_explicit_api_server_platform(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules():
+            result = install_profile(
+                profile_home=Path(temporary) / TEST_PROFILE,
+                profile=TEST_PROFILE,
+                identity=TEST_IDENTITY,
+                team=TEST_TEAM,
+                chat_id=TEST_CHAT_ID,
+                atm_home="/tmp/atm",
+                workspace_root="/tmp/workspace",
+                platform="api_server",
+            )
+            self.assertEqual(result["config"]["platform"], "api_server")
+
+    def test_install_rejects_unknown_injection_platform_before_writing_files(self):
+        with tempfile.TemporaryDirectory() as temporary, GatewayModules():
+            profile_home = Path(temporary) / TEST_PROFILE
+            with self.assertRaisesRegex(
+                HermesAtmInstallError, "unsupported Hermes injection platform 'unknown'"
+            ):
+                install_profile(
+                    profile_home=profile_home,
+                    profile=TEST_PROFILE,
+                    identity=TEST_IDENTITY,
+                    team=TEST_TEAM,
+                    chat_id=TEST_CHAT_ID,
+                    atm_home="/tmp/atm",
+                    workspace_root="/tmp/workspace",
+                    platform="unknown",
+                )
+            self.assertFalse(profile_home.exists())
 
     def test_install_preserves_existing_plugin_allowlist_and_enables_native_tools(self):
         with tempfile.TemporaryDirectory() as temporary, GatewayModules():

--- a/crates/hermes-atm/tests/test_runtime.py
+++ b/crates/hermes-atm/tests/test_runtime.py
@@ -326,6 +326,50 @@ class RuntimeTests(unittest.TestCase):
 
         asyncio.run(scenario())
 
+    def test_gateway_runner_api_rejects_unavailable_platform(self):
+        async def scenario():
+            import hermes_atm.runtime as module
+
+            original_gateway = sys.modules.get("gateway")
+            original_config = sys.modules.get("gateway.config")
+
+            class FakePlatform(Enum):
+                TELEGRAM = "telegram"
+
+            gateway_module = types.ModuleType("gateway")
+            config_module = types.ModuleType("gateway.config")
+            config_module.Platform = FakePlatform
+            gateway_module.config = config_module
+            sys.modules["gateway"] = gateway_module
+            sys.modules["gateway.config"] = config_module
+            try:
+                with self.assertRaisesRegex(HermesAtmRuntimeError, "not available"):
+                    HermesAtmRuntime.from_gateway_runner(
+                        types.SimpleNamespace(
+                            gateway_loop=asyncio.get_running_loop(),
+                            inject_internal_message=FakeInjector(),
+                        ),
+                        profile=TEST_PROFILE,
+                        platform="missing_platform",
+                        environment={
+                            "ATM_HOME": "/tmp/atm",
+                            "ATM_IDENTITY": TEST_IDENTITY,
+                            "ATM_TEAM": TEST_TEAM,
+                            "ATM_CHAT_ID": TEST_CHAT_ID,
+                        },
+                    )
+            finally:
+                if original_gateway is None:
+                    sys.modules.pop("gateway", None)
+                else:
+                    sys.modules["gateway"] = original_gateway
+                if original_config is None:
+                    sys.modules.pop("gateway.config", None)
+                else:
+                    sys.modules["gateway.config"] = original_config
+
+        asyncio.run(scenario())
+
     def test_gateway_runner_api_uses_running_loop_when_host_omits_loop_attribute(self):
         async def scenario():
             import hermes_atm.runtime as module

--- a/crates/hermes-atm/tests/test_runtime.py
+++ b/crates/hermes-atm/tests/test_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 import sys
 import types
 import unittest
@@ -218,8 +219,9 @@ class RuntimeTests(unittest.TestCase):
             original_config = sys.modules.get("gateway.config")
             sessions = []
 
-            class FakePlatform:
-                TELEGRAM = object()
+            class FakePlatform(Enum):
+                TELEGRAM = "telegram"
+                API_SERVER = "api_server"
 
             gateway_module = types.ModuleType("gateway")
             config_module = types.ModuleType("gateway.config")
@@ -270,6 +272,60 @@ class RuntimeTests(unittest.TestCase):
 
         asyncio.run(scenario())
 
+    def test_gateway_runner_api_resolves_explicit_api_server_platform(self):
+        async def scenario():
+            import hermes_atm.runtime as module
+
+            original_session = module.atm_graft.PyGraftSession
+            original_gateway = sys.modules.get("gateway")
+            original_config = sys.modules.get("gateway.config")
+
+            class FakePlatform(Enum):
+                TELEGRAM = "telegram"
+                API_SERVER = "api_server"
+
+            gateway_module = types.ModuleType("gateway")
+            config_module = types.ModuleType("gateway.config")
+            config_module.Platform = FakePlatform
+            gateway_module.config = config_module
+            sys.modules["gateway"] = gateway_module
+            sys.modules["gateway.config"] = config_module
+
+            def make_session(caller):
+                return FakeSession(caller)
+
+            module.atm_graft.PyGraftSession = make_session
+            try:
+                injector = FakeInjector()
+                runtime = HermesAtmRuntime.from_gateway_runner(
+                    types.SimpleNamespace(
+                        gateway_loop=asyncio.get_running_loop(),
+                        inject_internal_message=injector,
+                    ),
+                    profile=TEST_PROFILE,
+                    platform="api_server",
+                    environment={
+                        "ATM_HOME": "/tmp/atm",
+                        "ATM_IDENTITY": TEST_IDENTITY,
+                        "ATM_TEAM": TEST_TEAM,
+                        "ATM_CHAT_ID": TEST_CHAT_ID,
+                    },
+                )
+                self.assertIs(runtime.platform, FakePlatform.API_SERVER)
+                runtime.close()
+            finally:
+                module.atm_graft.PyGraftSession = original_session
+                if original_gateway is None:
+                    sys.modules.pop("gateway", None)
+                else:
+                    sys.modules["gateway"] = original_gateway
+                if original_config is None:
+                    sys.modules.pop("gateway.config", None)
+                else:
+                    sys.modules["gateway.config"] = original_config
+
+        asyncio.run(scenario())
+
     def test_gateway_runner_api_uses_running_loop_when_host_omits_loop_attribute(self):
         async def scenario():
             import hermes_atm.runtime as module
@@ -278,8 +334,8 @@ class RuntimeTests(unittest.TestCase):
             original_gateway = sys.modules.get("gateway")
             original_config = sys.modules.get("gateway.config")
 
-            class FakePlatform:
-                TELEGRAM = object()
+            class FakePlatform(Enum):
+                TELEGRAM = "telegram"
 
             gateway_module = types.ModuleType("gateway")
             config_module = types.ModuleType("gateway.config")

--- a/docs/user-documents/hermes-atm.md
+++ b/docs/user-documents/hermes-atm.md
@@ -75,6 +75,10 @@ atm teams update-member "$ATM_TEAM" "$ATM_IDENTITY" \
 
 Then run the package installer with that same gateway Python interpreter:
 
+The installer defaults to the `telegram` platform. For a headless Hermes
+gateway, pass `--platform api_server`; the accepted values are `telegram` and
+`api_server`.
+
 ```bash
 python -m hermes_atm install \
   --profile "$HERMES_PROFILE" \
@@ -84,6 +88,7 @@ python -m hermes_atm install \
   --chat-id "$ATM_CHAT_ID" \
   --atm-home "$ATM_HOME" \
   --workspace-root "$ATM_WORKSPACE_ROOT" \
+  --platform telegram \
   --launch-agent-plist "$HERMES_GATEWAY_PLIST"
 ```
 


### PR DESCRIPTION
Fixes #1307.

The installer writes a validated injection platform to hook config (default telegram); the runtime resolves it through the Hermes Platform enum at injection time. Headless gateways can install with --platform api_server. Includes installer and runtime coverage for default, explicit api_server, and unknown-platform rejection.