### PR TITLE
triage(phase-ay): closeout layer — DOCS-AY-R4-001 closure, RBQA-AY15-F002 disposition, RSH-AY-R5-001

### DIFF
--- a/.triage/phase-ay/findings/DOCS-AY-R4-001.ttl
+++ b/.triage/phase-ay/findings/DOCS-AY-R4-001.ttl
@@ -15,9 +15,12 @@
   triage:severity "minor" ;
   triage:repeatable true ;
   triage:sweepScope "all sprint docs under docs/plans/phase-ay/ cross-checked against the phase AY sprint status table in docs/project-plan.md" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-08T06:10:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-09-08T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Confirmed fixed on PR #1324 (fix/ay-gate-r4-sprintdoc-status, head 2788d3feca0e83edb5998759d779bc14492244d9), merged as 6099e385d then carried forward by develop-merge to integrate/phase-ay@97cf27f51. Independently re-verified by quality-mgr (round-5 gate) via direct reads plus arch-qa and req-qa round-5 re-confirmation: all eleven listed sprint docs (AY.1-AY.9, AY.13, AY.14) now read status: complete at the cited lines, matching docs/project-plan.md's merged entries; AY.10/AY.12 correctly left status: gated, AY.11 correctly left status: draft (never executed, absent from project-plan status table), AY.15 unchanged (already complete). Written to fix/ay-closeout per fenix's branch-redirect (integrate/phase-ay frozen for PR #1308 CI); not committed to integrate/phase-ay directly." ;
   triage:foundIn triage:AY15 ;
   triage:foundAt "2026-09-08T05:50:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/DOCS-AY-R4-001/1> ;
@@ -38,10 +41,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.1-herdr-audit-docs.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.1 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/2>
@@ -49,10 +53,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.2-herdr-transport-seam.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.2 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/3>
@@ -60,10 +65,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.3-herdr-endpoint-doctor-config.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.3 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/4>
@@ -71,10 +77,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.4-herdr-breaker-lifecycle.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.4 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/5>
@@ -82,10 +89,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.5-herdr-entry-control-plane.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.5 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/6>
@@ -93,10 +101,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.6-herdr-restart-coordination.md" ;
   triage:line 9 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.6 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/7>
@@ -104,10 +113,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.7-windows-herdr-process-installer.md" ;
   triage:line 12 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.7 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/8>
@@ -115,10 +125,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.8-herdr-socket-transport.md" ;
   triage:line 12 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.8 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/9>
@@ -126,10 +137,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.9-herdr-socket-cutover.md" ;
   triage:line 12 ;
   triage:snippet "frontmatter reads status: draft while docs/project-plan.md records AY.9 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/10>
@@ -137,10 +149,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.13-doctor-team-scope.md" ;
   triage:line 12 ;
   triage:snippet "frontmatter reads status: dispatched while docs/project-plan.md records AY.13 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:occurrence/DOCS-AY-R4-001/11>
@@ -148,10 +161,11 @@
   triage:file "docs/plans/phase-ay/sprint-AY.14-herdr-agent-name-mapping.md" ;
   triage:line 12 ;
   triage:snippet "frontmatter reads status: dispatched while docs/project-plan.md records AY.14 as merged" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ay" ;
   triage:headSha "82c6e428b" ;
+  triage:fixedAtHeadSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
   triage:occursIn <urn:atm:triage:worktree/gate-r4-1> .
 
 <urn:atm:triage:worktree/gate-r4-1>

--- a/.triage/phase-ay/findings/RBQA-AY15-F002.ttl
+++ b/.triage/phase-ay/findings/RBQA-AY15-F002.ttl
@@ -18,6 +18,7 @@
   triage:status "open" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-09-07T22:20:00Z"^^xsd:dateTime ;
+  triage:dispositionNote "Round-5 phase-ending gate disposition (quality-mgr): stays open by design, not closed. ruthless-boundary-qa (round 5, full unscoped workspace sweep, not scope-locked) independently re-confirmed RBQA-AY15-F001's underlying duplication collapsed to a single shared owner (atm_storage::roster_unique_name_collisions, crates/atm-storage/src/contract.rs:591, consumed by all three former call sites), so this lint_gap record is not moot with F001 fixed -- it documents the absence of a mechanical guard against a future third re-derivation, per docs/architecture/boundary/general-guidelines.md priority-5 guidance (one-off duplication does not yet warrant a new lint; only a repeated pattern would). No new occurrence and no repeat of the pattern were found this round. Correctly deferred, not a merge blocker for PR #1308." ;
   triage:foundIn triage:AY15 ;
   triage:foundAt "2026-09-07T21:55:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-AY15-F002/1> ;

--- a/.triage/phase-ay/findings/RSH-AY-R5-001.ttl
+++ b/.triage/phase-ay/findings/RSH-AY-R5-001.ttl
@@ -1,0 +1,42 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/RSH-AY-R5-001>
+  a triage:Finding ;
+  triage:findingId "RSH-AY-R5-001" ;
+  triage:title "/v1/health always returns 200, never consults computed RuntimeHealth/Lifecycle readiness state" ;
+  triage:description "rust-service-hardening-agent phase-ay gate round 5 (RSH-001; worktree fix/ay-gate-r4-sprintdoc-status, head 2788d3feca0e83edb5998759d779bc14492244d9). Important. crates/atm-http-runtime/src/health_route.rs:24's health handler builds its response solely from DiagnosticCountersSource::snapshot() and has no branch that can produce a non-200 status; it never reads the Lifecycle (NotReady/Ready/Draining/Stopped) value that runtime_health.rs already computes for atm doctor/status use. An external HTTP health probe therefore cannot detect a draining, not-yet-ready, or already-stopped runtime via /v1/health. This is pre-existing atm-http-runtime infrastructure, not introduced by any phase-ay sprint diff -- surfaced incidentally by this round's phase-end sweep, not a phase-ay regression. Non-blocking for PR #1308 (integrate/phase-ay -> develop); does not gate this phase's merge. Required correction: add the RuntimeHealth/Lifecycle projection as an explicit input to the /v1/health handler and return a non-2xx (e.g. 503) status when Lifecycle is NotReady, Draining, or Stopped, matching the readiness/liveness distinction in .claude/skills/rust-service-hardening/references/production-checklist.md item 11." ;
+  triage:phaseId "phase-ay" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "service-hardening" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "atm-http-runtime health/readiness endpoint" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-09-08T06:40:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AY15 ;
+  triage:foundAt "2026-09-08T06:20:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RSH-AY-R5-001/1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/RSH-AY-R5-001/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-http-runtime/src/health_route.rs" ;
+  triage:line 24 ;
+  triage:snippet "async fn health(...) -> Json<RetainedObservabilityHealthResponse> builds its response solely from DiagnosticCountersSource; no RuntimeHealth/Lifecycle value is read, handler has no non-200 branch" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-ay" ;
+  triage:headSha "97cf27f51" ;
+  triage:occursIn <urn:atm:triage:worktree/gate-r5-1> .
+
+<urn:atm:triage:worktree/gate-r5-1>
+  a triage:WorktreeSnapshot ;
+  triage:path "fix/ay-gate-r4-sprintdoc-status" ;
+  triage:branch "fix/ay-gate-r4-sprintdoc-status" ;
+  triage:headSha "2788d3feca0e83edb5998759d779bc14492244d9" ;
+  triage:orderIndex 0 .

--- a/docs/plans/phase-ao2/evidence/AY-BENCH-R1-ssh-auth-nonstart-20260908T0421Z.md
+++ b/docs/plans/phase-ao2/evidence/AY-BENCH-R1-ssh-auth-nonstart-20260908T0421Z.md
@@ -1,0 +1,46 @@
+# AY-BENCH-R1 SSH authentication failed-attempt note — 2026-09-08
+
+## Scope
+
+This records the Rand-directed Phase AY ordinary benchmark attempt that did
+not reach measurement. It is not a benchmark campaign and contains no
+performance result.
+
+| Field | Value |
+|---|---|
+| Account | `atmbench@rand-m5.local` |
+| Selected branch | `fix/ay-closeout` |
+| Selected branch source | `f3f89da1562651c17aeb916e526113842f6629e4` |
+| Code-equivalent trunk source | `integrate/phase-ay` at `97cf27f5121695fe9601d7a86fffcd0acc84f092` |
+| Trigger | Direct SSH preflight for `ATM_CAPACITY_HOST_LABEL=rand-m5 just benchmark` |
+| Measurement started | No |
+| Failure boundary | SSH public-key authentication before benchmark-account checkout access |
+
+## Observed outcome
+
+The required dedicated benchmark account was contacted directly. Its
+configured login key and each other locally available explicit identity were
+rejected by the SSH server. Password and keyboard-interactive authentication
+cannot run in the non-interactive benchmark procedure.
+
+```text
+atmbench@rand-m5.local: Permission denied (publickey,password,keyboard-interactive).
+```
+
+No developer account, alternate host, sudo path, or substitute runner was
+used. The benchmark checkout, `daemon-switch` preflight, `atm doctor`,
+bootstrap, and matrix command were therefore not entered.
+
+## Cleanup proof
+
+The failure occurred before remote shell access, so no account process,
+benchmark daemon, temporary ATM home, benchmark database, trace, campaign
+JSON, report artifact, or source state was created or altered. No cleanup was
+needed or attempted against the inaccessible dedicated account.
+
+## Disposition
+
+The Phase AY benchmark remains unmeasured. A new immutable attempt is required
+after the `atmbench@rand-m5.local` public-key authorization is restored; it
+must begin with the ordinary account preflight and run the full four-target
+matrix without altering this note.


### PR DESCRIPTION
Phase-ay closeout layer, stacked over `integrate/phase-ay`. Trunk is frozen so PR #1308's CI can reach green undisturbed; all remaining phase-ay writes land here.

## Contents (quality-mgr, AY-GATE-R5)

- **DOCS-AY-R4-001** — closed: `triage:status "fixed"`, `triage:closedBy "quality-mgr"`, all 11 occurrences updated. The fix itself is PR #1324 (sprint-doc frontmatter wording), merged as `6099e385d`.
- **RBQA-AY15-F002** — left open with a `dispositionNote`: correct-by-design, not a merge blocker. Rides a future PR touching that code.
- **RSH-AY-R5-001** — new record, important / non-blocking: pre-existing `/v1/health` readiness gap, unrelated to the phase-ay diff, surfaced by `rust-service-hardening-agent` in the round-5 sweep.

Triage records only — no source changes. `validate-findings.py` passed at the pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sVcDUfetCpfiYeQLxYPQK
